### PR TITLE
fix component palette focus policy for keyboard navigation

### DIFF
--- a/app/GUI/component_palette.py
+++ b/app/GUI/component_palette.py
@@ -71,6 +71,7 @@ class ComponentPalette(QWidget):
 
     def __init__(self):
         super().__init__()
+        self.setFocusPolicy(Qt.FocusPolicy.TabFocus)
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(4)


### PR DESCRIPTION
## Summary
- Sets `TabFocus` policy on `ComponentPalette` widget so it's reachable via Tab key
- Fixes `test_palette_focus_policy` failure introduced in PR #172 that is breaking CI on main

## Test plan
- [x] `test_keyboard_navigation.py::TestTabOrder::test_palette_focus_policy` should now pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)