### PR TITLE
consolidate SPICE value formatting: dedup _format_sweep_value

### DIFF
--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -491,30 +491,10 @@ class SimulationController:
 
     @staticmethod
     def _format_sweep_value(value: float) -> str:
-        """Format a float as a SPICE-compatible value string."""
-        if value == 0:
-            return "0"
+        """Format a float as a SPICE-compatible value string.
 
-        abs_val = abs(value)
-        # SPICE prefixes (MEG for mega to avoid ambiguity with milli)
-        prefixes = [
-            (1e12, "T"),
-            (1e9, "G"),
-            (1e6, "MEG"),
-            (1e3, "k"),
-            (1, ""),
-            (1e-3, "m"),
-            (1e-6, "u"),
-            (1e-9, "n"),
-            (1e-12, "p"),
-            (1e-15, "f"),
-        ]
+        Delegates to the canonical implementation in simulation.monte_carlo.
+        """
+        from simulation.monte_carlo import format_spice_value
 
-        for mult, prefix in prefixes:
-            if abs_val >= mult:
-                scaled = value / mult
-                if scaled == int(scaled):
-                    return f"{int(scaled)}{prefix}"
-                return f"{scaled:.6g}{prefix}"
-
-        return f"{value:.6g}"
+        return format_spice_value(value)


### PR DESCRIPTION
## Summary
- Replaced 25-line duplicate `SimulationController._format_sweep_value()` with a 3-line delegation to the canonical `simulation.monte_carlo.format_spice_value()`
- Added 8 new tests: delegation equivalence, parse/format round-trip, negative values, very small/large values, case sensitivity

Part of Epic #210 (Advanced Simulation).

## Test plan
- [x] 8 new tests in `test_monte_carlo.py` (40 total)
- [x] All 1021 tests pass
- [x] Lint clean (`make lint`)
- [x] `_format_sweep_value` produces identical output to `format_spice_value` for all test values

🤖 Generated with [Claude Code](https://claude.com/claude-code)