### PR TITLE
Add pyproject.toml so pytest works from repo root

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+pythonpath = ["app"]
+testpaths = ["app/tests"]


### PR DESCRIPTION
## Summary
- Adds `pyproject.toml` with `pythonpath = ["app"]` and `testpaths = ["app/tests"]`
- `python -m pytest` now works from the repo root (previously only worked from `app/`)
- No changes to existing imports or test code

Closes #98

## Test plan
- [x] `python -m pytest` passes from repo root (446 tests)
- [x] `python -m pytest tests/` still passes from `app/` directory (446 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)