### PR TITLE
remove duplicate wire rerouting on component drag

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from models.component import DEFAULT_VALUES, ComponentData
 
 from .format_utils import validate_component_value
-from .styles import GRID_SIZE, TERMINAL_HOVER_RADIUS, WIRE_UPDATE_DELAY_MS, theme_manager
+from .styles import GRID_SIZE, TERMINAL_HOVER_RADIUS, theme_manager
 
 
 class ComponentGraphicsItem(QGraphicsItem):
@@ -42,8 +42,6 @@ class ComponentGraphicsItem(QGraphicsItem):
         self.terminals = []  # List[QPointF] - Qt rendering positions
         self.connections = []  # Store wire connections
         self.is_being_dragged = False
-        self.last_position = None
-        self.update_timer = None
         self._group_moving = False  # Guard against recursive group moves
 
         # Phase 5: Debounced position updates to controller
@@ -273,29 +271,6 @@ class ComponentGraphicsItem(QGraphicsItem):
         for terminal in self.terminals:
             painter.drawEllipse(terminal, 3, 3)
 
-    def schedule_wire_update(self):
-        """Schedule a wire update after a short delay"""
-        if self.update_timer is not None:
-            self.update_timer.stop()
-            self.update_timer = None
-
-        self.update_timer = QTimer()
-        self.update_timer.setSingleShot(True)
-        self.update_timer.timeout.connect(self.update_wires_after_drag)
-        self.update_timer.start(WIRE_UPDATE_DELAY_MS)
-
-    def update_wires_after_drag(self):
-        """Called after drag motion has stopped"""
-        if self.last_position is not None and self.last_position != self.pos():
-            if self.scene():
-                views = self.scene().views()
-                if views:
-                    canvas = views[0]
-                    if hasattr(canvas, "reroute_connected_wires"):
-                        canvas.reroute_connected_wires(self)
-        self.last_position = None
-        self.update_timer = None
-
     def itemChange(self, change, value):
         if change == QGraphicsItem.GraphicsItemChange.ItemPositionChange and self.scene():
             # Snap to grid
@@ -317,11 +292,6 @@ class ComponentGraphicsItem(QGraphicsItem):
             # Phase 5: Schedule debounced controller update instead of direct model write
             self._pending_position = (grid_x, grid_y)
             self._schedule_controller_update()
-
-            # Track that we're moving and schedule an update
-            if self.last_position is None:
-                self.last_position = self.pos()
-            self.schedule_wire_update()
 
             return snapped_pos
         elif change == QGraphicsItem.GraphicsItemChange.ItemPositionHasChanged:

--- a/app/tests/unit/test_wire_reroute_dedup.py
+++ b/app/tests/unit/test_wire_reroute_dedup.py
@@ -1,0 +1,105 @@
+"""Tests for wire rerouting deduplication (#189).
+
+Verifies that component drags trigger wire rerouting through exactly one
+path (the observer/controller path) instead of two (observer + timer).
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from controllers.circuit_controller import CircuitController
+from models.circuit import CircuitModel
+
+
+class TestObserverRerouteOnMove:
+    """The observer path should fire component_moved on move_component."""
+
+    def test_move_component_fires_event(self):
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Resistor", (0, 0))
+
+        events = []
+        ctrl.add_observer(lambda e, d: events.append(e))
+
+        ctrl.move_component(comp.component_id, (100, 100))
+
+        assert "component_moved" in events
+
+    def test_move_component_updates_model_position(self):
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Resistor", (0, 0))
+
+        ctrl.move_component(comp.component_id, (200, 300))
+
+        assert model.components[comp.component_id].position == (200, 300)
+
+    def test_move_component_passes_data_to_observer(self):
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Resistor", (0, 0))
+
+        data_received = []
+        ctrl.add_observer(lambda e, d: data_received.append(d) if e == "component_moved" else None)
+
+        ctrl.move_component(comp.component_id, (50, 75))
+
+        assert len(data_received) == 1
+        assert data_received[0].position == (50, 75)
+
+
+class TestTimerPathRemoved:
+    """The old timer-based wire reroute path should not exist."""
+
+    def test_no_schedule_wire_update_method(self):
+        """ComponentGraphicsItem should not have schedule_wire_update."""
+        from GUI.component_item import ComponentGraphicsItem
+
+        assert not hasattr(ComponentGraphicsItem, "schedule_wire_update")
+
+    def test_no_update_wires_after_drag_method(self):
+        """ComponentGraphicsItem should not have update_wires_after_drag."""
+        from GUI.component_item import ComponentGraphicsItem
+
+        assert not hasattr(ComponentGraphicsItem, "update_wires_after_drag")
+
+    def test_no_wire_update_timer_attribute(self):
+        """ComponentGraphicsItem should not have self.update_timer in init."""
+        import inspect
+
+        from GUI.component_item import ComponentGraphicsItem
+
+        source = inspect.getsource(ComponentGraphicsItem.__init__)
+        assert "self.update_timer" not in source
+
+    def test_no_last_position_attribute(self):
+        """ComponentGraphicsItem should not reference last_position in init."""
+        import inspect
+
+        from GUI.component_item import ComponentGraphicsItem
+
+        source = inspect.getsource(ComponentGraphicsItem.__init__)
+        assert "last_position" not in source
+
+
+class TestSingleReroutePath:
+    """Verify only one code path exists from drag to reroute."""
+
+    def test_itemchange_does_not_call_schedule_wire_update(self):
+        """itemChange source should not reference schedule_wire_update."""
+        import inspect
+
+        from GUI.component_item import ComponentGraphicsItem
+
+        source = inspect.getsource(ComponentGraphicsItem.itemChange)
+        assert "schedule_wire_update" not in source
+
+    def test_itemchange_schedules_controller_update(self):
+        """itemChange source should still schedule controller updates."""
+        import inspect
+
+        from GUI.component_item import ComponentGraphicsItem
+
+        source = inspect.getsource(ComponentGraphicsItem.itemChange)
+        assert "_schedule_controller_update" in source


### PR DESCRIPTION
## Summary
- Removed the timer-based wire rerouting path (`schedule_wire_update` / `update_wires_after_drag`) from `ComponentGraphicsItem`
- Wires are now rerouted through exactly one path: the observer pattern (`controller.move_component()` → `component_moved` event → `_handle_component_moved()` → `reroute_connected_wires()`)
- Removed `last_position` and `update_timer` instance variables and the `WIRE_UPDATE_DELAY_MS` import
- Added 9 tests verifying the observer path works and the old timer path is gone

## Test plan
- [x] All 1089 tests pass
- [x] Lint clean
- [ ] Manual: drag a component with wires — verify wires reroute once (no flicker) and performance is unchanged

Fixes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)