### PR TITLE
add multi-run overlay for simulation result plots

### DIFF
--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -715,7 +715,11 @@ class MainWindow(QMainWindow):
                     if len(rows) > 20:
                         self.results_text.append(f"  ... ({len(rows)} total rows)")
                 self.results_text.append("\nPlot opened in a new window.")
-                self._show_plot_dialog(DCSweepPlotDialog(sweep_data, self))
+                if isinstance(self._plot_dialog, DCSweepPlotDialog) and self._plot_dialog.isVisible():
+                    self._plot_dialog.add_result(sweep_data)
+                    self._plot_dialog.raise_()
+                else:
+                    self._show_plot_dialog(DCSweepPlotDialog(sweep_data, self))
             else:
                 self.results_text.append("\nDC Sweep data - see raw output below")
             self.canvas.clear_node_voltages()
@@ -733,7 +737,11 @@ class MainWindow(QMainWindow):
                 if freqs:
                     self.results_text.append(f"  Range: {freqs[0]:.4g} Hz — {freqs[-1]:.4g} Hz")
                 self.results_text.append("\nBode plot opened in a new window.")
-                self._show_plot_dialog(ACSweepPlotDialog(ac_data, self))
+                if isinstance(self._plot_dialog, ACSweepPlotDialog) and self._plot_dialog.isVisible():
+                    self._plot_dialog.add_result(ac_data)
+                    self._plot_dialog.raise_()
+                else:
+                    self._show_plot_dialog(ACSweepPlotDialog(ac_data, self))
             else:
                 self.results_text.append("\nAC Sweep data - see raw output below")
             self.canvas.clear_node_voltages()
@@ -753,14 +761,16 @@ class MainWindow(QMainWindow):
                 self.results_text.append("\n" + "-" * 40)
                 self.results_text.append("Waveform plot has also been generated in a new window.")
 
-                # Clean up previous waveform dialog
-                if self._waveform_dialog is not None:
-                    self._waveform_dialog.close()
-                    self._waveform_dialog.deleteLater()
-
-                # Show waveform plot
-                self._waveform_dialog = WaveformDialog(tran_data, self)
-                self._waveform_dialog.show()
+                # Overlay on existing dialog or create new one
+                if self._waveform_dialog is not None and self._waveform_dialog.isVisible():
+                    self._waveform_dialog.add_run(tran_data)
+                    self._waveform_dialog.raise_()
+                else:
+                    if self._waveform_dialog is not None:
+                        self._waveform_dialog.close()
+                        self._waveform_dialog.deleteLater()
+                    self._waveform_dialog = WaveformDialog(tran_data, self)
+                    self._waveform_dialog.show()
             else:
                 self.results_text.append("\nNo transient data found in output.")
             self.canvas.clear_node_voltages()

--- a/app/GUI/results_plot_dialog.py
+++ b/app/GUI/results_plot_dialog.py
@@ -1,7 +1,9 @@
 """
 results_plot_dialog.py — Matplotlib-based dialogs for DC Sweep and AC Sweep results.
 
-Uses the same FigureCanvasQTAgg embedding pattern as waveform_dialog.py.
+Supports overlaying multiple simulation runs on the same plot.  Each run is
+distinguished by line style (solid, dashed, dash-dot, dotted) while nodes
+share consistent colors across runs.
 """
 
 import logging
@@ -10,52 +12,175 @@ import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
-from PyQt6.QtWidgets import QDialog, QVBoxLayout
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
 
 matplotlib.use("QtAgg")
 
 logger = logging.getLogger(__name__)
 
+# Line styles cycle to visually distinguish overlaid simulation runs.
+_LINE_STYLES = ["-", "--", "-.", ":"]
+
 
 class DCSweepPlotDialog(QDialog):
-    """Plot dialog for DC Sweep results (voltage vs. sweep variable)."""
+    """Plot dialog for DC Sweep results with multi-run overlay support.
 
-    def __init__(self, data, parent=None):
+    Accepts one or more result datasets.  Each run is plotted with a
+    distinct line style; nodes share colours across runs so the same
+    signal is easy to compare.
+    """
+
+    def __init__(self, data=None, parent=None):
         super().__init__(parent)
         self.setWindowTitle("DC Sweep Results")
