### PR TITLE
Add voltage-controlled switch element

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -856,6 +856,43 @@ class MOSFETPMOS(ComponentItem):
         return [(-12.0, -15.0), (12.0, -15.0), (12.0, 15.0), (-12.0, 15.0)]
 
 
+class VCSwitch(ComponentItem):
+    """Voltage-Controlled Switch (S element)"""
+    type_name = 'VC Switch'
+
+    def __init__(self, component_id, model=None):
+        super().__init__(component_id, self.type_name, model=model)
+
+    def boundingRect(self):
+        return QRectF(-40, -25, 80, 50)
+
+    def draw_component_body(self, painter):
+        # Control and switch path terminal lines
+        if self.scene() is not None:
+            painter.drawLine(-30, -10, -15, -10)   # ctrl+ terminal
+            painter.drawLine(-30, 10, -15, 10)     # ctrl- terminal
+            painter.drawLine(15, -10, 30, -10)     # switch+ terminal
+            painter.drawLine(15, 10, 30, 10)       # switch- terminal
+
+        # Box outline for the switch body
+        painter.drawRect(-15, -15, 30, 30)
+
+        # Switch symbol inside: open switch (angled line)
+        painter.drawLine(-8, 8, 8, -4)
+        # Contact dots
+        painter.drawEllipse(-10, 6, 4, 4)
+        painter.drawEllipse(6, -4, 4, 4)
+
+        # Control arrow from left side
+        painter.setPen(QPen(Qt.GlobalColor.black, 1))
+        painter.drawLine(-12, 0, -5, 0)
+        painter.drawLine(-7, -2, -5, 0)
+        painter.drawLine(-7, 2, -5, 0)
+
+    def get_obstacle_shape(self):
+        return [(-18.0, -18.0), (18.0, -18.0), (18.0, 18.0), (-18.0, 18.0)]
+
+
 # Component registry for factory pattern
 COMPONENT_CLASSES = {
     'Resistor': Resistor,
@@ -884,6 +921,8 @@ COMPONENT_CLASSES = {
     'MOSFETNMOS': MOSFETNMOS,
     'MOSFET PMOS': MOSFETPMOS,
     'MOSFETPMOS': MOSFETPMOS,
+    'VC Switch': VCSwitch,
+    'VCSwitch': VCSwitch,
 }
 
 

--- a/app/GUI/format_utils.py
+++ b/app/GUI/format_utils.py
@@ -96,7 +96,7 @@ def format_value(value: float, unit: str = "") -> str:
 _POSITIVE_ONLY_TYPES = {'Resistor', 'Capacitor', 'Inductor'}
 
 # Component types that don't need value validation
-_SKIP_VALIDATION_TYPES = {'Ground', 'Op-Amp', 'Waveform Source', 'BJT NPN', 'BJT PNP', 'MOSFET NMOS', 'MOSFET PMOS'}
+_SKIP_VALIDATION_TYPES = {'Ground', 'Op-Amp', 'Waveform Source', 'BJT NPN', 'BJT PNP', 'MOSFET NMOS', 'MOSFET PMOS', 'VC Switch'}
 
 
 def validate_component_value(value: str, component_type: str) -> tuple[bool, str]:

--- a/app/GUI/styles/constants.py
+++ b/app/GUI/styles/constants.py
@@ -60,6 +60,7 @@ _COLOR_KEYS = {
     'BJT PNP': 'component_bjt_pnp',
     'MOSFET NMOS': 'component_mosfet_nmos',
     'MOSFET PMOS': 'component_mosfet_pmos',
+    'VC Switch': 'component_vc_switch',
 }
 
 # Component definitions - symbol and terminals sourced from models

--- a/app/GUI/styles/light_theme.py
+++ b/app/GUI/styles/light_theme.py
@@ -44,6 +44,7 @@ class LightTheme(BaseTheme):
             'component_bjt_pnp': '#4ECDC4',        # Teal green
             'component_mosfet_nmos': '#7B1FA2',    # Deep purple
             'component_mosfet_pmos': '#512DA8',    # Indigo
+            'component_vc_switch': '#795548',       # Brown
 
             # ===== Algorithm Layer Colors =====
             'algorithm_astar': '#2196F3',          # Blue (33, 150, 243)

--- a/app/models/component.py
+++ b/app/models/component.py
@@ -32,6 +32,7 @@ COMPONENT_TYPES = [
     'BJT PNP',
     'MOSFET NMOS',
     'MOSFET PMOS',
+    'VC Switch',
 ]
 
 # Mapping of component types to SPICE symbols
@@ -52,6 +53,7 @@ SPICE_SYMBOLS = {
     'BJT PNP': 'Q',
     'MOSFET NMOS': 'M',
     'MOSFET PMOS': 'M',
+    'VC Switch': 'S',
 }
 
 # Number of terminals per component type (default is 2)
@@ -66,6 +68,7 @@ TERMINAL_COUNTS = {
     'BJT PNP': 3,
     'MOSFET NMOS': 3,
     'MOSFET PMOS': 3,
+    'VC Switch': 4,
 }
 
 # Default values per component type
@@ -86,6 +89,7 @@ DEFAULT_VALUES = {
     'BJT PNP': '2N3906',
     'MOSFET NMOS': 'NMOS1',
     'MOSFET PMOS': 'PMOS1',
+    'VC Switch': 'VT=2.5 RON=1 ROFF=1e6',
 }
 
 # Component colors (hex strings)
@@ -106,6 +110,7 @@ COMPONENT_COLORS = {
     'BJT PNP': '#4ECDC4',
     'MOSFET NMOS': '#7B1FA2',
     'MOSFET PMOS': '#512DA8',
+    'VC Switch': '#795548',
 }
 
 # Terminal geometry configuration per component type
@@ -129,6 +134,7 @@ TERMINAL_GEOMETRY = {
     'BJT PNP': (20, 10, [(20, -20), (-20, 0), (20, 20)]),   # Collector, Base, Emitter
     'MOSFET NMOS': (20, 10, [(20, -20), (-20, 0), (20, 20)]),
     'MOSFET PMOS': (20, 10, [(20, -20), (-20, 0), (20, 20)]),
+    'VC Switch': (20, 10, [(-30, -10), (-30, 10), (30, -10), (30, 10)]),
 }
 
 # Mapping from serialized class names to canonical display names
@@ -146,6 +152,7 @@ _CLASS_TO_DISPLAY = {
     'BJTPNP': 'BJT PNP',
     'MOSFETNMOS': 'MOSFET NMOS',
     'MOSFETPMOS': 'MOSFET PMOS',
+    'VCSwitch': 'VC Switch',
 }
 
 # Mapping from display names to Python class names (for serialization)
@@ -162,6 +169,7 @@ _DISPLAY_TO_CLASS = {
     'BJT PNP': 'BJTPNP',
     'MOSFET NMOS': 'MOSFETNMOS',
     'MOSFET PMOS': 'MOSFETPMOS',
+    'VC Switch': 'VCSwitch',
 }
 
 

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -166,6 +166,11 @@ class NetlistGenerator:
                 # Terminals: 0=drain, 1=gate, 2=source
                 # Bulk (body) tied to source for simplicity
                 lines.append(f"{comp_id} {nodes[0]} {nodes[1]} {nodes[2]} {nodes[2]} {comp.value}")
+            elif comp.component_type == 'VC Switch':
+                # S<name> switch+ switch- ctrl+ ctrl- model_name
+                # Terminals: 0=ctrl+, 1=ctrl-, 2=switch+, 3=switch-
+                model_name = f"SW_{comp_id}"
+                lines.append(f"{comp_id} {nodes[2]} {nodes[3]} {nodes[0]} {nodes[1]} {model_name}")
 
         # Add BJT model directives
         bjt_models = set()
@@ -200,6 +205,16 @@ class NetlistGenerator:
                     lines.append(f".model {model_name} NMOS(VTO=0.7 KP=110u)")
                 else:
                     lines.append(f".model {model_name} PMOS(VTO=-0.7 KP=50u)")
+
+        # Add VC Switch model directives
+        vc_switches = [c for c in self.components.values()
+                       if c.component_type == 'VC Switch']
+        if vc_switches:
+            lines.append("")
+            lines.append("* Voltage-Controlled Switch Model Definitions")
+            for sw in vc_switches:
+                model_name = f"SW_{sw.component_id}"
+                lines.append(f".model {model_name} SW({sw.value})")
 
         # Add comments about labeled nodes
         if node_labels:


### PR DESCRIPTION
## Summary
- Adds VC Switch component with 4 terminals (ctrl+/ctrl- for control voltage, sw+/sw- for switch path)
- Switch schematic symbol with open-contact indicator and control arrow
- SPICE netlist: `S<name> sw+ sw- ctrl+ ctrl- SW_<name>` with `.model SW_<name> SW(VT=2.5 RON=1 ROFF=1e6)`
- Parameters (VT, RON, ROFF) editable via double-click on component
- Brown theme color for visual distinction from other components

## Test plan
- [x] All 221 existing tests pass
- [x] Ruff linter clean
- [ ] Manual: Place VC Switch on canvas, verify schematic symbol renders correctly
- [ ] Manual: Connect switch in circuit with voltage source control, run simulation
- [ ] Manual: Double-click to edit switch parameters (VT, RON, ROFF)
- [ ] Manual: Verify rotation works for all orientations

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)