### PR TITLE
add parameter sweep across component values

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -3,7 +3,8 @@ import os
 import sys
 
 from PyQt6.QtCore import QPointF, QRectF, Qt, QTimer
-from PyQt6.QtGui import QBrush, QColor, QPen  # QPainterPath imported locally where needed
+from PyQt6.QtGui import QBrush  # QPainterPath imported locally where needed
+from PyQt6.QtGui import QColor, QPen
 from PyQt6.QtWidgets import QGraphicsItem, QInputDialog, QLineEdit, QMessageBox
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))

--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -29,11 +29,11 @@ from PyQt6.QtWidgets import (
 )
 
 from .analysis_dialog import AnalysisDialog
-from .parameter_sweep_dialog import ParameterSweepDialog
-from .parameter_sweep_plot_dialog import ParameterSweepPlotDialog
 from .circuit_canvas import CircuitCanvasView
 from .component_palette import ComponentPalette
 from .keybindings import KeybindingsRegistry
+from .parameter_sweep_dialog import ParameterSweepDialog
+from .parameter_sweep_plot_dialog import ParameterSweepPlotDialog
 from .properties_panel import PropertiesPanel
 from .results_plot_dialog import ACSweepPlotDialog, DCSweepPlotDialog
 from .styles import DEFAULT_SPLITTER_SIZES, DEFAULT_WINDOW_SIZE, theme_manager
@@ -430,8 +430,7 @@ class MainWindow(QMainWindow):
         sweep_action = QAction("&Parameter Sweep...", self)
         sweep_action.setCheckable(True)
         sweep_action.setToolTip(
-            "Sweep a component parameter across a range of values "
-            "and overlay results from each step"
+            "Sweep a component parameter across a range of values and overlay results from each step"
         )
         sweep_action.triggered.connect(self.set_analysis_parameter_sweep)
         analysis_menu.addAction(sweep_action)
@@ -719,7 +718,10 @@ class MainWindow(QMainWindow):
 
         progress = QProgressDialog(
             f"Running parameter sweep on {component_id}...",
-            "Cancel", 0, num_steps, self,
+            "Cancel",
+            0,
+            num_steps,
+            self,
         )
         progress.setWindowTitle("Parameter Sweep")
         progress.setWindowModality(Qt.WindowModality.WindowModal)
@@ -727,14 +729,13 @@ class MainWindow(QMainWindow):
 
         def on_progress(step, total):
             progress.setValue(step)
-            progress.setLabelText(
-                f"Running step {step + 1} of {total}..."
-            )
+            progress.setLabelText(f"Running step {step + 1} of {total}...")
             QApplication.processEvents()
             return not progress.wasCanceled()
 
         result = self.simulation_ctrl.run_parameter_sweep(
-            sweep_config, progress_callback=on_progress,
+            sweep_config,
+            progress_callback=on_progress,
         )
         progress.setValue(num_steps)
         progress.close()
@@ -743,9 +744,7 @@ class MainWindow(QMainWindow):
         if result.data:
             from .format_utils import format_value
 
-            result.data["sweep_labels"] = [
-                format_value(v).strip() for v in result.data.get("sweep_values", [])
-            ]
+            result.data["sweep_labels"] = [format_value(v).strip() for v in result.data.get("sweep_values", [])]
 
         return result
 
@@ -1105,7 +1104,8 @@ class MainWindow(QMainWindow):
         """Set analysis type to Parameter Sweep with configuration dialog"""
         if not self.model.components:
             QMessageBox.warning(
-                self, "No Components",
+                self,
+                "No Components",
                 "Add components to the circuit before configuring a parameter sweep.",
             )
             self.op_action.setChecked(True)
@@ -1125,9 +1125,9 @@ class MainWindow(QMainWindow):
                     )
             else:
                 QMessageBox.warning(
-                    self, "Invalid Parameters",
-                    "Please enter valid sweep parameters. "
-                    "Start and stop values must be different.",
+                    self,
+                    "Invalid Parameters",
+                    "Please enter valid sweep parameters. Start and stop values must be different.",
                 )
                 self.op_action.setChecked(True)
         else:

