### PR TITLE
Fix 6 stale MVC migration tests

### DIFF
--- a/app/tests/unit/test_canvas_sync.py
+++ b/app/tests/unit/test_canvas_sync.py
@@ -183,7 +183,7 @@ class TestCanvasSyncMethods:
             component_type='Resistor',
             value='1k',
             position=(100, 200),
-            rotation_angle=90
+            rotation=90
         )
 
         # Convert to dict and verify all properties preserved
@@ -192,7 +192,7 @@ class TestCanvasSyncMethods:
         assert comp_dict['type'] == 'Resistor'
         assert comp_dict['value'] == '1k'
         assert comp_dict['pos'] == {'x': 100, 'y': 200}
-        assert comp_dict.get('rotation_angle') == 90
+        assert comp_dict['rotation'] == 90
 
     def test_sync_preserves_wire_properties(self):
         """Test that sync preserves all wire properties"""
@@ -201,7 +201,6 @@ class TestCanvasSyncMethods:
             start_terminal=0,
             end_component_id='R2',
             end_terminal=1,
-            algorithm='astar'
         )
 
         # Convert to dict and verify all properties preserved
@@ -210,7 +209,9 @@ class TestCanvasSyncMethods:
         assert wire_dict['start_term'] == 0
         assert wire_dict['end_comp'] == 'R2'
         assert wire_dict['end_term'] == 1
-        assert wire_dict['algorithm'] == 'astar'
+
+        # Algorithm is stored on the dataclass, not serialized
+        assert wire.algorithm == 'idastar'
 
 
 class TestSyncMethodErrorHandling:

--- a/app/tests/unit/test_phase3_renaming.py
+++ b/app/tests/unit/test_phase3_renaming.py
@@ -8,13 +8,12 @@ backward compatibility through aliases.
 import pytest
 
 
-def test_component_item_backward_compatibility():
-    """Test that ComponentItem is an alias for ComponentGraphicsItem"""
-    from GUI.component_item import ComponentGraphicsItem, ComponentItem
+def test_component_graphics_item_importable():
+    """Test that ComponentGraphicsItem can be imported from component_item"""
+    from GUI.component_item import ComponentGraphicsItem
 
-    # ComponentItem should be the same class as ComponentGraphicsItem
-    assert ComponentItem is ComponentGraphicsItem
-    assert ComponentItem.__name__ == 'ComponentGraphicsItem'
+    assert ComponentGraphicsItem is not None
+    assert ComponentGraphicsItem.__name__ == 'ComponentGraphicsItem'
 
 
 def test_wire_item_backward_compatibility():
@@ -88,7 +87,6 @@ def test_wire_data_integration():
         start_terminal=0,
         end_component_id='R2',
         end_terminal=0,
-        algorithm='astar'
     )
 
     # Verify it has the expected attributes
@@ -96,7 +94,7 @@ def test_wire_data_integration():
     assert wire_data.start_terminal == 0
     assert wire_data.end_component_id == 'R2'
     assert wire_data.end_terminal == 0
-    assert wire_data.algorithm == 'astar'
+    assert wire_data.algorithm == 'idastar'
 
     # WireGraphicsItem should accept a model parameter
     # (Can't instantiate without Qt, but we can check the signature)


### PR DESCRIPTION
## Summary
- Update `add_component()` calls in integration tests to match current `(type, position)` API signature
- Fix `rotation_angle` → `rotation` kwarg in canvas sync tests
- Remove `algorithm` from serialization assertions (field exists on dataclass but is not serialized by `to_dict()`)
- Replace removed `ComponentItem` backward-compat alias test with `ComponentGraphicsItem` importability check

All 446 tests pass, ruff clean.

Closes #96

## Test plan
- [ ] CI passes all 446 tests on both Ubuntu and Windows
- [ ] Lint check passes
- [ ] Import check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)