### PR TITLE
show straight-line wire preview during component drag

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -311,7 +311,8 @@ class ComponentGraphicsItem(QGraphicsItem):
 
             return snapped_pos
         elif change == QGraphicsItem.GraphicsItemChange.ItemPositionHasChanged:
-            # Update this item and connected wires to prevent dragging artifacts
+            # Show straight-line preview for connected wires during drag
+            # (full pathfinding runs after drag ends via debounced timer)
             self.update()
             if self.scene():
                 views = self.scene().views()
@@ -320,7 +321,7 @@ class ComponentGraphicsItem(QGraphicsItem):
                     if hasattr(canvas, "wires"):
                         for wire in canvas.wires:
                             if wire.start_comp is self or wire.end_comp is self:
-                                wire.update()
+                                wire.show_drag_preview()
 
         return super().itemChange(change, value)
 

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -78,6 +78,29 @@ class WireGraphicsItem(QGraphicsPathItem):
 
     # --- Methods ---
 
+    def show_drag_preview(self):
+        """Show a straight-line preview during component drag.
+
+        Much cheaper than full pathfinding — gives immediate visual
+        feedback while the component is being moved.  The real route
+        is recalculated by update_position() after the drag ends.
+        """
+        old_rect = self.boundingRect()
+        self.prepareGeometryChange()
+
+        start = self.start_comp.get_terminal_pos(self.start_term)
+        end = self.end_comp.get_terminal_pos(self.end_term)
+
+        path = QPainterPath()
+        path.moveTo(start)
+        path.lineTo(end)
+        self.setPath(path)
+
+        if self.scene():
+            self.scene().update(old_rect)
+            self.scene().update(self.boundingRect())
+        self.update()
+
     def update_position(self):
         """Update wire path using selected algorithm"""
         # Lazy import for faster startup - only loaded when wires are created


### PR DESCRIPTION
## Summary
- Added `show_drag_preview()` method to `WireGraphicsItem` that draws a simple straight line between terminal positions (no pathfinding)
- During component drag, connected wires now show this straight-line preview instead of their stale pre-drag path
- Full IDA* pathfinding still runs via the existing debounced timer (50ms) after drag ends
- Eliminates the visual artifact where wires appeared disconnected from moving terminals

## Test plan
- [x] All 562 tests pass
- [x] Ruff lint clean
- [ ] Manual testing: drag a component with multiple wires and verify smooth preview
- [ ] Manual testing: verify wire paths are correctly recalculated after drag ends

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)