--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -12,12 +12,14 @@ from models.circuit import CircuitModel
 from PyQt6.QtCore import QSettings, Qt
 from PyQt6.QtGui import QAction, QActionGroup
 from PyQt6.QtWidgets import (
+    QApplication,
     QDialog,
     QFileDialog,
     QHBoxLayout,
     QLabel,
     QMainWindow,
     QMessageBox,
+    QProgressDialog,
     QPushButton,
     QSplitter,
     QStackedWidget,
@@ -27,6 +29,8 @@ from PyQt6.QtWidgets import (
 )
 
 from .analysis_dialog import AnalysisDialog
+from .parameter_sweep_dialog import ParameterSweepDialog
+from .parameter_sweep_plot_dialog import ParameterSweepPlotDialog
 from .circuit_canvas import CircuitCanvasView
 from .component_palette import ComponentPalette
 from .keybindings import KeybindingsRegistry
@@ -421,6 +425,17 @@ class MainWindow(QMainWindow):
         temp_action.triggered.connect(self.set_analysis_temp_sweep)
         analysis_menu.addAction(temp_action)
 
+        analysis_menu.addSeparator()
+
+        sweep_action = QAction("&Parameter Sweep...", self)
+        sweep_action.setCheckable(True)
+        sweep_action.setToolTip(
+            "Sweep a component parameter across a range of values "
+            "and overlay results from each step"
+        )
+        sweep_action.triggered.connect(self.set_analysis_parameter_sweep)
+        analysis_menu.addAction(sweep_action)
+
         # Create action group for mutually exclusive analysis types
         self.analysis_group = QActionGroup(self)
         self.analysis_group.addAction(op_action)
@@ -428,12 +443,14 @@ class MainWindow(QMainWindow):
         self.analysis_group.addAction(ac_action)
         self.analysis_group.addAction(tran_action)
         self.analysis_group.addAction(temp_action)
+        self.analysis_group.addAction(sweep_action)
 
         self.op_action = op_action
         self.dc_action = dc_action
         self.ac_action = ac_action
         self.tran_action = tran_action
         self.temp_action = temp_action
+        self.sweep_action = sweep_action
 
         # Store action references for keybinding re-application
         self._bound_actions = {
@@ -681,9 +698,11 @@ class MainWindow(QMainWindow):
     def run_simulation(self):
         """Run SPICE simulation"""
         try:
-            # Phase 5: No sync needed - model always up to date
-            # Run simulation via controller
-            result = self.simulation_ctrl.run_simulation()
+            if self.model.analysis_type == "Parameter Sweep":
+                result = self._run_parameter_sweep()
+            else:
+                # Phase 5: No sync needed - model always up to date
+                result = self.simulation_ctrl.run_simulation()
 
             # Display results (view responsibility)
             self._display_simulation_results(result)
@@ -691,6 +710,44 @@ class MainWindow(QMainWindow):
         except (OSError, ValueError, KeyError, TypeError, RuntimeError) as e:
             logger.error("Simulation failed: %s", e, exc_info=True)
             QMessageBox.critical(self, "Error", f"Simulation failed: {e}")
+
+    def _run_parameter_sweep(self):
+        """Run parameter sweep with a progress dialog."""
+        sweep_config = self.model.analysis_params
+        num_steps = sweep_config.get("num_steps", 10)
+        component_id = sweep_config.get("component_id", "?")
+
+        progress = QProgressDialog(
+            f"Running parameter sweep on {component_id}...",
+            "Cancel", 0, num_steps, self,
+        )
+        progress.setWindowTitle("Parameter Sweep")
+        progress.setWindowModality(Qt.WindowModality.WindowModal)
+        progress.setMinimumDuration(0)
+
+        def on_progress(step, total):
+            progress.setValue(step)
+            progress.setLabelText(
+                f"Running step {step + 1} of {total}..."
+            )
+            QApplication.processEvents()
+            return not progress.wasCanceled()
+
+        result = self.simulation_ctrl.run_parameter_sweep(
+            sweep_config, progress_callback=on_progress,
+        )
+        progress.setValue(num_steps)
+        progress.close()
+
+        # Add sweep_labels to the data for the plot dialog
+        if result.data:
+            from .format_utils import format_value
+
+            result.data["sweep_labels"] = [
+                format_value(v).strip() for v in result.data.get("sweep_values", [])
+            ]
+
+        return result
 
     def _display_simulation_results(self, result):
         """Display simulation results based on analysis type"""
@@ -847,6 +904,39 @@ class MainWindow(QMainWindow):
                 self.results_text.append("Note: values shown are from the final temperature step.")
             else:
                 self.results_text.append("\nNo results found. Check raw output below.")
+            self.canvas.clear_node_voltages()
+
+        elif self.model.analysis_type == "Parameter Sweep":
+            sweep_data = result.data if result.data else None
+            if sweep_data:
+                self._last_results = sweep_data
+                comp_id = sweep_data.get("component_id", "?")
+                base_type = sweep_data.get("base_analysis_type", "?")
+                labels = sweep_data.get("sweep_labels", [])
+                step_results = sweep_data.get("results", [])
+                ok_count = sum(1 for r in step_results if r.success)
+
+                self.results_text.append("\nPARAMETER SWEEP RESULTS:")
+                self.results_text.append("-" * 40)
+                self.results_text.append(f"  Component:      {comp_id}")
+                self.results_text.append(f"  Base analysis:  {base_type}")
+                self.results_text.append(f"  Steps:          {ok_count}/{len(step_results)} succeeded")
+                if labels:
+                    self.results_text.append(f"  Range:          {labels[0]} to {labels[-1]}")
+                if sweep_data.get("cancelled"):
+                    self.results_text.append("  (sweep was cancelled)")
+                self.results_text.append("-" * 40)
+
+                if result.errors:
+                    self.results_text.append("\nStep errors:")
+                    for err in result.errors[:10]:
+                        self.results_text.append(f"  - {err}")
+
+                if ok_count > 0:
+                    self.results_text.append("\nPlot opened in a new window.")
+                    self._show_plot_dialog(ParameterSweepPlotDialog(sweep_data, self))
+            else:
+                self.results_text.append("\nNo parameter sweep data.")
             self.canvas.clear_node_voltages()
 
         self.results_text.append("=" * 70)
@@ -1011,6 +1101,38 @@ class MainWindow(QMainWindow):
         else:
             self.op_action.setChecked(True)
 
+    def set_analysis_parameter_sweep(self):
+        """Set analysis type to Parameter Sweep with configuration dialog"""
+        if not self.model.components:
+            QMessageBox.warning(
+                self, "No Components",
+                "Add components to the circuit before configuring a parameter sweep.",
+            )
+            self.op_action.setChecked(True)
+            return
+
+        dialog = ParameterSweepDialog(self.model.components, self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            params = dialog.get_parameters()
+            if params:
+                self.simulation_ctrl.set_analysis("Parameter Sweep", params)
+                statusBar = self.statusBar()
+                if statusBar:
+                    statusBar.showMessage(
+                        f"Analysis: Parameter Sweep on {params['component_id']} "
+                        f"({params['num_steps']} steps, base: {params['base_analysis_type']})",
+                        3000,
+                    )
+            else:
+                QMessageBox.warning(
+                    self, "Invalid Parameters",
+                    "Please enter valid sweep parameters. "
+                    "Start and stop values must be different.",
+                )
+                self.op_action.setChecked(True)
+        else:
+            self.op_action.setChecked(True)
+
     def _sync_analysis_menu(self):
         """Update Analysis menu checkboxes to match model state."""
         analysis_type = self.model.analysis_type
@@ -1024,6 +1146,8 @@ class MainWindow(QMainWindow):
             self.tran_action.setChecked(True)
         elif analysis_type == "Temperature Sweep":
             self.temp_action.setChecked(True)
+        elif analysis_type == "Parameter Sweep":
+            self.sweep_action.setChecked(True)
 
     # View Operations
 
@@ -1230,16 +1354,11 @@ class MainWindow(QMainWindow):
 
         analysis_type = settings.value("analysis/type")
         if analysis_type:
+            # Don't restore "Parameter Sweep" — it requires component selection
+            if analysis_type == "Parameter Sweep":
+                analysis_type = "DC Operating Point"
             self.simulation_ctrl.set_analysis(analysis_type, self.model.analysis_params)
-            # Update menu checkboxes
-            if analysis_type == "DC Operating Point":
-                self.op_action.setChecked(True)
-            elif analysis_type == "DC Sweep":
-                self.dc_action.setChecked(True)
-            elif analysis_type == "AC Sweep":
-                self.ac_action.setChecked(True)
-            elif analysis_type == "Transient":
-                self.tran_action.setChecked(True)
+            self._sync_analysis_menu()
 
         show_labels = settings.value("view/show_labels")
         if show_labels is not None:

--- a/app/GUI/parameter_sweep_dialog.py
+++ b/app/GUI/parameter_sweep_dialog.py
@@ -53,11 +53,7 @@ class ParameterSweepDialog(QDialog):
         self.setMinimumWidth(420)
 
         # Filter to sweepable components
-        self._sweepable = {
-            cid: comp
-            for cid, comp in components.items()
-            if comp.component_type in SWEEPABLE_TYPES
-        }
+        self._sweepable = {cid: comp for cid, comp in components.items() if comp.component_type in SWEEPABLE_TYPES}
 
         self._base_field_widgets = {}
         self._init_ui()
@@ -67,8 +63,7 @@ class ParameterSweepDialog(QDialog):
 
         # Description
         desc = QLabel(
-            "Sweep a component parameter across a range of values, "
-            "running the selected analysis at each step."
+            "Sweep a component parameter across a range of values, running the selected analysis at each step."
         )
         desc.setWordWrap(True)
         layout.addWidget(desc)
@@ -82,9 +77,7 @@ class ParameterSweepDialog(QDialog):
         self.component_combo.setToolTip("Select a component whose value will be swept")
         if self._sweepable:
             for cid, comp in sorted(self._sweepable.items()):
-                self.component_combo.addItem(
-                    f"{cid} ({comp.component_type}: {comp.value})", cid
-                )
+                self.component_combo.addItem(f"{cid} ({comp.component_type}: {comp.value})", cid)
         else:
             self.component_combo.addItem("(no sweepable components)")
             self.component_combo.setEnabled(False)
@@ -126,18 +119,14 @@ class ParameterSweepDialog(QDialog):
         self._build_base_form()
 
         # --- Buttons ---
-        buttons = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
-        )
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
 
         # Set defaults from first component
         self._update_defaults_from_component()
-        self.component_combo.currentIndexChanged.connect(
-            lambda _: self._update_defaults_from_component()
-        )
+        self.component_combo.currentIndexChanged.connect(lambda _: self._update_defaults_from_component())
 
     def _update_defaults_from_component(self):
         """Update start/stop defaults based on selected component's current value."""

--- a/app/GUI/parameter_sweep_dialog.py
+++ b/app/GUI/parameter_sweep_dialog.py
@@ -1,0 +1,231 @@
+"""
+Parameter Sweep Dialog — Configure sweeping a component parameter across a range
+of values with a selectable base analysis type.
+"""
+
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QGroupBox,
+    QLabel,
+    QLineEdit,
+    QSpinBox,
+    QVBoxLayout,
+)
+
+from .format_utils import format_value, parse_value
+
+# Component types whose primary value can be swept
+SWEEPABLE_TYPES = {
+    "Resistor",
+    "Capacitor",
+    "Inductor",
+    "Voltage Source",
+    "Current Source",
+    "VCVS",
+    "CCVS",
+    "VCCS",
+    "CCCS",
+}
+
+# Base analysis types available for parameter sweep
+BASE_ANALYSIS_TYPES = [
+    "DC Operating Point",
+    "Transient",
+    "AC Sweep",
+    "DC Sweep",
+]
+
+
+class ParameterSweepDialog(QDialog):
+    """Dialog for configuring a parameter sweep across component values."""
+
+    def __init__(self, components, parent=None):
+        """
+        Args:
+            components: dict of component_id -> ComponentData from the circuit model
+            parent: parent widget
+        """
+        super().__init__(parent)
+        self.setWindowTitle("Parameter Sweep Configuration")
+        self.setMinimumWidth(420)
+
+        # Filter to sweepable components
+        self._sweepable = {
+            cid: comp
+            for cid, comp in components.items()
+            if comp.component_type in SWEEPABLE_TYPES
+        }
+
+        self._base_field_widgets = {}
+        self._init_ui()
+
+    def _init_ui(self):
+        layout = QVBoxLayout(self)
+
+        # Description
+        desc = QLabel(
+            "Sweep a component parameter across a range of values, "
+            "running the selected analysis at each step."
+        )
+        desc.setWordWrap(True)
+        layout.addWidget(desc)
+
+        # --- Sweep Configuration ---
+        sweep_group = QGroupBox("Sweep Parameter")
+        sweep_form = QFormLayout(sweep_group)
+
+        # Component selector
+        self.component_combo = QComboBox()
+        self.component_combo.setToolTip("Select a component whose value will be swept")
+        if self._sweepable:
+            for cid, comp in sorted(self._sweepable.items()):
+                self.component_combo.addItem(
+                    f"{cid} ({comp.component_type}: {comp.value})", cid
+                )
+        else:
+            self.component_combo.addItem("(no sweepable components)")
+            self.component_combo.setEnabled(False)
+        sweep_form.addRow("Component:", self.component_combo)
+
+        # Start / Stop / Steps
+        self.start_edit = QLineEdit("1k")
+        self.start_edit.setToolTip("Start value (supports SI prefixes: 1k, 100n, etc.)")
+        sweep_form.addRow("Start Value:", self.start_edit)
+
+        self.stop_edit = QLineEdit("10k")
+        self.stop_edit.setToolTip("Stop value (supports SI prefixes)")
+        sweep_form.addRow("Stop Value:", self.stop_edit)
+
+        self.steps_spin = QSpinBox()
+        self.steps_spin.setRange(2, 100)
+        self.steps_spin.setValue(10)
+        self.steps_spin.setToolTip("Number of sweep steps (2-100)")
+        sweep_form.addRow("Number of Steps:", self.steps_spin)
+
+        layout.addWidget(sweep_group)
+
+        # --- Base Analysis Configuration ---
+        analysis_group = QGroupBox("Base Analysis")
+        analysis_layout = QVBoxLayout(analysis_group)
+
+        self.analysis_combo = QComboBox()
+        self.analysis_combo.setToolTip("Analysis type to run at each sweep step")
+        self.analysis_combo.addItems(BASE_ANALYSIS_TYPES)
+        self.analysis_combo.currentTextChanged.connect(self._on_analysis_changed)
+        analysis_layout.addWidget(self.analysis_combo)
+
+        self._base_form = QFormLayout()
+        analysis_layout.addLayout(self._base_form)
+
+        layout.addWidget(analysis_group)
+
+        # Build initial base analysis form
+        self._build_base_form()
+
+        # --- Buttons ---
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        # Set defaults from first component
+        self._update_defaults_from_component()
+        self.component_combo.currentIndexChanged.connect(
+            lambda _: self._update_defaults_from_component()
+        )
+
+    def _update_defaults_from_component(self):
+        """Update start/stop defaults based on selected component's current value."""
+        cid = self.component_combo.currentData()
+        if cid and cid in self._sweepable:
+            comp = self._sweepable[cid]
+            try:
+                current_val = parse_value(comp.value)
+                # Default: sweep from 1/10 to 10x current value
+                start = current_val / 10
+                stop = current_val * 10
+                self.start_edit.setText(format_value(start).strip().replace(" ", ""))
+                self.stop_edit.setText(format_value(stop).strip().replace(" ", ""))
+            except (ValueError, TypeError):
+                pass
+
+    def _on_analysis_changed(self, analysis_type):
+        self._build_base_form()
+
+    def _build_base_form(self):
+        """Build form fields for the selected base analysis type."""
+        # Clear existing
+        while self._base_form.count():
+            item = self._base_form.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+        self._base_field_widgets.clear()
+
+        from .analysis_dialog import AnalysisDialog
+
+        analysis_type = self.analysis_combo.currentText()
+        config = AnalysisDialog.ANALYSIS_CONFIGS.get(analysis_type, {})
+
+        for field_config in config.get("fields", []):
+            if field_config[2] == "combo":
+                label, key, _, options, default = field_config
+                widget = QComboBox()
+                widget.addItems(options)
+                widget.setCurrentText(default)
+            else:
+                label, key, field_type, default = field_config
+                widget = QLineEdit(str(default))
+
+            self._base_field_widgets[key] = (widget, field_config[2])
+            self._base_form.addRow(f"{label}:", widget)
+
+    def get_parameters(self):
+        """
+        Get all sweep parameters.
+
+        Returns:
+            dict with keys: component_id, start, stop, num_steps,
+                            base_analysis_type, base_params
+            or None if validation fails.
+        """
+        try:
+            component_id = self.component_combo.currentData()
+            if not component_id:
+                return None
+
+            start = parse_value(self.start_edit.text())
+            stop = parse_value(self.stop_edit.text())
+            num_steps = self.steps_spin.value()
+
+            if start == stop:
+                return None
+
+            base_analysis_type = self.analysis_combo.currentText()
+
+            # Parse base analysis params
+            base_params = {"analysis_type": base_analysis_type}
+            for key, (widget, field_type) in self._base_field_widgets.items():
+                if field_type == "combo":
+                    base_params[key] = widget.currentText()
+                elif field_type == "float":
+                    base_params[key] = parse_value(widget.text())
+                elif field_type == "int":
+                    base_params[key] = int(parse_value(widget.text()))
+                else:
+                    base_params[key] = widget.text()
+
+            return {
+                "component_id": component_id,
+                "start": start,
+                "stop": stop,
+                "num_steps": num_steps,
+                "base_analysis_type": base_analysis_type,
+                "base_params": base_params,
+            }
+        except (ValueError, TypeError):
+            return None

--- a/app/GUI/parameter_sweep_plot_dialog.py
+++ b/app/GUI/parameter_sweep_plot_dialog.py
@@ -1,0 +1,218 @@
+"""
+Parameter Sweep Plot Dialog — Matplotlib-based overlay of simulation results
+from sweeping a component parameter across a range of values.
+"""
+
+import logging
+
+import matplotlib
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+from PyQt6.QtWidgets import QDialog, QVBoxLayout
+
+matplotlib.use("QtAgg")
+
+logger = logging.getLogger(__name__)
+
+
+class ParameterSweepPlotDialog(QDialog):
+    """Plot dialog for parameter sweep results.
+
+    Routes to the appropriate plotting method based on the base analysis type.
+    """
+
+    def __init__(self, sweep_data, parent=None):
+        super().__init__(parent)
+        component_id = sweep_data["component_id"]
+        base_type = sweep_data["base_analysis_type"]
+        self.setWindowTitle(f"Parameter Sweep — {component_id} ({base_type})")
+        self.setMinimumSize(900, 600)
+
+        layout = QVBoxLayout(self)
+
+        fig = Figure(figsize=(9, 6), dpi=100)
+        self._canvas = FigureCanvas(fig)
+        layout.addWidget(self._canvas)
+
+        if base_type == "DC Operating Point":
+            self._plot_op_sweep(fig, sweep_data)
+        elif base_type == "Transient":
+            self._plot_transient_sweep(fig, sweep_data)
+        elif base_type == "AC Sweep":
+            self._plot_ac_sweep(fig, sweep_data)
+        elif base_type == "DC Sweep":
+            self._plot_dc_sweep(fig, sweep_data)
+        else:
+            ax = fig.add_subplot(111)
+            ax.text(
+                0.5, 0.5, f"No plot available for base analysis: {base_type}",
+                ha="center", va="center", transform=ax.transAxes,
+            )
+
+        fig.tight_layout()
+
+    # ------------------------------------------------------------------
+    # DC Operating Point base: X = parameter value, Y = node voltages
+    # ------------------------------------------------------------------
+    def _plot_op_sweep(self, fig, sweep_data):
+        ax = fig.add_subplot(111)
+
+        sweep_values = sweep_data["sweep_values"]
+        results = sweep_data["results"]
+        component_id = sweep_data["component_id"]
+
+        # Collect all node names
+        all_nodes = set()
+        for r in results:
+            if r.success and r.data:
+                all_nodes.update(r.data.keys())
+
+        if not all_nodes:
+            ax.text(0.5, 0.5, "No data available",
+                    ha="center", va="center", transform=ax.transAxes)
+            return
+
+        cmap = plt.get_cmap("tab10")
+
+        for idx, node in enumerate(sorted(all_nodes)):
+            vals = []
+            voltages = []
+            for sv, r in zip(sweep_values, results):
+                if r.success and r.data and node in r.data:
+                    vals.append(sv)
+                    voltages.append(r.data[node])
+            if vals:
+                ax.plot(vals, voltages, "o-", label=node,
+                        color=cmap(idx % 10), markersize=4)
+
+        ax.set_xlabel(f"{component_id} Value")
+        ax.set_ylabel("Voltage (V)")
+        ax.set_title(f"Parameter Sweep — {component_id}")
+        ax.legend(loc="best", fontsize="small")
+        ax.grid(True, alpha=0.3)
+
+    # ------------------------------------------------------------------
+    # Transient base: overlay time-domain waveforms per sweep step
+    # ------------------------------------------------------------------
+    def _plot_transient_sweep(self, fig, sweep_data):
+        ax = fig.add_subplot(111)
+
+        results = sweep_data["results"]
+        sweep_labels = sweep_data.get("sweep_labels", [])
+        component_id = sweep_data["component_id"]
+
+        cmap = plt.get_cmap("viridis")
+        n = len(results)
+
+        for i, r in enumerate(results):
+            if not r.success or not r.data:
+                continue
+
+            label = sweep_labels[i] if i < len(sweep_labels) else str(i)
+            times = [pt["time"] for pt in r.data]
+            nodes = [k for k in r.data[0].keys() if k != "time"]
+
+            color = cmap(i / max(n - 1, 1))
+
+            for node in nodes:
+                values = [pt[node] for pt in r.data]
+                ax.plot(times, values, color=color,
+                        label=f"{node} ({component_id}={label})",
+                        alpha=0.8, linewidth=1)
+
+        ax.set_xlabel("Time (s)")
+        ax.set_ylabel("Voltage (V)")
+        ax.set_title(f"Transient Parameter Sweep — {component_id}")
+        ax.legend(loc="best", fontsize="x-small", ncol=2)
+        ax.grid(True, alpha=0.3)
+
+    # ------------------------------------------------------------------
+    # AC Sweep base: overlay Bode plots per sweep step
+    # ------------------------------------------------------------------
+    def _plot_ac_sweep(self, fig, sweep_data):
+        ax_mag = fig.add_subplot(211)
+        ax_phase = fig.add_subplot(212, sharex=ax_mag)
+
+        results = sweep_data["results"]
+        sweep_labels = sweep_data.get("sweep_labels", [])
+        component_id = sweep_data["component_id"]
+
+        cmap = plt.get_cmap("viridis")
+        n = len(results)
+
+        for i, r in enumerate(results):
+            if not r.success or not r.data:
+                continue
+
+            label = sweep_labels[i] if i < len(sweep_labels) else str(i)
+            freqs = r.data.get("frequencies", [])
+            magnitude = r.data.get("magnitude", {})
+            phase = r.data.get("phase", {})
+
+            color = cmap(i / max(n - 1, 1))
+
+            for node, mag_vals in sorted(magnitude.items()):
+                ax_mag.semilogx(freqs, mag_vals, color=color,
+                                label=f"{node} ({component_id}={label})",
+                                alpha=0.8)
+                if node in phase:
+                    ax_phase.semilogx(freqs, phase[node], color=color,
+                                      label=f"{node} ({component_id}={label})",
+                                      alpha=0.8)
+
+        ax_mag.set_ylabel("Magnitude")
+        ax_mag.set_title(f"AC Parameter Sweep — {component_id}")
+        ax_mag.legend(loc="best", fontsize="x-small")
+        ax_mag.grid(True, which="both", alpha=0.3)
+
+        ax_phase.set_xlabel("Frequency (Hz)")
+        ax_phase.set_ylabel("Phase (degrees)")
+        ax_phase.legend(loc="best", fontsize="x-small")
+        ax_phase.grid(True, which="both", alpha=0.3)
+
+    # ------------------------------------------------------------------
+    # DC Sweep base: overlay DC sweep curves per parameter value
+    # ------------------------------------------------------------------
+    def _plot_dc_sweep(self, fig, sweep_data):
+        ax = fig.add_subplot(111)
+
+        results = sweep_data["results"]
+        sweep_labels = sweep_data.get("sweep_labels", [])
+        component_id = sweep_data["component_id"]
+
+        cmap = plt.get_cmap("viridis")
+        n = len(results)
+        x_label = "Sweep"
+
+        for i, r in enumerate(results):
+            if not r.success or not r.data:
+                continue
+
+            label = sweep_labels[i] if i < len(sweep_labels) else str(i)
+            headers = r.data.get("headers", [])
+            rows = r.data.get("data", [])
+
+            if not rows or len(headers) < 3:
+                continue
+
+            sweep_vals = [row[1] for row in rows]
+            color = cmap(i / max(n - 1, 1))
+            x_label = headers[1] if len(headers) > 1 else "Sweep"
+
+            for col_idx in range(2, len(headers)):
+                col_label = headers[col_idx]
+                values = [row[col_idx] for row in rows]
+                ax.plot(sweep_vals, values, color=color,
+                        label=f"{col_label} ({component_id}={label})",
+                        alpha=0.8)
+
+        ax.set_xlabel(x_label)
+        ax.set_ylabel("Voltage (V)")
+        ax.set_title(f"DC Sweep with Parameter Sweep — {component_id}")
+        ax.legend(loc="best", fontsize="x-small")
+        ax.grid(True, alpha=0.3)
+
+    def closeEvent(self, event):
+        plt.close(self._canvas.figure)
+        super().closeEvent(event)

--- a/app/GUI/parameter_sweep_plot_dialog.py
+++ b/app/GUI/parameter_sweep_plot_dialog.py
@@ -46,8 +46,12 @@ class ParameterSweepPlotDialog(QDialog):
         else:
             ax = fig.add_subplot(111)
             ax.text(
-                0.5, 0.5, f"No plot available for base analysis: {base_type}",
-                ha="center", va="center", transform=ax.transAxes,
+                0.5,
+                0.5,
+                f"No plot available for base analysis: {base_type}",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
             )
 
         fig.tight_layout()
@@ -69,8 +73,7 @@ class ParameterSweepPlotDialog(QDialog):
                 all_nodes.update(r.data.keys())
 
         if not all_nodes:
-            ax.text(0.5, 0.5, "No data available",
-                    ha="center", va="center", transform=ax.transAxes)
+            ax.text(0.5, 0.5, "No data available", ha="center", va="center", transform=ax.transAxes)
             return
 
         cmap = plt.get_cmap("tab10")
@@ -83,8 +86,7 @@ class ParameterSweepPlotDialog(QDialog):
                     vals.append(sv)
                     voltages.append(r.data[node])
             if vals:
-                ax.plot(vals, voltages, "o-", label=node,
-                        color=cmap(idx % 10), markersize=4)
+                ax.plot(vals, voltages, "o-", label=node, color=cmap(idx % 10), markersize=4)
 
         ax.set_xlabel(f"{component_id} Value")
         ax.set_ylabel("Voltage (V)")
@@ -117,9 +119,7 @@ class ParameterSweepPlotDialog(QDialog):
 
             for node in nodes:
                 values = [pt[node] for pt in r.data]
-                ax.plot(times, values, color=color,
-                        label=f"{node} ({component_id}={label})",
-                        alpha=0.8, linewidth=1)
+                ax.plot(times, values, color=color, label=f"{node} ({component_id}={label})", alpha=0.8, linewidth=1)
 
         ax.set_xlabel("Time (s)")
         ax.set_ylabel("Voltage (V)")
@@ -153,13 +153,11 @@ class ParameterSweepPlotDialog(QDialog):
             color = cmap(i / max(n - 1, 1))
 
             for node, mag_vals in sorted(magnitude.items()):
-                ax_mag.semilogx(freqs, mag_vals, color=color,
-                                label=f"{node} ({component_id}={label})",
-                                alpha=0.8)
+                ax_mag.semilogx(freqs, mag_vals, color=color, label=f"{node} ({component_id}={label})", alpha=0.8)
                 if node in phase:
-                    ax_phase.semilogx(freqs, phase[node], color=color,
-                                      label=f"{node} ({component_id}={label})",
-                                      alpha=0.8)
+                    ax_phase.semilogx(
+                        freqs, phase[node], color=color, label=f"{node} ({component_id}={label})", alpha=0.8
+                    )
 
         ax_mag.set_ylabel("Magnitude")
         ax_mag.set_title(f"AC Parameter Sweep — {component_id}")
@@ -203,9 +201,7 @@ class ParameterSweepPlotDialog(QDialog):
             for col_idx in range(2, len(headers)):
                 col_label = headers[col_idx]
                 values = [row[col_idx] for row in rows]
-                ax.plot(sweep_vals, values, color=color,
-                        label=f"{col_label} ({component_id}={label})",
-                        alpha=0.8)
+                ax.plot(sweep_vals, values, color=color, label=f"{col_label} ({component_id}={label})", alpha=0.8)
 
         ax.set_xlabel(x_label)
         ax.set_ylabel("Voltage (V)")

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -275,9 +275,7 @@ class SimulationController:
             )
 
         # Calculate sweep values (linear spacing)