-        self.setMinimumSize(800, 500)
+        self.setMinimumSize(900, 550)
 
-        layout = QVBoxLayout(self)
+        self._results: list[dict] = []
+        self._run_counter = 0
+        self._checkboxes: list[QCheckBox] = []
 
-        fig = Figure(figsize=(8, 5), dpi=100)
-        self._canvas = FigureCanvas(fig)
-        layout.addWidget(self._canvas)
+        # --- layout: sidebar | plot -----------------------------------------
+        main_layout = QHBoxLayout(self)
 
-        ax = fig.add_subplot(111)
-        self._plot_dc_sweep(ax, data)
-        fig.tight_layout()
+        # Left sidebar
+        sidebar = QVBoxLayout()
 
-    def _plot_dc_sweep(self, ax, data):
-        headers = data.get("headers", [])
-        rows = data.get("data", [])
-        if not rows or len(headers) < 3:
-            ax.text(0.5, 0.5, "No sweep data available", ha="center", va="center", transform=ax.transAxes)
+        self._toggle_group = QGroupBox("Simulation Runs")
+        toggle_inner = QVBoxLayout()
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        self._scroll_content = QWidget()
+        self._scroll_layout = QVBoxLayout(self._scroll_content)
+        self._scroll_layout.addStretch()
+        scroll.setWidget(self._scroll_content)
+        toggle_inner.addWidget(scroll)
+        self._toggle_group.setLayout(toggle_inner)
+        sidebar.addWidget(self._toggle_group)
+
+        clear_btn = QPushButton("Clear All")
+        clear_btn.clicked.connect(self.clear_all)
+        sidebar.addWidget(clear_btn)
+
+        sidebar_widget = QWidget()
+        sidebar_widget.setLayout(sidebar)
+        sidebar_widget.setMaximumWidth(200)
+        main_layout.addWidget(sidebar_widget)
+
+        # Right: matplotlib canvas
+        self._fig = Figure(figsize=(8, 5), dpi=100)
+        self._canvas = FigureCanvas(self._fig)
+        self._ax = self._fig.add_subplot(111)
+        main_layout.addWidget(self._canvas, 3)
+
+        # Backwards compat: if caller passes data directly, add it as Run 1.
+        if data is not None:
+            self.add_result(data)
+
+    # -- public API ----------------------------------------------------------
+
+    def add_result(self, data, label=None):
+        """Add a new simulation run to the overlay."""
+        self._run_counter += 1
+        if label is None:
+            label = f"Run {self._run_counter}"
+
+        entry = {"label": label, "data": data, "visible": True}
+        self._results.append(entry)
+
+        cb = QCheckBox(label)
+        cb.setChecked(True)
+        idx = len(self._results) - 1
+        cb.toggled.connect(lambda state, i=idx: self._set_visible(i, state))
+        # Insert before the trailing stretch.
+        self._scroll_layout.insertWidget(self._scroll_layout.count() - 1, cb)
+        self._checkboxes.append(cb)
+
+        self._refresh_plot()
+
+    def clear_all(self):
+        """Remove all simulation runs and reset the plot."""
+        self._results.clear()
+        self._checkboxes.clear()
+        while self._scroll_layout.count() > 1:  # keep the stretch
+            item = self._scroll_layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+        self._run_counter = 0
+        self._refresh_plot()
+
+    # -- internals -----------------------------------------------------------
+
+    def _set_visible(self, index, visible):
+        self._results[index]["visible"] = visible
+        self._refresh_plot()
+
+    def _refresh_plot(self):
+        self._ax.clear()
+
+        visible = [e for e in self._results if e["visible"]]
+        if not visible:
+            self._ax.text(
+                0.5, 0.5, "No sweep data available",
+                ha="center", va="center", transform=self._ax.transAxes,
+            )
+            self._canvas.draw()
             return
 
