### PR TITLE
add overlay support for multiple simulation results (#77)

### DIFF
--- a/app/GUI/results_plot_dialog.py
+++ b/app/GUI/results_plot_dialog.py
@@ -1,7 +1,10 @@
 """
 results_plot_dialog.py — Matplotlib-based dialogs for DC Sweep and AC Sweep results.
 
-Uses the same FigureCanvasQTAgg embedding pattern as waveform_dialog.py.
+Supports overlaying multiple simulation runs on the same plot with:
+- Interactive legend click-to-toggle traces
+- Distinct line styles per dataset
+- Clear All button to reset
 """
 
 import logging
@@ -10,52 +13,143 @@ import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
-from PyQt6.QtWidgets import QDialog, QVBoxLayout
+from PyQt6.QtWidgets import QDialog, QHBoxLayout, QPushButton, QVBoxLayout
 
 matplotlib.use("QtAgg")
 
 logger = logging.getLogger(__name__)
 
+# Line styles cycled per dataset for visual distinction
+_LINE_STYLES = ["-", "--", "-.", ":"]
+
 
 class DCSweepPlotDialog(QDialog):
-    """Plot dialog for DC Sweep results (voltage vs. sweep variable)."""
+    """Plot dialog for DC Sweep results (voltage vs. sweep variable).
 
-    def __init__(self, data, parent=None):
+    Supports overlaying multiple datasets from successive simulation runs.
+    """
+
+    analysis_type = "DC Sweep"
+
+    def __init__(self, data, parent=None, label=None):
         super().__init__(parent)
         self.setWindowTitle("DC Sweep Results")
         self.setMinimumSize(800, 500)
 
+        self._datasets = []
+        self._lines = {}
+        self._legend_line_map = {}
+
         layout = QVBoxLayout(self)
 
-        fig = Figure(figsize=(8, 5), dpi=100)
-        self._canvas = FigureCanvas(fig)
+        # Toolbar
+        toolbar = QHBoxLayout()
+        clear_btn = QPushButton("Clear All")
+        clear_btn.setToolTip("Remove all overlaid results and clear the plot")
+        clear_btn.clicked.connect(self.clear_all)
+        toolbar.addStretch()
+        toolbar.addWidget(clear_btn)
+        layout.addLayout(toolbar)
+
+        self._fig = Figure(figsize=(8, 5), dpi=100)
+        self._canvas = FigureCanvas(self._fig)
         layout.addWidget(self._canvas)
 
-        ax = fig.add_subplot(111)
-        self._plot_dc_sweep(ax, data)
-        fig.tight_layout()
+        self._ax = self._fig.add_subplot(111)
 
-    def _plot_dc_sweep(self, ax, data):
-        headers = data.get("headers", [])
-        rows = data.get("data", [])
-        if not rows or len(headers) < 3:
-            ax.text(0.5, 0.5, "No sweep data available", ha="center", va="center", transform=ax.transAxes)
-            return
+        self._canvas.mpl_connect("pick_event", self._on_legend_pick)
 
-        # Column 0 = index, column 1 = sweep value, columns 2+ = node voltages
-        sweep_vals = [row[1] for row in rows]
+        if data:
+            self.add_dataset(data, label)
+
+    def add_dataset(self, data, label=None):
+        """Add a new dataset to the overlay plot."""
+        if label is None:
+            label = f"Run {len(self._datasets) + 1}"
+        self._datasets.append((label, data))
+        self._replot()
+
+    def _replot(self):
+        """Redraw all datasets on the axes."""
+        self._ax.clear()
+        self._lines.clear()
+        self._legend_line_map.clear()
+
         cmap = plt.get_cmap("tab10")
 
-        for col_idx in range(2, len(headers)):
-            label = headers[col_idx]
-            values = [row[col_idx] for row in rows]
-            ax.plot(sweep_vals, values, label=label, color=cmap((col_idx - 2) % 10))
+        for ds_idx, (ds_label, data) in enumerate(self._datasets):
+            headers = data.get("headers", [])
+            rows = data.get("data", [])
+            if not rows or len(headers) < 3:
+                continue
 
-        ax.set_xlabel(headers[1] if len(headers) > 1 else "Sweep")
-        ax.set_ylabel("Voltage (V)")
-        ax.set_title("DC Sweep")
-        ax.legend(loc="best", fontsize="small")
-        ax.grid(True, alpha=0.3)
+            sweep_vals = [row[1] for row in rows]
+            linestyle = _LINE_STYLES[ds_idx % len(_LINE_STYLES)]
+            prefix = f"{ds_label} — " if len(self._datasets) > 1 else ""
+
+            for col_idx in range(2, len(headers)):
+                trace_label = f"{prefix}{headers[col_idx]}"
+                values = [row[col_idx] for row in rows]
+                (line,) = self._ax.plot(
+                    sweep_vals,
+                    values,
+                    label=trace_label,
+                    color=cmap((col_idx - 2) % 10),
+                    linestyle=linestyle,
+                )
+                self._lines[trace_label] = line
+
+        if not self._lines:
+            self._ax.text(0.5, 0.5, "No sweep data available", ha="center", va="center", transform=self._ax.transAxes)
+        else:
+            first_headers = self._datasets[0][1].get("headers", [])
+            self._ax.set_xlabel(first_headers[1] if len(first_headers) > 1 else "Sweep")
+
+        self._ax.set_ylabel("Voltage (V)")
+        self._ax.set_title("DC Sweep")
+        self._ax.grid(True, alpha=0.3)
+
+        if self._lines:
+            legend = self._ax.legend(loc="best", fontsize="small")
+            self._setup_legend_toggle(legend)
+
+        self._fig.tight_layout()
+        self._canvas.draw()
+
+    def _setup_legend_toggle(self, legend):
+        """Wire up click-to-toggle on legend entries."""
+        self._legend_line_map = {}
+        for legend_line, legend_text in zip(legend.get_lines(), legend.get_texts()):
+            legend_line.set_picker(5)
+            label = legend_text.get_text()
+            if label in self._lines:
+                self._legend_line_map[legend_line] = (self._lines[label], legend_text)
+
+    def _on_legend_pick(self, event):
+        legend_line = event.artist
+        if legend_line not in self._legend_line_map:
+            return
+        orig_line, legend_text = self._legend_line_map[legend_line]
+        visible = not orig_line.get_visible()
+        orig_line.set_visible(visible)
+        legend_line.set_alpha(1.0 if visible else 0.2)
+        legend_text.set_alpha(1.0 if visible else 0.2)
+        self._canvas.draw()
+
+    def clear_all(self):
+        """Remove all datasets and clear the plot."""
+        self._datasets.clear()
+        self._lines.clear()
+        self._legend_line_map.clear()
+        self._ax.clear()
+        self._ax.text(0.5, 0.5, "All results cleared", ha="center", va="center", transform=self._ax.transAxes)
+        self._ax.set_title("DC Sweep")
+        self._fig.tight_layout()
+        self._canvas.draw()
+
+    @property
+    def dataset_count(self):
+        return len(self._datasets)
 
     def closeEvent(self, event):
         plt.close(self._canvas.figure)
@@ -63,55 +157,157 @@ class DCSweepPlotDialog(QDialog):
 
 
 class ACSweepPlotDialog(QDialog):
-    """Bode plot dialog for AC Sweep results (magnitude + phase vs. frequency)."""
+    """Bode plot dialog for AC Sweep results (magnitude + phase vs. frequency).
 
-    def __init__(self, data, parent=None):
+    Supports overlaying multiple datasets from successive simulation runs.
+    """
+
+    analysis_type = "AC Sweep"
+
+    def __init__(self, data, parent=None, label=None):
         super().__init__(parent)
         self.setWindowTitle("AC Sweep Results — Bode Plot")
         self.setMinimumSize(800, 600)
 
+        self._datasets = []
+        self._lines = {}
+        self._legend_line_map = {}
+
         layout = QVBoxLayout(self)
 
-        fig = Figure(figsize=(8, 6), dpi=100)
-        self._canvas = FigureCanvas(fig)
+        # Toolbar
+        toolbar = QHBoxLayout()
+        clear_btn = QPushButton("Clear All")
+        clear_btn.setToolTip("Remove all overlaid results and clear the plot")
+        clear_btn.clicked.connect(self.clear_all)
+        toolbar.addStretch()
+        toolbar.addWidget(clear_btn)
+        layout.addLayout(toolbar)
+
+        self._fig = Figure(figsize=(8, 6), dpi=100)
+        self._canvas = FigureCanvas(self._fig)
         layout.addWidget(self._canvas)
 
-        ax_mag = fig.add_subplot(211)
-        ax_phase = fig.add_subplot(212, sharex=ax_mag)
-        self._plot_bode(ax_mag, ax_phase, data)
-        fig.tight_layout()
+        self._ax_mag = self._fig.add_subplot(211)
+        self._ax_phase = self._fig.add_subplot(212, sharex=self._ax_mag)
 
-    def _plot_bode(self, ax_mag, ax_phase, data):
-        frequencies = data.get("frequencies", [])
-        magnitude = data.get("magnitude", {})
-        phase = data.get("phase", {})
+        self._canvas.mpl_connect("pick_event", self._on_legend_pick)
 
-        if not frequencies or (not magnitude and not phase):
-            ax_mag.text(0.5, 0.5, "No AC data available", ha="center", va="center", transform=ax_mag.transAxes)
-            return
+        if data:
+            self.add_dataset(data, label)
+
+    def add_dataset(self, data, label=None):
+        """Add a new dataset to the overlay Bode plot."""
+        if label is None:
+            label = f"Run {len(self._datasets) + 1}"
+        self._datasets.append((label, data))
+        self._replot()
+
+    def _replot(self):
+        """Redraw all datasets on the Bode plot axes."""
+        self._ax_mag.clear()
+        self._ax_phase.clear()
+        self._lines.clear()
+        self._legend_line_map.clear()
 
         cmap = plt.get_cmap("tab10")
 
-        for i, (node, mag_vals) in enumerate(sorted(magnitude.items())):
-            color = cmap(i % 10)
-            ax_mag.semilogx(frequencies, mag_vals, label=node, color=color)
-            if node in phase:
-                ax_phase.semilogx(frequencies, phase[node], label=node, color=color)
+        for ds_idx, (ds_label, data) in enumerate(self._datasets):
+            frequencies = data.get("frequencies", [])
+            magnitude = data.get("magnitude", {})
+            phase = data.get("phase", {})
 
-        # Plot any phase-only signals not in magnitude
-        for i, (node, ph_vals) in enumerate(sorted(phase.items())):
-            if node not in magnitude:
-                ax_phase.semilogx(frequencies, ph_vals, label=node, color=cmap((len(magnitude) + i) % 10))
+            if not frequencies or (not magnitude and not phase):
+                continue
 
-        ax_mag.set_ylabel("Magnitude")
-        ax_mag.set_title("Bode Plot")
-        ax_mag.legend(loc="best", fontsize="small")
-        ax_mag.grid(True, which="both", alpha=0.3)
+            linestyle = _LINE_STYLES[ds_idx % len(_LINE_STYLES)]
+            prefix = f"{ds_label} — " if len(self._datasets) > 1 else ""
 
-        ax_phase.set_xlabel("Frequency (Hz)")
-        ax_phase.set_ylabel("Phase (degrees)")
-        ax_phase.legend(loc="best", fontsize="small")
-        ax_phase.grid(True, which="both", alpha=0.3)
+            for i, (node, mag_vals) in enumerate(sorted(magnitude.items())):
+                color = cmap(i % 10)
+                trace_label = f"{prefix}{node}"
+                (line,) = self._ax_mag.semilogx(
+                    frequencies, mag_vals, label=trace_label, color=color, linestyle=linestyle
+                )
+                self._lines[trace_label] = line
+
+                if node in phase:
+                    phase_label = f"{prefix}{node} (phase)"
+                    (pline,) = self._ax_phase.semilogx(
+                        frequencies, phase[node], label=trace_label, color=color, linestyle=linestyle
+                    )
+                    self._lines[phase_label] = pline
+
+            for i, (node, ph_vals) in enumerate(sorted(phase.items())):
+                if node not in magnitude:
+                    color = cmap((len(magnitude) + i) % 10)
+                    trace_label = f"{prefix}{node}"
+                    (pline,) = self._ax_phase.semilogx(
+                        frequencies, ph_vals, label=trace_label, color=color, linestyle=linestyle
+                    )
+                    self._lines[f"{prefix}{node} (phase-only)"] = pline
+
+        has_data = bool(self._lines)
+
+        if not has_data:
+            self._ax_mag.text(
+                0.5, 0.5, "No AC data available", ha="center", va="center", transform=self._ax_mag.transAxes
+            )
+
+        self._ax_mag.set_ylabel("Magnitude")
+        self._ax_mag.set_title("Bode Plot")
+        self._ax_mag.grid(True, which="both", alpha=0.3)
+
+        self._ax_phase.set_xlabel("Frequency (Hz)")
+        self._ax_phase.set_ylabel("Phase (degrees)")
+        self._ax_phase.grid(True, which="both", alpha=0.3)
+
+        if has_data:
+            mag_legend = self._ax_mag.legend(loc="best", fontsize="small")
+            self._setup_legend_toggle(mag_legend, self._ax_mag)
+            phase_legend = self._ax_phase.legend(loc="best", fontsize="small")
+            self._setup_legend_toggle(phase_legend, self._ax_phase)
+
+        self._fig.tight_layout()
+        self._canvas.draw()
+
+    def _setup_legend_toggle(self, legend, ax):
+        """Wire up click-to-toggle on legend entries for a given axes."""
+        for legend_line, legend_text in zip(legend.get_lines(), legend.get_texts()):
+            legend_line.set_picker(5)
+            label = legend_text.get_text()
+            # Find the matching line on this axes
+            for line in ax.get_lines():
+                if line.get_label() == label:
+                    self._legend_line_map[legend_line] = (line, legend_text)
+                    break
+
+    def _on_legend_pick(self, event):
+        legend_line = event.artist
+        if legend_line not in self._legend_line_map:
+            return
+        orig_line, legend_text = self._legend_line_map[legend_line]
+        visible = not orig_line.get_visible()
+        orig_line.set_visible(visible)
+        legend_line.set_alpha(1.0 if visible else 0.2)
+        legend_text.set_alpha(1.0 if visible else 0.2)
+        self._canvas.draw()
+
+    def clear_all(self):
+        """Remove all datasets and clear the plot."""
+        self._datasets.clear()
+        self._lines.clear()
+        self._legend_line_map.clear()
+        self._ax_mag.clear()
+        self._ax_phase.clear()
+        self._ax_mag.text(0.5, 0.5, "All results cleared", ha="center", va="center", transform=self._ax_mag.transAxes)
+        self._ax_mag.set_title("Bode Plot")
+        self._fig.tight_layout()
+        self._canvas.draw()
+
+    @property
+    def dataset_count(self):
+        return len(self._datasets)
 
     def closeEvent(self, event):
         plt.close(self._canvas.figure)

--- a/app/tests/unit/test_results_plot_dialog.py
+++ b/app/tests/unit/test_results_plot_dialog.py
@@ -6,21 +6,48 @@ import pytest
 from GUI.results_plot_dialog import ACSweepPlotDialog, DCSweepPlotDialog
 
 # ---------------------------------------------------------------------------
+# Helper fixtures
+# ---------------------------------------------------------------------------
+
+DC_DATA_A = {
+    "headers": ["Index", "v-sweep", "v(nodeA)"],
+    "data": [
+        [0, 0.0, 0.0],
+        [1, 1.0, 0.5],
+        [2, 2.0, 1.0],
+    ],
+}
+
+DC_DATA_B = {
+    "headers": ["Index", "v-sweep", "v(nodeA)"],
+    "data": [
+        [0, 0.0, 0.1],
+        [1, 1.0, 0.6],
+        [2, 2.0, 1.1],
+    ],
+}
+
+AC_DATA_A = {
+    "frequencies": [100, 1000, 10000],
+    "magnitude": {"out": [1.0, 0.7, 0.3]},
+    "phase": {"out": [-10.0, -45.0, -80.0]},
+}
+
+AC_DATA_B = {
+    "frequencies": [100, 1000, 10000],
+    "magnitude": {"out": [0.9, 0.6, 0.2]},
+    "phase": {"out": [-15.0, -50.0, -85.0]},
+}
+
+
+# ---------------------------------------------------------------------------
 # DC Sweep Plot
 # ---------------------------------------------------------------------------
 
 
 class TestDCSweepPlotDialog:
     def test_opens_with_valid_data(self, qtbot):
-        data = {
-            "headers": ["Index", "v-sweep", "v(nodeA)"],
-            "data": [
-                [0, 0.0, 0.0],
-                [1, 1.0, 0.5],
-                [2, 2.0, 1.0],
-            ],
-        }
-        dlg = DCSweepPlotDialog(data)
+        dlg = DCSweepPlotDialog(DC_DATA_A)
         qtbot.addWidget(dlg)
         assert dlg.windowTitle() == "DC Sweep Results"
 
@@ -41,6 +68,50 @@ class TestDCSweepPlotDialog:
         dlg = DCSweepPlotDialog(data)
         qtbot.addWidget(dlg)
 
+    def test_analysis_type_attribute(self, qtbot):
+        dlg = DCSweepPlotDialog(DC_DATA_A)
+        qtbot.addWidget(dlg)
+        assert dlg.analysis_type == "DC Sweep"
+
+    def test_dataset_count_initial(self, qtbot):
+        dlg = DCSweepPlotDialog(DC_DATA_A)
+        qtbot.addWidget(dlg)
+        assert dlg.dataset_count == 1
+
+    def test_add_dataset_increments_count(self, qtbot):
+        dlg = DCSweepPlotDialog(DC_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(DC_DATA_B, "Run 2")
+        assert dlg.dataset_count == 2
+
+    def test_add_multiple_datasets(self, qtbot):
+        dlg = DCSweepPlotDialog(DC_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(DC_DATA_B, "Run 2")
+        dlg.add_dataset(DC_DATA_A, "Run 3")
+        assert dlg.dataset_count == 3
+
+    def test_clear_all_resets_datasets(self, qtbot):
+        dlg = DCSweepPlotDialog(DC_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(DC_DATA_B, "Run 2")
+        dlg.clear_all()
+        assert dlg.dataset_count == 0
+
+    def test_add_dataset_after_clear(self, qtbot):
+        dlg = DCSweepPlotDialog(DC_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.clear_all()
+        dlg.add_dataset(DC_DATA_B, "Fresh")
+        assert dlg.dataset_count == 1
+
+    def test_add_dataset_with_default_label(self, qtbot):
+        dlg = DCSweepPlotDialog(DC_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(DC_DATA_B)
+        # Should not crash; auto-labels as "Run 2"
+        assert dlg.dataset_count == 2
+
 
 # ---------------------------------------------------------------------------
 # AC Sweep Bode Plot
@@ -49,12 +120,7 @@ class TestDCSweepPlotDialog:
 
 class TestACSweepPlotDialog:
     def test_opens_with_valid_data(self, qtbot):
-        data = {
-            "frequencies": [100, 1000, 10000],
-            "magnitude": {"out": [1.0, 0.7, 0.3]},
-            "phase": {"out": [-10.0, -45.0, -80.0]},
-        }
-        dlg = ACSweepPlotDialog(data)
+        dlg = ACSweepPlotDialog(AC_DATA_A)
         qtbot.addWidget(dlg)
         assert "Bode" in dlg.windowTitle()
 
@@ -81,3 +147,46 @@ class TestACSweepPlotDialog:
         }
         dlg = ACSweepPlotDialog(data)
         qtbot.addWidget(dlg)
+
+    def test_analysis_type_attribute(self, qtbot):
+        dlg = ACSweepPlotDialog(AC_DATA_A)
+        qtbot.addWidget(dlg)
+        assert dlg.analysis_type == "AC Sweep"
+
+    def test_dataset_count_initial(self, qtbot):
+        dlg = ACSweepPlotDialog(AC_DATA_A)
+        qtbot.addWidget(dlg)
+        assert dlg.dataset_count == 1
+
+    def test_add_dataset_increments_count(self, qtbot):
+        dlg = ACSweepPlotDialog(AC_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(AC_DATA_B, "Run 2")
+        assert dlg.dataset_count == 2
+
+    def test_add_multiple_datasets(self, qtbot):
+        dlg = ACSweepPlotDialog(AC_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(AC_DATA_B, "Run 2")
+        dlg.add_dataset(AC_DATA_A, "Run 3")
+        assert dlg.dataset_count == 3
+
+    def test_clear_all_resets_datasets(self, qtbot):
+        dlg = ACSweepPlotDialog(AC_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(AC_DATA_B, "Run 2")
+        dlg.clear_all()
+        assert dlg.dataset_count == 0
+
+    def test_add_dataset_after_clear(self, qtbot):
+        dlg = ACSweepPlotDialog(AC_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.clear_all()
+        dlg.add_dataset(AC_DATA_B, "Fresh")
+        assert dlg.dataset_count == 1
+
+    def test_add_dataset_with_default_label(self, qtbot):
+        dlg = ACSweepPlotDialog(AC_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(AC_DATA_B)
+        assert dlg.dataset_count == 2

--- a/app/tests/unit/test_waveform_dialog_overlay.py
+++ b/app/tests/unit/test_waveform_dialog_overlay.py
@@ -1,0 +1,79 @@
+"""
+Unit tests for WaveformDialog overlay functionality.
+"""
+
+import pytest
+from GUI.waveform_dialog import WaveformDialog
+
+# ---------------------------------------------------------------------------
+# Helper data
+# ---------------------------------------------------------------------------
+
+TRAN_DATA_A = [
+    {"time": 0.0, "v(out)": 0.0, "v(in)": 1.0},
+    {"time": 1e-6, "v(out)": 0.5, "v(in)": 0.9},
+    {"time": 2e-6, "v(out)": 1.0, "v(in)": 0.8},
+]
+
+TRAN_DATA_B = [
+    {"time": 0.0, "v(out)": 0.1, "v(in)": 1.1},
+    {"time": 1e-6, "v(out)": 0.6, "v(in)": 1.0},
+    {"time": 2e-6, "v(out)": 1.1, "v(in)": 0.9},
+]
+
+
+class TestWaveformDialogOverlay:
+    def test_analysis_type_attribute(self, qtbot):
+        dlg = WaveformDialog(TRAN_DATA_A)
+        qtbot.addWidget(dlg)
+        assert dlg.analysis_type == "Transient"
+
+    def test_initial_no_overlays(self, qtbot):
+        dlg = WaveformDialog(TRAN_DATA_A)
+        qtbot.addWidget(dlg)
+        assert len(dlg._overlay_datasets) == 0
+
+    def test_add_dataset(self, qtbot):
+        dlg = WaveformDialog(TRAN_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(TRAN_DATA_B, "Run 2")
+        assert len(dlg._overlay_datasets) == 1
+
+    def test_add_multiple_datasets(self, qtbot):
+        dlg = WaveformDialog(TRAN_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(TRAN_DATA_B, "Run 2")
+        dlg.add_dataset(TRAN_DATA_A, "Run 3")
+        assert len(dlg._overlay_datasets) == 2
+
+    def test_add_dataset_default_label(self, qtbot):
+        dlg = WaveformDialog(TRAN_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(TRAN_DATA_B)
+        label, _ = dlg._overlay_datasets[0]
+        assert label == "Run 1"
+
+    def test_overlay_visibility_tracking(self, qtbot):
+        dlg = WaveformDialog(TRAN_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(TRAN_DATA_B, "Run 2")
+        # Each signal in the overlay should have a visibility entry
+        assert "Run 2 — v(out)" in dlg._overlay_visibility
+        assert "Run 2 — v(in)" in dlg._overlay_visibility
+        assert dlg._overlay_visibility["Run 2 — v(out)"] is True
+
+    def test_clear_overlays(self, qtbot):
+        dlg = WaveformDialog(TRAN_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(TRAN_DATA_B, "Run 2")
+        dlg.clear_overlays()
+        assert len(dlg._overlay_datasets) == 0
+        assert len(dlg._overlay_visibility) == 0
+
+    def test_add_dataset_after_clear(self, qtbot):
+        dlg = WaveformDialog(TRAN_DATA_A)
+        qtbot.addWidget(dlg)
+        dlg.add_dataset(TRAN_DATA_B, "Run 2")
+        dlg.clear_overlays()
+        dlg.add_dataset(TRAN_DATA_A, "Run 3")
+        assert len(dlg._overlay_datasets) == 1


### PR DESCRIPTION
## Summary
- Refactors DC Sweep, AC Sweep, and Transient plot dialogs to support overlaying results from successive simulation runs
- When a compatible plot window is already open, users are prompted to overlay new results or replace the existing plot
- Each dataset uses distinct line styles (solid, dashed, dash-dot, dotted) for visual distinction
- Legend entries are click-to-toggle for individual trace visibility
- "Clear All" button removes all overlaid results
- Adds 21 new tests (29 total in plot dialog tests, 8 for waveform overlay)

## Changes
- **`app/GUI/results_plot_dialog.py`** — Complete rewrite: both `DCSweepPlotDialog` and `ACSweepPlotDialog` now support `add_dataset()`, `clear_all()`, interactive legend toggle, and dataset counting
- **`app/GUI/waveform_dialog.py`** — Added `add_dataset()` and `clear_overlays()` methods with per-signal toggle checkboxes for overlay traces
- **`app/GUI/main_window.py`** — Added `_show_or_overlay_plot()` helper; DC Sweep, AC Sweep, and Transient branches now check for existing compatible dialogs before creating new ones
- **`app/tests/unit/test_results_plot_dialog.py`** — Expanded from 7 to 21 tests covering overlay, clear, and dataset management
- **`app/tests/unit/test_waveform_dialog_overlay.py`** — New test file with 8 tests for transient overlay functionality

## Test plan
- [x] All 614 tests pass
- [x] Ruff linting passes
- [ ] Manual test: run DC Sweep twice, verify overlay prompt appears and traces overlay correctly
- [ ] Manual test: click legend entries to toggle individual traces
- [ ] Manual test: "Clear All" button resets the plot
- [ ] Manual test: closing plot window and re-running creates fresh plot

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)