### PR TITLE
add graphical plots for DC sweep and AC sweep results

### DIFF
--- a/app/GUI/results_plot_dialog.py
+++ b/app/GUI/results_plot_dialog.py
@@ -1,0 +1,121 @@
+"""
+results_plot_dialog.py — Matplotlib-based dialogs for DC Sweep and AC Sweep results.
+
+Uses the same FigureCanvasQTAgg embedding pattern as waveform_dialog.py.
+"""
+
+import logging
+
+import matplotlib
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+from PyQt6.QtWidgets import QDialog, QVBoxLayout
+
+matplotlib.use("QtAgg")
+
+logger = logging.getLogger(__name__)
+
+
+class DCSweepPlotDialog(QDialog):
+    """Plot dialog for DC Sweep results (voltage vs. sweep variable)."""
+
+    def __init__(self, data, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("DC Sweep Results")
+        self.setMinimumSize(800, 500)
+
+        layout = QVBoxLayout(self)
+
+        fig = Figure(figsize=(8, 5), dpi=100)
+        self._canvas = FigureCanvas(fig)
+        layout.addWidget(self._canvas)
+
+        ax = fig.add_subplot(111)
+        self._plot_dc_sweep(ax, data)
+        fig.tight_layout()
+
+    def _plot_dc_sweep(self, ax, data):
+        headers = data.get("headers", [])
+        rows = data.get("data", [])
+        if not rows or len(headers) < 3:
+            ax.text(0.5, 0.5, "No sweep data available", ha="center", va="center",
+                    transform=ax.transAxes)
+            return
+
+        # Column 0 = index, column 1 = sweep value, columns 2+ = node voltages
+        sweep_vals = [row[1] for row in rows]
+        cmap = plt.get_cmap("tab10")
+
+        for col_idx in range(2, len(headers)):
+            label = headers[col_idx]
+            values = [row[col_idx] for row in rows]
+            ax.plot(sweep_vals, values, label=label, color=cmap((col_idx - 2) % 10))
+
+        ax.set_xlabel(headers[1] if len(headers) > 1 else "Sweep")
+        ax.set_ylabel("Voltage (V)")
+        ax.set_title("DC Sweep")
+        ax.legend(loc="best", fontsize="small")
+        ax.grid(True, alpha=0.3)
+
+    def closeEvent(self, event):
+        plt.close(self._canvas.figure)
+        super().closeEvent(event)
+
+
+class ACSweepPlotDialog(QDialog):
+    """Bode plot dialog for AC Sweep results (magnitude + phase vs. frequency)."""
+
+    def __init__(self, data, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("AC Sweep Results — Bode Plot")
+        self.setMinimumSize(800, 600)
+
+        layout = QVBoxLayout(self)
+
+        fig = Figure(figsize=(8, 6), dpi=100)
+        self._canvas = FigureCanvas(fig)
+        layout.addWidget(self._canvas)
+
+        ax_mag = fig.add_subplot(211)
+        ax_phase = fig.add_subplot(212, sharex=ax_mag)
+        self._plot_bode(ax_mag, ax_phase, data)
+        fig.tight_layout()
+
+    def _plot_bode(self, ax_mag, ax_phase, data):
+        frequencies = data.get("frequencies", [])
+        magnitude = data.get("magnitude", {})
+        phase = data.get("phase", {})
+
+        if not frequencies or (not magnitude and not phase):
+            ax_mag.text(0.5, 0.5, "No AC data available", ha="center", va="center",
+                        transform=ax_mag.transAxes)
+            return
+
+        cmap = plt.get_cmap("tab10")
+
+        for i, (node, mag_vals) in enumerate(sorted(magnitude.items())):
+            color = cmap(i % 10)
+            ax_mag.semilogx(frequencies, mag_vals, label=node, color=color)
+            if node in phase:
+                ax_phase.semilogx(frequencies, phase[node], label=node, color=color)
+
+        # Plot any phase-only signals not in magnitude
+        for i, (node, ph_vals) in enumerate(sorted(phase.items())):
+            if node not in magnitude:
+                ax_phase.semilogx(frequencies, ph_vals, label=node,
+                                  color=cmap((len(magnitude) + i) % 10))
+
+        ax_mag.set_ylabel("Magnitude")
+        ax_mag.set_title("Bode Plot")
+        ax_mag.legend(loc="best", fontsize="small")
+        ax_mag.grid(True, which="both", alpha=0.3)
+
+        ax_phase.set_xlabel("Frequency (Hz)")
+        ax_phase.set_ylabel("Phase (degrees)")
+        ax_phase.legend(loc="best", fontsize="small")
+        ax_phase.grid(True, which="both", alpha=0.3)
+
+    def closeEvent(self, event):
+        plt.close(self._canvas.figure)
+        super().closeEvent(event)

--- a/app/tests/unit/test_results_plot_dialog.py
+++ b/app/tests/unit/test_results_plot_dialog.py
@@ -1,0 +1,84 @@
+"""
+Unit tests for results_plot_dialog.py — DC Sweep and AC Sweep plot dialogs.
+"""
+import pytest
+
+from GUI.results_plot_dialog import ACSweepPlotDialog, DCSweepPlotDialog
+
+
+# ---------------------------------------------------------------------------
+# DC Sweep Plot
+# ---------------------------------------------------------------------------
+
+
+class TestDCSweepPlotDialog:
+    def test_opens_with_valid_data(self, qtbot):
+        data = {
+            "headers": ["Index", "v-sweep", "v(nodeA)"],
+            "data": [
+                [0, 0.0, 0.0],
+                [1, 1.0, 0.5],
+                [2, 2.0, 1.0],
+            ],
+        }
+        dlg = DCSweepPlotDialog(data)
+        qtbot.addWidget(dlg)
+        assert dlg.windowTitle() == "DC Sweep Results"
+
+    def test_opens_with_empty_data(self, qtbot):
+        data = {"headers": [], "data": []}
+        dlg = DCSweepPlotDialog(data)
+        qtbot.addWidget(dlg)
+        # Should not crash — shows placeholder text
+
+    def test_opens_with_multiple_signals(self, qtbot):
+        data = {
+            "headers": ["Index", "v-sweep", "v(nodeA)", "v(nodeB)"],
+            "data": [
+                [0, 0.0, 0.0, 0.0],
+                [1, 1.0, 0.5, 0.3],
+            ],
+        }
+        dlg = DCSweepPlotDialog(data)
+        qtbot.addWidget(dlg)
+
+
+# ---------------------------------------------------------------------------
+# AC Sweep Bode Plot
+# ---------------------------------------------------------------------------
+
+
+class TestACSweepPlotDialog:
+    def test_opens_with_valid_data(self, qtbot):
+        data = {
+            "frequencies": [100, 1000, 10000],
+            "magnitude": {"out": [1.0, 0.7, 0.3]},
+            "phase": {"out": [-10.0, -45.0, -80.0]},
+        }
+        dlg = ACSweepPlotDialog(data)
+        qtbot.addWidget(dlg)
+        assert "Bode" in dlg.windowTitle()
+
+    def test_opens_with_empty_data(self, qtbot):
+        data = {"frequencies": [], "magnitude": {}, "phase": {}}
+        dlg = ACSweepPlotDialog(data)
+        qtbot.addWidget(dlg)
+
+    def test_opens_with_multiple_signals(self, qtbot):
+        data = {
+            "frequencies": [100, 1000],
+            "magnitude": {"out": [1.0, 0.5], "node2": [0.8, 0.4]},
+            "phase": {"out": [-45.0, -90.0], "node2": [-30.0, -60.0]},
+        }
+        dlg = ACSweepPlotDialog(data)
+        qtbot.addWidget(dlg)
+
+    def test_phase_only_signal(self, qtbot):
+        """Phase data for a node not in magnitude should still be plotted."""
+        data = {
+            "frequencies": [100, 1000],
+            "magnitude": {"out": [1.0, 0.5]},
+            "phase": {"out": [-45.0, -90.0], "extra": [-10.0, -20.0]},
+        }
+        dlg = ACSweepPlotDialog(data)
+        qtbot.addWidget(dlg)


### PR DESCRIPTION
- New results_plot_dialog.py with DCSweepPlotDialog (line plot of voltage vs sweep variable) and ACSweepPlotDialog (Bode plot with magnitude and phase subplots, log frequency scale)
- Both use matplotlib embedded via FigureCanvasQTAgg (same pattern as existing WaveformDialog for transient results)
- DC Sweep results text now shows formatted table instead of raw dict
- AC Sweep results text now shows signal summary
- Plot dialogs open automatically when simulation completes
- 7 new tests for plot dialog construction with various data shapes

Closes #119

## Summary

<!-- What does this PR do? Link the issue: Closes #N -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / tech debt
- [ ] Documentation
- [ ] CI/CD or infrastructure
- [ ] Other: ___

## Testing

<!-- How did you verify this works? -->

- [ ] `python -m pytest` passes
- [ ] `ruff check app/` passes
- [ ] Manual testing (describe below)

<!-- If manual testing was done, briefly describe what you tested: -->

## Checklist

- [ ] My changes follow the existing code style
- [ ] I've updated relevant documentation (if applicable)
- [ ] No new warnings or errors introduced
- [ ] Linked issue is referenced above

---

<details>
<summary>AI-assisted contributions</summary>

If this PR was created with AI assistance (Claude Code, Copilot, etc.), include the co-author tag in your commits:

```
Co-Authored-By: Claude <model> <noreply@anthropic.com>
```

</details>
