### PR TITLE
Add auto-save and crash recovery

### DIFF
--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -9,7 +9,7 @@ from controllers.circuit_controller import CircuitController
 from controllers.file_controller import FileController
 from controllers.simulation_controller import SimulationController
 from models.circuit import CircuitModel
-from PyQt6.QtCore import QSettings, Qt
+from PyQt6.QtCore import QSettings, QTimer, Qt
 from PyQt6.QtGui import QAction, QActionGroup, QKeySequence
 from PyQt6.QtWidgets import (
     QDialog,
@@ -72,7 +72,13 @@ class MainWindow(QMainWindow):
 
         # Restore state
         self._restore_settings()
+        self._check_auto_save_recovery()
         self._load_last_session()
+
+        # Auto-save timer
+        self._autosave_timer = QTimer(self)
+        self._autosave_timer.timeout.connect(self._auto_save)
+        self._start_autosave_timer()
 
     def _connect_signals(self):
         """Connect signals between UI components"""
@@ -496,6 +502,7 @@ class MainWindow(QMainWindow):
             try:
                 # Phase 5: No sync needed - model always up to date
                 self.file_ctrl.save_circuit(self.file_ctrl.current_file)
+                self.file_ctrl.clear_auto_save()
                 statusBar = self.statusBar()
                 if statusBar:
                     statusBar.showMessage(f"Saved to {self.file_ctrl.current_file}", 3000)
@@ -511,6 +518,7 @@ class MainWindow(QMainWindow):
             try:
                 # Phase 5: No sync needed - model always up to date
                 self.file_ctrl.save_circuit(filename)
+                self.file_ctrl.clear_auto_save()
                 self.setWindowTitle(f"Circuit Design GUI - {filename}")
                 QMessageBox.information(self, "Success", "Circuit saved successfully!")
             except (OSError, TypeError) as e:
@@ -1104,6 +1112,11 @@ class MainWindow(QMainWindow):
         settings.setValue("view/show_labels", self.canvas.show_component_labels)
         settings.setValue("view/show_values", self.canvas.show_component_values)
         settings.setValue("view/show_nodes", self.canvas.show_node_labels)
+        # Preserve auto-save defaults if not yet set
+        if settings.value("autosave/interval") is None:
+            settings.setValue("autosave/interval", 60)
+        if settings.value("autosave/enabled") is None:
+            settings.setValue("autosave/enabled", True)
 
     def _restore_settings(self):
         """Restore user preferences from QSettings"""
@@ -1155,4 +1168,47 @@ class MainWindow(QMainWindow):
     def closeEvent(self, event):
         """Save settings before closing"""
         self._save_settings()
+        self.file_ctrl.clear_auto_save()
         super().closeEvent(event)
+
+    # Auto-save and crash recovery
+
+    def _start_autosave_timer(self):
+        """Start or restart the auto-save timer using the configured interval."""
+        settings = QSettings("SDSMT", "SDM Spice")
+        interval = int(settings.value("autosave/interval", 60))
+        enabled = settings.value("autosave/enabled", True)
+        if enabled == "false" or enabled is False:
+            self._autosave_timer.stop()
+            return
+        self._autosave_timer.start(interval * 1000)
+
+    def _auto_save(self):
+        """Periodic auto-save callback — saves to recovery file."""
+        if not self.model.components:
+            return
+        self.file_ctrl.auto_save()
+
+    def _check_auto_save_recovery(self):
+        """On startup, check for auto-save file and offer recovery."""
+        if not self.file_ctrl.has_auto_save():
+            return
+        reply = QMessageBox.question(
+            self,
+            "Recover Unsaved Changes",
+            "An auto-save recovery file was found.\n\n"
+            "This may contain unsaved work from a previous session "
+            "that was not closed cleanly.\n\n"
+            "Would you like to recover it?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            source = self.file_ctrl.load_auto_save()
+            if source is not None:
+                title = f"Circuit Design GUI - {source}" if source else "Circuit Design GUI - (Recovered)"
+                self.setWindowTitle(title)
+                self._sync_analysis_menu()
+                statusBar = self.statusBar()
+                if statusBar:
+                    statusBar.showMessage("Auto-save recovered", 5000)
+        self.file_ctrl.clear_auto_save()

--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -9,7 +9,7 @@ from controllers.circuit_controller import CircuitController
 from controllers.file_controller import FileController
 from controllers.simulation_controller import SimulationController
 from models.circuit import CircuitModel
-from PyQt6.QtCore import QSettings, QTimer, Qt
+from PyQt6.QtCore import QSettings, Qt, QTimer
 from PyQt6.QtGui import QAction, QActionGroup
 from PyQt6.QtWidgets import (
     QDialog,

--- a/app/tests/unit/test_auto_save.py
+++ b/app/tests/unit/test_auto_save.py
@@ -1,0 +1,237 @@
+"""Tests for auto-save and crash recovery (Issue #123)."""
+
+import json
+from pathlib import Path
+
+import pytest
+from controllers.file_controller import FileController
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from models.wire import WireData
+
+
+def _build_simple_circuit():
+    """Build a simple V1-R1-GND circuit model."""
+    model = CircuitModel()
+    model.components["V1"] = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value="5V",
+        position=(0.0, 0.0),
+    )
+    model.components["R1"] = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value="1k",
+        position=(100.0, 0.0),
+    )
+    model.components["GND1"] = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(0.0, 100.0),
+    )
+    model.wires = [
+        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
+        WireData(start_component_id="R1", start_terminal=1, end_component_id="GND1", end_terminal=0),
+        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+    ]
+    model.component_counter = {"V": 1, "R": 1, "GND": 1}
+    model.rebuild_nodes()
+    return model
+
+
+class TestAutoSave:
+    def test_auto_save_creates_file(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.auto_save()
+        assert Path(autosave).exists()
+
+    def test_auto_save_writes_valid_json(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.auto_save()
+        data = json.loads(Path(autosave).read_text())
+        assert "components" in data
+        assert "wires" in data
+
+    def test_auto_save_includes_source_path(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.current_file = Path("/some/circuit.json")
+        ctrl.auto_save()
+        data = json.loads(Path(autosave).read_text())
+        assert data["_autosave_source"] == "/some/circuit.json"
+
+    def test_auto_save_empty_source_when_no_file(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.auto_save()
+        data = json.loads(Path(autosave).read_text())
+        assert data["_autosave_source"] == ""
+
+    def test_auto_save_does_not_update_current_file(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        assert ctrl.current_file is None
+        ctrl.auto_save()
+        assert ctrl.current_file is None
+
+    def test_auto_save_preserves_analysis_settings(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        model = _build_simple_circuit()
+        model.analysis_type = "Transient"
+        model.analysis_params = {"duration": 0.01, "step": 1e-5}
+        ctrl = FileController(model, autosave_file=autosave)
+        ctrl.auto_save()
+        data = json.loads(Path(autosave).read_text())
+        assert data["analysis_type"] == "Transient"
+        assert data["analysis_params"]["duration"] == 0.01
+
+
+class TestHasAutoSave:
+    def test_has_auto_save_false_initially(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(autosave_file=autosave)
+        assert not ctrl.has_auto_save()
+
+    def test_has_auto_save_true_after_save(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.auto_save()
+        assert ctrl.has_auto_save()
+
+
+class TestClearAutoSave:
+    def test_clear_removes_file(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.auto_save()
+        assert Path(autosave).exists()
+        ctrl.clear_auto_save()
+        assert not Path(autosave).exists()
+
+    def test_clear_no_error_when_no_file(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(autosave_file=autosave)
+        ctrl.clear_auto_save()  # Should not raise
+
+
+class TestLoadAutoSave:
+    def test_load_restores_components(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.auto_save()
+
+        # Load into fresh controller
+        ctrl2 = FileController(autosave_file=autosave)
+        source = ctrl2.load_auto_save()
+        assert source is not None
+        assert "V1" in ctrl2.model.components
+        assert "R1" in ctrl2.model.components
+        assert "GND1" in ctrl2.model.components
+
+    def test_load_restores_wires(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.auto_save()
+
+        ctrl2 = FileController(autosave_file=autosave)
+        ctrl2.load_auto_save()
+        assert len(ctrl2.model.wires) == 3
+
+    def test_load_returns_source_path(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.current_file = Path("/my/circuit.json")
+        ctrl.auto_save()
+
+        ctrl2 = FileController(autosave_file=autosave)
+        source = ctrl2.load_auto_save()
+        assert source == "/my/circuit.json"
+
+    def test_load_returns_empty_string_for_unsaved(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.auto_save()
+
+        ctrl2 = FileController(autosave_file=autosave)
+        source = ctrl2.load_auto_save()
+        assert source == ""
+
+    def test_load_sets_current_file_from_source(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.current_file = Path("/my/circuit.json")
+        ctrl.auto_save()
+
+        ctrl2 = FileController(autosave_file=autosave)
+        ctrl2.load_auto_save()
+        assert ctrl2.current_file == Path("/my/circuit.json")
+
+    def test_load_returns_none_when_no_file(self, tmp_path):
+        autosave = str(tmp_path / "nonexistent.json")
+        ctrl = FileController(autosave_file=autosave)
+        assert ctrl.load_auto_save() is None
+
+    def test_load_returns_none_for_corrupt_file(self, tmp_path):
+        autosave = tmp_path / "recovery.json"
+        autosave.write_text("not json")
+        ctrl = FileController(autosave_file=str(autosave))
+        assert ctrl.load_auto_save() is None
+
+    def test_load_restores_analysis_settings(self, tmp_path):
+        autosave = str(tmp_path / "recovery.json")
+        model = _build_simple_circuit()
+        model.analysis_type = "AC Sweep"
+        model.analysis_params = {"fStart": 1, "fStop": 1e6}
+        ctrl = FileController(model, autosave_file=autosave)
+        ctrl.auto_save()
+
+        ctrl2 = FileController(autosave_file=autosave)
+        ctrl2.load_auto_save()
+        assert ctrl2.model.analysis_type == "AC Sweep"
+        assert ctrl2.model.analysis_params["fStart"] == 1
+
+    def test_load_notifies_observers(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.auto_save()
+
+        ctrl2 = FileController(autosave_file=autosave)
+        mock_ctrl = MagicMock()
+        ctrl2.circuit_ctrl = mock_ctrl
+        ctrl2.load_auto_save()
+        mock_ctrl._notify.assert_called_once_with("model_loaded", None)
+
+    def test_autosave_source_not_in_model_data(self, tmp_path):
+        """The _autosave_source metadata should not leak into the model."""
+        autosave = str(tmp_path / "recovery.json")
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.current_file = Path("/my/circuit.json")
+        ctrl.auto_save()
+
+        ctrl2 = FileController(autosave_file=autosave)
+        ctrl2.load_auto_save()
+        # The model should not have _autosave_source in its serialized form
+        model_data = ctrl2.model.to_dict()
+        assert "_autosave_source" not in model_data
+
+
+class TestAutoSaveIntegrationWithSave:
+    """Test that auto-save is cleared on explicit save."""
+
+    def test_save_does_not_affect_autosave_directly(self, tmp_path):
+        """FileController.save_circuit does not touch auto-save file.
+        Clearing is MainWindow's responsibility."""
+        autosave = str(tmp_path / "recovery.json")
+        circuit_file = tmp_path / "circuit.json"
+        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl.auto_save()
+        assert ctrl.has_auto_save()
+        ctrl.save_circuit(circuit_file)
+        # FileController save_circuit does NOT clear auto-save (that's MainWindow's job)
+        assert ctrl.has_auto_save()


### PR DESCRIPTION
## Summary
- Auto-save circuit to a recovery file every 60 seconds (configurable via QSettings)
- On startup, detect recovery file and prompt user to restore unsaved work
- Recovery file is cleared on clean exit and explicit save operations

## Changes
- **Modified**: `app/controllers/file_controller.py` — Added `auto_save()`, `load_auto_save()`, `has_auto_save()`, `clear_auto_save()` methods
- **Modified**: `app/GUI/main_window.py` — Added `QTimer`-based auto-save, recovery dialog on startup, auto-save clear on save/close
- **New**: `app/tests/unit/test_auto_save.py` — 21 unit tests covering save, load, clear, recovery, and edge cases

## Test plan
- [x] 21 new unit tests all pass
- [x] Full test suite: 553 passed, 60 pre-existing errors (Qt display)
- [x] Ruff lint clean
- [ ] Manual: verify auto-save file appears in `app/` after 60s of editing
- [ ] Manual: kill app (SIGKILL), relaunch, verify recovery prompt appears
- [ ] Manual: accept recovery, verify circuit is restored
- [ ] Manual: decline recovery, verify clean start
- [ ] Manual: verify auto-save file is deleted after Ctrl+S

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)