### PR TITLE
fix .op simulation crash from dict key iteration

### DIFF
--- a/app/GUI/main_window_simulation.py
+++ b/app/GUI/main_window_simulation.py
@@ -395,7 +395,7 @@ class SimulationMixin:
         """Calculate and display power dissipation for all components."""
         from simulation.power_calculator import calculate_power, total_power
 
-        components = self.circuit_ctrl.model.components
+        components = list(self.circuit_ctrl.model.components.values())
         nodes = self.circuit_ctrl.model.nodes
         power_data = calculate_power(components, nodes, node_voltages)
 


### PR DESCRIPTION
## Summary
- `_calculate_power()` in `main_window_simulation.py` passed `self.circuit_ctrl.model.components` (a dict) to `calculate_power()`, which iterated over the dict keys (strings) instead of values (ComponentData objects), causing `AttributeError: 'str' object has no attribute 'component_id'`
- Fixed by using `list(self.circuit_ctrl.model.components.values())` to pass the actual ComponentData objects
- Added 5 regression tests covering dict_values input, raw dict error, multi-component sums, single-component, and empty dict

## Test plan
- [x] All 1064 tests pass
- [x] Lint clean
- [ ] Manual: create a circuit and run .op simulation — should display results without crashing

Fixes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)