### PR TITLE
add simulation presets with save/load/delete

### DIFF
--- a/app/simulation/preset_manager.py
+++ b/app/simulation/preset_manager.py
@@ -1,0 +1,141 @@
+"""Simulation preset manager - save/load analysis configurations as named presets."""
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Built-in presets shipped with the application
+BUILTIN_PRESETS = [
+    {
+        "name": "Quick Transient",
+        "analysis_type": "Transient",
+        "builtin": True,
+        "params": {"duration": 0.01, "step": 1e-05, "startTime": 0},
+    },
+    {
+        "name": "Audio AC Sweep",
+        "analysis_type": "AC Sweep",
+        "builtin": True,
+        "params": {"fStart": 20, "fStop": 20000, "points": 100, "sweepType": "dec"},
+    },
+    {
+        "name": "Wide AC Sweep",
+        "analysis_type": "AC Sweep",
+        "builtin": True,
+        "params": {"fStart": 1, "fStop": 1e9, "points": 100, "sweepType": "dec"},
+    },
+    {
+        "name": "Fine DC Sweep 0-5V",
+        "analysis_type": "DC Sweep",
+        "builtin": True,
+        "params": {"source": "V1", "min": 0, "max": 5, "step": 0.01},
+    },
+    {
+        "name": "Industrial Temp Range",
+        "analysis_type": "Temperature Sweep",
+        "builtin": True,
+        "params": {"tempStart": -40, "tempStop": 85, "tempStep": 25},
+    },
+]
+
+
+class PresetManager:
+    """Manages simulation presets (built-in + user-defined).
+
+    Presets are stored as JSON in a user-writable file. Built-in presets
+    are always available and cannot be deleted.
+    """
+
+    def __init__(self, preset_file: Optional[Path] = None):
+        if preset_file is None:
+            preset_file = self._default_preset_path()
+        self._preset_file = preset_file
+        self._user_presets: list[dict] = []
+        self._load()
+
+    @staticmethod
+    def _default_preset_path() -> Path:
+        """Return the default path for the user presets file."""
+        config_dir = Path.home() / ".spice-gui"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        return config_dir / "simulation_presets.json"
+
+    # --- Public API ---
+
+    def get_presets(self, analysis_type: Optional[str] = None) -> list[dict]:
+        """Return all presets, optionally filtered by analysis type."""
+        all_presets = BUILTIN_PRESETS + self._user_presets
+        if analysis_type:
+            return [p for p in all_presets if p["analysis_type"] == analysis_type]
+        return list(all_presets)
+
+    def get_preset_by_name(self, name: str, analysis_type: Optional[str] = None) -> Optional[dict]:
+        """Look up a preset by name (and optionally analysis type)."""
+        for p in self.get_presets(analysis_type):
+            if p["name"] == name:
+                return p
+        return None
+
+    def save_preset(self, name: str, analysis_type: str, params: dict) -> dict:
+        """Save a user preset. Overwrites if name+type already exists."""
+        # Don't overwrite built-in presets
+        for bp in BUILTIN_PRESETS:
+            if bp["name"] == name and bp["analysis_type"] == analysis_type:
+                raise ValueError(f"Cannot overwrite built-in preset '{name}'")
+
+        # Remove existing user preset with same name+type
+        self._user_presets = [
+            p for p in self._user_presets if not (p["name"] == name and p["analysis_type"] == analysis_type)
+        ]
+
+        preset = {
+            "name": name,
+            "analysis_type": analysis_type,
+            "params": params.copy(),
+        }
+        self._user_presets.append(preset)
+        self._save()
+        return preset
+
+    def delete_preset(self, name: str, analysis_type: Optional[str] = None) -> bool:
+        """Delete a user preset. Returns True if deleted, False if not found or built-in."""
+        for bp in BUILTIN_PRESETS:
+            if bp["name"] == name and (analysis_type is None or bp["analysis_type"] == analysis_type):
+                return False  # Can't delete built-in
+
+        before = len(self._user_presets)
+        self._user_presets = [
+            p
+            for p in self._user_presets
+            if not (p["name"] == name and (analysis_type is None or p["analysis_type"] == analysis_type))
+        ]
+        if len(self._user_presets) < before:
+            self._save()
+            return True
+        return False
+
+    # --- Persistence ---
+
+    def _load(self):
+        """Load user presets from disk."""
+        if not self._preset_file.exists():
+            self._user_presets = []
+            return
+        try:
+            data = json.loads(self._preset_file.read_text())
+            self._user_presets = data.get("presets", [])
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("Failed to load presets from %s: %s", self._preset_file, e)
+            self._user_presets = []
+
+    def _save(self):
+        """Write user presets to disk."""
+        try:
+            self._preset_file.parent.mkdir(parents=True, exist_ok=True)
+            data = {"presets": self._user_presets}
+            self._preset_file.write_text(json.dumps(data, indent=2))
+        except OSError as e:
+            logger.error("Failed to save presets to %s: %s", self._preset_file, e)

