### PR TITLE
Add portable autonomous workflow (CLAUDE.md + settings + setup scripts)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,41 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python -m pytest:*)",
+      "Bash(python -m py_compile:*)",
+      "Bash(python -c:*)",
+      "Bash(ruff check:*)",
+      "Bash(ruff format:*)",
+      "Bash(pip install:*)",
+      "Bash(pip show:*)",
+      "Bash(python -m pip:*)",
+      "Bash(gh project:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh api:*)",
+      "Bash(gh run:*)",
+      "Bash(gh label:*)",
+      "Bash(gh repo:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git checkout:*)",
+      "Bash(git switch:*)",
+      "Bash(git branch:*)",
+      "Bash(git fetch:*)",
+      "Bash(git merge:*)",
+      "Bash(git rebase:*)",
+      "Bash(git stash:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git remote:*)",
+      "Bash(git worktree:*)",
+      "Bash(git pull:*)",
+      "Bash(ls:*)",
+      "Bash(rm:*)",
+      "Bash(wc:*)",
+      "Bash(mkdir:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -225,7 +225,8 @@ simulation_output/
 
 # python virtual environment
 Spice_GUI_env/
-.claude/*
+# Claude Code - track shared settings, ignore local
+.claude/settings.local.json
 last_session.txt
 transient_data.txt
 nul

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,117 @@
+# Spice-GUI
+
+## Project
+- **Stack**: Python 3.11+, PyQt6, ngspice
+- **Repo**: SDSMT-Capstone-Spice-GUI-Team/Spice-GUI
+- **Org**: SDSMT-Capstone-Spice-GUI-Team
+- **Board**: GitHub Projects #2 on the org
+
+## Setup
+Prerequisites: Python 3.11+, `gh` CLI (authenticated), git.
+```bash
+python -m venv .venv
+# Windows: .venv\Scripts\activate
+# Linux/Mac: source .venv/bin/activate
+pip install -r app/requirements.txt
+pip install pytest ruff
+```
+Or run `scripts/setup.sh` (Linux/Mac) or `scripts/setup.ps1` (Windows).
+
+## Testing & Linting
+```bash
+python -m pytest              # run all tests (works from repo root)
+python -m pytest -v           # verbose
+python -m pytest app/tests/unit/test_foo.py  # single file
+ruff check app/               # lint
+```
+
+## Project Structure
+```
+app/
+├── models/          # Data classes, no Qt (CircuitModel, ComponentData, WireData, NodeData)
+├── controllers/     # Business logic (CircuitController, SimulationController, FileController)
+├── GUI/             # PyQt6 views (MainWindow, CircuitCanvas, dialogs, graphics items)
+├── simulation/      # ngspice pipeline (netlist gen, runner, parser, validator, CSV export)
+└── tests/           # pytest suite (unit/ and integration/)
+```
+
+## Git Conventions
+- Branch naming: `issue-<N>-short-description` (e.g. `issue-75-csv-export`)
+- Commit messages: lowercase imperative (e.g. "add CSV export", "fix wire rendering")
+- Co-author tag on all commits:
+  ```
+  Co-Authored-By: Claude <model> <noreply@anthropic.com>
+  ```
+
+## GitHub Board (Project #2)
+
+**All IDs must be discovered dynamically — do NOT hardcode them.**
+
+### Discover IDs at Session Start
+```bash
+# Get project node ID:
+gh project view 2 --owner SDSMT-Capstone-Spice-GUI-Team --format json
+# Get field IDs and status option IDs:
+gh project field-list 2 --owner SDSMT-Capstone-Spice-GUI-Team --format json
+# Get all board items (issue-to-item ID mapping):
+gh project item-list 2 --owner SDSMT-Capstone-Spice-GUI-Team --format json --limit 100
+```
+Parse the JSON to find: project ID, Status field ID, Hours field ID, and the option IDs for each status (Backlog, Ready, In progress, Blocked, In review, Done).
+
+### Board Commands
+```bash
+# Move item to a status:
+gh project item-edit --project-id <PROJECT_ID> --id <ITEM_ID> \
+  --field-id <STATUS_FIELD_ID> --single-select-option-id <STATUS_OPTION_ID>
+
+# Update hours:
+gh api graphql -f query='mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "<PROJECT_ID>", itemId: "<ITEM_ID>",
+    fieldId: "<HOURS_FIELD_ID>", value: { number: <N> }
+  }) { projectV2Item { id } }
+}'
+
+# Add issue to board:
+gh project item-add 2 --owner SDSMT-Capstone-Spice-GUI-Team --url <ISSUE_URL>
+```
+
+## Autonomous Workflow
+
+Claude Code is authorized to work **fully autonomously** on Ready items.
+
+### Work Loop
+1. Discover board IDs (see above)
+2. Query board for next **Ready** item (prefer higher priority, lower issue number)
+3. Move issue to **In Progress**
+4. Create branch `issue-<N>-short-description` from `main`
+5. Write a brief plan, assess complexity
+6. Implement the change
+7. Run `python -m pytest` — all tests must pass
+8. Run `ruff check app/` — fix any lint errors
+9. Commit with descriptive message, push branch to remote
+10. Create PR targeting `main` (or push directly for small fixes)
+11. Close the GitHub issue (reference the commit/PR)
+12. Move issue to **In Review** on the board
+13. Log hours: comment `⏱️ Xh - description` on issue, update Hours field
+14. Pick next Ready item → repeat from step 2
+
+### Hours Estimates
+- Small fix/tweak: **0.5h**
+- Medium feature/refactor: **1–2h**
+- Large feature/multi-file: **3h+**
+
+### Stop Conditions
+- **Blocked**: Move issue to Blocked with explanatory comment. Pick next Ready item.
+- **Ready queue empty**: **Stop and notify user.** Do NOT pull from Backlog.
+
+### Edge Cases
+| Scenario | Action |
+|----------|--------|
+| Hard to test (UI, ngspice) | Implement, commit, flag manual testing needed in issue comment |
+| Vague requirements | Make judgment call, note assumptions in commit/issue comment |
+| Conflicting issues | Move to Blocked with explanation, pick next Ready item |
+
+## Platform Notes
+- **Windows**: Avoid piping `gh` output directly to `python` (fails with "pipe is being closed"). Write to a temp file first, then read it.
+- **Board field updates**: `updateProjectV2Field` with `singleSelectOptions` regenerates all option IDs. Always re-query IDs after modifying field options.

--- a/Doc/autonomous-workflow.md
+++ b/Doc/autonomous-workflow.md
@@ -1,6 +1,8 @@
 # Autonomous Development Workflow
 
-This document defines the workflow for Claude Code to autonomously work through issues on the project board.
+This document explains the AI-assisted development methodology used on this project.
+
+> **For machine-readable workflow instructions**, see [`CLAUDE.md`](../CLAUDE.md) at the repo root. That file is auto-loaded by Claude Code and contains the operational work loop, board commands, and setup instructions.
 
 ---
 
@@ -144,70 +146,11 @@ This project is transparent about AI assistance:
 
 ---
 
-## The Work Loop
+## Operational Details
 
-```
-1. Query the project board for the next "Ready" item
-2. Move the issue to "In Progress"
-3. Write a brief internal plan and assess complexity
-4. Implement the change
-5. Run tests: python -m pytest tests/ -v (from app/)
-6. Commit with a descriptive message
-7. Push to remote
-8. Close the GitHub issue (reference the commit)
-9. Move the issue to "In Review" on the board
-10. Log estimated hours on the issue
-11. Pick the next Ready item and repeat from step 1
-```
+The work loop, board commands, stop conditions, edge case handling, hours logging, and git conventions are defined in [`CLAUDE.md`](../CLAUDE.md) (the machine-readable source of truth).
 
-### Stop Conditions
-
-- **Blocked** on an issue (dependency, ambiguity, conflict)
-- **Ready queue is empty** (notify the user)
-
----
-
-## Edge Case Handling
-
-| Scenario | Action |
-|----------|--------|
-| **Hard to test** (UI-heavy, needs manual verification, depends on ngspice) | Implement, commit, and push. Flag in the issue comment that manual testing is needed. |
-| **Vague requirements** (unclear scope, multiple interpretations) | Make a reasonable judgment call. Note assumptions in the commit message and issue comment. |
-| **Conflicting issues** (overlapping scope, contradictory requirements) | Move to **Blocked** with a comment explaining the conflict. Pick the next Ready item. |
-| **Blocked for any reason** | Move to **Blocked** with an explanatory comment. Pick the next Ready item. |
-| **Ready queue empty** | **Stop and notify the user.** Do not pull from Backlog autonomously. |
-
----
-
-## Planning
-
-- Always write a brief plan before implementing
-- **Low complexity** issues: proceed immediately without waiting for approval
-- **High complexity** issues: still proceed, using judgment calls for ambiguous decisions
-- The plan is a record of decisions and assumptions, not a gate
-
----
-
-## Hours Logging
-
-- Estimate time based on issue complexity:
-  - Small fix / tweak: ~0.5h
-  - Medium feature or refactor: ~1-2h
-  - Large feature or multi-file change: ~3h+
-- Add a comment on the issue: `⏱️ Xh - description of work done`
-- Update the "Hours" number field on the project board
-
----
-
-## Git Rules
-
-- Auto-commit with descriptive messages after implementation
-- Auto-push to remote after each commit
-- Work on the current active branch
-
----
-
-## Board Status Flow
+### Board Status Flow
 
 ```
 Backlog → Ready → In Progress → In Review → Done
@@ -215,20 +158,7 @@ Backlog → Ready → In Progress → In Review → Done
                     Blocked
 ```
 
-### Status Definitions
-
-| Status | Meaning |
-|--------|---------|
-| **Backlog** | Validated request, not yet prioritized for work |
-| **Ready** | Fully understood, prioritized, ready for autonomous work |
-| **In Progress** | Actively being worked on |
-| **Blocked** | Waiting on a dependency, conflict, or user decision |
-| **In Review** | Code complete, pushed, awaiting validation |
-| **Done** | Review passed |
-
----
-
-## User's Role
+### User's Role
 
 - **Curate the Ready queue**: Move issues from Backlog to Ready when they should be worked on
 - **Review completed work**: Items in "In Review" need validation before moving to Done

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,39 @@
+Write-Host "=== Spice-GUI Development Setup ==="
+
+# Check prerequisites
+try {
+    $pyVersion = python --version 2>&1
+    Write-Host "Using Python: $pyVersion"
+} catch {
+    Write-Host "ERROR: Python 3.11+ is required but not found."
+    exit 1
+}
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Host "ERROR: GitHub CLI (gh) is required. Install from https://cli.github.com/"
+    exit 1
+}
+
+$authStatus = gh auth status 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "ERROR: gh CLI is not authenticated. Run: gh auth login"
+    exit 1
+}
+
+# Create virtual environment
+Write-Host "Creating virtual environment..."
+python -m venv .venv
+& .\.venv\Scripts\Activate.ps1
+
+# Install dependencies
+Write-Host "Installing dependencies..."
+pip install -r app/requirements.txt
+pip install pytest ruff
+
+# Verify
+Write-Host "Verifying test collection..."
+python -m pytest --co -q 2>$null | Select-Object -Last 1
+
+Write-Host ""
+Write-Host "=== Setup complete ==="
+Write-Host "Activate with: .\.venv\Scripts\Activate.ps1"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -e
+
+echo "=== Spice-GUI Development Setup ==="
+
+# Check prerequisites
+PYTHON=""
+if command -v python3 &>/dev/null; then
+    PYTHON=python3
+elif command -v python &>/dev/null; then
+    PYTHON=python
+else
+    echo "ERROR: Python 3.11+ is required but not found."
+    exit 1
+fi
+
+echo "Using Python: $($PYTHON --version)"
+
+if ! command -v gh &>/dev/null; then
+    echo "ERROR: GitHub CLI (gh) is required. Install from https://cli.github.com/"
+    exit 1
+fi
+
+if ! gh auth status &>/dev/null; then
+    echo "ERROR: gh CLI is not authenticated. Run: gh auth login"
+    exit 1
+fi
+
+# Create virtual environment
+echo "Creating virtual environment..."
+$PYTHON -m venv .venv
+source .venv/bin/activate
+
+# Install dependencies
+echo "Installing dependencies..."
+pip install -r app/requirements.txt
+pip install pytest ruff
+
+# Verify
+echo "Verifying test collection..."
+python -m pytest --co -q 2>/dev/null | tail -1
+
+echo ""
+echo "=== Setup complete ==="
+echo "Activate with: source .venv/bin/activate"


### PR DESCRIPTION
## Summary
Makes the autonomous development workflow portable across machines. After this PR, any fresh clone with authenticated `gh` CLI can run Claude Code and it will automatically understand the full workflow.

### What changed
- **`CLAUDE.md`** (new) — Auto-loaded by Claude Code. Contains setup guide, project structure, git conventions, dynamic board ID discovery, the full autonomous work loop, stop conditions, and platform notes
- **`.claude/settings.json`** (new, tracked) — 35 pre-approved permission rules (pytest, ruff, gh, git, pip, etc.) so agents don't need interactive approval for common commands
- **`.gitignore`** — Changed `.claude/*` → `.claude/settings.local.json` so shared settings are tracked while local permissions stay untracked
- **`scripts/setup.sh` + `scripts/setup.ps1`** (new) — Bootstrap scripts to create venv and install dependencies
- **`Doc/autonomous-workflow.md`** — Trimmed duplicated operational details, now points to CLAUDE.md as source of truth

### Key design decision
**No hardcoded board IDs.** CLAUDE.md instructs agents to discover all project/field/option IDs dynamically via `gh project view/field-list`. This eliminates the stale-ID problem permanently.

## Test plan
- [x] All 446 tests pass
- [ ] Clone repo to fresh directory, open Claude Code, verify it articulates the workflow unprompted
- [ ] Verify `gh project field-list` works for dynamic ID discovery
- [ ] Verify common commands (pytest, git, gh) execute without permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)