### PR TITLE
Add issue templates, PR template, and sync contributing guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+name: Bug Report
+description: Report something that isn't working correctly
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below so we can reproduce and fix it.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: "When I do X, Y happens instead of Z."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Open the application
+        2. Place a resistor on the canvas
+        3. Try to connect a wire to terminal 2
+        4. Wire snaps to wrong position
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows 11
+        - Windows 10
+        - macOS 14 (Sonoma)
+        - macOS 13 (Ventura)
+        - macOS (other)
+        - Ubuntu 22.04
+        - Ubuntu 24.04
+        - Linux (other)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: python-version
+    attributes:
+      label: Python version
+      options:
+        - "3.13"
+        - "3.12"
+        - "3.11"
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or error output
+      description: Paste screenshots or error tracebacks here (if applicable).
+
+  - type: textarea
+    id: circuit-file
+    attributes:
+      label: Circuit file
+      description: If relevant, paste the contents of your .json circuit file or attach it.
+      render: json
+
+  - type: checkboxes
+    id: checked-existing
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this hasn't been reported yet
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for SDM Spice? We'd love to hear it.
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What problem does this solve? Who benefits?
+      placeholder: "As a student working on lab assignments, I need to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: How do you think this should work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you thought about?
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the application does this relate to?
+      options:
+        - Circuit editor (canvas, components, wires)
+        - Simulation (analysis types, ngspice)
+        - UI/UX (layout, themes, usability)
+        - File I/O (save, load, export)
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Screenshots, mockups, links to similar tools, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Summary
+
+<!-- What does this PR do? Link the issue: Closes #N -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactoring / tech debt
+- [ ] Documentation
+- [ ] CI/CD or infrastructure
+- [ ] Other: ___
+
+## Testing
+
+<!-- How did you verify this works? -->
+
+- [ ] `python -m pytest` passes
+- [ ] `ruff check app/` passes
+- [ ] Manual testing (describe below)
+
+<!-- If manual testing was done, briefly describe what you tested: -->
+
+## Checklist
+
+- [ ] My changes follow the existing code style
+- [ ] I've updated relevant documentation (if applicable)
+- [ ] No new warnings or errors introduced
+- [ ] Linked issue is referenced above
+
+---
+
+<details>
+<summary>AI-assisted contributions</summary>
+
+If this PR was created with AI assistance (Claude Code, Copilot, etc.), include the co-author tag in your commits:
+
+```
+Co-Authored-By: Claude <model> <noreply@anthropic.com>
+```
+
+</details>

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -35,7 +35,7 @@ SDM Spice is an SDSMT Capstone project currently in active development. We welco
 ## Development Setup
 
 ### Prerequisites
-- Python 3.10+
+- Python 3.11+
 - Git
 - ngspice
 
@@ -60,6 +60,7 @@ python app/main.py
 
 ### Create a Branch
 
+**Human contributors:**
 ```bash
 git checkout -b feature/your-feature-name
 ```
@@ -68,6 +69,11 @@ Branch naming conventions:
 - `feature/description` - New features
 - `bugfix/description` - Bug fixes
 - `docs/description` - Documentation updates
+
+**Automated/agent contributions** use issue-linked branches:
+```bash
+git checkout -b issue-42-add-csv-export
+```
 
 ## Code Guidelines
 
@@ -121,6 +127,16 @@ Format:
 - Blank line
 - Detailed description (if needed)
 
+### AI-Assisted Contributions
+
+If your contribution was made with AI assistance (Claude Code, GitHub Copilot, etc.), include a co-author tag in your commit messages:
+
+```
+Co-Authored-By: Claude <model> <noreply@anthropic.com>
+```
+
+This applies to both human-authored commits with AI assistance and fully agent-generated commits.
+
 ## Pull Request Process
 
 1. **Update documentation** if you changed functionality
@@ -155,14 +171,18 @@ If applicable, add screenshots
 
 ## Testing
 
-### Manual Testing
-Currently, SDM Spice relies on manual testing. Before submitting:
-1. Test the specific feature/fix
-2. Verify existing functionality still works
-3. Test on your platform
+### Running Tests
+```bash
+cd app
+python -m pytest              # run all tests
+python -m pytest -v           # verbose output
+ruff check app/               # lint check
+```
 
-### Future: Automated Testing
-We plan to add automated tests. Contributions to test infrastructure are welcome!
+### Before Submitting
+1. Run `python -m pytest` — all tests must pass
+2. Run `ruff check app/` — no lint errors
+3. Test your specific change manually if it involves UI
 
 ## Project Structure
 
@@ -171,17 +191,13 @@ Spice-GUI/
 ├── app/
 │   ├── main.py              # Entry point
 │   ├── requirements.txt     # Dependencies
-│   ├── GUI/                  # UI components
-│   │   ├── main_window.py
-│   │   ├── circuit_canvas.py
-│   │   ├── component_item.py
-│   │   └── ...
-│   └── simulation/           # SPICE integration
-│       ├── netlist_generator.py
-│       ├── ngspice_runner.py
-│       └── result_parser.py
-├── DiscoveryDocs/           # Project documentation
-├── Doc/                     # Additional docs
+│   ├── models/              # Data classes (no Qt dependencies)
+│   ├── controllers/         # Business logic
+│   ├── GUI/                 # PyQt6 views and graphics items
+│   ├── simulation/          # ngspice pipeline
+│   └── tests/               # pytest suite (unit/ and integration/)
+├── wiki/                    # GitHub wiki source
+├── Doc/                     # Architecture decisions, references
 └── README.md
 ```
 
@@ -205,6 +221,20 @@ Issues and PRs use these labels:
 | `tech-debt` | Code cleanup/refactoring |
 | `testing` | Test-related |
 | `ui/ux` | User interface related |
+| `ci/cd` | CI/CD pipeline related |
+| `needs-discussion` | Needs design discussion before work |
+
+## Definition of Ready
+
+An issue is **Ready** for work when it has:
+
+1. **Clear acceptance criteria** — you can tell when it is done
+2. **Enough context** — no major open questions remain
+3. **Appropriate labels** — at least one type label (`bug`, `enhancement`, `tech-debt`, etc.)
+4. **Priority set** — on the project board
+5. **Reasonable scope** — can be completed in a single PR
+
+Issues that are vague or need design discussion should have the `needs-discussion` label and stay in Backlog until refined.
 
 ## Getting Help
 


### PR DESCRIPTION
## Summary
- Add YAML-based issue templates for bug reports and feature requests (form-based with dropdowns and required fields)
- Add PR template with testing checklist and AI co-author guidance
- Sync wiki/Contributing.md with current conventions (Python 3.11+, agent branch naming, co-author tags, Definition of Ready, updated project structure, actual test commands)

## Type of change
- [x] CI/CD or infrastructure

## Testing
- [x] No app code changed — tests and lint unaffected
- [ ] Verify issue template chooser appears when creating a new issue
- [ ] Verify PR template auto-populates when creating a new PR

## Manual step required after merge
Enable the built-in board automation workflows in the [project board settings](https://github.com/orgs/SDSMT-Capstone-Spice-GUI-Team/projects/2/settings/workflows):
- **Item closed** → move to Done
- **Pull request merged** → move to Done

This prevents closed issues from getting stuck in "In review" on the board (54 items had to be manually moved today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)