### PR TITLE
Add Diode, LED, and Zener Diode elements

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -893,6 +893,84 @@ class VCSwitch(ComponentItem):
         return [(-18.0, -18.0), (18.0, -18.0), (18.0, 18.0), (-18.0, 18.0)]
 
 
+class Diode(ComponentItem):
+    """Standard Diode (D element)"""
+    type_name = 'Diode'
+
+    def __init__(self, component_id, model=None):
+        super().__init__(component_id, self.type_name, model=model)
+
+    def draw_component_body(self, painter):
+        # Terminal lines (anode left, cathode right)
+        if self.scene() is not None:
+            painter.drawLine(-30, 0, -10, 0)
+            painter.drawLine(10, 0, 30, 0)
+        # Triangle (anode side)
+        painter.drawLine(-10, -10, -10, 10)
+        painter.drawLine(-10, -10, 10, 0)
+        painter.drawLine(-10, 10, 10, 0)
+        # Cathode bar
+        painter.drawLine(10, -10, 10, 10)
+
+    def get_obstacle_shape(self):
+        return [(-12.0, -12.0), (12.0, -12.0), (12.0, 12.0), (-12.0, 12.0)]
+
+
+class LEDComponent(ComponentItem):
+    """Light Emitting Diode (D element with LED model)"""
+    type_name = 'LED'
+
+    def __init__(self, component_id, model=None):
+        super().__init__(component_id, self.type_name, model=model)
+
+    def draw_component_body(self, painter):
+        # Terminal lines
+        if self.scene() is not None:
+            painter.drawLine(-30, 0, -10, 0)
+            painter.drawLine(10, 0, 30, 0)
+        # Triangle (anode side)
+        painter.drawLine(-10, -10, -10, 10)
+        painter.drawLine(-10, -10, 10, 0)
+        painter.drawLine(-10, 10, 10, 0)
+        # Cathode bar
+        painter.drawLine(10, -10, 10, 10)
+        # Light emission arrows (distinctive LED indicator)
+        painter.drawLine(2, -10, 6, -16)
+        painter.drawLine(4, -16, 6, -16)
+        painter.drawLine(6, -14, 6, -16)
+        painter.drawLine(7, -8, 11, -14)
+        painter.drawLine(9, -14, 11, -14)
+        painter.drawLine(11, -12, 11, -14)
+
+    def get_obstacle_shape(self):
+        return [(-12.0, -18.0), (14.0, -18.0), (14.0, 12.0), (-12.0, 12.0)]
+
+
+class ZenerDiode(ComponentItem):
+    """Zener Diode (D element with breakdown voltage)"""
+    type_name = 'Zener Diode'
+
+    def __init__(self, component_id, model=None):
+        super().__init__(component_id, self.type_name, model=model)
+
+    def draw_component_body(self, painter):
+        # Terminal lines
+        if self.scene() is not None:
+            painter.drawLine(-30, 0, -10, 0)
+            painter.drawLine(10, 0, 30, 0)
+        # Triangle (anode side)
+        painter.drawLine(-10, -10, -10, 10)
+        painter.drawLine(-10, -10, 10, 0)
+        painter.drawLine(-10, 10, 10, 0)
+        # Zener cathode bar (bent ends)
+        painter.drawLine(10, -10, 10, 10)
+        painter.drawLine(10, -10, 7, -13)
+        painter.drawLine(10, 10, 13, 13)
+
+    def get_obstacle_shape(self):
+        return [(-12.0, -15.0), (15.0, -15.0), (15.0, 15.0), (-12.0, 15.0)]
+
+
 # Component registry for factory pattern
 COMPONENT_CLASSES = {
     'Resistor': Resistor,
@@ -923,6 +1001,10 @@ COMPONENT_CLASSES = {
     'MOSFETPMOS': MOSFETPMOS,
     'VC Switch': VCSwitch,
     'VCSwitch': VCSwitch,
+    'Diode': Diode,
+    'LED': LEDComponent,
+    'Zener Diode': ZenerDiode,
+    'ZenerDiode': ZenerDiode,
 }
 
 

--- a/app/GUI/format_utils.py
+++ b/app/GUI/format_utils.py
@@ -96,7 +96,7 @@ def format_value(value: float, unit: str = "") -> str:
 _POSITIVE_ONLY_TYPES = {'Resistor', 'Capacitor', 'Inductor'}
 
 # Component types that don't need value validation
-_SKIP_VALIDATION_TYPES = {'Ground', 'Op-Amp', 'Waveform Source', 'BJT NPN', 'BJT PNP', 'MOSFET NMOS', 'MOSFET PMOS', 'VC Switch'}
+_SKIP_VALIDATION_TYPES = {'Ground', 'Op-Amp', 'Waveform Source', 'BJT NPN', 'BJT PNP', 'MOSFET NMOS', 'MOSFET PMOS', 'VC Switch', 'Diode', 'LED', 'Zener Diode'}
 
 
 def validate_component_value(value: str, component_type: str) -> tuple[bool, str]:

--- a/app/GUI/styles/constants.py
+++ b/app/GUI/styles/constants.py
@@ -61,6 +61,9 @@ _COLOR_KEYS = {
     'MOSFET NMOS': 'component_mosfet_nmos',
     'MOSFET PMOS': 'component_mosfet_pmos',
     'VC Switch': 'component_vc_switch',
+    'Diode': 'component_diode',
+    'LED': 'component_led',
+    'Zener Diode': 'component_zener',
 }
 
 # Component definitions - symbol and terminals sourced from models

--- a/app/GUI/styles/light_theme.py
+++ b/app/GUI/styles/light_theme.py
@@ -45,6 +45,9 @@ class LightTheme(BaseTheme):
             'component_mosfet_nmos': '#7B1FA2',    # Deep purple
             'component_mosfet_pmos': '#512DA8',    # Indigo
             'component_vc_switch': '#795548',       # Brown
+            'component_diode': '#607D8B',           # Blue-gray
+            'component_led': '#FFEB3B',             # Yellow
+            'component_zener': '#8D6E63',           # Brown
 
             # ===== Algorithm Layer Colors =====
             'algorithm_astar': '#2196F3',          # Blue (33, 150, 243)

--- a/app/models/component.py
+++ b/app/models/component.py
@@ -33,6 +33,9 @@ COMPONENT_TYPES = [
     'MOSFET NMOS',
     'MOSFET PMOS',
     'VC Switch',
+    'Diode',
+    'LED',
+    'Zener Diode',
 ]
 
 # Mapping of component types to SPICE symbols
@@ -54,6 +57,9 @@ SPICE_SYMBOLS = {
     'MOSFET NMOS': 'M',
     'MOSFET PMOS': 'M',
     'VC Switch': 'S',
+    'Diode': 'D',
+    'LED': 'D',
+    'Zener Diode': 'D',
 }
 
 # Number of terminals per component type (default is 2)
@@ -90,6 +96,9 @@ DEFAULT_VALUES = {
     'MOSFET NMOS': 'NMOS1',
     'MOSFET PMOS': 'PMOS1',
     'VC Switch': 'VT=2.5 RON=1 ROFF=1e6',
+    'Diode': 'IS=1e-14 N=1',
+    'LED': 'IS=1e-20 N=1.8 EG=1.9',
+    'Zener Diode': 'IS=1e-14 N=1 BV=5.1 IBV=1e-3',
 }
 
 # Component colors (hex strings)
@@ -111,6 +120,9 @@ COMPONENT_COLORS = {
     'MOSFET NMOS': '#7B1FA2',
     'MOSFET PMOS': '#512DA8',
     'VC Switch': '#795548',
+    'Diode': '#607D8B',
+    'LED': '#FFEB3B',
+    'Zener Diode': '#8D6E63',
 }
 
 # Terminal geometry configuration per component type
@@ -135,6 +147,9 @@ TERMINAL_GEOMETRY = {
     'MOSFET NMOS': (20, 10, [(20, -20), (-20, 0), (20, 20)]),
     'MOSFET PMOS': (20, 10, [(20, -20), (-20, 0), (20, 20)]),
     'VC Switch': (20, 10, [(-30, -10), (-30, 10), (30, -10), (30, 10)]),
+    'Diode': (10, 20, None),
+    'LED': (10, 20, None),
+    'Zener Diode': (10, 20, None),
 }
 
 # Mapping from serialized class names to canonical display names
@@ -153,6 +168,7 @@ _CLASS_TO_DISPLAY = {
     'MOSFETNMOS': 'MOSFET NMOS',
     'MOSFETPMOS': 'MOSFET PMOS',
     'VCSwitch': 'VC Switch',
+    'ZenerDiode': 'Zener Diode',
 }
 
 # Mapping from display names to Python class names (for serialization)
@@ -170,6 +186,7 @@ _DISPLAY_TO_CLASS = {
     'MOSFET NMOS': 'MOSFETNMOS',
     'MOSFET PMOS': 'MOSFETPMOS',
     'VC Switch': 'VCSwitch',
+    'Zener Diode': 'ZenerDiode',
 }
 
 

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -171,6 +171,11 @@ class NetlistGenerator:
                 # Terminals: 0=ctrl+, 1=ctrl-, 2=switch+, 3=switch-
                 model_name = f"SW_{comp_id}"
                 lines.append(f"{comp_id} {nodes[2]} {nodes[3]} {nodes[0]} {nodes[1]} {model_name}")
+            elif comp.component_type in ('Diode', 'LED', 'Zener Diode'):
+                # D<name> anode cathode model_name
+                # Terminals: 0=anode, 1=cathode
+                model_name = f"D_{comp_id}"
+                lines.append(f"{comp_id} {nodes[0]} {nodes[1]} {model_name}")
 
         # Add BJT model directives
         bjt_models = set()
@@ -215,6 +220,16 @@ class NetlistGenerator:
             for sw in vc_switches:
                 model_name = f"SW_{sw.component_id}"
                 lines.append(f".model {model_name} SW({sw.value})")
+
+        # Add diode model directives
+        diode_comps = [c for c in self.components.values()
+                       if c.component_type in ('Diode', 'LED', 'Zener Diode')]
+        if diode_comps:
+            lines.append("")
+            lines.append("* Diode Model Definitions")
+            for diode in diode_comps:
+                model_name = f"D_{diode.component_id}"
+                lines.append(f".model {model_name} D({diode.value})")
 
         # Add comments about labeled nodes
         if node_labels:


### PR DESCRIPTION
## Summary
- Adds base **Diode** element (#21) with standard triangle+bar symbol
- Adds **LED** variant with distinctive emission arrows symbol
- Adds **Zener Diode** variant with bent cathode bar symbol
- All use SPICE `D` element with per-component `.model D()` directives
- Model parameters stored as value string, editable via double-click
- Default params: Diode (IS=1e-14 N=1), LED (IS=1e-20 N=1.8 EG=1.9), Zener (BV=5.1)

## Test plan
- [x] All 221 existing tests pass
- [x] Ruff linter clean
- [ ] Manual: Place each diode type on canvas, verify symbols render correctly
- [ ] Manual: Connect diodes in circuit, run simulation, verify netlist output
- [ ] Manual: Double-click to edit model parameters
- [ ] Manual: Verify rotation works for all orientations

Closes #73, closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)