### PR TITLE
Add measurement cursors to waveform viewer

### DIFF
--- a/app/GUI/measurement_cursors.py
+++ b/app/GUI/measurement_cursors.py
@@ -1,0 +1,305 @@
+"""
+Measurement Cursors — Interactive dual vertical cursors for matplotlib plots.
+
+Provides two draggable cursors (A and B) that snap to nearest data points and
+display X/Y values and delta measurements in a readout panel.
+
+Usage:
+    cursors = MeasurementCursors(canvas, [ax1, ax2])
+    cursors.set_readout_callback(lambda data: label.setText(format_readout_html(data)))
+    cursors.set_enabled(True)
+
+    # After replotting (axes.clear() + replot), call:
+    cursors.refresh()
+"""
+
+import numpy as np
+
+# Cursor colors (red-ish for A, blue-ish for B)
+CURSOR_A_COLOR = "#E74C3C"
+CURSOR_B_COLOR = "#3498DB"
+
+
+class MeasurementCursors:
+    """Manages two vertical measurement cursors on one or more matplotlib axes.
+
+    Left-click places/drags Cursor A. Right-click places/drags Cursor B.
+    Cursors snap to the nearest X data point for accuracy.
+    """
+
+    def __init__(self, canvas, axes):
+        """
+        Args:
+            canvas: FigureCanvasQTAgg instance
+            axes: a single Axes or list of Axes to synchronize cursors across
+        """
+        self.canvas = canvas
+        self.axes = axes if isinstance(axes, list) else [axes]
+
+        self._cursor_a_x = None
+        self._cursor_b_x = None
+        self._cursor_a_lines = []
+        self._cursor_b_lines = []
+        self._enabled = False
+        self._dragging = None
+        self._readout_callback = None
+
+        self._cids = [
+            canvas.mpl_connect("button_press_event", self._on_press),
+            canvas.mpl_connect("button_release_event", self._on_release),
+            canvas.mpl_connect("motion_notify_event", self._on_motion),
+        ]
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def set_readout_callback(self, callback):
+        """Set a callback invoked with readout data dict whenever cursors change."""
+        self._readout_callback = callback
+
+    def set_enabled(self, enabled):
+        self._enabled = enabled
+        if not enabled:
+            self._remove_all()
+        self._fire_readout()
+
+    @property
+    def enabled(self):
+        return self._enabled
+
+    def refresh(self):
+        """Recreate cursor lines after the axes have been cleared and replotted."""
+        self._cursor_a_lines.clear()
+        self._cursor_b_lines.clear()
+        if self._enabled:
+            if self._cursor_a_x is not None:
+                self._create_lines("a", self._cursor_a_x)
+            if self._cursor_b_x is not None:
+                self._create_lines("b", self._cursor_b_x)
+            self._fire_readout()
+            self.canvas.draw_idle()
+
+    def get_readout_data(self):
+        """Return structured readout data for both cursors and their delta.
+
+        Returns dict that may contain keys 'a', 'b', 'delta'.
+        Each cursor entry has 'x' and 'y' (dict of label -> value).
+        Delta has 'dx' and 'dy' (dict of label -> value).
+        """
+        data = {}
+        if self._cursor_a_x is not None:
+            y_vals = {}
+            for ax in self.axes:
+                y_vals.update(self._get_y_at_x(ax, self._cursor_a_x))
+            data["a"] = {"x": self._cursor_a_x, "y": y_vals}
+
+        if self._cursor_b_x is not None:
+            y_vals = {}
+            for ax in self.axes:
+                y_vals.update(self._get_y_at_x(ax, self._cursor_b_x))
+            data["b"] = {"x": self._cursor_b_x, "y": y_vals}
+
+        if "a" in data and "b" in data:
+            dx = data["b"]["x"] - data["a"]["x"]
+            dy = {}
+            for label in data["a"]["y"]:
+                if label in data["b"]["y"]:
+                    dy[label] = data["b"]["y"][label] - data["a"]["y"][label]
+            data["delta"] = {"dx": dx, "dy": dy}
+
+        return data
+
+    def disconnect(self):
+        """Disconnect all matplotlib event handlers."""
+        for cid in self._cids:
+            self.canvas.mpl_disconnect(cid)
+        self._cids.clear()
+
+    # ------------------------------------------------------------------
+    # Mouse event handlers
+    # ------------------------------------------------------------------
+
+    def _on_press(self, event):
+        if not self._enabled or event.inaxes not in self.axes:
+            return
+        x = event.xdata
+        if x is None:
+            return
+
+        thresh = self._drag_threshold()
+
+        # Check if clicking near an existing cursor to start dragging
+        if self._cursor_a_x is not None and abs(x - self._cursor_a_x) < thresh:
+            self._dragging = "a"
+            return
+        if self._cursor_b_x is not None and abs(x - self._cursor_b_x) < thresh:
+            self._dragging = "b"
+            return
+
+        # Place cursor: left-click = A, right-click = B
+        if event.button == 1:
+            self._place("a", x)
+        elif event.button == 3:
+            self._place("b", x)
+
+    def _on_motion(self, event):
+        if self._dragging and event.inaxes in self.axes and event.xdata is not None:
+            self._place(self._dragging, event.xdata)
+
+    def _on_release(self, event):
+        self._dragging = None
+
+    # ------------------------------------------------------------------
+    # Cursor placement
+    # ------------------------------------------------------------------
+
+    def _place(self, which, x):
+        snapped = self._snap_to_data(x)
+        if snapped is not None:
+            x = snapped
+
+        if which == "a":
+            self._cursor_a_x = x
+            self._update_lines("a", x)
+        else:
+            self._cursor_b_x = x
+            self._update_lines("b", x)
+
+        self._fire_readout()
+        self.canvas.draw_idle()
+
+    def _update_lines(self, which, x):
+        lines = self._cursor_a_lines if which == "a" else self._cursor_b_lines
+        if lines:
+            for line in lines:
+                line.set_xdata([x, x])
+        else:
+            self._create_lines(which, x)
+
+    def _create_lines(self, which, x):
+        color = CURSOR_A_COLOR if which == "a" else CURSOR_B_COLOR
+        lines = []
+        for ax in self.axes:
+            line = ax.axvline(x, color=color, linestyle="--", linewidth=1.5, alpha=0.8)
+            line.set_label(f"_Cursor {which.upper()}")
+            lines.append(line)
+        if which == "a":
+            self._cursor_a_lines = lines
+        else:
+            self._cursor_b_lines = lines
+
+    def _remove_all(self):
+        for line in self._cursor_a_lines + self._cursor_b_lines:
+            try:
+                line.remove()
+            except ValueError:
+                pass
+        self._cursor_a_lines.clear()
+        self._cursor_b_lines.clear()
+        self._cursor_a_x = None
+        self._cursor_b_x = None
+        self.canvas.draw_idle()
+
+    # ------------------------------------------------------------------
+    # Data snapping and interpolation
+    # ------------------------------------------------------------------
+
+    def _drag_threshold(self):
+        """Return 2% of the X-axis range for cursor proximity detection."""
+        xlim = self.axes[0].get_xlim()
+        return (xlim[1] - xlim[0]) * 0.02
+
+    def _snap_to_data(self, x):
+        """Snap to the nearest X data point across all plotted lines."""
+        best_x = None
+        best_dist = float("inf")
+
+        for ax in self.axes:
+            for line in ax.get_lines():
+                if line.get_label().startswith("_"):
+                    continue
+                xdata = np.asarray(line.get_xdata(), dtype=float)
+                if len(xdata) == 0:
+                    continue
+                idx = int(np.searchsorted(xdata, x))
+                for i in [max(0, idx - 1), min(len(xdata) - 1, idx)]:
+                    dist = abs(xdata[i] - x)
+                    if dist < best_dist:
+                        best_dist = dist
+                        best_x = float(xdata[i])
+
+        return best_x
+
+    def _get_y_at_x(self, ax, x):
+        """Interpolate Y values at X for each data line on the given axes."""
+        result = {}
+        for line in ax.get_lines():
+            label = line.get_label()
+            if label.startswith("_"):
+                continue
+            xdata = np.asarray(line.get_xdata(), dtype=float)
+            ydata = np.asarray(line.get_ydata(), dtype=float)
+            if len(xdata) < 1:
+                continue
+
+            idx = int(np.searchsorted(xdata, x))
+            if idx == 0:
+                result[label] = float(ydata[0])
+            elif idx >= len(xdata):
+                result[label] = float(ydata[-1])
+            else:
+                x0, x1 = xdata[idx - 1], xdata[idx]
+                y0, y1 = ydata[idx - 1], ydata[idx]
+                if x1 != x0:
+                    t = (x - x0) / (x1 - x0)
+                    result[label] = float(y0 + t * (y1 - y0))
+                else:
+                    result[label] = float(y0)
+        return result
+
+    def _fire_readout(self):
+        if self._readout_callback:
+            self._readout_callback(self.get_readout_data())
+
+
+def format_readout_html(data, x_label="X", y_label="Y"):
+    """Format cursor readout data as HTML for display in a QLabel.
+
+    Args:
+        data: dict from MeasurementCursors.get_readout_data()
+        x_label: label for X axis (e.g. "Time", "Frequency")
+        y_label: label for Y axis (e.g. "Voltage", "Magnitude")
+    """
+    if not data:
+        return (
+            "<i>Left-click to place Cursor A, right-click for Cursor B</i>"
+        )
+
+    parts = []
+
+    if "a" in data:
+        a = data["a"]
+        parts.append(
+            f"<b style='color:{CURSOR_A_COLOR}'>Cursor A</b> "
+            f"&mdash; {x_label}: {a['x']:.6g}"
+        )
+        for label, y in a["y"].items():
+            parts.append(f"&nbsp;&nbsp;{label}: {y:.6g}")
+
+    if "b" in data:
+        b = data["b"]
+        parts.append(
+            f"<b style='color:{CURSOR_B_COLOR}'>Cursor B</b> "
+            f"&mdash; {x_label}: {b['x']:.6g}"
+        )
+        for label, y in b["y"].items():
+            parts.append(f"&nbsp;&nbsp;{label}: {y:.6g}")
+
+    if "delta" in data:
+        d = data["delta"]
+        parts.append(f"<b>Delta</b> &mdash; \u0394{x_label}: {d['dx']:.6g}")
+        for label, dy in d["dy"].items():
+            parts.append(f"&nbsp;&nbsp;\u0394{label}: {dy:.6g}")
+
+    return "<br>".join(parts)

