### PR TITLE
add measurement cursors to waveform viewer (#78)

### DIFF
--- a/app/GUI/analysis_dialog.py
+++ b/app/GUI/analysis_dialog.py
@@ -8,7 +8,10 @@ class AnalysisDialog(QDialog):
 
     # Analysis type configurations
     ANALYSIS_CONFIGS = {
-        "DC Operating Point": {"fields": [], "description": "Calculate DC operating point of the circuit"},
+        "DC Operating Point": {
+            "fields": [],
+            "description": "Calculate DC operating point of the circuit",
+        },
         "DC Sweep": {
             "fields": [
                 ("Source", "source", "text", "V1"),

--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -220,7 +220,12 @@ class CircuitCanvasView(QGraphicsView):
 
         if start_comp and end_comp:
             wire = WireGraphicsItem(
-                start_comp, wire_data.start_terminal, end_comp, wire_data.end_terminal, canvas=self, model=wire_data
+                start_comp,
+                wire_data.start_terminal,
+                end_comp,
+                wire_data.end_terminal,
+                canvas=self,
+                model=wire_data,
             )
             self.scene.addItem(wire)
             self.wires.append(wire)
@@ -271,7 +276,10 @@ class CircuitCanvasView(QGraphicsView):
             self.nodes.append(node)
 
         # Rebuild terminal mapping
-        for (comp_id, term_idx), node_data in self.controller.model.terminal_to_node.items():
+        for (
+            comp_id,
+            term_idx,
+        ), node_data in self.controller.model.terminal_to_node.items():
             # Find corresponding Qt Node
             qt_node = next((n for n in self.nodes if n.matches_node_data(node_data)), None)
             if qt_node:
@@ -512,7 +520,10 @@ class CircuitCanvasView(QGraphicsView):
                                     clicked_component.component_id,
                                     target_term,
                                 )
-                                self.wireAdded.emit(self.wire_start_comp.component_id, clicked_component.component_id)
+                                self.wireAdded.emit(
+                                    self.wire_start_comp.component_id,
+                                    clicked_component.component_id,
+                                )
                             else:
                                 # Fallback to old method if no controller (shouldn't happen)
                                 wire = WireItem(
@@ -526,7 +537,10 @@ class CircuitCanvasView(QGraphicsView):
                                 self.scene.addItem(wire)
                                 self.wires.append(wire)
                                 self.update_nodes_for_wire(wire)
-                                self.wireAdded.emit(self.wire_start_comp.component_id, clicked_component.component_id)
+                                self.wireAdded.emit(
+                                    self.wire_start_comp.component_id,
+                                    clicked_component.component_id,
+                                )
 
                     # Clean up temporary wire line
                     if self.temp_wire_line:
@@ -598,7 +612,10 @@ class CircuitCanvasView(QGraphicsView):
             self._rubber_band.hide()
             # Map rubber band rect to scene coordinates and select enclosed items
             rb_rect = self._rubber_band.geometry()
-            scene_rect = QRectF(self.mapToScene(rb_rect.topLeft()), self.mapToScene(rb_rect.bottomRight()))
+            scene_rect = QRectF(
+                self.mapToScene(rb_rect.topLeft()),
+                self.mapToScene(rb_rect.bottomRight()),
+            )
             for item in self.scene.items(scene_rect, Qt.ItemSelectionMode.IntersectsItemShape):
                 if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem)):
                     item.setSelected(True)
@@ -982,7 +999,8 @@ class CircuitCanvasView(QGraphicsView):
                 n = len(comp_dicts)
                 w = len(wire_dicts)
                 status.showMessage(
-                    f"Copied {n} component{'s' if n != 1 else ''} and {w} wire{'s' if w != 1 else ''}", 2000
+                    f"Copied {n} component{'s' if n != 1 else ''} and {w} wire{'s' if w != 1 else ''}",
+                    2000,
                 )
         return True
 
@@ -1118,7 +1136,10 @@ class CircuitCanvasView(QGraphicsView):
                 text_height = metrics.height() * len(lines)
 
                 label_rect = QRectF(
-                    pos.x() - max_width / 2 - 2, pos.y() - text_height - 2, max_width + 4, text_height + 4
+                    pos.x() - max_width / 2 - 2,
+                    pos.y() - text_height - 2,
+                    max_width + 4,
+                    text_height + 4,
                 )
                 painter.drawRect(label_rect)
 
@@ -1431,7 +1452,12 @@ class CircuitCanvasView(QGraphicsView):
             for i in range(len(comp.terminals)):
                 term_pos = comp.get_terminal_pos(i)
                 terminal_circle = self.scene.addEllipse(
-                    term_pos.x() - 5, term_pos.y() - 5, 10, 10, terminal_pen, terminal_brush
+                    term_pos.x() - 5,
+                    term_pos.y() - 5,
+                    10,
+                    10,
+                    terminal_pen,
+                    terminal_brush,
                 )
                 terminal_circle.setZValue(100)
                 self.obstacle_boundary_items.append(terminal_circle)
@@ -1445,7 +1471,12 @@ class CircuitCanvasView(QGraphicsView):
 
         # Full boundary legend (red solid frame)
         full_legend_rect = self.scene.addRect(
-            legend_x, legend_y, 30, 15, theme_manager.pen("obstacle_full"), QBrush(Qt.BrushStyle.NoBrush)
+            legend_x,
+            legend_y,
+            30,
+            15,
+            theme_manager.pen("obstacle_full"),
+            QBrush(Qt.BrushStyle.NoBrush),
         )
         full_legend_rect.setZValue(1000)
         self.obstacle_boundary_items.append(full_legend_rect)
@@ -1458,7 +1489,12 @@ class CircuitCanvasView(QGraphicsView):
 
         # Inset boundary legend (blue dotted frame)
         inset_legend_rect = self.scene.addRect(
-            legend_x, legend_y + 25, 30, 15, theme_manager.pen("obstacle_inset"), QBrush(Qt.BrushStyle.NoBrush)
+            legend_x,
+            legend_y + 25,
+            30,
+            15,
+            theme_manager.pen("obstacle_inset"),
+            QBrush(Qt.BrushStyle.NoBrush),
         )
         inset_legend_rect.setZValue(1000)
         self.obstacle_boundary_items.append(inset_legend_rect)
@@ -1666,7 +1702,13 @@ class CircuitCanvasView(QGraphicsView):
         for wire_data in data["wires"]:
             start_comp = self.components[wire_data["start_comp"]]
             end_comp = self.components[wire_data["end_comp"]]
-            wire = WireItem(start_comp, wire_data["start_term"], end_comp, wire_data["end_term"], canvas=self)
+            wire = WireItem(
+                start_comp,
+                wire_data["start_term"],
+                end_comp,
+                wire_data["end_term"],
+                canvas=self,
+            )
             self.scene.addItem(wire)
             self.wires.append(wire)
 

--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -3,7 +3,8 @@ import os
 import sys
 
 from PyQt6.QtCore import QPointF, QRectF, Qt, QTimer
-from PyQt6.QtGui import QBrush, QColor, QPen  # QPainterPath imported locally where needed
+from PyQt6.QtGui import QBrush  # QPainterPath imported locally where needed
+from PyQt6.QtGui import QColor, QPen
 from PyQt6.QtWidgets import QGraphicsItem, QInputDialog, QLineEdit, QMessageBox
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -132,7 +133,9 @@ class ComponentGraphicsItem(QGraphicsItem):
 
         if self.component_type == "Waveform Source":
             QMessageBox.information(
-                None, "Waveform Source", "Use the 'Configure Waveform...' button in the Properties panel."
+                None,
+                "Waveform Source",
+                "Use the 'Configure Waveform...' button in the Properties panel.",
             )
             return
 

--- a/app/GUI/format_utils.py
+++ b/app/GUI/format_utils.py
@@ -141,7 +141,10 @@ def validate_component_value(value: str, component_type: str) -> tuple[bool, str
     try:
         numeric = parse_value(value)
     except (ValueError, TypeError):
-        return False, f"Invalid value '{value}'. Use a number with optional suffix (e.g. 10k, 100n, 4.7M)."
+        return (
+            False,
+            f"Invalid value '{value}'. Use a number with optional suffix (e.g. 10k, 100n, 4.7M).",
+        )
 
     if component_type in _POSITIVE_ONLY_TYPES and numeric <= 0:
         return False, f"{component_type} value must be positive (got {value})."

--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -944,7 +944,8 @@ class MainWindow(QMainWindow):
                 statusBar = self.statusBar()
                 if statusBar:
                     statusBar.showMessage(
-                        f"Analysis: DC Sweep (V: {params['min']}V to {params['max']}V, step {params['step']}V)", 3000
+                        f"Analysis: DC Sweep (V: {params['min']}V to {params['max']}V, step {params['step']}V)",
+                        3000,
                     )
             else:
                 QMessageBox.warning(self, "Invalid Parameters", "Please enter valid numeric values.")
@@ -981,7 +982,8 @@ class MainWindow(QMainWindow):
                 statusBar = self.statusBar()
                 if statusBar:
                     statusBar.showMessage(
-                        f"Analysis: Transient (duration: {params['duration']}s, step: {params['step']}s)", 3000
+                        f"Analysis: Transient (duration: {params['duration']}s, step: {params['step']}s)",
+                        3000,
                     )
             else:
                 QMessageBox.warning(self, "Invalid Parameters", "Please enter valid numeric values.")

--- a/app/GUI/measurement_cursors.py
+++ b/app/GUI/measurement_cursors.py
@@ -124,14 +124,22 @@ class MeasurementCursors:
         if self._line_a is not None:
             self._line_a.remove()
         self._line_a = self._ax.axvline(
-            self._a_x, color=self.CURSOR_A_COLOR, linewidth=1.5, linestyle="--", label="_cursor_a"
+            self._a_x,
+            color=self.CURSOR_A_COLOR,
+            linewidth=1.5,
+            linestyle="--",
+            label="_cursor_a",
         )
 
     def _draw_cursor_b(self):
         if self._line_b is not None:
             self._line_b.remove()
         self._line_b = self._ax.axvline(
-            self._b_x, color=self.CURSOR_B_COLOR, linewidth=1.5, linestyle="--", label="_cursor_b"
+            self._b_x,
+            color=self.CURSOR_B_COLOR,
+            linewidth=1.5,
+            linestyle="--",
+            label="_cursor_b",
         )
 
     def _notify(self):

--- a/app/GUI/measurement_cursors.py
+++ b/app/GUI/measurement_cursors.py
@@ -1,0 +1,276 @@
+"""
+measurement_cursors.py — Reusable measurement cursor system for matplotlib plots.
+
+Provides two draggable vertical cursors (A and B) with snap-to-data,
+a readout panel showing X/Y values and deltas, and real-time updates.
+"""
+
+import numpy as np
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QGroupBox, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+
+
+class MeasurementCursors:
+    """Two draggable vertical cursors on a matplotlib axes.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The axes to attach cursors to.
+    canvas : FigureCanvasQTAgg
+        The canvas (needed for draw/event connection).
+    on_cursor_moved : callable, optional
+        Callback ``(cursor_a_x, cursor_b_x)`` called whenever a cursor moves.
+    """
+
+    CURSOR_A_COLOR = "#e74c3c"  # red
+    CURSOR_B_COLOR = "#2980b9"  # blue
+
+    def __init__(self, ax, canvas, on_cursor_moved=None):
+        self._ax = ax
+        self._canvas = canvas
+        self._on_cursor_moved = on_cursor_moved
+
+        # Data arrays for snap-to (set via set_data)
+        self._x_data = None
+
+        # Cursor positions (None = not placed)
+        self._a_x = None
+        self._b_x = None
+
+        # Cursor line artists
+        self._line_a = None
+        self._line_b = None
+
+        # Drag state
+        self._dragging = None  # "a" or "b" or None
+        self._active_cursor = "a"  # next click places this cursor
+
+        # Connect events
+        self._cid_press = canvas.mpl_connect("button_press_event", self._on_press)
+        self._cid_release = canvas.mpl_connect("button_release_event", self._on_release)
+        self._cid_motion = canvas.mpl_connect("motion_notify_event", self._on_motion)
+
+    def set_data(self, x_data):
+        """Set the X data array for snap-to-nearest behaviour."""
+        if x_data is not None and len(x_data) > 0:
+            self._x_data = np.asarray(x_data, dtype=float)
+        else:
+            self._x_data = None
+
+    def set_active_cursor(self, cursor):
+        """Set which cursor the next click places: 'a' or 'b'."""
+        self._active_cursor = cursor
+
+    def _snap(self, x):
+        """Snap *x* to the nearest value in the data array."""
+        if self._x_data is None or len(self._x_data) == 0:
+            return x
+        idx = int(np.argmin(np.abs(self._x_data - x)))
+        return float(self._x_data[idx])
+
+    # ------ event handlers -----------------------------------------------
+
+    def _on_press(self, event):
+        if event.inaxes != self._ax or event.button != 1:
+            return
+
+        # Check if clicking near an existing cursor to drag it
+        threshold = self._drag_threshold()
+
+        if self._a_x is not None and abs(event.xdata - self._a_x) < threshold:
+            self._dragging = "a"
+            return
+        if self._b_x is not None and abs(event.xdata - self._b_x) < threshold:
+            self._dragging = "b"
+            return
+
+        # Place the active cursor
+        x = self._snap(event.xdata)
+        if self._active_cursor == "a":
+            self._a_x = x
+            self._draw_cursor_a()
+        else:
+            self._b_x = x
+            self._draw_cursor_b()
+
+        self._notify()
+        self._canvas.draw_idle()
+
+    def _on_motion(self, event):
+        if self._dragging is None or event.inaxes != self._ax:
+            return
+        x = self._snap(event.xdata)
+        if self._dragging == "a":
+            self._a_x = x
+            self._draw_cursor_a()
+        else:
+            self._b_x = x
+            self._draw_cursor_b()
+        self._notify()
+        self._canvas.draw_idle()
+
+    def _on_release(self, event):
+        self._dragging = None
+
+    def _drag_threshold(self):
+        """Return a reasonable x-distance threshold for cursor grabbing."""
+        xlim = self._ax.get_xlim()
+        return (xlim[1] - xlim[0]) * 0.02
+
+    # ------ drawing helpers -----------------------------------------------
+
+    def _draw_cursor_a(self):
+        if self._line_a is not None:
+            self._line_a.remove()
+        self._line_a = self._ax.axvline(
+            self._a_x, color=self.CURSOR_A_COLOR, linewidth=1.5, linestyle="--", label="_cursor_a"
+        )
+
+    def _draw_cursor_b(self):
+        if self._line_b is not None:
+            self._line_b.remove()
+        self._line_b = self._ax.axvline(
+            self._b_x, color=self.CURSOR_B_COLOR, linewidth=1.5, linestyle="--", label="_cursor_b"
+        )
+
+    def _notify(self):
+        if self._on_cursor_moved:
+            self._on_cursor_moved(self._a_x, self._b_x)
+
+    # ------ public queries -----------------------------------------------
+
+    @property
+    def cursor_a_x(self):
+        return self._a_x
+
+    @property
+    def cursor_b_x(self):
+        return self._b_x
+
+    def get_y_values_at(self, x):
+        """Return dict of {line_label: y_value} for all visible lines at *x*.
+
+        Uses linear interpolation between the two nearest data points.
+        """
+        if x is None:
+            return {}
+        results = {}
+        for line in self._ax.get_lines():
+            label = line.get_label()
+            if label.startswith("_") or not line.get_visible():
+                continue
+            xd = line.get_xdata()
+            yd = line.get_ydata()
+            if len(xd) < 2:
+                continue
+            y_interp = np.interp(x, xd, yd)
+            results[label] = float(y_interp)
+        return results
+
+    def remove(self):
+        """Disconnect events and remove cursor lines."""
+        self._canvas.mpl_disconnect(self._cid_press)
+        self._canvas.mpl_disconnect(self._cid_release)
+        self._canvas.mpl_disconnect(self._cid_motion)
+        if self._line_a is not None:
+            self._line_a.remove()
+        if self._line_b is not None:
+            self._line_b.remove()
+
+
+class CursorReadoutPanel(QWidget):
+    """Panel displaying cursor position readouts and delta values.
+
+    Call ``update_readout(cursors)`` whenever cursor positions change.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._cursors = None
+
+        group = QGroupBox("Measurement Cursors")
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.addWidget(group)
+
+        layout = QVBoxLayout(group)
+
+        # Cursor selector buttons
+        btn_row = QHBoxLayout()
+        self._btn_a = QPushButton("Place Cursor A")
+        self._btn_a.setStyleSheet(f"color: {MeasurementCursors.CURSOR_A_COLOR};")
+        self._btn_a.setCheckable(True)
+        self._btn_a.setChecked(True)
+        self._btn_b = QPushButton("Place Cursor B")
+        self._btn_b.setStyleSheet(f"color: {MeasurementCursors.CURSOR_B_COLOR};")
+        self._btn_b.setCheckable(True)
+        self._btn_a.clicked.connect(lambda: self._select_cursor("a"))
+        self._btn_b.clicked.connect(lambda: self._select_cursor("b"))
+        btn_row.addWidget(self._btn_a)
+        btn_row.addWidget(self._btn_b)
+        layout.addLayout(btn_row)
+
+        # Readout labels
+        self._label_a = QLabel("Cursor A: —")
+        self._label_a.setStyleSheet(f"color: {MeasurementCursors.CURSOR_A_COLOR};")
+        self._label_b = QLabel("Cursor B: —")
+        self._label_b.setStyleSheet(f"color: {MeasurementCursors.CURSOR_B_COLOR};")
+        self._label_delta = QLabel("Delta: —")
+        self._label_delta.setStyleSheet("font-weight: bold;")
+
+        layout.addWidget(self._label_a)
+        layout.addWidget(self._label_b)
+        layout.addWidget(self._label_delta)
+
+        # Y-value readout area
+        self._y_label = QLabel("")
+        self._y_label.setWordWrap(True)
+        self._y_label.setAlignment(Qt.AlignmentFlag.AlignTop)
+        layout.addWidget(self._y_label)
+
+    def set_cursors(self, cursors):
+        """Attach cursor object so button clicks can switch active cursor."""
+        self._cursors = cursors
+
+    def _select_cursor(self, which):
+        if self._cursors:
+            self._cursors.set_active_cursor(which)
+        self._btn_a.setChecked(which == "a")
+        self._btn_b.setChecked(which == "b")
+
+    def update_readout(self, cursors):
+        """Update the readout panel from cursor positions."""
+        a_x = cursors.cursor_a_x
+        b_x = cursors.cursor_b_x
+
+        # Cursor A text
+        if a_x is not None:
+            y_vals_a = cursors.get_y_values_at(a_x)
+            y_str_a = ", ".join(f"{k}={v:.4g}" for k, v in y_vals_a.items())
+            self._label_a.setText(f"Cursor A: X={a_x:.6g}  |  {y_str_a}")
+        else:
+            self._label_a.setText("Cursor A: —")
+
+        # Cursor B text
+        if b_x is not None:
+            y_vals_b = cursors.get_y_values_at(b_x)
+            y_str_b = ", ".join(f"{k}={v:.4g}" for k, v in y_vals_b.items())
+            self._label_b.setText(f"Cursor B: X={b_x:.6g}  |  {y_str_b}")
+        else:
+            self._label_b.setText("Cursor B: —")
+
+        # Delta text
+        if a_x is not None and b_x is not None:
+            dx = b_x - a_x
+            y_vals_a = cursors.get_y_values_at(a_x)
+            y_vals_b = cursors.get_y_values_at(b_x)
+            dy_parts = []
+            for key in y_vals_a:
+                if key in y_vals_b:
+                    dy = y_vals_b[key] - y_vals_a[key]
+                    dy_parts.append(f"Δ{key}={dy:.4g}")
+            dy_str = ", ".join(dy_parts) if dy_parts else ""
+            self._label_delta.setText(f"ΔX={dx:.6g}  |  {dy_str}")
+        else:
+            self._label_delta.setText("Delta: —")

--- a/app/GUI/path_finding.py
+++ b/app/GUI/path_finding.py
@@ -73,7 +73,13 @@ class WeightedPathfinder(ABC):
 
     @abstractmethod
     def _calculate_edge_cost(
-        self, current, neighbor, direction, bend_count, existing_wires=None, current_net=None
+        self,
+        current,
+        neighbor,
+        direction,
+        bend_count,
+        existing_wires=None,
+        current_net=None,
     ) -> int:
         """
         Calculate the cost of traversing an edge in the grid.
@@ -224,11 +230,27 @@ class IDAStarPathfinder(WeightedPathfinder):
         self.last_runtime = time.time() - start_time
         return waypoints, self.last_runtime, self.last_iterations
 
-    def _calculate_edge_cost(self, current, neighbor, direction, bend_count, existing_wires=None, current_net=None):
+    def _calculate_edge_cost(
+        self,
+        current,
+        neighbor,
+        direction,
+        bend_count,
+        existing_wires=None,
+        current_net=None,
+    ):
         """Calculate edge cost"""
         return 1  # Base cost
 
-    def _find_path_impl(self, start_pos, end_pos, obstacles, bounds, existing_wires=None, current_net=None):
+    def _find_path_impl(
+        self,
+        start_pos,
+        end_pos,
+        obstacles,
+        bounds,
+        existing_wires=None,
+        current_net=None,
+    ):
         """
         IDA* (Iterative Deepening A*) algorithm - memory-efficient A* variant
 
@@ -250,7 +272,18 @@ class IDAStarPathfinder(WeightedPathfinder):
 
         while iterations < max_iterations:
             result = self._idastar_search(
-                start_grid, end_grid, 0, threshold, None, 0, obstacles, min_x, max_x, min_y, max_y, {}
+                start_grid,
+                end_grid,
+                0,
+                threshold,
+                None,
+                0,
+                obstacles,
+                min_x,
+                max_x,
+                min_y,
+                max_y,
+                {},
             )
             iterations += 1
 
@@ -272,7 +305,19 @@ class IDAStarPathfinder(WeightedPathfinder):
         return [start_pos, end_pos]
 
     def _idastar_search(
-        self, current, goal, g_score, threshold, direction, bend_count, obstacles, min_x, max_x, min_y, max_y, visited
+        self,
+        current,
+        goal,
+        g_score,
+        threshold,
+        direction,
+        bend_count,
+        obstacles,
+        min_x,
+        max_x,
+        min_y,
+        max_y,
+        visited,
     ):
         """
         Recursive depth-first search for IDA*
@@ -344,7 +389,12 @@ class IDAStarPathfinder(WeightedPathfinder):
 
 
 def polygon_to_grid_filled(
-    polygon_points, position, rotation_angle, grid_size, inset=0, active_terminal_positions=None
+    polygon_points,
+    position,
+    rotation_angle,
+    grid_size,
+    inset=0,
+    active_terminal_positions=None,
 ):
     """
     Convert a polygon shape to grid cells filling the entire interior.
@@ -474,7 +524,14 @@ def polygon_to_grid_filled(
     return obstacles
 
 
-def polygon_to_grid_frame(polygon_points, position, rotation_angle, grid_size, inset=0, active_terminal_positions=None):
+def polygon_to_grid_frame(
+    polygon_points,
+    position,
+    rotation_angle,
+    grid_size,
+    inset=0,
+    active_terminal_positions=None,
+):
     """
     Convert a polygon shape to grid cells forming a perimeter frame.
     Used for non-connected components to allow wires near them.
@@ -672,7 +729,10 @@ def get_component_obstacles(
         terminal_info = []
         for i in range(len(comp.terminals)):
             term_pos = comp.get_terminal_pos(i)
-            term_grid = (round(term_pos.x() / grid_size), round(term_pos.y() / grid_size))
+            term_grid = (
+                round(term_pos.x() / grid_size),
+                round(term_pos.y() / grid_size),
+            )
             terminal_key = (comp.component_id, i)
             is_active = terminal_key in active_terminals_set
             terminal_info.append({"grid": term_grid, "pos": term_pos, "is_active": is_active})
@@ -733,7 +793,10 @@ def get_component_obstacles(
                 obstacles.discard((term_grid_x, term_grid_y))
                 for direction_dx, direction_dy in [(0, 1), (0, -1), (1, 0), (-1, 0)]:
                     for step in range(1, 4):
-                        clear_pos = (term_grid_x + direction_dx * step, term_grid_y + direction_dy * step)
+                        clear_pos = (
+                            term_grid_x + direction_dx * step,
+                            term_grid_y + direction_dy * step,
+                        )
                         obstacles.discard(clear_pos)
             # Non-active terminals are left as obstacles (already added above)
             # This creates infinite cost for routing through unused terminals

--- a/app/GUI/results_plot_dialog.py
+++ b/app/GUI/results_plot_dialog.py
@@ -5,6 +5,7 @@ Supports overlaying multiple simulation runs on the same plot with:
 - Interactive legend click-to-toggle traces
 - Distinct line styles per dataset
 - Clear All button to reset
+- Interactive measurement cursors for precise signal measurement
 """
 
 import logging
@@ -14,6 +15,8 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from PyQt6.QtWidgets import QDialog, QHBoxLayout, QPushButton, QVBoxLayout
+
+from .measurement_cursors import CursorReadoutPanel, MeasurementCursors
 
 matplotlib.use("QtAgg")
 
@@ -34,30 +37,40 @@ class DCSweepPlotDialog(QDialog):
     def __init__(self, data, parent=None, label=None):
         super().__init__(parent)
         self.setWindowTitle("DC Sweep Results")
-        self.setMinimumSize(800, 500)
+        self.setMinimumSize(900, 500)
 
         self._datasets = []
         self._lines = {}
         self._legend_line_map = {}
 
-        layout = QVBoxLayout(self)
+        main_layout = QHBoxLayout(self)
 
-        # Toolbar
+        # Left: toolbar + plot
+        plot_layout = QVBoxLayout()
+
         toolbar = QHBoxLayout()
         clear_btn = QPushButton("Clear All")
         clear_btn.setToolTip("Remove all overlaid results and clear the plot")
         clear_btn.clicked.connect(self.clear_all)
         toolbar.addStretch()
         toolbar.addWidget(clear_btn)
-        layout.addLayout(toolbar)
+        plot_layout.addLayout(toolbar)
 
         self._fig = Figure(figsize=(8, 5), dpi=100)
         self._canvas = FigureCanvas(self._fig)
-        layout.addWidget(self._canvas)
+        plot_layout.addWidget(self._canvas)
+        main_layout.addLayout(plot_layout, 3)
+
+        # Right: cursor readout
+        self._readout = CursorReadoutPanel()
+        main_layout.addWidget(self._readout, 1)
 
         self._ax = self._fig.add_subplot(111)
 
         self._canvas.mpl_connect("pick_event", self._on_legend_pick)
+
+        # Cursors (initialized after first plot)
+        self._cursors = None
 
         if data:
             self.add_dataset(data, label)
@@ -76,6 +89,7 @@ class DCSweepPlotDialog(QDialog):
         self._legend_line_map.clear()
 
         cmap = plt.get_cmap("tab10")
+        sweep_vals_first = []
 
         for ds_idx, (ds_label, data) in enumerate(self._datasets):
             headers = data.get("headers", [])
@@ -84,6 +98,8 @@ class DCSweepPlotDialog(QDialog):
                 continue
 
             sweep_vals = [row[1] for row in rows]
+            if ds_idx == 0:
+                sweep_vals_first = sweep_vals
             linestyle = _LINE_STYLES[ds_idx % len(_LINE_STYLES)]
             prefix = f"{ds_label} — " if len(self._datasets) > 1 else ""
 
@@ -100,10 +116,19 @@ class DCSweepPlotDialog(QDialog):
                 self._lines[trace_label] = line
 
         if not self._lines:
-            self._ax.text(0.5, 0.5, "No sweep data available", ha="center", va="center", transform=self._ax.transAxes)
+            self._ax.text(
+                0.5,
+                0.5,
+                "No sweep data available",
+                ha="center",
+                va="center",
+                transform=self._ax.transAxes,
+            )
         else:
             first_headers = self._datasets[0][1].get("headers", [])
-            self._ax.set_xlabel(first_headers[1] if len(first_headers) > 1 else "Sweep")
+            self._ax.set_xlabel(
+                first_headers[1] if len(first_headers) > 1 else "Sweep"
+            )
 
         self._ax.set_ylabel("Voltage (V)")
         self._ax.set_title("DC Sweep")
@@ -114,16 +139,32 @@ class DCSweepPlotDialog(QDialog):
             self._setup_legend_toggle(legend)
 
         self._fig.tight_layout()
+
+        # Update cursors
+        if self._cursors is not None:
+            self._cursors.remove()
+        self._cursors = MeasurementCursors(
+            self._ax, self._canvas, on_cursor_moved=self._on_cursor_moved
+        )
+        self._readout.set_cursors(self._cursors)
+        if sweep_vals_first:
+            self._cursors.set_data(sweep_vals_first)
+
         self._canvas.draw()
 
     def _setup_legend_toggle(self, legend):
         """Wire up click-to-toggle on legend entries."""
         self._legend_line_map = {}
-        for legend_line, legend_text in zip(legend.get_lines(), legend.get_texts()):
+        for legend_line, legend_text in zip(
+            legend.get_lines(), legend.get_texts()
+        ):
             legend_line.set_picker(5)
             label = legend_text.get_text()
             if label in self._lines:
-                self._legend_line_map[legend_line] = (self._lines[label], legend_text)
+                self._legend_line_map[legend_line] = (
+                    self._lines[label],
+                    legend_text,
+                )
 
     def _on_legend_pick(self, event):
         legend_line = event.artist
@@ -136,13 +177,23 @@ class DCSweepPlotDialog(QDialog):
         legend_text.set_alpha(1.0 if visible else 0.2)
         self._canvas.draw()
 
+    def _on_cursor_moved(self, a_x, b_x):
+        self._readout.update_readout(self._cursors)
+
     def clear_all(self):
         """Remove all datasets and clear the plot."""
         self._datasets.clear()
         self._lines.clear()
         self._legend_line_map.clear()
         self._ax.clear()
-        self._ax.text(0.5, 0.5, "All results cleared", ha="center", va="center", transform=self._ax.transAxes)
+        self._ax.text(
+            0.5,
+            0.5,
+            "All results cleared",
+            ha="center",
+            va="center",
+            transform=self._ax.transAxes,
+        )
         self._ax.set_title("DC Sweep")
         self._fig.tight_layout()
         self._canvas.draw()
@@ -152,6 +203,8 @@ class DCSweepPlotDialog(QDialog):
         return len(self._datasets)
 
     def closeEvent(self, event):
+        if self._cursors is not None:
+            self._cursors.remove()
         plt.close(self._canvas.figure)
         super().closeEvent(event)
 
@@ -167,31 +220,41 @@ class ACSweepPlotDialog(QDialog):
     def __init__(self, data, parent=None, label=None):
         super().__init__(parent)
         self.setWindowTitle("AC Sweep Results — Bode Plot")
-        self.setMinimumSize(800, 600)
+        self.setMinimumSize(900, 600)
 
         self._datasets = []
         self._lines = {}
         self._legend_line_map = {}
 
-        layout = QVBoxLayout(self)
+        main_layout = QHBoxLayout(self)
 
-        # Toolbar
+        # Left: toolbar + plot
+        plot_layout = QVBoxLayout()
+
         toolbar = QHBoxLayout()
         clear_btn = QPushButton("Clear All")
         clear_btn.setToolTip("Remove all overlaid results and clear the plot")
         clear_btn.clicked.connect(self.clear_all)
         toolbar.addStretch()
         toolbar.addWidget(clear_btn)
-        layout.addLayout(toolbar)
+        plot_layout.addLayout(toolbar)
 
         self._fig = Figure(figsize=(8, 6), dpi=100)
         self._canvas = FigureCanvas(self._fig)
-        layout.addWidget(self._canvas)
+        plot_layout.addWidget(self._canvas)
+        main_layout.addLayout(plot_layout, 3)
+
+        # Right: cursor readout
+        self._readout = CursorReadoutPanel()
+        main_layout.addWidget(self._readout, 1)
 
         self._ax_mag = self._fig.add_subplot(211)
         self._ax_phase = self._fig.add_subplot(212, sharex=self._ax_mag)
 
         self._canvas.mpl_connect("pick_event", self._on_legend_pick)
+
+        # Cursors (initialized after first plot)
+        self._cursors = None
 
         if data:
             self.add_dataset(data, label)
@@ -211,6 +274,7 @@ class ACSweepPlotDialog(QDialog):
         self._legend_line_map.clear()
 
         cmap = plt.get_cmap("tab10")
+        frequencies_first = []
 
         for ds_idx, (ds_label, data) in enumerate(self._datasets):
             frequencies = data.get("frequencies", [])
@@ -220,6 +284,9 @@ class ACSweepPlotDialog(QDialog):
             if not frequencies or (not magnitude and not phase):
                 continue
 
+            if ds_idx == 0:
+                frequencies_first = frequencies
+
             linestyle = _LINE_STYLES[ds_idx % len(_LINE_STYLES)]
             prefix = f"{ds_label} — " if len(self._datasets) > 1 else ""
 
@@ -227,14 +294,22 @@ class ACSweepPlotDialog(QDialog):
                 color = cmap(i % 10)
                 trace_label = f"{prefix}{node}"
                 (line,) = self._ax_mag.semilogx(
-                    frequencies, mag_vals, label=trace_label, color=color, linestyle=linestyle
+                    frequencies,
+                    mag_vals,
+                    label=trace_label,
+                    color=color,
+                    linestyle=linestyle,
                 )
                 self._lines[trace_label] = line
 
                 if node in phase:
                     phase_label = f"{prefix}{node} (phase)"
                     (pline,) = self._ax_phase.semilogx(
-                        frequencies, phase[node], label=trace_label, color=color, linestyle=linestyle
+                        frequencies,
+                        phase[node],
+                        label=trace_label,
+                        color=color,
+                        linestyle=linestyle,
                     )
                     self._lines[phase_label] = pline
 
@@ -243,7 +318,11 @@ class ACSweepPlotDialog(QDialog):
                     color = cmap((len(magnitude) + i) % 10)
                     trace_label = f"{prefix}{node}"
                     (pline,) = self._ax_phase.semilogx(
-                        frequencies, ph_vals, label=trace_label, color=color, linestyle=linestyle
+                        frequencies,
+                        ph_vals,
+                        label=trace_label,
+                        color=color,
+                        linestyle=linestyle,
                     )
                     self._lines[f"{prefix}{node} (phase-only)"] = pline
 
@@ -251,7 +330,12 @@ class ACSweepPlotDialog(QDialog):
 
         if not has_data:
             self._ax_mag.text(
-                0.5, 0.5, "No AC data available", ha="center", va="center", transform=self._ax_mag.transAxes
+                0.5,
+                0.5,
+                "No AC data available",
+                ha="center",
+                va="center",
+                transform=self._ax_mag.transAxes,
             )
 
         self._ax_mag.set_ylabel("Magnitude")
@@ -269,11 +353,24 @@ class ACSweepPlotDialog(QDialog):
             self._setup_legend_toggle(phase_legend, self._ax_phase)
 
         self._fig.tight_layout()
+
+        # Update cursors on magnitude axes (shared x with phase)
+        if self._cursors is not None:
+            self._cursors.remove()
+        self._cursors = MeasurementCursors(
+            self._ax_mag, self._canvas, on_cursor_moved=self._on_cursor_moved
+        )
+        self._readout.set_cursors(self._cursors)
+        if frequencies_first:
+            self._cursors.set_data(frequencies_first)
+
         self._canvas.draw()
 
     def _setup_legend_toggle(self, legend, ax):
         """Wire up click-to-toggle on legend entries for a given axes."""
-        for legend_line, legend_text in zip(legend.get_lines(), legend.get_texts()):
+        for legend_line, legend_text in zip(
+            legend.get_lines(), legend.get_texts()
+        ):
             legend_line.set_picker(5)
             label = legend_text.get_text()
             # Find the matching line on this axes
@@ -293,6 +390,9 @@ class ACSweepPlotDialog(QDialog):
         legend_text.set_alpha(1.0 if visible else 0.2)
         self._canvas.draw()
 
+    def _on_cursor_moved(self, a_x, b_x):
+        self._readout.update_readout(self._cursors)
+
     def clear_all(self):
         """Remove all datasets and clear the plot."""
         self._datasets.clear()
@@ -300,7 +400,14 @@ class ACSweepPlotDialog(QDialog):
         self._legend_line_map.clear()
         self._ax_mag.clear()
         self._ax_phase.clear()
-        self._ax_mag.text(0.5, 0.5, "All results cleared", ha="center", va="center", transform=self._ax_mag.transAxes)
+        self._ax_mag.text(
+            0.5,
+            0.5,
+            "All results cleared",
+            ha="center",
+            va="center",
+            transform=self._ax_mag.transAxes,
+        )
         self._ax_mag.set_title("Bode Plot")
         self._fig.tight_layout()
         self._canvas.draw()
@@ -310,5 +417,7 @@ class ACSweepPlotDialog(QDialog):
         return len(self._datasets)
 
     def closeEvent(self, event):
+        if self._cursors is not None:
+            self._cursors.remove()
         plt.close(self._canvas.figure)
         super().closeEvent(event)

--- a/app/GUI/results_plot_dialog.py
+++ b/app/GUI/results_plot_dialog.py
@@ -126,9 +126,7 @@ class DCSweepPlotDialog(QDialog):
             )
         else:
             first_headers = self._datasets[0][1].get("headers", [])
-            self._ax.set_xlabel(
-                first_headers[1] if len(first_headers) > 1 else "Sweep"
-            )
+            self._ax.set_xlabel(first_headers[1] if len(first_headers) > 1 else "Sweep")
 
         self._ax.set_ylabel("Voltage (V)")
         self._ax.set_title("DC Sweep")
@@ -143,9 +141,7 @@ class DCSweepPlotDialog(QDialog):
         # Update cursors
         if self._cursors is not None:
             self._cursors.remove()
-        self._cursors = MeasurementCursors(
-            self._ax, self._canvas, on_cursor_moved=self._on_cursor_moved
-        )
+        self._cursors = MeasurementCursors(self._ax, self._canvas, on_cursor_moved=self._on_cursor_moved)
         self._readout.set_cursors(self._cursors)
         if sweep_vals_first:
             self._cursors.set_data(sweep_vals_first)
@@ -155,9 +151,7 @@ class DCSweepPlotDialog(QDialog):
     def _setup_legend_toggle(self, legend):
         """Wire up click-to-toggle on legend entries."""
         self._legend_line_map = {}
-        for legend_line, legend_text in zip(
-            legend.get_lines(), legend.get_texts()
-        ):
+        for legend_line, legend_text in zip(legend.get_lines(), legend.get_texts()):
             legend_line.set_picker(5)
             label = legend_text.get_text()
             if label in self._lines:
@@ -357,9 +351,7 @@ class ACSweepPlotDialog(QDialog):
         # Update cursors on magnitude axes (shared x with phase)
         if self._cursors is not None:
             self._cursors.remove()
-        self._cursors = MeasurementCursors(
-            self._ax_mag, self._canvas, on_cursor_moved=self._on_cursor_moved
-        )
+        self._cursors = MeasurementCursors(self._ax_mag, self._canvas, on_cursor_moved=self._on_cursor_moved)
         self._readout.set_cursors(self._cursors)
         if frequencies_first:
             self._cursors.set_data(frequencies_first)
@@ -368,9 +360,7 @@ class ACSweepPlotDialog(QDialog):
 
     def _setup_legend_toggle(self, legend, ax):
         """Wire up click-to-toggle on legend entries for a given axes."""
-        for legend_line, legend_text in zip(
-            legend.get_lines(), legend.get_texts()
-        ):
+        for legend_line, legend_text in zip(legend.get_lines(), legend.get_texts()):
             legend_line.set_picker(5)
             label = legend_text.get_text()
             # Find the matching line on this axes

--- a/app/GUI/waveform_dialog.py
+++ b/app/GUI/waveform_dialog.py
@@ -406,7 +406,11 @@ class WaveformDialog(QDialog):
         self.canvas.axes.clear()
         if not data:
             self.canvas.axes.text(
-                0.5, 0.5, "No data to display.", horizontalalignment="center", verticalalignment="center"
+                0.5,
+                0.5,
+                "No data to display.",
+                horizontalalignment="center",
+                verticalalignment="center",
             )
             self.canvas.draw()
             return
@@ -415,7 +419,11 @@ class WaveformDialog(QDialog):
         time_key = "time"
         if time_key not in headers:
             self.canvas.axes.text(
-                0.5, 0.5, 'No "time" column found in data.', horizontalalignment="center", verticalalignment="center"
+                0.5,
+                0.5,
+                'No "time" column found in data.',
+                horizontalalignment="center",
+                verticalalignment="center",
             )
             self.canvas.draw()
             return
@@ -554,7 +562,11 @@ class WaveformDialog(QDialog):
     def _show_fft_analysis(self):
         """Show FFT analysis dialog for transient results."""
         if not self.full_data or len(self.full_data) < 4:
-            QMessageBox.warning(self, "Insufficient Data", "Need at least 4 data points for FFT analysis.")
+            QMessageBox.warning(
+                self,
+                "Insufficient Data",
+                "Need at least 4 data points for FFT analysis.",
+            )
             return
 
         # Extract time array
@@ -564,7 +576,11 @@ class WaveformDialog(QDialog):
         signal_names = [k for k in self.voltage_keys if self.column_visibility.get(k, True)]
 
         if not signal_names:
-            QMessageBox.warning(self, "No Signals", "No visible signals to analyze. Enable at least one signal.")
+            QMessageBox.warning(
+                self,
+                "No Signals",
+                "No visible signals to analyze. Enable at least one signal.",
+            )
             return
 
         # Show FFT dialog with signal selection

--- a/app/GUI/waveform_dialog.py
+++ b/app/GUI/waveform_dialog.py
@@ -26,6 +26,7 @@ from PyQt6.QtWidgets import (
 from simulation.fft_analysis import analyze_signal_spectrum
 
 from .format_utils import format_value, parse_value
+from .measurement_cursors import CursorReadoutPanel, MeasurementCursors
 from .styles import SCROLL_LOAD_COUNT
 
 matplotlib.use("QtAgg")
@@ -152,6 +153,11 @@ class WaveformDialog(QDialog):
         fft_button.clicked.connect(self._show_fft_analysis)
         right_layout.addWidget(fft_button)
 
+        # Measurement cursors
+        self._cursor_readout = CursorReadoutPanel()
+        right_layout.addWidget(self._cursor_readout)
+        self._cursors = None  # initialized in plot_data when axes are ready
+
         # Data Table
         right_layout.addWidget(QLabel("Simulation Data"))
         self.table = QTableWidget()
@@ -170,6 +176,10 @@ class WaveformDialog(QDialog):
         """Updates overlay trace visibility and refreshes the view."""
         self._overlay_visibility[overlay_key] = is_checked
         self.update_view()
+
+    def _on_cursor_moved(self, a_x, b_x):
+        """Callback when measurement cursors are dragged."""
+        self._cursor_readout.update_readout(self._cursors)
 
     def add_dataset(self, data, label=None):
         """Add an overlay dataset from a previous simulation run.
@@ -517,6 +527,15 @@ class WaveformDialog(QDialog):
         self.canvas.axes.legend(fontsize="small")
         self.canvas.axes.grid(True)
         self.canvas.figure.tight_layout()
+
+        # Set up measurement cursors (re-attach after axes clear)
+        if self._cursors is not None:
+            self._cursors.remove()
+        self._cursors = MeasurementCursors(self.canvas.axes, self.canvas, on_cursor_moved=self._on_cursor_moved)
+        self._cursor_readout.set_cursors(self._cursors)
+        if time_full:
+            self._cursors.set_data(time_full)
+
         self.canvas.draw()
 
     def _export_csv(self):

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -23,7 +23,15 @@ class WireGraphicsItem(QGraphicsPathItem):
     """
 
     def __init__(
-        self, start_comp, start_term, end_comp, end_term, canvas=None, algorithm="astar", layer_color=None, model=None
+        self,
+        start_comp,
+        start_term,
+        end_comp,
+        end_term,
+        canvas=None,
+        algorithm="astar",
+        layer_color=None,
+        model=None,
     ):
         super().__init__()
 
@@ -32,9 +40,11 @@ class WireGraphicsItem(QGraphicsPathItem):
             self.model = model
         else:
             self.model = WireData(
-                start_component_id=start_comp.component_id if hasattr(start_comp, "component_id") else str(start_comp),
+                start_component_id=(
+                    start_comp.component_id if hasattr(start_comp, "component_id") else str(start_comp)
+                ),
                 start_terminal=start_term,
-                end_component_id=end_comp.component_id if hasattr(end_comp, "component_id") else str(end_comp),
+                end_component_id=(end_comp.component_id if hasattr(end_comp, "component_id") else str(end_comp)),
                 end_terminal=end_term,
                 algorithm=algorithm,
             )
@@ -119,7 +129,10 @@ class WireGraphicsItem(QGraphicsPathItem):
         if self.canvas:
             # Don't exclude connected components entirely, but only clear their terminal areas
             # This prevents wires from crossing through component bodies
-            terminal_clearance = {self.start_comp.component_id, self.end_comp.component_id}
+            terminal_clearance = {
+                self.start_comp.component_id,
+                self.end_comp.component_id,
+            }
 
             # Specify the exact terminals this wire is using - these MUST be cleared for pathfinding
             active_terminals = [
@@ -208,7 +221,10 @@ class WireGraphicsItem(QGraphicsPathItem):
 
     def get_terminals(self):
         """Get both terminal identifiers for this wire"""
-        return [(self.start_comp.component_id, self.start_term), (self.end_comp.component_id, self.end_term)]
+        return [
+            (self.start_comp.component_id, self.start_term),
+            (self.end_comp.component_id, self.end_term),
+        ]
 
     def to_dict(self):
         """Serialize wire to dictionary via the model"""

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -62,7 +62,12 @@ class FileController:
     the current file path for quick-save and session restore.
     """
 
-    def __init__(self, model: Optional[CircuitModel] = None, circuit_ctrl=None, session_file: str = SESSION_FILE):
+    def __init__(
+        self,
+        model: Optional[CircuitModel] = None,
+        circuit_ctrl=None,
+        session_file: str = SESSION_FILE,
+    ):
         self.model = model or CircuitModel()
         self.circuit_ctrl = circuit_ctrl  # Phase 5: For observer notifications
         self.current_file: Optional[Path] = None

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -173,7 +173,12 @@ class SimulationController:
         return result
 
     def _parse_results(
-        self, output_file: str, wrdata_filepath: str, netlist: str, raw_output: str, warnings: list[str]
+        self,
+        output_file: str,
+        wrdata_filepath: str,
+        netlist: str,
+        raw_output: str,
+        warnings: list[str],
     ) -> SimulationResult:
         """Parse simulation results based on analysis type."""
         from simulation import ResultParser

--- a/app/models/component.py
+++ b/app/models/component.py
@@ -220,9 +220,31 @@ class ComponentData:
     def _default_waveform_params() -> dict:
         """Return default waveform parameters for all waveform types."""
         return {
-            "SIN": {"offset": "0", "amplitude": "5", "frequency": "1k", "delay": "0", "theta": "0", "phase": "0"},
-            "PULSE": {"v1": "0", "v2": "5", "td": "0", "tr": "1n", "tf": "1n", "pw": "500u", "per": "1m"},
-            "EXP": {"v1": "0", "v2": "5", "td1": "0", "tau1": "1u", "td2": "2u", "tau2": "2u"},
+            "SIN": {
+                "offset": "0",
+                "amplitude": "5",
+                "frequency": "1k",
+                "delay": "0",
+                "theta": "0",
+                "phase": "0",
+            },
+            "PULSE": {
+                "v1": "0",
+                "v2": "5",
+                "td": "0",
+                "tr": "1n",
+                "tf": "1n",
+                "pw": "500u",
+                "per": "1m",
+            },
+            "EXP": {
+                "v1": "0",
+                "v2": "5",
+                "td1": "0",
+                "tau1": "1u",
+                "td2": "2u",
+                "tau2": "2u",
+            },
         }
 
     def get_terminal_count(self) -> int:

--- a/app/models/wire.py
+++ b/app/models/wire.py
@@ -34,7 +34,10 @@ class WireData:
         Returns:
             List of two (component_id, terminal_index) tuples.
         """
-        return [(self.start_component_id, self.start_terminal), (self.end_component_id, self.end_terminal)]
+        return [
+            (self.start_component_id, self.start_terminal),
+            (self.end_component_id, self.end_terminal),
+        ]
 
     def connects_component(self, component_id: str) -> bool:
         """Check if this wire connects to the given component."""

--- a/app/simulation/__init__.py
+++ b/app/simulation/__init__.py
@@ -4,4 +4,10 @@ from .netlist_generator import NetlistGenerator
 from .ngspice_runner import NgspiceRunner
 from .result_parser import ResultParser
 
-__all__ = ["validate_circuit", "NetlistGenerator", "NgspiceRunner", "ResultParser", "csv_exporter"]
+__all__ = [
+    "validate_circuit",
+    "NetlistGenerator",
+    "NgspiceRunner",
+    "ResultParser",
+    "csv_exporter",
+]

--- a/app/simulation/fft_analysis.py
+++ b/app/simulation/fft_analysis.py
@@ -185,7 +185,10 @@ def compute_thd(fft_result: FFTResult, fundamental_freq: float, num_harmonics: i
 
 
 def analyze_signal_spectrum(
-    time: np.ndarray, signal: np.ndarray, signal_name: str = "Signal", window: str = "hanning"
+    time: np.ndarray,
+    signal: np.ndarray,
+    signal_name: str = "Signal",
+    window: str = "hanning",
 ) -> FFTResult:
     """
     Complete spectral analysis including FFT, fundamental detection, and THD.

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -334,7 +334,11 @@ class NetlistGenerator:
                     resistor_voltages_let.append(f"let {alias} = {let_expression}")
                     resistor_voltages_print.append(alias)
             except (KeyError, TypeError, AttributeError) as e:
-                logger.warning("Could not create voltage calculation for %s: %s", res.component_id, e)
+                logger.warning(
+                    "Could not create voltage calculation for %s: %s",
+                    res.component_id,
+                    e,
+                )
 
         if resistor_voltages_let:
             lines.extend(resistor_voltages_let)

--- a/app/simulation/ngspice_runner.py
+++ b/app/simulation/ngspice_runner.py
@@ -98,10 +98,20 @@ class NgspiceRunner:
             if os.path.exists(output_filename):
                 return True, output_filename, result.stdout, result.stderr
             else:
-                return False, None, result.stdout, result.stderr or "Output file not created"
+                return (
+                    False,
+                    None,
+                    result.stdout,
+                    result.stderr or "Output file not created",
+                )
 
         except subprocess.TimeoutExpired:
-            return False, None, "", f"Simulation timed out (>{SIMULATION_TIMEOUT} seconds)"
+            return (
+                False,
+                None,
+                "",
+                f"Simulation timed out (>{SIMULATION_TIMEOUT} seconds)",
+            )
         except (OSError, subprocess.SubprocessError) as e:
             return False, None, "", f"Simulation error: {str(e)}"
 

--- a/app/tests/unit/test_canvas_sync.py
+++ b/app/tests/unit/test_canvas_sync.py
@@ -35,7 +35,12 @@ class TestCanvasSyncMethods:
         comp = Mock()
         comp.component_id = "R1"
         comp.pos = Mock(return_value=Mock(x=Mock(return_value=100), y=Mock(return_value=200)))
-        comp.model = ComponentData(component_id="R1", component_type="Resistor", value="1k", position=(100, 200))
+        comp.model = ComponentData(
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(100, 200),
+        )
         return comp
 
     @pytest.fixture
@@ -173,7 +178,13 @@ class TestCanvasSyncMethods:
 
     def test_sync_preserves_component_properties(self):
         """Test that sync preserves all component properties"""
-        comp = ComponentData(component_id="R1", component_type="Resistor", value="1k", position=(100, 200), rotation=90)
+        comp = ComponentData(
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(100, 200),
+            rotation=90,
+        )
 
         # Convert to dict and verify all properties preserved
         comp_dict = comp.to_dict()

--- a/app/tests/unit/test_circuit_file_validation.py
+++ b/app/tests/unit/test_circuit_file_validation.py
@@ -10,8 +10,18 @@ def _valid_data():
     """Return minimal valid circuit data dict."""
     return {
         "components": [
-            {"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0.0, "y": 0.0}},
-            {"id": "GND1", "type": "Ground", "value": "0V", "pos": {"x": 100.0, "y": 100.0}},
+            {
+                "id": "R1",
+                "type": "Resistor",
+                "value": "1k",
+                "pos": {"x": 0.0, "y": 0.0},
+            },
+            {
+                "id": "GND1",
+                "type": "Ground",
+                "value": "0V",
+                "pos": {"x": 100.0, "y": 100.0},
+            },
         ],
         "wires": [
             {"start_comp": "R1", "start_term": 0, "end_comp": "GND1", "end_term": 0},

--- a/app/tests/unit/test_circuit_model.py
+++ b/app/tests/unit/test_circuit_model.py
@@ -194,8 +194,20 @@ class TestSerialization:
     def test_from_dict_restores_state(self):
         data = {
             "components": [
-                {"type": "Resistor", "id": "R1", "value": "1k", "pos": {"x": 100.0, "y": 200.0}, "rotation": 0},
-                {"type": "VoltageSource", "id": "V1", "value": "5V", "pos": {"x": 50.0, "y": 50.0}, "rotation": 0},
+                {
+                    "type": "Resistor",
+                    "id": "R1",
+                    "value": "1k",
+                    "pos": {"x": 100.0, "y": 200.0},
+                    "rotation": 0,
+                },
+                {
+                    "type": "VoltageSource",
+                    "id": "V1",
+                    "value": "5V",
+                    "pos": {"x": 50.0, "y": 50.0},
+                    "rotation": 0,
+                },
             ],
             "wires": [
                 {"start_comp": "R1", "start_term": 1, "end_comp": "V1", "end_term": 0},

--- a/app/tests/unit/test_csv_exporter.py
+++ b/app/tests/unit/test_csv_exporter.py
@@ -57,7 +57,10 @@ class TestExportOpResults:
 
 class TestExportDcSweepResults:
     def test_basic_export(self):
-        data = {"headers": ["Index", "v-sweep", "v(1)"], "data": [[0, 0.0, 0.0], [1, 1.0, 0.5], [2, 2.0, 1.0]]}
+        data = {
+            "headers": ["Index", "v-sweep", "v(1)"],
+            "data": [[0, 0.0, 0.0], [1, 1.0, 0.5], [2, 2.0, 1.0]],
+        }
         result = export_dc_sweep_results(data)
         assert "DC Sweep" in result
         assert "v-sweep" in result
@@ -79,19 +82,31 @@ class TestExportDcSweepResults:
 
 class TestExportAcResults:
     def test_basic_export(self):
-        data = {"frequencies": [100.0, 1000.0], "magnitude": {"1": [0.5, 0.3]}, "phase": {"1": [-45.0, -90.0]}}
+        data = {
+            "frequencies": [100.0, 1000.0],
+            "magnitude": {"1": [0.5, 0.3]},
+            "phase": {"1": [-45.0, -90.0]},
+        }
         result = export_ac_results(data)
         assert "AC Sweep" in result
         assert "Frequency" in result
 
     def test_magnitude_and_phase_columns(self):
-        data = {"frequencies": [100.0], "magnitude": {"out": [0.5]}, "phase": {"out": [-45.0]}}
+        data = {
+            "frequencies": [100.0],
+            "magnitude": {"out": [0.5]},
+            "phase": {"out": [-45.0]},
+        }
         result = export_ac_results(data)
         assert "|V(out)|" in result
         assert "phase(V(out))" in result
 
     def test_multiple_nodes(self):
-        data = {"frequencies": [100.0], "magnitude": {"1": [0.5], "2": [0.3]}, "phase": {"1": [-45.0], "2": [-90.0]}}
+        data = {
+            "frequencies": [100.0],
+            "magnitude": {"1": [0.5], "2": [0.3]},
+            "phase": {"1": [-45.0], "2": [-90.0]},
+        }
         result = export_ac_results(data)
         assert "|V(1)|" in result
         assert "|V(2)|" in result

--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -33,9 +33,24 @@ def _build_simple_circuit():
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.component_counter = {"V": 1, "R": 1, "GND": 1}
     model.rebuild_nodes()
@@ -250,7 +265,10 @@ class TestHasFile:
 
 class TestValidateCircuitData:
     def test_valid_data_passes(self):
-        data = {"components": [{"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}}], "wires": []}
+        data = {
+            "components": [{"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}}],
+            "wires": [],
+        }
         validate_circuit_data(data)  # Should not raise
 
     def test_not_a_dict_raises(self):
@@ -260,7 +278,14 @@ class TestValidateCircuitData:
     def test_wire_references_unknown_component(self):
         data = {
             "components": [{"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}}],
-            "wires": [{"start_comp": "R1", "start_term": 0, "end_comp": "UNKNOWN", "end_term": 0}],
+            "wires": [
+                {
+                    "start_comp": "R1",
+                    "start_term": 0,
+                    "end_comp": "UNKNOWN",
+                    "end_term": 0,
+                }
+            ],
         }
         with pytest.raises(ValueError, match="unknown component"):
             validate_circuit_data(data)

--- a/app/tests/unit/test_main_window_mvc.py
+++ b/app/tests/unit/test_main_window_mvc.py
@@ -422,7 +422,9 @@ class TestMainWindowIntegrationPoints:
 
         # Simulation returns result object
         result = SimulationResult(
-            success=True, analysis_type="DC Operating Point", raw_output="v(node1) = 5.0\nv(node2) = 3.3"
+            success=True,
+            analysis_type="DC Operating Point",
+            raw_output="v(node1) = 5.0\nv(node2) = 3.3",
         )
 
         # MainWindow formats for display

--- a/app/tests/unit/test_measurement_cursors.py
+++ b/app/tests/unit/test_measurement_cursors.py
@@ -1,0 +1,226 @@
+"""
+Unit tests for measurement_cursors.py — MeasurementCursors and CursorReadoutPanel.
+"""
+
+import numpy as np
+import pytest
+from GUI.measurement_cursors import CursorReadoutPanel, MeasurementCursors
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_axes_with_data():
+    """Create a Figure/Canvas/Axes with sample data plotted."""
+    fig = Figure(figsize=(4, 3))
+    canvas = FigureCanvasAgg(fig)
+    ax = fig.add_subplot(111)
+    x = np.linspace(0, 10, 100)
+    y = np.sin(x)
+    ax.plot(x, y, label="sin")
+    return fig, canvas, ax, x
+
+
+# ---------------------------------------------------------------------------
+# MeasurementCursors unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestMeasurementCursors:
+    def test_initial_state(self):
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        assert mc.cursor_a_x is None
+        assert mc.cursor_b_x is None
+
+    def test_set_data(self):
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        mc.set_data(x)
+        assert mc._x_data is not None
+        assert len(mc._x_data) == 100
+
+    def test_snap_to_nearest(self):
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        mc.set_data(x)
+        # Should snap to nearest value in x
+        snapped = mc._snap(5.01)
+        assert abs(snapped - 5.0) < 0.2  # within one step
+
+    def test_snap_without_data(self):
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        # Without data, snap returns the input
+        assert mc._snap(5.0) == 5.0
+
+    def test_set_active_cursor(self):
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        mc.set_active_cursor("b")
+        assert mc._active_cursor == "b"
+        mc.set_active_cursor("a")
+        assert mc._active_cursor == "a"
+
+    def test_get_y_values_at_returns_interpolated(self):
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        y_vals = mc.get_y_values_at(0.0)
+        assert "sin" in y_vals
+        assert abs(y_vals["sin"] - np.sin(0.0)) < 0.01
+
+    def test_get_y_values_at_none(self):
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        assert mc.get_y_values_at(None) == {}
+
+    def test_remove_does_not_crash(self):
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        mc.remove()  # should not raise
+
+    def test_callback_called(self):
+        fig, canvas, ax, x = _make_axes_with_data()
+        calls = []
+        mc = MeasurementCursors(ax, canvas, on_cursor_moved=lambda a, b: calls.append((a, b)))
+        mc._notify()
+        assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# CursorReadoutPanel widget tests
+# ---------------------------------------------------------------------------
+
+
+class TestCursorReadoutPanel:
+    def test_creates_without_crash(self, qtbot):
+        panel = CursorReadoutPanel()
+        qtbot.addWidget(panel)
+        assert panel._label_a.text() == "Cursor A: —"
+        assert panel._label_b.text() == "Cursor B: —"
+
+    def test_set_cursors(self, qtbot):
+        panel = CursorReadoutPanel()
+        qtbot.addWidget(panel)
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        panel.set_cursors(mc)
+        assert panel._cursors is mc
+
+    def test_update_readout_no_cursors_placed(self, qtbot):
+        panel = CursorReadoutPanel()
+        qtbot.addWidget(panel)
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        panel.update_readout(mc)
+        assert "—" in panel._label_a.text()
+
+    def test_select_cursor_a(self, qtbot):
+        panel = CursorReadoutPanel()
+        qtbot.addWidget(panel)
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        panel.set_cursors(mc)
+        panel._select_cursor("a")
+        assert mc._active_cursor == "a"
+        assert panel._btn_a.isChecked()
+        assert not panel._btn_b.isChecked()
+
+    def test_select_cursor_b(self, qtbot):
+        panel = CursorReadoutPanel()
+        qtbot.addWidget(panel)
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        panel.set_cursors(mc)
+        panel._select_cursor("b")
+        assert mc._active_cursor == "b"
+        assert not panel._btn_a.isChecked()
+        assert panel._btn_b.isChecked()
+
+
+# ---------------------------------------------------------------------------
+# Integration with plot dialogs
+# ---------------------------------------------------------------------------
+
+
+class TestDCSweepCursorIntegration:
+    def test_dc_sweep_has_cursors(self, qtbot):
+        from GUI.results_plot_dialog import DCSweepPlotDialog
+
+        data = {
+            "headers": ["Index", "v-sweep", "v(out)"],
+            "data": [[0, 0.0, 0.0], [1, 1.0, 0.5], [2, 2.0, 1.0]],
+        }
+        dlg = DCSweepPlotDialog(data)
+        qtbot.addWidget(dlg)
+        assert hasattr(dlg, "_cursors")
+        assert dlg._cursors is not None
+        assert hasattr(dlg, "_readout")
+
+    def test_dc_sweep_cursor_data_set(self, qtbot):
+        from GUI.results_plot_dialog import DCSweepPlotDialog
+
+        data = {
+            "headers": ["Index", "v-sweep", "v(out)"],
+            "data": [[0, 0.0, 0.0], [1, 1.0, 0.5], [2, 2.0, 1.0]],
+        }
+        dlg = DCSweepPlotDialog(data)
+        qtbot.addWidget(dlg)
+        assert dlg._cursors._x_data is not None
+
+
+class TestACSweepCursorIntegration:
+    def test_ac_sweep_has_cursors(self, qtbot):
+        from GUI.results_plot_dialog import ACSweepPlotDialog
+
+        data = {
+            "frequencies": [100, 1000, 10000],
+            "magnitude": {"out": [1.0, 0.7, 0.3]},
+            "phase": {"out": [-10.0, -45.0, -80.0]},
+        }
+        dlg = ACSweepPlotDialog(data)
+        qtbot.addWidget(dlg)
+        assert hasattr(dlg, "_cursors")
+        assert dlg._cursors is not None
+
+    def test_ac_sweep_cursor_data_set(self, qtbot):
+        from GUI.results_plot_dialog import ACSweepPlotDialog
+
+        data = {
+            "frequencies": [100, 1000, 10000],
+            "magnitude": {"out": [1.0, 0.7, 0.3]},
+            "phase": {"out": [-10.0, -45.0, -80.0]},
+        }
+        dlg = ACSweepPlotDialog(data)
+        qtbot.addWidget(dlg)
+        assert dlg._cursors._x_data is not None
+
+
+class TestWaveformCursorIntegration:
+    def test_waveform_has_cursors(self, qtbot):
+        from GUI.waveform_dialog import WaveformDialog
+
+        data = [
+            {"time": 0.0, "v(out)": 0.0},
+            {"time": 1e-6, "v(out)": 0.5},
+            {"time": 2e-6, "v(out)": 1.0},
+        ]
+        dlg = WaveformDialog(data)
+        qtbot.addWidget(dlg)
+        assert hasattr(dlg, "_cursors")
+        assert dlg._cursors is not None
+
+    def test_waveform_cursor_data_set(self, qtbot):
+        from GUI.waveform_dialog import WaveformDialog
+
+        data = [
+            {"time": 0.0, "v(out)": 0.0},
+            {"time": 1e-6, "v(out)": 0.5},
+            {"time": 2e-6, "v(out)": 1.0},
+        ]
+        dlg = WaveformDialog(data)
+        qtbot.addWidget(dlg)
+        assert dlg._cursors._x_data is not None

--- a/app/tests/unit/test_netlist_generator.py
+++ b/app/tests/unit/test_netlist_generator.py
@@ -9,7 +9,14 @@ from models.wire import WireData
 from simulation.netlist_generator import NetlistGenerator
 
 
-def _generate(components, wires, nodes, terminal_to_node, analysis_type="DC Operating Point", analysis_params=None):
+def _generate(
+    components,
+    wires,
+    nodes,
+    terminal_to_node,
+    analysis_type="DC Operating Point",
+    analysis_params=None,
+):
     """Helper to generate a netlist string from circuit data."""
     gen = NetlistGenerator(
         components=components,

--- a/app/tests/unit/test_new_components.py
+++ b/app/tests/unit/test_new_components.py
@@ -28,7 +28,14 @@ from tests.conftest import make_component, make_wire
 # ---------------------------------------------------------------------------
 
 
-def _generate(components, wires, nodes, terminal_to_node, analysis_type="DC Operating Point", analysis_params=None):
+def _generate(
+    components,
+    wires,
+    nodes,
+    terminal_to_node,
+    analysis_type="DC Operating Point",
+    analysis_params=None,
+):
     """Generate a netlist string from circuit data."""
     gen = NetlistGenerator(
         components=components,
@@ -607,32 +614,64 @@ class TestCircuitModelIntegration:
 
     def test_add_bjt_to_model(self):
         model = CircuitModel()
-        bjt = ComponentData(component_id="Q1", component_type="BJT NPN", value="2N3904", position=(0.0, 0.0))
+        bjt = ComponentData(
+            component_id="Q1",
+            component_type="BJT NPN",
+            value="2N3904",
+            position=(0.0, 0.0),
+        )
         model.add_component(bjt)
         assert "Q1" in model.components
         assert model.components["Q1"].component_type == "BJT NPN"
 
     def test_add_mosfet_to_model(self):
         model = CircuitModel()
-        mos = ComponentData(component_id="M1", component_type="MOSFET NMOS", value="NMOS1", position=(0.0, 0.0))
+        mos = ComponentData(
+            component_id="M1",
+            component_type="MOSFET NMOS",
+            value="NMOS1",
+            position=(0.0, 0.0),
+        )
         model.add_component(mos)
         assert "M1" in model.components
 
     def test_add_diode_to_model(self):
         model = CircuitModel()
-        diode = ComponentData(component_id="D1", component_type="Diode", value="IS=1e-14 N=1", position=(0.0, 0.0))
+        diode = ComponentData(
+            component_id="D1",
+            component_type="Diode",
+            value="IS=1e-14 N=1",
+            position=(0.0, 0.0),
+        )
         model.add_component(diode)
         assert "D1" in model.components
 
     def test_wire_bjt_creates_node(self):
         model = CircuitModel()
         model.add_component(
-            ComponentData(component_id="Q1", component_type="BJT NPN", value="2N3904", position=(0.0, 0.0))
+            ComponentData(
+                component_id="Q1",
+                component_type="BJT NPN",
+                value="2N3904",
+                position=(0.0, 0.0),
+            )
         )
         model.add_component(
-            ComponentData(component_id="R1", component_type="Resistor", value="1k", position=(100.0, 0.0))
+            ComponentData(
+                component_id="R1",
+                component_type="Resistor",
+                value="1k",
+                position=(100.0, 0.0),
+            )
         )
-        model.add_wire(WireData(start_component_id="Q1", start_terminal=0, end_component_id="R1", end_terminal=0))
+        model.add_wire(
+            WireData(
+                start_component_id="Q1",
+                start_terminal=0,
+                end_component_id="R1",
+                end_terminal=0,
+            )
+        )
         assert len(model.nodes) == 1
         assert ("Q1", 0) in model.nodes[0].terminals
         assert ("R1", 0) in model.nodes[0].terminals
@@ -641,12 +680,29 @@ class TestCircuitModelIntegration:
         """Save and load a circuit containing a BJT."""
         model = CircuitModel()
         model.add_component(
-            ComponentData(component_id="Q1", component_type="BJT NPN", value="2N3904", position=(100.0, 200.0))
+            ComponentData(
+                component_id="Q1",
+                component_type="BJT NPN",
+                value="2N3904",
+                position=(100.0, 200.0),
+            )
         )
         model.add_component(
-            ComponentData(component_id="GND1", component_type="Ground", value="0V", position=(0.0, 0.0))
+            ComponentData(
+                component_id="GND1",
+                component_type="Ground",
+                value="0V",
+                position=(0.0, 0.0),
+            )
         )
-        model.add_wire(WireData(start_component_id="Q1", start_terminal=2, end_component_id="GND1", end_terminal=0))
+        model.add_wire(
+            WireData(
+                start_component_id="Q1",
+                start_terminal=2,
+                end_component_id="GND1",
+                end_terminal=0,
+            )
+        )
         model.component_counter = {"Q": 1, "GND": 1}
 
         data = model.to_dict()
@@ -663,18 +719,52 @@ class TestCircuitModelIntegration:
         model = CircuitModel()
         model.add_component(
             ComponentData(
-                component_id="D1", component_type="Zener Diode", value="IS=1e-14 N=1 BV=5.1", position=(50.0, 50.0)
+                component_id="D1",
+                component_type="Zener Diode",
+                value="IS=1e-14 N=1 BV=5.1",
+                position=(50.0, 50.0),
             )
         )
         model.add_component(
-            ComponentData(component_id="V1", component_type="Voltage Source", value="10V", position=(0.0, 0.0))
+            ComponentData(
+                component_id="V1",
+                component_type="Voltage Source",
+                value="10V",
+                position=(0.0, 0.0),
+            )
         )
         model.add_component(
-            ComponentData(component_id="GND1", component_type="Ground", value="0V", position=(100.0, 100.0))
+            ComponentData(
+                component_id="GND1",
+                component_type="Ground",
+                value="0V",
+                position=(100.0, 100.0),
+            )
         )
-        model.add_wire(WireData(start_component_id="V1", start_terminal=0, end_component_id="D1", end_terminal=0))
-        model.add_wire(WireData(start_component_id="D1", start_terminal=1, end_component_id="GND1", end_terminal=0))
-        model.add_wire(WireData(start_component_id="V1", start_terminal=1, end_component_id="GND1", end_terminal=0))
+        model.add_wire(
+            WireData(
+                start_component_id="V1",
+                start_terminal=0,
+                end_component_id="D1",
+                end_terminal=0,
+            )
+        )
+        model.add_wire(
+            WireData(
+                start_component_id="D1",
+                start_terminal=1,
+                end_component_id="GND1",
+                end_terminal=0,
+            )
+        )
+        model.add_wire(
+            WireData(
+                start_component_id="V1",
+                start_terminal=1,
+                end_component_id="GND1",
+                end_terminal=0,
+            )
+        )
         model.component_counter = {"D": 1, "V": 1, "GND": 1}
 
         data = model.to_dict()
@@ -728,10 +818,18 @@ class TestTerminalGeometry:
     def test_bjt_rotation_transforms_terminals(self):
         """Rotating a BJT should transform terminal positions."""
         comp_0 = ComponentData(
-            component_id="Q1", component_type="BJT NPN", value="2N3904", position=(0.0, 0.0), rotation=0
+            component_id="Q1",
+            component_type="BJT NPN",
+            value="2N3904",
+            position=(0.0, 0.0),
+            rotation=0,
         )
         comp_90 = ComponentData(
-            component_id="Q1", component_type="BJT NPN", value="2N3904", position=(0.0, 0.0), rotation=90
+            component_id="Q1",
+            component_type="BJT NPN",
+            value="2N3904",
+            position=(0.0, 0.0),
+            rotation=90,
         )
         pos_0 = comp_0.get_terminal_positions()
         pos_90 = comp_90.get_terminal_positions()

--- a/app/tests/unit/test_path_finding.py
+++ b/app/tests/unit/test_path_finding.py
@@ -53,7 +53,10 @@ class TestGridConversion:
 
     def test_round_trip(self, pathfinder):
         for gx, gy in [(0, 0), (5, -3), (-10, 7)]:
-            assert pathfinder._pos_to_grid(pathfinder._grid_to_pos((gx, gy))) == (gx, gy)
+            assert pathfinder._pos_to_grid(pathfinder._grid_to_pos((gx, gy))) == (
+                gx,
+                gy,
+            )
 
     def test_pos_to_grid_rounds(self, pathfinder):
         """Positions that aren't exactly on grid should round to nearest cell."""

--- a/app/tests/unit/test_simulation_controller.py
+++ b/app/tests/unit/test_simulation_controller.py
@@ -31,9 +31,24 @@ def _build_simple_circuit():
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.analysis_type = "DC Operating Point"
     model.rebuild_nodes()
@@ -84,7 +99,12 @@ class TestValidation:
             position=(100.0, 0.0),
         )
         model.wires = [
-            WireData(start_component_id="R1", start_terminal=1, end_component_id="V1", end_terminal=0),
+            WireData(
+                start_component_id="R1",
+                start_terminal=1,
+                end_component_id="V1",
+                end_terminal=0,
+            ),
         ]
         model.analysis_type = "DC Operating Point"
         model.rebuild_nodes()


### PR DESCRIPTION
## Summary
- Adds interactive measurement cursors (Cursor A and Cursor B) to all plot dialogs: DC Sweep, AC Sweep, and Transient waveform viewer
- Cursors snap to nearest data points for accuracy
- Readout panel shows X/Y values at each cursor position with delta (ΔX, ΔY) between cursors
- Reusable `MeasurementCursors` and `CursorReadoutPanel` classes in new `measurement_cursors.py` module

## Changes
- **`app/GUI/measurement_cursors.py`** — New module with `MeasurementCursors` (draggable vertical lines with snap-to-data) and `CursorReadoutPanel` (QWidget with cursor selector buttons and value readouts)
- **`app/GUI/results_plot_dialog.py`** — Both `DCSweepPlotDialog` and `ACSweepPlotDialog` now include cursor support with readout panel on the right side
- **`app/GUI/waveform_dialog.py`** — Transient `WaveformDialog` now includes cursor readout panel and re-initializes cursors on each plot update
- **`app/tests/unit/test_measurement_cursors.py`** — 20 new tests covering cursor logic, readout panel, and integration with all 3 dialog types

## Test plan
- [x] All 612 tests pass
- [x] Ruff linting passes
- [ ] Manual test: click on DC Sweep plot to place Cursor A, see readout update
- [ ] Manual test: switch to Cursor B, place it, verify ΔX/ΔY shown
- [ ] Manual test: drag a cursor to see real-time readout updates
- [ ] Manual test: verify cursors work on AC Sweep and Transient plots

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)