-        sweep_values = [
-            start + (stop - start) * i / (num_steps - 1) for i in range(num_steps)
-        ]
+        sweep_values = [start + (stop - start) * i / (num_steps - 1) for i in range(num_steps)]
 
         # Run sweep
         step_results = []
@@ -295,16 +293,12 @@ class SimulationController:
 
                 # Generate netlist
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-                wrdata_filepath = os.path.join(
-                    self.runner.output_dir, f"wrdata_sweep_{i}_{timestamp}.txt"
-                )
+                wrdata_filepath = os.path.join(self.runner.output_dir, f"wrdata_sweep_{i}_{timestamp}.txt")
 
                 try:
                     netlist = self.generate_netlist(wrdata_filepath=wrdata_filepath)
                 except (ValueError, KeyError, TypeError) as e:
-                    step_results.append(
-                        SimulationResult(success=False, error=f"Netlist generation failed: {e}")
-                    )
+                    step_results.append(SimulationResult(success=False, error=f"Netlist generation failed: {e}"))
                     errors.append(f"Step {i + 1} ({comp.value}): netlist failed: {e}")
                     continue
 

--- a/app/tests/unit/test_parameter_sweep.py
+++ b/app/tests/unit/test_parameter_sweep.py
@@ -1,0 +1,319 @@
+"""Tests for parameter sweep functionality."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from controllers.simulation_controller import SimulationController, SimulationResult
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from models.wire import WireData
+
+
+def _build_simple_circuit():
+    """Build a simple V1-R1-GND circuit model."""
+    model = CircuitModel()
+    model.components["V1"] = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value="5V",
+        position=(0.0, 0.0),
+    )
+    model.components["R1"] = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value="1k",
+        position=(100.0, 0.0),
+    )
+    model.components["GND1"] = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(0.0, 100.0),
+    )
+    model.wires = [
+        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
+        WireData(start_component_id="R1", start_terminal=1, end_component_id="GND1", end_terminal=0),
+        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+    ]
+    model.analysis_type = "DC Operating Point"
+    model.rebuild_nodes()
+    return model
+
+
+class TestFormatSweepValue:
+    """Test the _format_sweep_value static method."""
+
+    def test_zero(self):
+        assert SimulationController._format_sweep_value(0) == "0"
+
+    def test_integer_kilo(self):
+        assert SimulationController._format_sweep_value(1000) == "1k"
+
+    def test_fractional_kilo(self):
+        assert SimulationController._format_sweep_value(1500) == "1.5k"
+
+    def test_mega(self):
+        assert SimulationController._format_sweep_value(1e6) == "1MEG"
+
+    def test_milli(self):
+        assert SimulationController._format_sweep_value(0.001) == "1m"
+
+    def test_micro(self):
+        assert SimulationController._format_sweep_value(1e-6) == "1u"
+
+    def test_nano(self):
+        assert SimulationController._format_sweep_value(1e-9) == "1n"
+
+    def test_pico(self):
+        assert SimulationController._format_sweep_value(1e-12) == "1p"
+
+    def test_plain_number(self):
+        assert SimulationController._format_sweep_value(100) == "100"
+
+    def test_giga(self):
+        assert SimulationController._format_sweep_value(1e9) == "1G"
+
+    def test_negative_value(self):
+        result = SimulationController._format_sweep_value(-5)
+        assert result == "-5"
+
+    def test_small_fractional(self):
+        result = SimulationController._format_sweep_value(4.7e3)
+        assert result == "4.7k"
+
+
+class TestParameterSweepMissingComponent:
+    """Test sweep when component doesn't exist."""
+
+    def test_missing_component_returns_error(self):
+        model = _build_simple_circuit()
+        ctrl = SimulationController(model)
+
+        config = {
+            "component_id": "R99",
+            "start": 1000,
+            "stop": 10000,
+            "num_steps": 5,
+            "base_analysis_type": "DC Operating Point",
+            "base_params": {"analysis_type": "DC Operating Point"},
+        }
+        result = ctrl.run_parameter_sweep(config)
+        assert not result.success
+        assert "R99" in result.error
+
+
+class TestParameterSweepValidation:
+    """Test that sweep validates the circuit first."""
+
+    def test_sweep_fails_on_invalid_circuit(self):
+        ctrl = SimulationController()  # empty model
+        config = {
+            "component_id": "R1",
+            "start": 1000,
+            "stop": 10000,
+            "num_steps": 5,
+            "base_analysis_type": "DC Operating Point",
+            "base_params": {"analysis_type": "DC Operating Point"},
+        }
+        result = ctrl.run_parameter_sweep(config)
+        assert not result.success
+
+
+class TestParameterSweepNgspiceNotFound:
+    """Test sweep when ngspice is not available."""
+
+    def test_sweep_fails_without_ngspice(self):
+        model = _build_simple_circuit()
+        ctrl = SimulationController(model)
+        mock_runner = MagicMock()
+        mock_runner.find_ngspice.return_value = None
+        mock_runner.output_dir = "simulation_output"
+        ctrl._runner = mock_runner
+
+        config = {
+            "component_id": "R1",
+            "start": 1000,
+            "stop": 10000,
+            "num_steps": 3,
+            "base_analysis_type": "DC Operating Point",
+            "base_params": {"analysis_type": "DC Operating Point"},
+        }
+        result = ctrl.run_parameter_sweep(config)
+        assert not result.success
+        assert "ngspice" in result.error.lower()
+
+
+class TestParameterSweepExecution:
+    """Test the parameter sweep execution flow with mocked ngspice."""
+
+    def _make_ctrl_with_mock_runner(self):
+        model = _build_simple_circuit()
+        ctrl = SimulationController(model)
+        mock_runner = MagicMock()
+        mock_runner.find_ngspice.return_value = "/usr/bin/ngspice"
+        mock_runner.output_dir = "/tmp/sim_output"
+        mock_runner.run_simulation.return_value = (True, "/tmp/output.txt", "stdout", "")
+        mock_runner.read_output.return_value = (
+            "Node                      Voltage\n"
+            "----                      -------\n"
+            "nodea                     5.000000e+00\n"
+        )
+        ctrl._runner = mock_runner
+        return ctrl, mock_runner
+
+    def test_sweep_runs_correct_number_of_steps(self):
+        ctrl, mock_runner = self._make_ctrl_with_mock_runner()
+        config = {
+            "component_id": "R1",
+            "start": 1000,
+            "stop": 10000,
+            "num_steps": 5,
+            "base_analysis_type": "DC Operating Point",
+            "base_params": {"analysis_type": "DC Operating Point"},
+        }
+        result = ctrl.run_parameter_sweep(config)
+        assert result.success
+        assert result.analysis_type == "Parameter Sweep"
+        assert mock_runner.run_simulation.call_count == 5
+
+    def test_sweep_restores_original_value(self):
+        ctrl, _ = self._make_ctrl_with_mock_runner()
+        original_value = ctrl.model.components["R1"].value
+        config = {
+            "component_id": "R1",
+            "start": 500,
+            "stop": 5000,
+            "num_steps": 3,
+            "base_analysis_type": "DC Operating Point",
+            "base_params": {"analysis_type": "DC Operating Point"},
+        }
+        ctrl.run_parameter_sweep(config)
+        assert ctrl.model.components["R1"].value == original_value
+
+    def test_sweep_restores_original_analysis(self):
+        ctrl, _ = self._make_ctrl_with_mock_runner()
+        ctrl.set_analysis("Transient", {"duration": 0.01, "step": 0.001})
+        config = {
+            "component_id": "R1",
+            "start": 1000,
+            "stop": 5000,
+            "num_steps": 3,
+            "base_analysis_type": "DC Operating Point",
+            "base_params": {"analysis_type": "DC Operating Point"},
+        }
+        ctrl.run_parameter_sweep(config)
+        assert ctrl.model.analysis_type == "Transient"
+
+    def test_sweep_data_structure(self):
+        ctrl, _ = self._make_ctrl_with_mock_runner()
+        config = {
+            "component_id": "R1",
+            "start": 1000,
+            "stop": 5000,
+            "num_steps": 3,
+            "base_analysis_type": "DC Operating Point",
+            "base_params": {"analysis_type": "DC Operating Point"},
+        }
+        result = ctrl.run_parameter_sweep(config)
+        data = result.data
+        assert data["component_id"] == "R1"
+        assert data["component_type"] == "Resistor"
+        assert data["base_analysis_type"] == "DC Operating Point"
+        assert len(data["sweep_values"]) == 3
+        assert len(data["results"]) == 3
+        assert data["sweep_values"][0] == 1000
+        assert data["sweep_values"][-1] == 5000
+
+    def test_sweep_with_cancellation(self):
+        ctrl, mock_runner = self._make_ctrl_with_mock_runner()
+        cancel_after = 2
+        call_count = [0]
+
+        def progress_cb(step, total):
+            call_count[0] += 1
+            return call_count[0] <= cancel_after
+
+        config = {
+            "component_id": "R1",
+            "start": 1000,
+            "stop": 10000,
+            "num_steps": 10,
+            "base_analysis_type": "DC Operating Point",
+            "base_params": {"analysis_type": "DC Operating Point"},
+        }
+        result = ctrl.run_parameter_sweep(config, progress_callback=progress_cb)
+        # Should have run fewer steps than total
+        assert result.data["cancelled"] is True
+        assert len(result.data["results"]) < 10
+
+    def test_sweep_handles_step_failure(self):
+        ctrl, mock_runner = self._make_ctrl_with_mock_runner()
+        # Fail on second call
+        mock_runner.run_simulation.side_effect = [
+            (True, "/tmp/output.txt", "stdout", ""),
+            (False, None, "", "ngspice error"),
+            (True, "/tmp/output.txt", "stdout", ""),
+        ]
+        config = {
+            "component_id": "R1",
+            "start": 1000,
+            "stop": 3000,
+            "num_steps": 3,
+            "base_analysis_type": "DC Operating Point",
+            "base_params": {"analysis_type": "DC Operating Point"},
+        }
+        result = ctrl.run_parameter_sweep(config)
+        # Should still succeed (at least one step succeeded)
+        assert result.success
+        assert len(result.errors) == 1
+        assert len(result.data["results"]) == 3
+
+    def test_sweep_values_are_linearly_spaced(self):
+        ctrl, _ = self._make_ctrl_with_mock_runner()
+        config = {
+            "component_id": "R1",
+            "start": 100,
+            "stop": 500,
+            "num_steps": 5,
+            "base_analysis_type": "DC Operating Point",
+            "base_params": {"analysis_type": "DC Operating Point"},
+        }
+        result = ctrl.run_parameter_sweep(config)
+        values = result.data["sweep_values"]
+        assert values == [100, 200, 300, 400, 500]
+
+
+class TestSweepableComponentTypes:
+    """Test that the dialog correctly identifies sweepable components."""
+
+    def test_sweepable_types_list(self):
+        from GUI.parameter_sweep_dialog import SWEEPABLE_TYPES
+
+        assert "Resistor" in SWEEPABLE_TYPES
+        assert "Capacitor" in SWEEPABLE_TYPES
+        assert "Inductor" in SWEEPABLE_TYPES
+        assert "Voltage Source" in SWEEPABLE_TYPES
+        assert "Current Source" in SWEEPABLE_TYPES
+        assert "Ground" not in SWEEPABLE_TYPES
+        assert "Op-Amp" not in SWEEPABLE_TYPES
+        assert "Waveform Source" not in SWEEPABLE_TYPES
+
+    def test_base_analysis_types(self):
+        from GUI.parameter_sweep_dialog import BASE_ANALYSIS_TYPES
+
+        assert "DC Operating Point" in BASE_ANALYSIS_TYPES
+        assert "Transient" in BASE_ANALYSIS_TYPES
+        assert "AC Sweep" in BASE_ANALYSIS_TYPES
+        assert "DC Sweep" in BASE_ANALYSIS_TYPES
+
+
+class TestNoQtDependenciesInController:
+    """Verify the controller still has no Qt imports after adding parameter sweep."""
+
+    def test_no_pyqt_imports(self):
+        import controllers.simulation_controller as mod
+
+        source = open(mod.__file__).read()
+        assert "PyQt" not in source
+        assert "QtCore" not in source
+        assert "QtWidgets" not in source


