### PR TITLE
Implement terminal availability check and duplicate wire prevention

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -1496,7 +1496,51 @@ class CircuitCanvasView(QGraphicsView):
                 viewPort.update()
 
     def is_terminal_available(self, component, terminal_index):
-        """Check if a component's terminal is available for connection"""
+        """Check if a terminal can accept a new wire connection.
+
+        Multi-wire terminals are allowed (junctions are valid in SPICE).
+        However, duplicate wires between the exact same terminal pair are
+        rejected — this is checked when completing the wire, not when
+        starting it.  When starting a wire, any terminal is valid.
+        """
+        if self.wire_start_comp is None:
+            # Starting a wire — any terminal is valid
+            return True
+
+        # Completing a wire — check for duplicate wire
+        start_id = self.wire_start_comp.component_id
+        start_term = self.wire_start_term
+        end_id = component.component_id
+        end_term = terminal_index
+
+        for wire in self.wires:
+            same_fwd = (
+                wire.model.start_component_id == start_id
+                and wire.model.start_terminal == start_term
+                and wire.model.end_component_id == end_id
+                and wire.model.end_terminal == end_term
+            )
+            same_rev = (
+                wire.model.start_component_id == end_id
+                and wire.model.start_terminal == end_term
+                and wire.model.end_component_id == start_id
+                and wire.model.end_terminal == start_term
+            )
+            if same_fwd or same_rev:
+                logger.info(
+                    "Duplicate wire rejected: %s[%s] -> %s[%s]",
+                    start_id,
+                    start_term,
+                    end_id,
+                    end_term,
+                )
+                main_window = self.window() if hasattr(self, "window") else None
+                if main_window and hasattr(main_window, "statusBar"):
+                    status = main_window.statusBar()
+                    if status:
+                        status.showMessage("Wire already exists between these terminals", 3000)
+                return False
+
         return True
 
     def handle_ground_added(self, ground_comp):


### PR DESCRIPTION
## Summary
- Replace stub `is_terminal_available()` that always returned `True` with actual duplicate wire validation
- Multi-wire terminals (junctions) are allowed since they are electrically valid in SPICE
- Duplicate wires between the exact same terminal pair are rejected (both directions checked)
- Defense-in-depth: `has_duplicate_wire()` check added in `CircuitController.add_wire()` as well
- Status bar shows "Wire already exists between these terminals" when rejected

Closes #156

## Test plan
- [x] 7 new tests added (904 total, was 897)
- [x] `has_duplicate_wire` returns False when no wires exist
- [x] `has_duplicate_wire` detects exact match
- [x] `has_duplicate_wire` detects reverse-direction match
- [x] Different terminal on same component is NOT a duplicate
- [x] `add_wire` returns None for duplicate
- [x] `add_wire` returns None for reverse duplicate
- [x] Multi-wire terminals to different components are allowed
- [ ] Manual: draw two wires between same terminals — verify second is rejected with status bar message

🤖 Generated with [Claude Code](https://claude.com/claude-code)