### PR TITLE
remove duplicate COMPONENTS dict from circuit_node.py

### DIFF
--- a/app/GUI/circuit_node.py
+++ b/app/GUI/circuit_node.py
@@ -1,15 +1,5 @@
 from PyQt6.QtCore import QPointF
 
-# Component definitions
-COMPONENTS = {
-    "Resistor": {"symbol": "R", "terminals": 2, "color": "#2196F3"},
-    "Capacitor": {"symbol": "C", "terminals": 2, "color": "#4CAF50"},
-    "Inductor": {"symbol": "L", "terminals": 2, "color": "#FF9800"},
-    "Voltage Source": {"symbol": "V", "terminals": 2, "color": "#F44336"},
-    "Current Source": {"symbol": "I", "terminals": 2, "color": "#9C27B0"},
-    "Ground": {"symbol": "GND", "terminals": 1, "color": "#000000"},
-}
-
 
 class Node:
     """Represents an electrical node - a set of electrically connected terminals"""


### PR DESCRIPTION
## Summary
- Removed the stale, hardcoded `COMPONENTS` dictionary from `GUI/circuit_node.py` that contained only 6 components and was never imported or used by any module
- The canonical `COMPONENTS` definition lives in `GUI/styles/constants.py`, built dynamically from `models/component.py` (all 20 component types)
- All consumers (`circuit_canvas.py`, `component_palette.py`, `light_theme.py`, tests) already import from `GUI/styles`

## Test plan
- [x] All 562 tests pass
- [x] Ruff lint clean
- [x] Verified no imports of `COMPONENTS` from `circuit_node.py` exist

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)