### PR TITLE
Add circuit annotations and net labels

### DIFF
--- a/app/GUI/annotation_item.py
+++ b/app/GUI/annotation_item.py
@@ -1,0 +1,64 @@
+"""Movable text annotation for the circuit canvas."""
+
+from PyQt6.QtWidgets import QGraphicsTextItem, QInputDialog, QGraphicsItem
+from PyQt6.QtGui import QFont, QColor
+
+
+class AnnotationItem(QGraphicsTextItem):
+    """A free-form text annotation that can be placed on the canvas.
+
+    Supports move, double-click to edit, delete, bold, font size,
+    and serialization for save/load.
+    """
+
+    def __init__(self, text="Annotation", x=0.0, y=0.0, font_size=10, bold=False, color="#FFFFFF"):
+        super().__init__(text)
+        self.setPos(x, y)
+        self.setDefaultTextColor(QColor(color))
+        self._color_hex = color
+
+        font = QFont()
+        font.setPointSize(font_size)
+        font.setBold(bold)
+        self.setFont(font)
+
+        self.setFlags(
+            QGraphicsItem.GraphicsItemFlag.ItemIsMovable
+            | QGraphicsItem.GraphicsItemFlag.ItemIsSelectable
+            | QGraphicsItem.GraphicsItemFlag.ItemSendsGeometryChanges
+        )
+        self.setZValue(90)  # Above wires, below debug overlays
+
+    # -- Editing ---------------------------------------------------------------
+
+    def mouseDoubleClickEvent(self, event):
+        """Open a dialog to edit the annotation text."""
+        text, ok = QInputDialog.getText(
+            None, "Edit Annotation", "Text:", text=self.toPlainText()
+        )
+        if ok and text:
+            self.setPlainText(text)
+
+    # -- Serialization ---------------------------------------------------------
+
+    def to_dict(self):
+        font = self.font()
+        return {
+            'text': self.toPlainText(),
+            'x': self.pos().x(),
+            'y': self.pos().y(),
+            'font_size': font.pointSize(),
+            'bold': font.bold(),
+            'color': self._color_hex,
+        }
+
+    @staticmethod
+    def from_dict(data):
+        return AnnotationItem(
+            text=data.get('text', 'Annotation'),
+            x=data.get('x', 0.0),
+            y=data.get('y', 0.0),
+            font_size=data.get('font_size', 10),
+            bold=data.get('bold', False),
+            color=data.get('color', '#FFFFFF'),
+        )


### PR DESCRIPTION
## Summary
- New `AnnotationItem` class for placing free-form text annotations on the canvas
- Right-click context menu on empty canvas offers "Add Annotation"
- Annotations support: move (drag), double-click to edit, delete (via context menu or Del key)
- Annotations are saved/loaded with circuit files (backward compatible — old files without annotations still load fine)
- Net labels already supported via the existing node labeling system (right-click on wires/terminals)
- Named nodes appear with their labels in simulation results

**Note:** This PR depends on #84 (copy/paste) due to shared changes in `circuit_canvas.py`.

Closes #82

## Test plan
- [ ] Right-click on empty canvas area → "Add Annotation" appears in menu
- [ ] Add annotation → dialog prompts for text → annotation appears at click position
- [ ] Double-click annotation → edit dialog appears
- [ ] Drag annotation to move it
- [ ] Select annotation + Del key to delete
- [ ] Right-click annotation → Delete/Edit options
- [ ] Save circuit with annotations → reload → annotations preserved
- [ ] Load old circuit file without annotations field → no errors
- [ ] Clear canvas removes annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)