### PR TITLE
Align formatter toolchain: consistent order across Makefile, pre-commit, CI

### DIFF
--- a/.claude-feedback/session-summary-2026-02-09-session-2.md
+++ b/.claude-feedback/session-summary-2026-02-09-session-2.md
@@ -1,0 +1,156 @@
+# Session Summary - 2026-02-09 (Session 2)
+
+## Overview
+- **Duration**: ~3h
+- **Issues Completed**: 2 (#78 Measurement Cursors, #123 Auto-save & Crash Recovery)
+- **PRs Created**: 2 (PR #161/162, PR #164)
+- **PRs Merged**: 2 (both merged and CI passing)
+- **Tests Added**: 43 (22 for cursors, 21 for auto-save)
+- **Success Rate**: 100%
+- **Context Restores**: 1 (session ran out of context mid-CI-fix)
+
+## Issues Completed
+
+### Issue #78: Add Measurement Cursors to Waveform Viewer
+- **Time**: 2h
+- **PR**: #161 (closed) → #162 (merged via squash)
+- **Files Created**:
+  - `app/GUI/measurement_cursors.py` — MeasurementCursors class + CursorReadoutPanel widget
+  - `app/tests/unit/test_measurement_cursors.py` — 22 unit tests
+- **Files Modified**:
+  - `app/GUI/results_plot_dialog.py` — Integrated cursors into DCSweepPlotDialog, ACSweepPlotDialog
+  - `app/GUI/waveform_dialog.py` — Integrated cursors into WaveformDialog
+  - `app/GUI/main_window.py` — Minor wiring
+- **Tests Added**: 22 tests covering:
+  - MeasurementCursors: initial state, set_data, snap_to_nearest, active cursor switching, Y interpolation, removal, callback notification
+  - CursorReadoutPanel: creation, cursor setting, readout update, cursor selection buttons
+  - Integration: DC sweep, AC sweep, and waveform dialog cursor presence and data binding
+- **Status**: Merged
+- **Architecture**: Click-to-place with A/B cursor selection, drag-to-reposition, snap-to-data via `np.searchsorted`, Y interpolation via `np.interp`, delta display in readout panel
+
+### Issue #123: Auto-save and Crash Recovery
+- **Time**: 1h (implementation) + ~1h (CI fixes)
+- **PR**: #164 (merged, all 9 CI checks passing)
+- **Files Created**:
+  - `app/tests/unit/test_auto_save.py` — 21 unit tests
+- **Files Modified**:
+  - `app/controllers/file_controller.py` — Added `AUTOSAVE_FILE` constant, `autosave_file` param, 4 new methods
+  - `app/GUI/main_window.py` — QTimer-based auto-save, recovery dialog, clear on save/exit
+- **Tests Added**: 21 tests covering:
+  - AutoSave: file creation, valid JSON, source path tracking, no current_file update, analysis settings preservation
+  - HasAutoSave: false initially, true after save
+  - ClearAutoSave: file removal, no error on missing
+  - LoadAutoSave: component/wire restoration, source path return, current_file update, corrupt file handling, observer notification, metadata isolation
+  - Integration: save_circuit does not affect auto-save (MainWindow's responsibility)
+- **Status**: Merged
+- **Notes**: Required 3 CI fix commits after initial implementation
+
+## Challenges
+
+### Challenge 1: Readout Callback Ordering Bug
+- **Issue**: `set_enabled(True)` on the CursorReadoutPanel fired the cursor callback with empty data, causing 2 callbacks instead of expected 1
+- **Solution**: Moved `set_enabled(True)` before setting the callback function
+- **Prevention**: When connecting Qt signals, ensure the handler is connected after any state changes that would trigger it
+
+### Challenge 2: Merge Conflict with Keybindings Feature
+- **Issue**: While working on issue #123, the keybindings feature (#121) was merged to main, conflicting with the QTimer import addition in main_window.py
+- **Solution**: Merged main into the feature branch, resolved the import conflict (kept both QTimer and KeybindingsRegistry)
+- **Prevention**: Pull main more frequently during implementation, especially before pushing
+
+### Challenge 3: Ruff Format vs CI
+- **Issue**: The `__init__` signature in file_controller.py exceeded line length when adding the `autosave_file` parameter
+- **Solution**: Reformatted to multi-line parameter style
+- **Prevention**: Run `ruff format --check` locally before pushing, not just `ruff check`
+
+### Challenge 4: Windows Path Separators
+- **Issue**: Two tests used hardcoded Unix paths (`/some/circuit.json`), which produce `\some\circuit.json` on Windows
+- **Solution**: Replaced with `tmp_path / "my_circuit.json"` (pytest fixture)
+- **Prevention**: Never use hardcoded path strings in tests — always use `tmp_path` or `Path`
+
+### Challenge 5: Black vs Ruff Format Disagreement
+- **Issue**: Running `black` (user-requested) wanted to reformat 44 files, but the project uses `ruff format` — applying black would break CI
+- **Solution**: Did not apply black changes; only applied the isort fix (alphabetical import order)
+- **Prevention**: Document in CLAUDE.md that the project uses `ruff format` exclusively
+
+### Challenge 6: Context Window Exhaustion
+- **Issue**: Conversation ran out of context during CI fix iterations for PR #164
+- **Solution**: Conversation was restored with a summary; continued from where it left off
+- **Prevention**: Checkpoint progress to MEMORY.md after each issue; keep CI fix cycles tight
+
+## Metrics
+
+### Test Results
+- **Total tests**: 626 passed
+- **Pre-existing errors**: 97 (headless Qt display issues, not code bugs)
+- **New tests added**: 43
+- **Test failures**: 0
+- **Runtime**: 1.09s
+
+### Code Quality
+- **Ruff check**: Passed
+- **Ruff format**: Passed
+- **isort**: Passed (after fix)
+- **Black**: Not applicable (project uses ruff format)
+
+### Lines of Code
+- **Issue #78**: +1,135 / -103 (28 files, includes formatting normalization)
+- **Issue #123**: +370 / -2 (3 files)
+- **Total net change**: +1,400 lines
+
+## Recommendations
+
+### For Process Improvement
+1. Run `ruff format --check app/` AND `ruff check app/` before every push — not just one
+2. Always use `tmp_path` for file paths in tests — never hardcode Unix paths
+3. Merge main into feature branch before pushing if main has changed since branch creation
+4. Checkpoint to MEMORY.md after each issue to survive context exhaustion
+
+### For CLAUDE.md Updates
+1. Add explicit note: "Use `ruff format`, NOT `black`. They conflict and black will break CI."
+2. Add: "Run `ruff format --check app/` in addition to `ruff check app/` before pushing"
+3. Add: "Use `tmp_path` in tests — never hardcode paths like `/some/path`"
+4. Add: "After merging main to resolve conflicts, re-run full test suite + linters before pushing"
+
+### For Future Work
+1. Fix pre-existing headless Qt test errors (97 and growing) — consider `@pytest.mark.gui` skip marker
+2. Add pre-push hook that runs `ruff check` + `ruff format --check`
+3. Consider screenshot comparison tests for visual features (cursors, overlays)
+
+## Next Session
+
+### Suggested Next Items
+- Ready queue was empty at end of session
+- Check board for newly added Ready items
+- Review any open PRs that need attention
+
+### Preparation Needed
+- [ ] Re-query board IDs (may have changed)
+- [ ] Check if any items have been moved to Ready since last session
+- [ ] Pull latest main (several PRs merged during this session)
+
+## Session Notes
+
+### What Went Well
+- Both issues implemented and merged successfully
+- All CI checks green on final push
+- Test coverage is thorough (43 new tests, all passing)
+- Auto-save architecture cleanly separates FileController (logic) from MainWindow (timer/UI)
+- Measurement cursors integrate cleanly with all 3 plot dialog types
+
+### What Could Be Improved
+- Should have run `ruff format --check` locally before first push (would have avoided one CI fix cycle)
+- Should have used `tmp_path` from the start in auto-save tests (would have avoided Windows failures)
+- Context window management — session hit the limit, requiring a summary/restore
+
+### Key Learnings
+- `ruff format` and `black` are NOT compatible — they produce different output. Project must pick one.
+- Windows CI is valuable — catches real cross-platform bugs (path separators)
+- `isort` and `ruff check --select I` overlap — but isort catches alphabetical ordering that ruff may not
+- QTimer + auto-save is a clean pattern: timer in view (MainWindow), logic in controller (FileController)
+- When Qt signals fire during widget setup, order of operations matters (enable before connect, or connect before enable, depending on desired behavior)
+
+---
+
+**Generated by**: Claude Opus 4.6
+**Model**: claude-opus-4-6
+**Workflow**: Autonomous (CLAUDE.md)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,18 @@ jobs:
       - name: Install lint tools
         run: pip install -r app/requirements-dev.txt
 
+      # Check order matches make format: ruff lint → isort → ruff-format → black
       - name: Run ruff check
         run: ruff check app/ --output-format=github
+
+      - name: Run isort check
+        run: isort --check-only --profile=black --line-length=120 app/
 
       - name: Run ruff format check
         run: ruff format --check app/
 
       - name: Run black check
         run: black --check --line-length=120 app/
-
-      - name: Run isort check
-        run: isort --check-only --profile=black --line-length=120 app/
 
   security:
     name: Security Lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,12 @@
 # Install: pre-commit install
 # Run manually: pre-commit run --all-files
 # Update hooks: pre-commit autoupdate
+#
+# Hook order matters — formatters run in this sequence:
+#   1. ruff --fix        (lint auto-fixes: unused imports, etc.)
+#   2. isort             (import sorting)
+#   3. ruff-format       (stricter formatter: implicit string concat, etc.)
+#   4. black             (final authority — should be a no-op after ruff-format)
 
 repos:
   # General file hygiene
@@ -19,24 +25,27 @@ repos:
       - id: mixed-line-ending
         args: ['--fix=lf']
 
-  # Python linting with ruff (configured via ruff.toml)
+  # Step 1: Lint fixes (may remove unused imports, fix code issues)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.0
     hooks:
-      # Linter
       - id: ruff
         args: [--fix]
-      # Formatter
-      - id: ruff-format
 
-  # Import sorting
+  # Step 2: Import sorting (after ruff may have changed imports)
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:
       - id: isort
         args: [--profile=black, --line-length=120]
 
-  # Code formatting
+  # Step 3: ruff-format (stricter — handles implicit string concat, etc.)
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.0
+    hooks:
+      - id: ruff-format
+
+  # Step 4: black (final authority — output satisfies both formatters)
   - repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,13 +18,23 @@ make install-hooks  # Install pre-commit hooks (black, isort, ruff)
 Or run `scripts/setup.sh` (Linux/Mac) or `scripts/setup.ps1` (Windows).
 
 ## Testing & Linting
+
+**Formatters**: black + isort (canonical). Do NOT use `ruff format` — it conflicts with black.
+
 ```bash
 python -m pytest              # run all tests (works from repo root)
 python -m pytest -v           # verbose
 python -m pytest app/tests/unit/test_foo.py  # single file
-make lint                     # full lint: ruff + black --check + isort --check
 make format                   # auto-format: black + isort + ruff --fix
+make lint                     # full lint: ruff + black --check + isort --check
+make format-check             # verify formatting without modifying files
 ```
+
+### Testing Conventions
+- Use `tmp_path` (pytest fixture) for all file path tests — never hardcode paths like `/some/path` (Windows uses backslash separators)
+- Use `qtbot` fixture for Qt widget tests
+- Test count should increase by ≥5 for new features
+- Run tests from repo root: `python -m pytest` or `make test`
 
 ## Project Structure
 ```
@@ -170,6 +180,8 @@ Before starting implementation on any issue, verify:
 
 **If any check fails**: Fix the issue before creating new files or writing code.
 
+**Shortcut**: After creating your feature branch, run `make preflight` to verify all checks at once.
+
 ### Work Loop
 1. Discover board IDs (see above)
 2. Query board for next **Ready** item (prefer higher priority, lower issue number)
@@ -193,6 +205,7 @@ Before starting implementation on any issue, verify:
    - ✅ All new tests pass
    - ✅ All existing tests still pass (no regressions)
    - ✅ Full lint passes: ruff + black --check + isort --check (`make lint`)
+   - ✅ Formatting verified: `make format-check` (optional — `make lint` also checks)
    - ✅ Test count increased by ≥5 for new features
 
    **Troubleshooting**:
@@ -210,6 +223,13 @@ Before starting implementation on any issue, verify:
 15. Move issue to **In Review** on the board
 16. Log hours: comment `⏱️ Xh - description` on issue, update Hours field
 17. Pick next Ready item → repeat from step 2
+
+**Post-issue checklist** (verify before picking next item):
+- [ ] PR created and linked to issue
+- [ ] Issue closed (`gh issue close <N>`)
+- [ ] Board status updated to In Review
+- [ ] Hours logged (comment + field)
+- [ ] MEMORY.md updated with issue/PR number
 
 ### Hours Estimates
 - Small fix/tweak: **0.5h**
@@ -302,6 +322,8 @@ For sessions working on >3 issues or >4 hours of work:
 - **Board field updates**: `updateProjectV2Field` with `singleSelectOptions` regenerates all option IDs. Always re-query IDs after modifying field options.
 
 ### Legacy Branch Handling
+
+> **Note**: This section applies to branches created before PR #138 (2026-02-09). New branches from main already include `.pre-commit-config.yaml`.
 
 **Problem**: Feature branches created before Issue #106 (pre-commit hooks) lack `.pre-commit-config.yaml`.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test lint format check preflight install-dev install-hooks
+.PHONY: help test lint format format-check check preflight install-dev install-hooks
 
 help:  ## Show this help message
 	@echo 'Usage: make [target]'
@@ -9,15 +9,24 @@ help:  ## Show this help message
 test:  ## Run pytest test suite
 	cd app && python -m pytest tests/ -v --tb=short
 
-lint:  ## Run linting checks (ruff + black --check + isort --check)
+lint:  ## Run linting checks (ruff + isort + ruff-format + black)
 	ruff check app/
-	black --check --line-length=120 app/
 	isort --check-only --profile=black --line-length=120 app/
+	ruff format --check app/
+	black --check --line-length=120 app/
 
-format:  ## Auto-format code (black + isort + ruff --fix)
-	black --line-length=120 app/
-	isort --profile=black --line-length=120 app/
+format:  ## Auto-format code (ruff --fix + isort + ruff format + black)
 	ruff check --fix app/
+	isort --profile=black --line-length=120 app/
+	ruff format app/
+	black --line-length=120 app/
+
+format-check:  ## Check formatting without modifying files
+	@isort --check-only --profile=black --line-length=120 app/ && \
+		ruff format --check app/ && \
+		black --check --line-length=120 app/ && \
+		echo "✓ All files correctly formatted" || \
+		(echo "⚠️  Formatting issues found. Run 'make format' to fix." && false)
 
 check:  ## Run all checks (lint + test)
 	@echo "Running linting checks..."


### PR DESCRIPTION
## Summary

- Aligns tool execution order across all three formatting layers (Makefile, pre-commit hooks, CI) to prevent latent conflicts between `ruff-format` and `black`
- Adds `make format-check` target for verifying formatting without modifying files
- Improves CLAUDE.md with testing conventions, workflow shortcuts, and documentation fixes

## Problem

The formatter toolchain had inconsistent tool ordering:

| Layer | Order |
|---|---|
| `make format` | black → isort → ruff --fix (no ruff-format) |
| pre-commit hooks | ruff --fix → ruff-format → isort → black |
| CI | ruff check → ruff-format → black → isort |

`ruff-format` and `black` can disagree on edge cases (e.g. implicit string concatenation `"aaa" "bbb"` — ruff collapses to `"aaabbb"`, black preserves). Since `make format` didn't run `ruff-format` at all, code formatted locally could fail CI's `ruff format --check`.

## Solution

All three layers now run in the same order:
1. `ruff check --fix` — lint auto-fixes (may remove unused imports)
2. `isort` — import sorting (after ruff may have changed imports)
3. `ruff format` — stricter formatter (handles implicit string concat, etc.)
4. `black` — final authority (should be a no-op after ruff-format)

This order converges: running `make format` twice produces zero diff, and both `ruff format --check` and `black --check` pass on the result.

## CLAUDE.md improvements

- Added "Testing Conventions" subsection (use `tmp_path`, `qtbot`, test count guidance)
- Added `make preflight` shortcut mention in pre-flight checklist
- Added `make format-check` to work loop requirements
- Added post-issue completion checklist
- Added deprecation note to Legacy Branch Handling section
- Added formatter clarification (black + isort canonical)

## Test plan

- [x] `make format` produces zero changes on current codebase (85 files unchanged)
- [x] `make lint` passes all 4 checks
- [x] `make format` is idempotent (running twice = zero diff)
- [x] Edge case verified: implicit string concat converges correctly through full pipeline
- [ ] CI should pass all lint checks with the new ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)