### PR TITLE
add dark mode and theme switching

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -1,7 +1,7 @@
 import logging
 
 from PyQt6.QtCore import QPoint, QRect, QRectF, Qt, pyqtSignal
-from PyQt6.QtGui import QAction, QBrush, QPainter
+from PyQt6.QtGui import QAction, QBrush, QPainter, QPen
 from PyQt6.QtWidgets import (
     QGraphicsLineItem,
     QGraphicsScene,
@@ -321,6 +321,30 @@ class CircuitCanvasView(QGraphicsView):
     # def views(self) -> list | None:
     #     views = super().views() if super().views() else None
     #     return views
+
+    def refresh_theme(self):
+        """Redraw grid and repaint all items to reflect the current theme."""
+        if self.scene is None:
+            return
+        # Set scene background
+        bg = theme_manager.color("background_primary")
+        self.scene.setBackgroundBrush(QBrush(bg))
+
+        # Remove old grid items and redraw
+        for item in self._grid_items:
+            self.scene.removeItem(item)
+        self._grid_items.clear()
+        self.draw_grid()
+
+        # Update all wire pens with current theme color
+        default_wire_color = theme_manager.color("wire_default")
+        for wire in self.wires:
+            wire.layer_color = default_wire_color
+            if not wire.isSelected():
+                wire.setPen(QPen(default_wire_color, 2))
+
+        # Force full repaint of all items (components pick up theme in paint())
+        self.scene.update()
 
     def draw_grid(self):
         """Draw background grid with major grid lines labeled with position values"""

--- a/app/GUI/results_plot_dialog.py
+++ b/app/GUI/results_plot_dialog.py
@@ -17,6 +17,7 @@ from matplotlib.figure import Figure
 from PyQt6.QtWidgets import QDialog, QHBoxLayout, QPushButton, QVBoxLayout
 
 from .measurement_cursors import CursorReadoutPanel, MeasurementCursors
+from .styles import theme_manager
 
 matplotlib.use("QtAgg")
 
@@ -24,6 +25,23 @@ logger = logging.getLogger(__name__)
 
 # Line styles cycled per dataset for visual distinction
 _LINE_STYLES = ["-", "--", "-.", ":"]
+
+
+def _apply_mpl_theme(fig):
+    """Apply the current application theme colors to a matplotlib figure."""
+    is_dark = theme_manager.current_theme.name == "Dark Theme"
+    if is_dark:
+        bg = "#1E1E1E"
+        fg = "#D4D4D4"
+        fig.patch.set_facecolor(bg)
+        for ax in fig.axes:
+            ax.set_facecolor("#2D2D2D")
+            ax.tick_params(colors=fg)
+            ax.xaxis.label.set_color(fg)
+            ax.yaxis.label.set_color(fg)
+            ax.title.set_color(fg)
+            for spine in ax.spines.values():
+                spine.set_edgecolor("#555555")
 
 
 class DCSweepPlotDialog(QDialog):
@@ -136,6 +154,7 @@ class DCSweepPlotDialog(QDialog):
             legend = self._ax.legend(loc="best", fontsize="small")
             self._setup_legend_toggle(legend)
 
+        _apply_mpl_theme(self._fig)
         self._fig.tight_layout()
 
         # Update cursors
@@ -346,6 +365,7 @@ class ACSweepPlotDialog(QDialog):
             phase_legend = self._ax_phase.legend(loc="best", fontsize="small")
             self._setup_legend_toggle(phase_legend, self._ax_phase)
 
+        _apply_mpl_theme(self._fig)
         self._fig.tight_layout()
 
         # Update cursors on magnitude axes (shared x with phase)

--- a/app/GUI/styles/__init__.py
+++ b/app/GUI/styles/__init__.py
@@ -46,6 +46,7 @@ from .constants import (
     ZOOM_MAX,
     ZOOM_MIN,
 )
+from .dark_theme import DarkTheme
 from .light_theme import LightTheme
 
 # Theme system
@@ -78,4 +79,5 @@ __all__ = [
     "ThemeManager",
     "theme_manager",
     "LightTheme",
+    "DarkTheme",
 ]

--- a/app/GUI/styles/dark_theme.py
+++ b/app/GUI/styles/dark_theme.py
@@ -1,0 +1,167 @@
+"""
+dark_theme.py - Dark theme implementation.
+
+Provides a dark color scheme for reduced eye-strain during long lab sessions.
+"""
+
+from PyQt6.QtGui import QBrush, QColor, QPen
+
+from .constants import COMPONENTS
+from .theme import BaseTheme
+
+
+class DarkTheme(BaseTheme):
+    """Dark theme with high-contrast colors on a dark background."""
+
+    def __init__(self):
+        super().__init__()
+        self._define_colors()
+        self._define_pens()
+        self._define_brushes()
+        self._define_fonts()
+        self._define_stylesheets()
+
+    @property
+    def name(self) -> str:
+        return "Dark Theme"
+
+    def _define_colors(self):
+        """Define all color values for dark mode."""
+        self._colors = {
+            # ===== Component Colors (brightened for dark background) =====
+            "component_resistor": "#64B5F6",  # Light blue
+            "component_capacitor": "#81C784",  # Light green
+            "component_inductor": "#FFB74D",  # Light orange
+            "component_voltage_source": "#EF5350",  # Light red
+            "component_current_source": "#CE93D8",  # Light purple
+            "component_waveform_source": "#F48FB1",  # Light pink
+            "component_ground": "#BDBDBD",  # Light gray (not black)
+            "component_opamp": "#FFD54F",  # Light amber
+            "component_vcvs": "#4DB6AC",  # Light teal
+            "component_ccvs": "#4DD0E1",  # Light cyan
+            "component_vccs": "#80CBC4",  # Light teal variant
+            "component_cccs": "#4FC3F7",  # Light cyan variant
+            "component_bjt_npn": "#FF8A80",  # Light coral
+            "component_bjt_pnp": "#80CBC4",  # Light teal green
+            "component_mosfet_nmos": "#B39DDB",  # Light deep purple
+            "component_mosfet_pmos": "#9FA8DA",  # Light indigo
+            "component_vc_switch": "#BCAAA4",  # Light brown
+            "component_diode": "#90A4AE",  # Light blue-gray
+            "component_led": "#FFF176",  # Light yellow
+            "component_zener": "#A1887F",  # Light brown
+            # ===== Algorithm Layer Colors =====
+            "algorithm_astar": "#64B5F6",  # Light blue
+            "algorithm_idastar": "#81C784",  # Light green
+            "algorithm_dijkstra": "#FFB74D",  # Light orange
+            # ===== Grid Colors =====
+            "grid_minor": "#333333",  # Subtle dark gray
+            "grid_major": "#4A4A4A",  # Medium dark gray
+            "grid_label": "#888888",  # Lighter gray for readability
+            # ===== Canvas/UI Colors =====
+            "background_primary": "#1E1E1E",  # Dark background
+            "background_secondary": "#2D2D2D",  # Slightly lighter
+            "text_primary": "#D4D4D4",  # Light gray text
+            "text_secondary": "#999999",  # Medium gray
+            "text_muted": "#666666",  # Dimmed text
+            # ===== Selection & Highlight =====
+            "selection_highlight": "#FFFF00",  # Yellow (kept bright)
+            "node_label": "#FF80FF",  # Bright magenta
+            "node_label_bg": "#2D2D2D",  # Dark background
+            # ===== Wire Colors =====
+            "wire_default": "#D4D4D4",  # Light gray
+            "wire_preview": "#6699FF",  # Light blue
+            "wire_selected": "#FFFF00",  # Yellow
+            # ===== Terminal Colors =====
+            "terminal_default": "#FF6666",  # Light red
+            "terminal_highlight": "#66FF66",  # Light green
+            "terminal_fill": "#00CC00",  # Medium green
+            # ===== Obstacle Visualization =====
+            "obstacle_full": "#FF6464",  # Light red
+            "obstacle_inset": "#6496FF",  # Light blue
+        }
+
+    def _define_pens(self):
+        """Define all pen configurations."""
+        self._pens = {
+            # Grid pens
+            "grid_minor": {"color": "grid_minor", "width": 0.5, "cosmetic": True},
+            "grid_major": {"color": "grid_major", "width": 1.0, "cosmetic": True},
+            # Component pens
+            "component_outline": {"color": "text_primary", "width": 2.0},
+            "component_selected": {"color": "selection_highlight", "width": 3.0},
+            # Terminal pens
+            "terminal": {"color": "terminal_default", "width": 4.0},
+            "terminal_marker": {"color": "terminal_highlight", "width": 3.0},
+            # Wire pens
+            "wire_default": {"color": "wire_default", "width": 2.0},
+            "wire_preview": {"color": "wire_preview", "width": 3.0, "style": "dash"},
+            "wire_selected": {"color": "wire_selected", "width": 4.0},
+            # Node label pens
+            "node_label_outline": {"color": "node_label", "width": 1.0},
+            # Obstacle visualization
+            "obstacle_full": {"color": "obstacle_full", "width": 3.0},
+            "obstacle_inset": {"color": "obstacle_inset", "width": 2.0, "style": "dot"},
+        }
+
+    def _define_brushes(self):
+        """Define all brush configurations."""
+        self._brushes = {
+            "node_label_bg": {"color": "node_label_bg", "alpha": 200},
+            "terminal_fill": {"color": "terminal_fill", "alpha": 100},
+            "component_fill": {"color": "background_primary", "alpha": 255},
+        }
+
+    def _define_fonts(self):
+        """Define all font configurations."""
+        self._fonts = {
+            "grid_label": {"size": 8, "bold": False},
+            "node_label": {"size": 10, "bold": True},
+            "panel_title": {"size": 10, "bold": True},
+            "panel_subtitle": {"size": 12, "bold": True},
+            "monospace": {"family": "monospace", "size": 9, "bold": False},
+        }
+
+    def _define_stylesheets(self):
+        """Define all stylesheet strings for dark mode."""
+        self._stylesheets = {
+            "instructions_panel": """
+                QLabel {
+                    background-color: #2D2D2D;
+                    color: #D4D4D4;
+                    padding: 10px;
+                    border-radius: 5px;
+                }
+            """,
+            "muted_label": "QLabel { color: #999; }",
+            "title_bold": "font-weight: bold; font-size: 12pt; color: #D4D4D4;",
+            "metrics_text": "font-family: monospace; font-size: 9pt; color: #D4D4D4;",
+        }
+
+    # ===== Helper methods (inherited from BaseTheme, same logic) =====
+
+    def get_component_color(self, component_type: str) -> QColor:
+        """Get the themed color for a component type."""
+        comp_info = COMPONENTS.get(component_type, {})
+        color_key = comp_info.get("color_key", "text_primary")
+        return self.color(color_key)
+
+    def get_component_color_hex(self, component_type: str) -> str:
+        """Get the hex color string for a component type."""
+        comp_info = COMPONENTS.get(component_type, {})
+        color_key = comp_info.get("color_key", "text_primary")
+        return self.color_hex(color_key)
+
+    def get_algorithm_color(self, algorithm: str) -> QColor:
+        """Get the themed color for an algorithm layer."""
+        key = f"algorithm_{algorithm}"
+        return self.color(key)
+
+    def create_component_pen(self, component_type: str, width: float = 2.0) -> QPen:
+        """Create a pen for drawing a specific component type."""
+        color = self.get_component_color(component_type)
+        return QPen(color, width)
+
+    def create_component_brush(self, component_type: str) -> QBrush:
+        """Create a brush for filling a specific component type."""
+        color = self.get_component_color(component_type)
+        return QBrush(color.lighter(150))

--- a/app/GUI/waveform_dialog.py
+++ b/app/GUI/waveform_dialog.py
@@ -27,7 +27,7 @@ from simulation.fft_analysis import analyze_signal_spectrum
 
 from .format_utils import format_value, parse_value
 from .measurement_cursors import CursorReadoutPanel, MeasurementCursors
-from .styles import SCROLL_LOAD_COUNT
+from .styles import SCROLL_LOAD_COUNT, theme_manager
 
 matplotlib.use("QtAgg")
 
@@ -36,11 +36,29 @@ cmap = plt.get_cmap("Paired")
 HIGHLIGHT_COLORS = [QColor.fromRgbF(*cmap(i)) for i in range(12)]
 
 
+def _apply_mpl_theme(fig):
+    """Apply the current application theme colors to a matplotlib figure."""
+    is_dark = theme_manager.current_theme.name == "Dark Theme"
+    if is_dark:
+        bg = "#1E1E1E"
+        fg = "#D4D4D4"
+        fig.patch.set_facecolor(bg)
+        for ax in fig.axes:
+            ax.set_facecolor("#2D2D2D")
+            ax.tick_params(colors=fg)
+            ax.xaxis.label.set_color(fg)
+            ax.yaxis.label.set_color(fg)
+            ax.title.set_color(fg)
+            for spine in ax.spines.values():
+                spine.set_edgecolor("#555555")
+
+
 class MplCanvas(FigureCanvas):
     def __init__(self, parent=None, width=5, height=4, dpi=100):
         fig = Figure(figsize=(width, height), dpi=dpi)
         self.axes = fig.add_subplot(111)
         super(MplCanvas, self).__init__(fig)
+        _apply_mpl_theme(fig)
 
 
 class WaveformDialog(QDialog):
@@ -534,6 +552,7 @@ class WaveformDialog(QDialog):
         self.canvas.axes.set_ylabel("Voltage (V)")
         self.canvas.axes.legend(fontsize="small")
         self.canvas.axes.grid(True)
+        _apply_mpl_theme(self.canvas.figure)
         self.canvas.figure.tight_layout()
 
         # Set up measurement cursors (re-attach after axes clear)
@@ -674,6 +693,7 @@ class FFTAnalysisDialog(QDialog):
             self.mag_canvas.axes.set_xlabel("Frequency (Hz)")
             self.mag_canvas.axes.set_ylabel("Magnitude (dB)")
             self.mag_canvas.axes.grid(True, which="both", alpha=0.3)
+            _apply_mpl_theme(self.mag_canvas.figure)
             self.mag_canvas.figure.tight_layout()
             self.mag_canvas.draw()
 
@@ -684,6 +704,7 @@ class FFTAnalysisDialog(QDialog):
             self.phase_canvas.axes.set_xlabel("Frequency (Hz)")
             self.phase_canvas.axes.set_ylabel("Phase (degrees)")
             self.phase_canvas.axes.grid(True, which="both", alpha=0.3)
+            _apply_mpl_theme(self.phase_canvas.figure)
             self.phase_canvas.figure.tight_layout()
             self.phase_canvas.draw()
 

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 # path_finding imported lazily in update_position() for faster startup
 from models.wire import WireData
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QColor, QPainterPath, QPainterPathStroker, QPen
+from PyQt6.QtGui import QPainterPath, QPainterPathStroker, QPen
 from PyQt6.QtWidgets import QGraphicsPathItem
 
 from .styles import GRID_SIZE, WIRE_CLICK_WIDTH, theme_manager
@@ -60,7 +60,7 @@ class WireGraphicsItem(QGraphicsPathItem):
 
         # Algorithm layer support
         self.algorithm = algorithm  # Which algorithm generated this wire
-        self.layer_color = layer_color if layer_color else QColor(Qt.GlobalColor.black)
+        self.layer_color = layer_color if layer_color else theme_manager.color("wire_default")
 
         self.waypoints = []  # List of QPointF waypoints (computed during routing)
 

--- a/app/tests/unit/test_dark_theme.py
+++ b/app/tests/unit/test_dark_theme.py
@@ -1,10 +1,9 @@
 """Tests for dark theme and theme switching."""
 
 import pytest
-from PyQt6.QtGui import QColor
-
 from GUI.styles import DarkTheme, LightTheme, ThemeManager, theme_manager
 from GUI.styles.constants import COMPONENTS
+from PyQt6.QtGui import QColor
 
 
 class TestDarkThemeColors:

--- a/app/tests/unit/test_dark_theme.py
+++ b/app/tests/unit/test_dark_theme.py
@@ -1,0 +1,181 @@
+"""Tests for dark theme and theme switching."""
+
+import pytest
+from PyQt6.QtGui import QColor
+
+from GUI.styles import DarkTheme, LightTheme, ThemeManager, theme_manager
+from GUI.styles.constants import COMPONENTS
+
+
+class TestDarkThemeColors:
+    """Verify DarkTheme defines all required color keys."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.theme = DarkTheme()
+
+    def test_name(self):
+        assert self.theme.name == "Dark Theme"
+
+    def test_has_background_primary(self):
+        color = self.theme.color("background_primary")
+        assert isinstance(color, QColor)
+        # Dark background should be dark
+        assert color.lightness() < 100
+
+    def test_has_text_primary(self):
+        color = self.theme.color("text_primary")
+        assert isinstance(color, QColor)
+        # Text on dark bg should be light
+        assert color.lightness() > 150
+
+    def test_has_grid_colors(self):
+        for key in ("grid_minor", "grid_major", "grid_label"):
+            color = self.theme.color(key)
+            assert isinstance(color, QColor), f"Missing color: {key}"
+
+    def test_has_wire_colors(self):
+        for key in ("wire_default", "wire_preview", "wire_selected"):
+            color = self.theme.color(key)
+            assert isinstance(color, QColor), f"Missing color: {key}"
+
+    def test_has_terminal_colors(self):
+        for key in ("terminal_default", "terminal_highlight", "terminal_fill"):
+            color = self.theme.color(key)
+            assert isinstance(color, QColor), f"Missing color: {key}"
+
+    def test_has_selection_colors(self):
+        for key in ("selection_highlight", "node_label", "node_label_bg"):
+            color = self.theme.color(key)
+            assert isinstance(color, QColor), f"Missing color: {key}"
+
+    def test_all_component_types_have_colors(self):
+        """Every component type from COMPONENTS should have a valid color."""
+        for comp_type in COMPONENTS:
+            color = self.theme.get_component_color(comp_type)
+            assert isinstance(color, QColor), f"Missing color for {comp_type}"
+
+    def test_ground_not_black(self):
+        """Ground should not be pure black in dark theme (invisible)."""
+        color = self.theme.color("component_ground")
+        assert color != QColor("#000000")
+
+
+class TestLightThemeColors:
+    """Verify LightTheme still works as expected."""
+
+    def test_name(self):
+        assert LightTheme().name == "Light Theme"
+
+    def test_background_is_white(self):
+        color = LightTheme().color("background_primary")
+        assert color == QColor("#FFFFFF")
+
+
+class TestDarkThemePens:
+    """Verify pens are correctly defined."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.theme = DarkTheme()
+
+    def test_grid_pens_exist(self):
+        pen = self.theme.pen("grid_minor")
+        assert pen is not None
+        assert pen.widthF() == 0.5
+
+    def test_wire_pen(self):
+        pen = self.theme.pen("wire_default")
+        assert pen is not None
+
+    def test_component_pen(self):
+        pen = self.theme.create_component_pen("Resistor")
+        assert pen is not None
+
+
+class TestDarkThemeBrushes:
+    """Verify brushes are correctly defined."""
+
+    def test_node_label_bg(self):
+        theme = DarkTheme()
+        brush = theme.brush("node_label_bg")
+        assert brush is not None
+        # Should have alpha < 255 for semi-transparency
+        assert brush.color().alpha() == 200
+
+
+class TestDarkThemeStylesheets:
+    """Verify stylesheets are correctly defined."""
+
+    def test_instructions_panel(self):
+        theme = DarkTheme()
+        ss = theme.stylesheet("instructions_panel")
+        assert "background-color" in ss
+        assert "#2D2D2D" in ss
+
+    def test_muted_label(self):
+        theme = DarkTheme()
+        ss = theme.stylesheet("muted_label")
+        assert "color" in ss
+
+
+class TestThemeManagerSwitch:
+    """Test switching between themes via ThemeManager."""
+
+    @pytest.fixture(autouse=True)
+    def restore_theme(self):
+        """Ensure we restore the light theme after each test."""
+        yield
+        theme_manager.set_theme(LightTheme())
+
+    def test_switch_to_dark(self):
+        theme_manager.set_theme(DarkTheme())
+        assert theme_manager.current_theme.name == "Dark Theme"
+
+    def test_switch_back_to_light(self):
+        theme_manager.set_theme(DarkTheme())
+        theme_manager.set_theme(LightTheme())
+        assert theme_manager.current_theme.name == "Light Theme"
+
+    def test_listener_notified(self):
+        received = []
+        theme_manager.on_theme_changed(lambda t: received.append(t.name))
+        theme_manager.set_theme(DarkTheme())
+        assert received == ["Dark Theme"]
+        theme_manager.remove_listener(received.append)  # cleanup
+
+    def test_color_changes_with_theme(self):
+        light_bg = theme_manager.color_hex("background_primary")
+        theme_manager.set_theme(DarkTheme())
+        dark_bg = theme_manager.color_hex("background_primary")
+        assert light_bg != dark_bg
+
+    def test_component_color_accessible_after_switch(self):
+        theme_manager.set_theme(DarkTheme())
+        color = theme_manager.get_component_color("Resistor")
+        assert isinstance(color, QColor)
+
+
+class TestContrastRequirements:
+    """Ensure dark theme has sufficient contrast between key elements."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.theme = DarkTheme()
+
+    def _luminance_diff(self, key1, key2):
+        c1 = self.theme.color(key1)
+        c2 = self.theme.color(key2)
+        return abs(c1.lightness() - c2.lightness())
+
+    def test_text_vs_background_contrast(self):
+        diff = self._luminance_diff("text_primary", "background_primary")
+        assert diff > 100, "Text must be clearly visible on background"
+
+    def test_grid_minor_vs_background(self):
+        diff = self._luminance_diff("grid_minor", "background_primary")
+        assert diff > 10, "Grid lines must be visible but subtle"
+
+    def test_wire_vs_background(self):
+        diff = self._luminance_diff("wire_default", "background_primary")
+        assert diff > 100, "Wires must be clearly visible"


### PR DESCRIPTION
## Summary
- Adds `DarkTheme` class with high-contrast colors for all UI elements (canvas, grid, components, wires, terminals, nodes)
- Adds **View > Theme** submenu with Light/Dark options (mutually exclusive radio group)
- Canvas `refresh_theme()` redraws grid, updates wire colors, and triggers full scene repaint on theme switch
- Matplotlib plot dialogs (DC Sweep, AC Sweep, Transient, FFT) apply matching dark/light styles
- Theme preference persists across sessions via QSettings
- Ground component uses light gray in dark mode (not black/invisible)
- 25 new tests covering colors, contrast requirements, pens, brushes, stylesheets, theme switching, and listener notification

## Files changed
- **`app/GUI/styles/dark_theme.py`** — New: `DarkTheme` with all color keys, pens, brushes, fonts, stylesheets
- **`app/GUI/styles/__init__.py`** — Registers `DarkTheme` in the styles package
- **`app/GUI/main_window.py`** — View > Theme menu, `_set_theme()`, `_apply_theme()` with global dark stylesheet, QSettings persistence
- **`app/GUI/circuit_canvas.py`** — `refresh_theme()` method, QPen import
- **`app/GUI/wire_item.py`** — Uses `theme_manager.color("wire_default")` instead of hardcoded black
- **`app/GUI/results_plot_dialog.py`** — `_apply_mpl_theme()` for dark matplotlib figures
- **`app/GUI/waveform_dialog.py`** — `_apply_mpl_theme()` for transient/FFT plots
- **`app/tests/unit/test_dark_theme.py`** — 25 tests

## Test plan
- [x] All 657 tests pass
- [x] Ruff linting passes
- [ ] Manual: View > Theme > Dark applies immediately to canvas
- [ ] Manual: Components, wires, grid, node labels are legible in dark mode
- [ ] Manual: Plot dialogs open with dark background when dark theme is active
- [ ] Manual: Theme preference survives app restart
- [ ] Manual: Switching back to Light restores original appearance

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)