-        # Column 0 = index, column 1 = sweep value, columns 2+ = node voltages
-        sweep_vals = [row[1] for row in rows]
         cmap = plt.get_cmap("tab10")
 
-        for col_idx in range(2, len(headers)):
-            label = headers[col_idx]
-            values = [row[col_idx] for row in rows]
-            ax.plot(sweep_vals, values, label=label, color=cmap((col_idx - 2) % 10))
+        # Build a stable colour map: same node name → same colour.
+        all_nodes: list[str] = []
+        for entry in visible:
+            for h in entry["data"].get("headers", [])[2:]:
+                if h not in all_nodes:
+                    all_nodes.append(h)
+        node_colors = {node: cmap(i % 10) for i, node in enumerate(all_nodes)}
 
-        ax.set_xlabel(headers[1] if len(headers) > 1 else "Sweep")
-        ax.set_ylabel("Voltage (V)")
-        ax.set_title("DC Sweep")
-        ax.legend(loc="best", fontsize="small")
-        ax.grid(True, alpha=0.3)
+        multi = len(self._results) > 1
+
+        for run_idx, entry in enumerate(self._results):
+            if not entry["visible"]:
+                continue
+
+            data = entry["data"]
+            headers = data.get("headers", [])
+            rows = data.get("data", [])
+            if not rows or len(headers) < 3:
+                continue
+
+            linestyle = _LINE_STYLES[run_idx % len(_LINE_STYLES)]
+            sweep_vals = [row[1] for row in rows]
+
+            for col_idx in range(2, len(headers)):
+                node = headers[col_idx]
+                values = [row[col_idx] for row in rows]
+                color = node_colors.get(node, cmap(0))
+                display = f"{entry['label']}: {node}" if multi else node
+                self._ax.plot(
+                    sweep_vals, values,
+                    label=display, color=color, linestyle=linestyle,
+                )
+
+        xlabel = "Sweep"
+        if visible and len(visible[0]["data"].get("headers", [])) > 1:
+            xlabel = visible[0]["data"]["headers"][1]
+        self._ax.set_xlabel(xlabel)
+        self._ax.set_ylabel("Voltage (V)")
+        self._ax.set_title("DC Sweep")
+        if self._ax.get_legend_handles_labels()[1]:
+            self._ax.legend(loc="best", fontsize="small")
+        self._ax.grid(True, alpha=0.3)
+        self._fig.tight_layout()
+        self._canvas.draw()
 
     def closeEvent(self, event):
         plt.close(self._canvas.figure)
@@ -63,55 +188,169 @@ class DCSweepPlotDialog(QDialog):
 
 
 class ACSweepPlotDialog(QDialog):
-    """Bode plot dialog for AC Sweep results (magnitude + phase vs. frequency)."""
+    """Bode plot dialog for AC Sweep results with multi-run overlay support."""
 
-    def __init__(self, data, parent=None):
+    def __init__(self, data=None, parent=None):
         super().__init__(parent)
-        self.setWindowTitle("AC Sweep Results — Bode Plot")
-        self.setMinimumSize(800, 600)
+        self.setWindowTitle("AC Sweep Results \u2014 Bode Plot")
+        self.setMinimumSize(900, 650)
 
-        layout = QVBoxLayout(self)
+        self._results: list[dict] = []
+        self._run_counter = 0
+        self._checkboxes: list[QCheckBox] = []
 
-        fig = Figure(figsize=(8, 6), dpi=100)
-        self._canvas = FigureCanvas(fig)
-        layout.addWidget(self._canvas)
+        # --- layout: sidebar | plot -----------------------------------------
+        main_layout = QHBoxLayout(self)
 
-        ax_mag = fig.add_subplot(211)
-        ax_phase = fig.add_subplot(212, sharex=ax_mag)
-        self._plot_bode(ax_mag, ax_phase, data)
-        fig.tight_layout()
+        # Left sidebar
+        sidebar = QVBoxLayout()
 