### PR DESCRIPTION
## Summary
- Adds **Analysis > Parameter Sweep** menu option allowing users to sweep any component parameter (R, C, L, V, I, controlled sources) across a configurable range
- Runs a selectable base analysis (DC OP, Transient, AC Sweep, DC Sweep) at each sweep step
- Overlays all step results on a single matplotlib plot with labeled traces
- Shows progress dialog with cancel button during multi-step sweep execution

## New Files
- `app/GUI/parameter_sweep_dialog.py` — Configuration dialog (component selector, start/stop/steps, base analysis params)
- `app/GUI/parameter_sweep_plot_dialog.py` — Matplotlib overlay plots for 4 base analysis types
- `app/tests/unit/test_parameter_sweep.py` — 25 unit tests

## Modified Files
- `app/controllers/simulation_controller.py` — `run_parameter_sweep()` with progress/cancel callback, `_format_sweep_value()` for SPICE-compatible value strings
- `app/GUI/main_window.py` — Menu entry, sweep execution with QProgressDialog, result display

## Test plan
- [x] All 25 new parameter sweep tests pass
- [x] Full test suite: 557 passed (60 pre-existing GUI display errors unchanged)
- [x] ruff lint passes clean
- [ ] Manual test: open example circuit, select Analysis > Parameter Sweep, configure R1 sweep from 1k to 10k in 10 steps with DC OP base, verify plot shows overlaid node voltages

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)