--- a/app/tests/unit/test_measurement_cursors.py
+++ b/app/tests/unit/test_measurement_cursors.py
@@ -1,0 +1,315 @@
+"""Tests for MeasurementCursors — cursor placement, snapping, and readout."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from matplotlib.figure import Figure
+
+from GUI.measurement_cursors import MeasurementCursors, format_readout_html
+
+
+def _make_figure_with_data():
+    """Create a Figure with a single axes containing plotted data."""
+    fig = Figure(figsize=(6, 4))
+    ax = fig.add_subplot(111)
+    x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    y = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+    ax.plot(x, y, label="signal")
+    return fig, ax
+
+
+class FakeCanvas:
+    """Minimal canvas mock that tracks mpl_connect calls."""
+
+    def __init__(self, fig):
+        self.figure = fig
+        self._callbacks = {}
+        self._next_cid = 0
+
+    def mpl_connect(self, event, callback):
+        cid = self._next_cid
+        self._next_cid += 1
+        self._callbacks.setdefault(event, []).append((cid, callback))
+        return cid
+
+    def mpl_disconnect(self, cid):
+        for event in self._callbacks:
+            self._callbacks[event] = [
+                (c, cb) for c, cb in self._callbacks[event] if c != cid
+            ]
+
+    def draw_idle(self):
+        pass
+
+    def fire(self, event_name, **kwargs):
+        """Simulate a matplotlib event."""
+        event = MagicMock()
+        for k, v in kwargs.items():
+            setattr(event, k, v)
+        for _, cb in self._callbacks.get(event_name, []):
+            cb(event)
+
+
+class TestMeasurementCursorsSnap:
+    """Test data snapping logic."""
+
+    def test_snap_to_exact_point(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        cursors.set_enabled(True)
+        snapped = cursors._snap_to_data(2.0)
+        assert snapped == 2.0
+
+    def test_snap_to_nearest_point(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        cursors.set_enabled(True)
+        snapped = cursors._snap_to_data(2.3)
+        assert snapped == 2.0
+
+    def test_snap_rounds_up(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        cursors.set_enabled(True)
+        snapped = cursors._snap_to_data(2.8)
+        assert snapped == 3.0
+
+    def test_snap_ignores_underscore_labels(self):
+        fig = Figure()
+        ax = fig.add_subplot(111)
+        ax.axvline(1.5, label="_hidden")  # Should be ignored
+        ax.plot([0, 1, 2], [0, 1, 2], label="data")
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        snapped = cursors._snap_to_data(0.9)
+        assert snapped == 1.0  # Snaps to data, not axvline
+
+
+class TestMeasurementCursorsInterpolation:
+    """Test Y-value interpolation at cursor positions."""
+
+    def test_interpolation_at_exact_point(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        y_vals = cursors._get_y_at_x(ax, 2.0)
+        assert "signal" in y_vals
+        assert abs(y_vals["signal"] - 4.0) < 1e-10
+
+    def test_interpolation_between_points(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        y_vals = cursors._get_y_at_x(ax, 1.5)
+        assert "signal" in y_vals
+        assert abs(y_vals["signal"] - 3.0) < 1e-10
+
+    def test_interpolation_at_start(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        y_vals = cursors._get_y_at_x(ax, 0.0)
+        assert abs(y_vals["signal"] - 0.0) < 1e-10
+
+    def test_interpolation_beyond_end(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        y_vals = cursors._get_y_at_x(ax, 10.0)
+        assert abs(y_vals["signal"] - 8.0) < 1e-10
+
+
+class TestMeasurementCursorsPlacement:
+    """Test cursor placement and readout data."""
+
+    def test_place_cursor_a(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        cursors.set_enabled(True)
+
+        cursors._place("a", 2.0)
+        data = cursors.get_readout_data()
+        assert "a" in data
+        assert data["a"]["x"] == 2.0
+        assert abs(data["a"]["y"]["signal"] - 4.0) < 1e-10
+
+    def test_place_both_cursors_gives_delta(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        cursors.set_enabled(True)
+
+        cursors._place("a", 1.0)
+        cursors._place("b", 3.0)
+        data = cursors.get_readout_data()
+        assert "a" in data
+        assert "b" in data
+        assert "delta" in data
+        assert abs(data["delta"]["dx"] - 2.0) < 1e-10
+        assert abs(data["delta"]["dy"]["signal"] - 4.0) < 1e-10
+
+    def test_disable_removes_cursors(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        cursors.set_enabled(True)
+        cursors._place("a", 1.0)
+        cursors._place("b", 3.0)
+
+        cursors.set_enabled(False)
+        data = cursors.get_readout_data()
+        assert data == {}
+
+    def test_readout_callback_fires(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        cursors.set_enabled(True)
+        received = []
+        cursors.set_readout_callback(lambda d: received.append(d))
+        cursors._place("a", 2.0)
+        assert len(received) == 1
+        assert "a" in received[0]
+
+
+class TestMeasurementCursorsRefresh:
+    """Test cursor recreation after axes.clear()."""
+
+    def test_refresh_recreates_lines(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        cursors.set_enabled(True)
+        cursors._place("a", 1.0)
+        cursors._place("b", 3.0)
+
+        # Simulate replot: clear and replot data
+        ax.clear()
+        ax.plot([0, 1, 2, 3, 4], [0, 2, 4, 6, 8], label="signal")
+        cursors.refresh()
+
+        # Cursor positions should be preserved
+        data = cursors.get_readout_data()
+        assert "a" in data
+        assert "b" in data
+        assert data["a"]["x"] == 1.0
+        assert data["b"]["x"] == 3.0
+
+
+class TestMeasurementCursorsMultiAxes:
+    """Test cursor synchronization across multiple axes."""
+
+    def test_cursors_appear_on_all_axes(self):
+        fig = Figure()
+        ax1 = fig.add_subplot(211)
+        ax2 = fig.add_subplot(212)
+        ax1.plot([0, 1, 2], [0, 1, 2], label="mag")
+        ax2.plot([0, 1, 2], [0, -45, -90], label="phase")
+
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, [ax1, ax2])
+        cursors.set_enabled(True)
+        cursors._place("a", 1.0)
+
+        data = cursors.get_readout_data()
+        assert "mag" in data["a"]["y"]
+        assert "phase" in data["a"]["y"]
+        assert abs(data["a"]["y"]["mag"] - 1.0) < 1e-10
+        assert abs(data["a"]["y"]["phase"] - (-45.0)) < 1e-10
+
+
+class TestMeasurementCursorsDisconnect:
+    """Test cleanup."""
+
+    def test_disconnect_clears_cids(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        assert len(cursors._cids) == 3
+        cursors.disconnect()
+        assert len(cursors._cids) == 0
+
+
+class TestFormatReadoutHtml:
+    """Test HTML readout formatting."""
+
+    def test_empty_data(self):
+        html = format_readout_html({})
+        assert "Left-click" in html
+
+    def test_cursor_a_only(self):
+        data = {"a": {"x": 1.5, "y": {"signal": 3.0}}}
+        html = format_readout_html(data, x_label="Time")
+        assert "Cursor A" in html
+        assert "1.5" in html
+        assert "signal" in html
+        assert "Cursor B" not in html
+        assert "Delta" not in html
+
+    def test_both_cursors_with_delta(self):
+        data = {
+            "a": {"x": 1.0, "y": {"s1": 2.0}},
+            "b": {"x": 3.0, "y": {"s1": 6.0}},
+            "delta": {"dx": 2.0, "dy": {"s1": 4.0}},
+        }
+        html = format_readout_html(data)
+        assert "Cursor A" in html
+        assert "Cursor B" in html
+        assert "Delta" in html
+        assert "4" in html  # delta value
+
+
+class TestMouseInteraction:
+    """Test mouse event handling for cursor placement."""
+
+    def test_left_click_places_cursor_a(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        cursors.set_enabled(True)
+
+        canvas.fire("button_press_event", button=1, xdata=2.0, inaxes=ax)
+        canvas.fire("button_release_event", button=1, xdata=2.0, inaxes=ax)
+
+        data = cursors.get_readout_data()
+        assert "a" in data
+        assert data["a"]["x"] == 2.0
+
+    def test_right_click_places_cursor_b(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        cursors.set_enabled(True)
+
+        canvas.fire("button_press_event", button=3, xdata=3.0, inaxes=ax)
+        canvas.fire("button_release_event", button=3, xdata=3.0, inaxes=ax)
+
+        data = cursors.get_readout_data()
+        assert "b" in data
+        assert data["b"]["x"] == 3.0
+
+    def test_click_when_disabled_does_nothing(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        # Not enabled
+
+        canvas.fire("button_press_event", button=1, xdata=2.0, inaxes=ax)
+        data = cursors.get_readout_data()
+        assert data == {}
+
+    def test_click_outside_axes_does_nothing(self):
+        fig, ax = _make_figure_with_data()
+        canvas = FakeCanvas(fig)
+        cursors = MeasurementCursors(canvas, ax)
+        cursors.set_enabled(True)
+
+        other_ax = MagicMock()
+        canvas.fire("button_press_event", button=1, xdata=2.0, inaxes=other_ax)
+        data = cursors.get_readout_data()
+        assert data == {}


### PR DESCRIPTION
## Summary
- Add interactive dual measurement cursors (A/B) to all plot dialogs (Transient, DC Sweep, AC Sweep)
- Left-click places Cursor A (red), right-click places Cursor B (blue), with drag-to-reposition
- Cursors snap to nearest data points and display interpolated Y-values with delta readout
- Multi-axes support for synchronized cursors on Bode plots (magnitude + phase)

## Changes
- **New**: `app/GUI/measurement_cursors.py` — Reusable `MeasurementCursors` class and `format_readout_html()` helper
- **Modified**: `app/GUI/waveform_dialog.py` — Added cursor group box with enable checkbox and readout label
- **Modified**: `app/GUI/results_plot_dialog.py` — Added cursors to both `DCSweepPlotDialog` and `ACSweepPlotDialog`
- **New**: `app/tests/unit/test_measurement_cursors.py` — 22 unit tests covering snapping, interpolation, placement, multi-axes, mouse interaction, and HTML formatting

## Test plan
- [x] 22 new unit tests all pass
- [x] Full test suite: 554 passed, 60 pre-existing errors (Qt display)
- [x] Ruff lint clean
- [ ] Manual: open transient plot, left-click to place Cursor A, right-click for B, verify readout
- [ ] Manual: verify cursor snapping to data points
- [ ] Manual: verify drag-to-reposition cursors
- [ ] Manual: verify cursors on DC sweep and AC sweep (Bode) plots

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)