-    def _plot_bode(self, ax_mag, ax_phase, data):
-        frequencies = data.get("frequencies", [])
-        magnitude = data.get("magnitude", {})
-        phase = data.get("phase", {})
+        self._toggle_group = QGroupBox("Simulation Runs")
+        toggle_inner = QVBoxLayout()
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        self._scroll_content = QWidget()
+        self._scroll_layout = QVBoxLayout(self._scroll_content)
+        self._scroll_layout.addStretch()
+        scroll.setWidget(self._scroll_content)
+        toggle_inner.addWidget(scroll)
+        self._toggle_group.setLayout(toggle_inner)
+        sidebar.addWidget(self._toggle_group)
 
-        if not frequencies or (not magnitude and not phase):
-            ax_mag.text(0.5, 0.5, "No AC data available", ha="center", va="center", transform=ax_mag.transAxes)
+        clear_btn = QPushButton("Clear All")
+        clear_btn.clicked.connect(self.clear_all)
+        sidebar.addWidget(clear_btn)
+
+        sidebar_widget = QWidget()
+        sidebar_widget.setLayout(sidebar)
+        sidebar_widget.setMaximumWidth(200)
+        main_layout.addWidget(sidebar_widget)
+
+        # Right: matplotlib canvas with two subplots
+        self._fig = Figure(figsize=(8, 6), dpi=100)
+        self._canvas = FigureCanvas(self._fig)
+        self._ax_mag = self._fig.add_subplot(211)
+        self._ax_phase = self._fig.add_subplot(212, sharex=self._ax_mag)
+        main_layout.addWidget(self._canvas, 3)
+
+        if data is not None:
+            self.add_result(data)
+
+    # -- public API ----------------------------------------------------------
+
+    def add_result(self, data, label=None):
+        """Add a new simulation run to the overlay."""
+        self._run_counter += 1
+        if label is None:
+            label = f"Run {self._run_counter}"
+
+        entry = {"label": label, "data": data, "visible": True}
+        self._results.append(entry)
+
+        cb = QCheckBox(label)
+        cb.setChecked(True)
+        idx = len(self._results) - 1
+        cb.toggled.connect(lambda state, i=idx: self._set_visible(i, state))
+        self._scroll_layout.insertWidget(self._scroll_layout.count() - 1, cb)
+        self._checkboxes.append(cb)
+
+        self._refresh_plot()
+
+    def clear_all(self):
+        """Remove all simulation runs and reset the plot."""
+        self._results.clear()
+        self._checkboxes.clear()
+        while self._scroll_layout.count() > 1:
+            item = self._scroll_layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+        self._run_counter = 0
+        self._refresh_plot()
+
+    # -- internals -----------------------------------------------------------
+
+    def _set_visible(self, index, visible):
+        self._results[index]["visible"] = visible
+        self._refresh_plot()
+
+    def _refresh_plot(self):
+        self._ax_mag.clear()
+        self._ax_phase.clear()
+
+        visible = [e for e in self._results if e["visible"]]
+        if not visible:
+            self._ax_mag.text(
+                0.5, 0.5, "No AC data available",
+                ha="center", va="center", transform=self._ax_mag.transAxes,
+            )
+            self._canvas.draw()
             return
 
         cmap = plt.get_cmap("tab10")
 
-        for i, (node, mag_vals) in enumerate(sorted(magnitude.items())):
-            color = cmap(i % 10)
-            ax_mag.semilogx(frequencies, mag_vals, label=node, color=color)
-            if node in phase:
-                ax_phase.semilogx(frequencies, phase[node], label=node, color=color)
+        # Stable colour map across runs.
+        all_nodes: list[str] = []
+        for entry in visible:
+            for node in sorted(entry["data"].get("magnitude", {}).keys()):
+                if node not in all_nodes:
+                    all_nodes.append(node)
+            for node in sorted(entry["data"].get("phase", {}).keys()):
+                if node not in all_nodes:
+                    all_nodes.append(node)
+        node_colors = {node: cmap(i % 10) for i, node in enumerate(all_nodes)}
 
