### PR TITLE
add wire labels and net name persistence

### DIFF
--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -1320,7 +1320,8 @@ class MainWindow(QMainWindow):
 
         # Apply global widget stylesheet for dark mode
         if is_dark:
-            self.setStyleSheet("""
+            self.setStyleSheet(
+                """
                 QMainWindow, QWidget { background-color: #1E1E1E; color: #D4D4D4; }
                 QMenuBar { background-color: #2D2D2D; color: #D4D4D4; }
                 QMenuBar::item:selected { background-color: #3D3D3D; }
@@ -1343,7 +1344,8 @@ class MainWindow(QMainWindow):
                 QTableWidget { background-color: #2D2D2D; color: #D4D4D4;
                     gridline-color: #555555; }
                 QHeaderView::section { background-color: #3D3D3D; color: #D4D4D4; }
-            """)
+            """
+            )
         else:
             self.setStyleSheet("")
 
@@ -1370,6 +1372,7 @@ class MainWindow(QMainWindow):
             "wire_added",
             "wire_removed",
             "wire_routed",
+            "net_name_changed",
         }
         if event in dirty_events:
             self._set_dirty(True)

--- a/app/models/node.py
+++ b/app/models/node.py
@@ -86,8 +86,8 @@ class NodeData:
             return self.custom_label
         return self.auto_label
 
-    def set_custom_label(self, label: str) -> None:
-        """Set a custom label for this node."""
+    def set_custom_label(self, label: Optional[str]) -> None:
+        """Set a custom label for this node, or None to clear it."""
         self.custom_label = label
 
     def add_terminal(self, component_id: str, terminal_index: int) -> None:

--- a/app/tests/unit/test_node.py
+++ b/app/tests/unit/test_node.py
@@ -1,0 +1,67 @@
+"""Tests for NodeData custom labels and net names."""
+
+from models.node import NodeData, _generate_label, reset_node_counter
+
+
+class TestNodeCustomLabel:
+    def test_custom_label_overrides_auto_label(self):
+        node = NodeData(auto_label="nodeA")
+        node.set_custom_label("Vout")
+        assert node.get_label() == "Vout"
+
+    def test_clear_custom_label_reverts_to_auto(self):
+        node = NodeData(auto_label="nodeA")
+        node.set_custom_label("Vout")
+        assert node.get_label() == "Vout"
+        node.set_custom_label(None)
+        assert node.get_label() == "nodeA"
+
+    def test_ground_with_custom_label_shows_ground_suffix(self):
+        node = NodeData(is_ground=True, auto_label="0")
+        node.set_custom_label("GND_NET")
+        assert node.get_label() == "GND_NET (ground)"
+
+    def test_ground_without_custom_label_shows_zero(self):
+        node = NodeData(is_ground=True, auto_label="0")
+        assert node.get_label() == "0"
+
+    def test_set_custom_label_accepts_none(self):
+        node = NodeData(auto_label="nodeA")
+        node.set_custom_label(None)
+        assert node.custom_label is None
+        assert node.get_label() == "nodeA"
+
+
+class TestNodeLabelGeneration:
+    def test_generate_single_letter_labels(self):
+        assert _generate_label(0) == "nodeA"
+        assert _generate_label(25) == "nodeZ"
+
+    def test_generate_double_letter_labels(self):
+        assert _generate_label(26) == "nodeAA"
+        assert _generate_label(27) == "nodeAB"
+
+    def test_auto_label_increments(self):
+        reset_node_counter()
+        n1 = NodeData()
+        n2 = NodeData()
+        assert n1.auto_label == "nodeA"
+        assert n2.auto_label == "nodeB"
+
+    def test_ground_node_auto_label_is_zero(self):
+        node = NodeData(is_ground=True)
+        assert node.auto_label == "0"
+
+
+class TestNodeMerge:
+    def test_merge_preserves_custom_label(self):
+        node1 = NodeData(auto_label="nodeA")
+        node1.set_custom_label("Vout")
+        node1.add_terminal("R1", 0)
+
+        node2 = NodeData(auto_label="nodeB")
+        node2.add_terminal("R2", 0)
+
+        node1.merge_with(node2)
+        assert node1.custom_label == "Vout"
+        assert ("R2", 0) in node1.terminals


### PR DESCRIPTION
## Summary
- Persist custom net names through save/load cycle in CircuitModel serialization (new `net_names` key in JSON)
- Rename context menu from "Label Node" to "Set Net Name" for clearer UX
- Allow clearing net names by entering empty text in the dialog
- Notify controller on net name changes (marks circuit as dirty / unsaved)
- Update `NodeData.set_custom_label()` to accept `Optional[str]`

## Changes
- `app/models/circuit.py` — `to_dict()` / `from_dict()` serialize/restore custom node labels
- `app/models/node.py` — `set_custom_label()` accepts `None` to clear labels
- `app/GUI/circuit_canvas.py` — "Set Net Name" context menu, improved dialog, controller notification
- `app/GUI/main_window.py` — `net_name_changed` added to dirty events
- `app/tests/unit/test_circuit_model.py` — 5 new serialization tests for net names
- `app/tests/unit/test_node.py` — 10 new tests for NodeData labels, clearing, generation

## Test plan
- [x] All 912 tests pass (15 new)
- [x] Formatting and lint clean
- [ ] Manual: right-click wire → "Set Net Name" → enter name → verify label appears
- [ ] Manual: save circuit with net name → reload → verify name persists
- [ ] Manual: clear net name (empty text) → verify reverts to auto label

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)