### PR TITLE
Add BJT transistor elements (NPN/PNP)

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -711,6 +711,74 @@ class CCCS(ComponentItem):
         return [(-18.0, -18.0), (18.0, -18.0), (18.0, 18.0), (-18.0, 18.0)]
 
 
+class BJTNPN(ComponentItem):
+    """NPN Bipolar Junction Transistor"""
+    type_name = 'BJT NPN'
+
+    def __init__(self, component_id, model=None):
+        super().__init__(component_id, self.type_name, model=model)
+
+    def boundingRect(self):
+        return QRectF(-30, -30, 60, 60)
+
+    def draw_component_body(self, painter):
+        # Terminal leads
+        if self.scene() is not None:
+            painter.drawLine(-20, 0, -8, 0)       # Base lead
+            painter.drawLine(8, -12, 20, -20)      # Collector lead
+            painter.drawLine(8, 12, 20, 20)        # Emitter lead
+
+        # Vertical base bar
+        painter.drawLine(-8, -12, -8, 12)
+
+        # Collector line (from bar to upper-right)
+        painter.drawLine(-8, -6, 8, -12)
+
+        # Emitter line (from bar to lower-right)
+        painter.drawLine(-8, 6, 8, 12)
+
+        # Arrow on emitter (pointing outward for NPN)
+        painter.drawLine(8, 12, 4, 7)
+        painter.drawLine(8, 12, 3, 12)
+
+    def get_obstacle_shape(self):
+        return [(-12.0, -15.0), (12.0, -15.0), (12.0, 15.0), (-12.0, 15.0)]
+
+
+class BJTPNP(ComponentItem):
+    """PNP Bipolar Junction Transistor"""
+    type_name = 'BJT PNP'
+
+    def __init__(self, component_id, model=None):
+        super().__init__(component_id, self.type_name, model=model)
+
+    def boundingRect(self):
+        return QRectF(-30, -30, 60, 60)
+
+    def draw_component_body(self, painter):
+        # Terminal leads
+        if self.scene() is not None:
+            painter.drawLine(-20, 0, -8, 0)       # Base lead
+            painter.drawLine(8, -12, 20, -20)      # Collector lead
+            painter.drawLine(8, 12, 20, 20)        # Emitter lead
+
+        # Vertical base bar
+        painter.drawLine(-8, -12, -8, 12)
+
+        # Collector line (from bar to upper-right)
+        painter.drawLine(-8, -6, 8, -12)
+
+        # Emitter line (from bar to lower-right)
+        painter.drawLine(-8, 6, 8, 12)
+
+        # Arrow on emitter (pointing inward for PNP)
+        painter.drawLine(-8, 6, -3, 2)
+        painter.drawLine(-8, 6, -3, 7)
+
+    def get_obstacle_shape(self):
+        return [(-12.0, -15.0), (12.0, -15.0), (12.0, 15.0), (-12.0, 15.0)]
+
+
 # Component registry for factory pattern
 COMPONENT_CLASSES = {
     'Resistor': Resistor,
@@ -733,6 +801,8 @@ COMPONENT_CLASSES = {
     'VoltageControlledCurrentSource': VCCS,
     'CCCS': CCCS,
     'CurrentControlledCurrentSource': CCCS,
+    'BJT NPN': BJTNPN,
+    'BJT PNP': BJTPNP,
 }
 
 

--- a/app/GUI/format_utils.py
+++ b/app/GUI/format_utils.py
@@ -96,7 +96,7 @@ def format_value(value: float, unit: str = "") -> str:
 _POSITIVE_ONLY_TYPES = {'Resistor', 'Capacitor', 'Inductor'}
 
 # Component types that don't need value validation
-_SKIP_VALIDATION_TYPES = {'Ground', 'Op-Amp', 'Waveform Source'}
+_SKIP_VALIDATION_TYPES = {'Ground', 'Op-Amp', 'Waveform Source', 'BJT NPN', 'BJT PNP'}
 
 
 def validate_component_value(value: str, component_type: str) -> tuple[bool, str]:

--- a/app/GUI/styles/constants.py
+++ b/app/GUI/styles/constants.py
@@ -56,6 +56,8 @@ _COLOR_KEYS = {
     'CCVS': 'component_ccvs',
     'VCCS': 'component_vccs',
     'CCCS': 'component_cccs',
+    'BJT NPN': 'component_bjt_npn',
+    'BJT PNP': 'component_bjt_pnp',
 }
 
 # Component definitions - symbol and terminals sourced from models

--- a/app/GUI/styles/light_theme.py
+++ b/app/GUI/styles/light_theme.py
@@ -40,6 +40,8 @@ class LightTheme(BaseTheme):
             'component_ccvs': '#00ACC1',           # Cyan
             'component_vccs': '#26A69A',           # Teal variant
             'component_cccs': '#0097A7',           # Dark cyan
+            'component_bjt_npn': '#FF6B6B',        # Coral red
+            'component_bjt_pnp': '#4ECDC4',        # Teal green
 
             # ===== Algorithm Layer Colors =====
             'algorithm_astar': '#2196F3',          # Blue (33, 150, 243)

--- a/app/models/component.py
+++ b/app/models/component.py
@@ -28,6 +28,8 @@ COMPONENT_TYPES = [
     'CCVS',
     'VCCS',
     'CCCS',
+    'BJT NPN',
+    'BJT PNP',
 ]
 
 # Mapping of component types to SPICE symbols
@@ -44,6 +46,8 @@ SPICE_SYMBOLS = {
     'CCVS': 'H',
     'VCCS': 'G',
     'CCCS': 'F',
+    'BJT NPN': 'Q',
+    'BJT PNP': 'Q',
 }
 
 # Number of terminals per component type (default is 2)
@@ -54,6 +58,8 @@ TERMINAL_COUNTS = {
     'CCVS': 4,
     'VCCS': 4,
     'CCCS': 4,
+    'BJT NPN': 3,
+    'BJT PNP': 3,
 }
 
 # Default values per component type
@@ -70,6 +76,8 @@ DEFAULT_VALUES = {
     'CCVS': '1k',
     'VCCS': '1m',
     'CCCS': '1',
+    'BJT NPN': '2N3904',
+    'BJT PNP': '2N3906',
 }
 
 # Component colors (hex strings)
@@ -86,6 +94,8 @@ COMPONENT_COLORS = {
     'CCVS': '#00ACC1',
     'VCCS': '#26A69A',
     'CCCS': '#0097A7',
+    'BJT NPN': '#FF6B6B',
+    'BJT PNP': '#4ECDC4',
 }
 
 # Terminal geometry configuration per component type
@@ -105,6 +115,8 @@ TERMINAL_GEOMETRY = {
     'CCVS': (20, 10, [(-30, -10), (-30, 10), (30, -10), (30, 10)]),
     'VCCS': (20, 10, [(-30, -10), (-30, 10), (30, -10), (30, 10)]),
     'CCCS': (20, 10, [(-30, -10), (-30, 10), (30, -10), (30, 10)]),
+    'BJT NPN': (20, 10, [(20, -20), (-20, 0), (20, 20)]),   # Collector, Base, Emitter
+    'BJT PNP': (20, 10, [(20, -20), (-20, 0), (20, 20)]),   # Collector, Base, Emitter
 }
 
 # Mapping from serialized class names to canonical display names

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -154,7 +154,32 @@ class NetlistGenerator:
                 sense_name = f"Vsense_{comp_id}"
                 lines.append(f"{sense_name} {nodes[0]} {nodes[1]} 0")
                 lines.append(f"{comp_id} {nodes[2]} {nodes[3]} {sense_name} {comp.value}")
-        
+            elif comp.component_type == 'BJT NPN':
+                # Q<name> collector base emitter model_name
+                # Terminals: 0=collector, 1=base, 2=emitter
+                lines.append(f"{comp_id} {nodes[0]} {nodes[1]} {nodes[2]} {comp.value}")
+            elif comp.component_type == 'BJT PNP':
+                # Q<name> collector base emitter model_name
+                lines.append(f"{comp_id} {nodes[0]} {nodes[1]} {nodes[2]} {comp.value}")
+
+        # Add BJT model directives
+        bjt_models = set()
+        for comp in self.components.values():
+            if comp.component_type == 'BJT NPN':
+                bjt_models.add(('NPN', comp.value))
+            elif comp.component_type == 'BJT PNP':
+                bjt_models.add(('PNP', comp.value))
+        if bjt_models:
+            lines.append("")
+            lines.append("* BJT Model Definitions")
+            for polarity, model_name in sorted(bjt_models):
+                if model_name == '2N3904':
+                    lines.append(f".model {model_name} NPN(BF=300 IS=1e-14 VAF=100)")
+                elif model_name == '2N3906':
+                    lines.append(f".model {model_name} PNP(BF=200 IS=1e-14 VAF=100)")
+                else:
+                    lines.append(f".model {model_name} {polarity}(BF=100 IS=1e-14)")
+
         # Add comments about labeled nodes
         if node_labels:
             lines.append("")


### PR DESCRIPTION
## Summary
- New NPN and PNP bipolar junction transistor components
- Distinct schematic symbols with correct arrow directions (NPN outward, PNP inward)
- Three terminals: Collector, Base, Emitter
- SPICE netlist generation using `Q` prefix with `.model` directives
- Default models: 2N3904 (NPN BF=300) and 2N3906 (PNP BF=200)
- Custom model names supported via properties panel
- Theme colors: coral red (NPN), teal green (PNP)

Closes #70

## Test plan
- [ ] NPN and PNP appear in component palette
- [ ] Drag to canvas — correct symbols displayed
- [ ] Three terminals connectable via wires
- [ ] Rotation works correctly for all orientations
- [ ] Properties panel allows editing model name
- [ ] Netlist generation includes Q lines and .model directives
- [ ] Save/load preserves BJT components

🤖 Generated with [Claude Code](https://claude.com/claude-code)