-        # Plot any phase-only signals not in magnitude
-        for i, (node, ph_vals) in enumerate(sorted(phase.items())):
-            if node not in magnitude:
-                ax_phase.semilogx(frequencies, ph_vals, label=node, color=cmap((len(magnitude) + i) % 10))
+        multi = len(self._results) > 1
 
-        ax_mag.set_ylabel("Magnitude")
-        ax_mag.set_title("Bode Plot")
-        ax_mag.legend(loc="best", fontsize="small")
-        ax_mag.grid(True, which="both", alpha=0.3)
+        for run_idx, entry in enumerate(self._results):
+            if not entry["visible"]:
+                continue
 
-        ax_phase.set_xlabel("Frequency (Hz)")
-        ax_phase.set_ylabel("Phase (degrees)")
-        ax_phase.legend(loc="best", fontsize="small")
-        ax_phase.grid(True, which="both", alpha=0.3)
+            data = entry["data"]
+            frequencies = data.get("frequencies", [])
+            magnitude = data.get("magnitude", {})
+            phase = data.get("phase", {})
+            if not frequencies or (not magnitude and not phase):
+                continue
+
+            linestyle = _LINE_STYLES[run_idx % len(_LINE_STYLES)]
+
+            for node, mag_vals in sorted(magnitude.items()):
+                color = node_colors.get(node, cmap(0))
+                display = f"{entry['label']}: {node}" if multi else node
+                self._ax_mag.semilogx(
+                    frequencies, mag_vals,
+                    label=display, color=color, linestyle=linestyle,
+                )
+                if node in phase:
+                    self._ax_phase.semilogx(
+                        frequencies, phase[node],
+                        label=display, color=color, linestyle=linestyle,
+                    )
+
+            # Phase-only signals
+            for node, ph_vals in sorted(phase.items()):
+                if node not in magnitude:
+                    color = node_colors.get(node, cmap(0))
+                    display = f"{entry['label']}: {node}" if multi else node
+                    self._ax_phase.semilogx(
+                        frequencies, ph_vals,
+                        label=display, color=color, linestyle=linestyle,
+                    )
+
+        self._ax_mag.set_ylabel("Magnitude")
+        self._ax_mag.set_title("Bode Plot")
+        if self._ax_mag.get_legend_handles_labels()[1]:
+            self._ax_mag.legend(loc="best", fontsize="small")
+        self._ax_mag.grid(True, which="both", alpha=0.3)
+
+        self._ax_phase.set_xlabel("Frequency (Hz)")
+        self._ax_phase.set_ylabel("Phase (degrees)")
+        if self._ax_phase.get_legend_handles_labels()[1]:
+            self._ax_phase.legend(loc="best", fontsize="small")
+        self._ax_phase.grid(True, which="both", alpha=0.3)
+
+        self._fig.tight_layout()
+        self._canvas.draw()
 
     def closeEvent(self, event):
         plt.close(self._canvas.figure)