--- a/app/tests/unit/test_simulation_presets.py
+++ b/app/tests/unit/test_simulation_presets.py
@@ -1,0 +1,173 @@
+"""Tests for simulation presets - PresetManager and AnalysisDialog integration."""
+
+import json
+
+import pytest
+from simulation.preset_manager import BUILTIN_PRESETS, PresetManager
+
+
+@pytest.fixture
+def preset_file(tmp_path):
+    """Return a temporary preset file path."""
+    return tmp_path / "presets.json"
+
+
+@pytest.fixture
+def mgr(preset_file):
+    """Create a PresetManager with a temp file."""
+    return PresetManager(preset_file)
+
+
+# --- PresetManager unit tests ---
+
+
+class TestBuiltinPresets:
+    def test_builtin_presets_available(self, mgr):
+        presets = mgr.get_presets()
+        assert len(presets) >= len(BUILTIN_PRESETS)
+
+    def test_builtin_presets_have_required_fields(self, mgr):
+        for p in BUILTIN_PRESETS:
+            assert "name" in p
+            assert "analysis_type" in p
+            assert "params" in p
+
+    def test_filter_by_analysis_type(self, mgr):
+        ac_presets = mgr.get_presets("AC Sweep")
+        assert all(p["analysis_type"] == "AC Sweep" for p in ac_presets)
+        assert len(ac_presets) >= 2  # Audio + Wide
+
+    def test_filter_transient(self, mgr):
+        tran_presets = mgr.get_presets("Transient")
+        assert len(tran_presets) >= 1  # Quick Transient
+
+    def test_get_preset_by_name(self, mgr):
+        p = mgr.get_preset_by_name("Quick Transient")
+        assert p is not None
+        assert p["analysis_type"] == "Transient"
+
+    def test_get_preset_by_name_not_found(self, mgr):
+        assert mgr.get_preset_by_name("Nonexistent") is None
+
+
+class TestUserPresets:
+    def test_save_user_preset(self, mgr):
+        mgr.save_preset("My Sweep", "DC Sweep", {"source": "V2", "min": 0, "max": 3, "step": 0.5})
+        p = mgr.get_preset_by_name("My Sweep", "DC Sweep")
+        assert p is not None
+        assert p["params"]["source"] == "V2"
+
+    def test_save_overwrites_existing(self, mgr):
+        mgr.save_preset("My Sweep", "DC Sweep", {"source": "V1", "min": 0, "max": 5, "step": 0.1})
+        mgr.save_preset("My Sweep", "DC Sweep", {"source": "V2", "min": 0, "max": 10, "step": 1})
+        presets = mgr.get_presets("DC Sweep")
+        my_presets = [p for p in presets if p["name"] == "My Sweep"]
+        assert len(my_presets) == 1
+        assert my_presets[0]["params"]["source"] == "V2"
+
+    def test_cannot_overwrite_builtin(self, mgr):
+        with pytest.raises(ValueError, match="built-in"):
+            mgr.save_preset("Quick Transient", "Transient", {"duration": 1, "step": 0.001, "startTime": 0})
+
+    def test_delete_user_preset(self, mgr):
+        mgr.save_preset("Temp", "DC Sweep", {"source": "V1", "min": 0, "max": 5, "step": 0.1})
+        assert mgr.delete_preset("Temp", "DC Sweep") is True
+        assert mgr.get_preset_by_name("Temp", "DC Sweep") is None
+
+    def test_delete_nonexistent_returns_false(self, mgr):
+        assert mgr.delete_preset("Nonexistent") is False
+
+    def test_delete_builtin_returns_false(self, mgr):
+        assert mgr.delete_preset("Quick Transient") is False
+
+
+class TestPresetPersistence:
+    def test_presets_persist_to_disk(self, preset_file):
+        mgr1 = PresetManager(preset_file)
+        mgr1.save_preset("Saved", "Transient", {"duration": 0.1, "step": 1e-06, "startTime": 0})
+
+        mgr2 = PresetManager(preset_file)
+        p = mgr2.get_preset_by_name("Saved", "Transient")
+        assert p is not None
+        assert p["params"]["duration"] == 0.1
+
+    def test_corrupt_file_handled(self, preset_file):
+        preset_file.write_text("not valid json{{{")
+        mgr = PresetManager(preset_file)
+        # Should fall back to empty user presets, builtins still work
+        assert len(mgr.get_presets()) == len(BUILTIN_PRESETS)
+
+    def test_missing_file_handled(self, tmp_path):
+        mgr = PresetManager(tmp_path / "nonexistent" / "presets.json")
+        assert len(mgr.get_presets()) == len(BUILTIN_PRESETS)
+
+    def test_file_format_is_json(self, preset_file):
+        mgr = PresetManager(preset_file)
+        mgr.save_preset("Test", "AC Sweep", {"fStart": 10, "fStop": 1000, "points": 50, "sweepType": "dec"})
+        data = json.loads(preset_file.read_text())
+        assert "presets" in data
+        assert len(data["presets"]) == 1
+
+
+# --- AnalysisDialog + presets integration tests ---
+
+pytest.importorskip("PyQt6")
+
+from GUI.analysis_dialog import AnalysisDialog
+
+
+class TestDialogPresetUI:
+    def test_preset_combo_exists(self, qtbot, preset_file):
+        mgr = PresetManager(preset_file)
+        dialog = AnalysisDialog("AC Sweep", preset_manager=mgr)
+        qtbot.addWidget(dialog)
+        assert dialog.preset_combo is not None
+
+    def test_preset_combo_lists_builtins(self, qtbot, preset_file):
+        mgr = PresetManager(preset_file)
+        dialog = AnalysisDialog("AC Sweep", preset_manager=mgr)
+        qtbot.addWidget(dialog)
+        items = [dialog.preset_combo.itemText(i) for i in range(dialog.preset_combo.count())]
+        assert any("Audio AC Sweep" in item for item in items)
+        assert any("Wide AC Sweep" in item for item in items)
+
+    def test_selecting_preset_populates_fields(self, qtbot, preset_file):
+        mgr = PresetManager(preset_file)
+        dialog = AnalysisDialog("AC Sweep", preset_manager=mgr)
+        qtbot.addWidget(dialog)
+        # Find the "Audio AC Sweep" preset index
+        for i in range(dialog.preset_combo.count()):
+            if dialog.preset_combo.itemData(i) == "Audio AC Sweep":
+                dialog.preset_combo.setCurrentIndex(i)
+                break
+        # fStart should now be 20
+        widget, _ = dialog.field_widgets["fStart"]
+        assert widget.text() == "20"
+
+    def test_delete_button_disabled_for_builtin(self, qtbot, preset_file):
+        mgr = PresetManager(preset_file)
+        dialog = AnalysisDialog("AC Sweep", preset_manager=mgr)
+        qtbot.addWidget(dialog)
+        # Select a built-in preset
+        for i in range(dialog.preset_combo.count()):
+            if dialog.preset_combo.itemData(i) == "Audio AC Sweep":
+                dialog.preset_combo.setCurrentIndex(i)
+                break
+        assert not dialog.delete_preset_btn.isEnabled()
+
+    def test_delete_button_disabled_for_none(self, qtbot, preset_file):
+        mgr = PresetManager(preset_file)
+        dialog = AnalysisDialog("Transient", preset_manager=mgr)
+        qtbot.addWidget(dialog)
+        dialog.preset_combo.setCurrentIndex(0)  # (none)
+        assert not dialog.delete_preset_btn.isEnabled()
+
+    def test_preset_combo_only_shows_matching_type(self, qtbot, preset_file):
+        mgr = PresetManager(preset_file)
+        dialog = AnalysisDialog("DC Sweep", preset_manager=mgr)
+        qtbot.addWidget(dialog)
+        items = [dialog.preset_combo.itemText(i) for i in range(dialog.preset_combo.count())]
+        # Should not show AC Sweep presets
+        assert not any("Audio AC Sweep" in item for item in items)
+        # Should show DC Sweep presets
+        assert any("Fine DC Sweep" in item for item in items)


### PR DESCRIPTION
## Summary
- Adds `PresetManager` in `app/simulation/preset_manager.py` for persistent preset storage
- 5 built-in presets: Quick Transient, Audio AC Sweep, Wide AC Sweep, Fine DC Sweep 0-5V, Industrial Temp Range
- Analysis Dialog now has a Preset dropdown, Save button, and Delete button
- Presets filter by analysis type and persist to `~/.spice-gui/simulation_presets.json`
- Built-in presets are protected from deletion/overwriting

Closes #146

## Test plan
- [x] 22 new tests (16 PresetManager unit + 6 dialog integration)
- [x] All 745 tests pass (723 existing + 22 new)
- [x] Lint and format clean
- [ ] Manual: open Analysis Dialog, select preset, verify fields populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)