### PR TITLE
Enhance FFT spectrum analysis with harmonics and toggles

### DIFF
--- a/app/tests/unit/test_fft_analysis.py
+++ b/app/tests/unit/test_fft_analysis.py
@@ -8,6 +8,7 @@ from simulation.fft_analysis import (
     compute_fft,
     compute_thd,
     find_fundamental_frequency,
+    find_harmonics,
 )
 
 
@@ -232,3 +233,117 @@ class TestAnalyzeSignalSpectrum:
 
         # Should identify 10 Hz as fundamental (largest amplitude)
         assert result.fundamental_freq == pytest.approx(10.0, abs=1.0)
+
+
+class TestFindHarmonics:
+    def test_single_sine_returns_fundamental(self):
+        """Test that a pure sine wave returns the fundamental as harmonic 1."""
+        time = np.linspace(0, 1, 1000, endpoint=False)
+        freq = 60.0
+        signal = np.sin(2 * np.pi * freq * time)
+
+        result = compute_fft(time, signal, "Test", "hanning")
+        harmonics = find_harmonics(result, freq, num_harmonics=5)
+
+        assert len(harmonics) >= 1
+        assert harmonics[0]["harmonic"] == 1
+        assert harmonics[0]["frequency"] == pytest.approx(freq, abs=2.0)
+        assert harmonics[0]["magnitude"] > 0
+
+    def test_signal_with_harmonics(self):
+        """Test that harmonics are detected in a signal with known harmonic content."""
+        time = np.linspace(0, 1, 2000, endpoint=False)
+        freq = 50.0
+        signal = np.sin(2 * np.pi * freq * time)
+        signal += 0.3 * np.sin(2 * np.pi * 2 * freq * time)
+        signal += 0.15 * np.sin(2 * np.pi * 3 * freq * time)
+
+        result = compute_fft(time, signal, "Test", "hanning")
+        harmonics = find_harmonics(result, freq, num_harmonics=5)
+
+        # Should find at least fundamental + 2nd + 3rd
+        assert len(harmonics) >= 3
+        assert harmonics[0]["harmonic"] == 1
+        assert harmonics[1]["harmonic"] == 2
+        assert harmonics[2]["harmonic"] == 3
+        # 2nd harmonic should be ~30% of fundamental
+        ratio = harmonics[1]["magnitude"] / harmonics[0]["magnitude"]
+        assert ratio == pytest.approx(0.3, abs=0.1)
+
+    def test_zero_fundamental_returns_empty(self):
+        """Test that zero fundamental frequency returns empty list."""
+        time = np.linspace(0, 1, 100, endpoint=False)
+        signal = np.sin(2 * np.pi * 5 * time)
+        result = compute_fft(time, signal, "Test", "none")
+
+        harmonics = find_harmonics(result, 0.0)
+        assert harmonics == []
+
+    def test_harmonics_beyond_nyquist_truncated(self):
+        """Test that harmonics beyond Nyquist frequency are not returned."""
+        time = np.linspace(0, 1, 100, endpoint=False)
+        # Fundamental at 40 Hz, Nyquist at 50 Hz → only 1st harmonic fits
+        freq = 40.0
+        signal = np.sin(2 * np.pi * freq * time)
+
+        result = compute_fft(time, signal, "Test", "none")
+        harmonics = find_harmonics(result, freq, num_harmonics=5)
+
+        # 2nd harmonic (80 Hz) exceeds Nyquist (50 Hz), so at most 1 harmonic
+        assert len(harmonics) == 1
+        assert harmonics[0]["harmonic"] == 1
+
+    def test_harmonics_have_db_values(self):
+        """Test that harmonic results include dB magnitude values."""
+        time = np.linspace(0, 1, 1000, endpoint=False)
+        freq = 100.0
+        signal = np.sin(2 * np.pi * freq * time)
+
+        result = compute_fft(time, signal, "Test", "hanning")
+        harmonics = find_harmonics(result, freq, num_harmonics=3)
+
+        assert len(harmonics) >= 1
+        for h in harmonics:
+            assert "magnitude_db" in h
+            assert isinstance(h["magnitude_db"], float)
+
+    def test_analyze_populates_harmonics(self):
+        """Test that analyze_signal_spectrum populates harmonics on the result."""
+        time = np.linspace(0, 1, 1000, endpoint=False)
+        freq = 50.0
+        signal = np.sin(2 * np.pi * freq * time)
+        signal += 0.2 * np.sin(2 * np.pi * 2 * freq * time)
+
+        result = analyze_signal_spectrum(time, signal, "Test", "hanning")
+
+        assert hasattr(result, "harmonics")
+        assert len(result.harmonics) >= 1
+        assert result.harmonics[0]["harmonic"] == 1
+
+
+class TestFFTDialogFeatures:
+    """Tests for FFTAnalysisDialog features (non-GUI, testing data flow)."""
+
+    def test_format_freq_hz(self):
+        """Test frequency formatting for Hz range."""
+        from GUI.waveform_dialog import FFTAnalysisDialog
+
+        # Access the static-like method via class
+        dialog_cls = FFTAnalysisDialog
+        # Create a minimal instance-like check using the method directly
+        assert "Hz" in dialog_cls._format_freq(None, 50.0)
+        assert "50.00 Hz" == dialog_cls._format_freq(None, 50.0)
+
+    def test_format_freq_khz(self):
+        """Test frequency formatting for kHz range."""
+        from GUI.waveform_dialog import FFTAnalysisDialog
+
+        assert "kHz" in FFTAnalysisDialog._format_freq(None, 5000.0)
+        assert "5.00 kHz" == FFTAnalysisDialog._format_freq(None, 5000.0)
+
+    def test_format_freq_mhz(self):
+        """Test frequency formatting for MHz range."""
+        from GUI.waveform_dialog import FFTAnalysisDialog
+
+        assert "MHz" in FFTAnalysisDialog._format_freq(None, 2.5e6)
+        assert "2.50 MHz" == FFTAnalysisDialog._format_freq(None, 2.5e6)


### PR DESCRIPTION
## Summary
- Add **harmonic identification and labeling** (first 5 harmonics with F0, H2-H5 labels) on the magnitude spectrum plot
- Add **dB / linear magnitude toggle** for the Y-axis
- Add **log / linear frequency scale toggle** for the X-axis
- Format frequency axis with **SI prefixes** (Hz, kHz, MHz)
- Rename button from "Analyze FFT" to **"Show Spectrum"**
- Add `find_harmonics()` function to `fft_analysis.py` for programmatic harmonic detection
- Populate `FFTResult.harmonics` automatically in `analyze_signal_spectrum()`

Closes #143

## Test plan
- [x] 9 new tests added (855 total, all passing)
- [ ] Verify "Show Spectrum" button opens dialog from transient waveform view
- [ ] Verify dB/linear toggle switches magnitude axis correctly
- [ ] Verify log/linear toggle switches frequency axis correctly
- [ ] Verify harmonic labels (F0, H2-H5) appear on periodic signals
- [ ] Verify THD and fundamental frequency displayed in info bar
- [ ] Verify graceful behavior with non-periodic signals (no harmonics labeled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)