### PR TITLE
Add copy/paste/cut for circuit components

### DIFF
--- a/app/GUI/circuit_design_gui.py
+++ b/app/GUI/circuit_design_gui.py
@@ -300,6 +300,23 @@ class CircuitDesignGUI(QMainWindow):
         if edit_menu is None:
             return
 
+        copy_action = QAction("&Copy", self)
+        copy_action.setShortcut(QKeySequence.StandardKey.Copy)
+        copy_action.triggered.connect(self.canvas.copy_selected)
+        edit_menu.addAction(copy_action)
+
+        paste_action = QAction("&Paste", self)
+        paste_action.setShortcut(QKeySequence.StandardKey.Paste)
+        paste_action.triggered.connect(self.canvas.paste_clipboard)
+        edit_menu.addAction(paste_action)
+
+        cut_action = QAction("Cu&t", self)
+        cut_action.setShortcut(QKeySequence.StandardKey.Cut)
+        cut_action.triggered.connect(self.canvas.cut_selected)
+        edit_menu.addAction(cut_action)
+
+        edit_menu.addSeparator()
+
         delete_action = QAction("&Delete Selected", self)
         delete_action.setShortcut(QKeySequence.StandardKey.Delete)
         delete_action.triggered.connect(self.delete_selected)


### PR DESCRIPTION
## Summary
- Ctrl+C copies selected components and internal wires to an internal clipboard
- Ctrl+V pastes with new unique IDs at an offset position from originals
- Ctrl+X cuts (copy + delete originals)
- Only wires where both endpoints are in the selection get copied
- Pasted components are auto-selected for easy repositioning
- Edit menu entries added with standard keyboard shortcuts
- Fixed Shift+R rotation shortcut (was unreachable due to check order)

Closes #79

## Test plan
- [ ] Select a single component, Ctrl+C, Ctrl+V — verify new component appears offset with new ID
- [ ] Select multiple connected components, copy/paste — verify internal wires are recreated
- [ ] Verify wires to non-selected components are NOT copied
- [ ] Paste multiple times from same clipboard — each paste gets unique IDs
- [ ] Ctrl+X cuts (removes originals after copying)
- [ ] Edit menu Copy/Paste/Cut entries work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)