--- a/app/tests/unit/test_waveform_overlay.py
+++ b/app/tests/unit/test_waveform_overlay.py
@@ -1,0 +1,98 @@
+"""
+Unit tests for WaveformDialog multi-run overlay support.
+"""
+
+import pytest
+from GUI.waveform_dialog import WaveformDialog
+
+
+def _tran_data(node_count=1, points=5, offset=0.0):
+    """Create sample transient data."""
+    data = []
+    nodes = [f"node{i}" for i in range(node_count)]
+    for p in range(points):
+        row = {"time": p * 0.001}
+        for i, n in enumerate(nodes):
+            row[n] = (p + offset) * 0.1 * (i + 1)
+        data.append(row)
+    return data
+
+
+class TestWaveformOverlay:
+    def test_add_run_stashes_current_data(self, qtbot):
+        data1 = _tran_data(1)
+        dlg = WaveformDialog(data1)
+        qtbot.addWidget(dlg)
+
+        data2 = _tran_data(1, offset=1.0)
+        dlg.add_run(data2)
+
+        assert len(dlg._overlay_runs) == 1
+        assert dlg._overlay_runs[0]["data"] is data1
+        assert dlg.full_data is data2
+
+    def test_add_run_increments_counter(self, qtbot):
+        dlg = WaveformDialog(_tran_data(1))
+        qtbot.addWidget(dlg)
+        assert dlg._run_counter == 1
+        dlg.add_run(_tran_data(1))
+        assert dlg._run_counter == 2
+
+    def test_overlay_run_visible_by_default(self, qtbot):
+        dlg = WaveformDialog(_tran_data(1))
+        qtbot.addWidget(dlg)
+        dlg.add_run(_tran_data(1))
+        assert dlg._overlay_runs[0]["visible"] is True
+
+    def test_toggle_overlay_visibility(self, qtbot):
+        dlg = WaveformDialog(_tran_data(1))
+        qtbot.addWidget(dlg)
+        dlg.add_run(_tran_data(1))
+        dlg._set_overlay_visible(0, False)
+        assert dlg._overlay_runs[0]["visible"] is False
+
+    def test_clear_overlay_runs(self, qtbot):
+        dlg = WaveformDialog(_tran_data(1))
+        qtbot.addWidget(dlg)
+        dlg.add_run(_tran_data(1))
+        dlg.add_run(_tran_data(1))
+        assert len(dlg._overlay_runs) == 2
+        dlg._clear_overlay_runs()
+        assert len(dlg._overlay_runs) == 0
+
+    def test_runs_group_hidden_initially(self, qtbot):
+        dlg = WaveformDialog(_tran_data(1))
+        qtbot.addWidget(dlg)
+        assert dlg._runs_group.isHidden()
+
+    def test_runs_group_visible_after_add_run(self, qtbot):
+        dlg = WaveformDialog(_tran_data(1))
+        qtbot.addWidget(dlg)
+        dlg.add_run(_tran_data(1))
+        assert not dlg._runs_group.isHidden()
+
+    def test_runs_group_hidden_after_clear(self, qtbot):
+        dlg = WaveformDialog(_tran_data(1))
+        qtbot.addWidget(dlg)
+        dlg.add_run(_tran_data(1))
+        dlg._clear_overlay_runs()
+        assert dlg._runs_group.isHidden()
+
+    def test_add_run_with_custom_label(self, qtbot):
+        dlg = WaveformDialog(_tran_data(1))
+        qtbot.addWidget(dlg)
+        dlg.add_run(_tran_data(1), label="R1=1k")
+        assert dlg._overlay_runs[0]["label"] == "R1=1k"
+
+    def test_multiple_runs_preserve_order(self, qtbot):
+        data1 = _tran_data(1)
+        data2 = _tran_data(1, offset=1.0)
+        data3 = _tran_data(1, offset=2.0)
+        dlg = WaveformDialog(data1)
+        qtbot.addWidget(dlg)
+        dlg.add_run(data2)
+        dlg.add_run(data3)
+
+        assert dlg._overlay_runs[0]["data"] is data1
+        assert dlg._overlay_runs[1]["data"] is data2
+        assert dlg.full_data is data3


### PR DESCRIPTION
## Summary
- Refactors DC Sweep, AC Sweep, and Transient plot dialogs to retain previous simulation results when a new simulation runs
- Each run is distinguished by line style (solid, dashed, dash-dot, dotted) while nodes share consistent colours across runs
- Adds sidebar with per-run visibility checkboxes and "Clear All" button to all plot dialogs
- MainWindow reuses open plot dialogs for same analysis type instead of replacing them

Closes #77

## Test plan
- [x] All 612 existing + new tests pass
- [x] Ruff linting passes
- [ ] Manual: Run a DC Sweep, change a component value, run again — both results should overlay on the same plot
- [ ] Manual: Toggle individual runs on/off via sidebar checkboxes
- [ ] Manual: Click "Clear All" to reset the plot
- [ ] Manual: Repeat for AC Sweep and Transient analysis types
- [ ] Manual: Close dialog and run again — should create a fresh plot (no stale overlays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)