### PR TITLE
Fix pathfinding fallback drawing straight line through components

### DIFF
--- a/app/models/wire.py
+++ b/app/models/wire.py
@@ -26,6 +26,7 @@ class WireData:
     algorithm: str = "idastar"
     runtime: float = 0.0  # Time taken to route (seconds)
     iterations: int = 0  # Pathfinding iterations
+    routing_failed: bool = False  # True when pathfinding fell back to straight line
 
     def get_terminals(self) -> list[tuple[str, int]]:
         """


### PR DESCRIPTION
## Summary
- When IDA* pathfinding fails to find a valid route, the wire is now drawn with a **dashed red line** instead of a solid line passing through component bodies
- A **status bar message** warns the user: "Wire routing failed — move components to create space"
- Added `routing_failed` flag to `WireData` model so the failure state persists with the wire

Closes #155

## Test plan
- [x] 7 new tests added (904 total, was 897)
- [x] `find_path` returns `routing_failed=True` when completely blocked
- [x] `find_path` returns `routing_failed=False` on successful routing
- [x] Failed route returns straight-line fallback as start/end positions
- [x] Passable obstacles don't trigger false failure
- [x] Return value is now a 4-tuple
- [x] `WireData.routing_failed` defaults to False and is settable
- [ ] Manual: place components densely, draw wire through blocked area — verify dashed red line and status bar message

🤖 Generated with [Claude Code](https://claude.com/claude-code)