### PR TITLE
skip duplicate wire reroute for co-selected endpoints

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -419,10 +419,20 @@ class CircuitCanvasView(QGraphicsView):
                 self._grid_items.append(label)
 
     def reroute_connected_wires(self, component):
-        """Reroute all wires connected to a component"""
+        """Reroute all wires connected to a component.
+
+        For wires where both endpoints are selected (co-selected group drag),
+        only the endpoint with the lower component_id triggers the reroute.
+        This prevents the same wire being rerouted twice per drag event.
+        """
         wire_count = 0
         for wire in self.wires:
             if wire.start_comp == component or wire.end_comp == component:
+                # Skip if both endpoints are co-selected and the other has lower ID
+                # (that endpoint's reroute call will handle this wire)
+                other = wire.end_comp if wire.start_comp == component else wire.start_comp
+                if component.isSelected() and other.isSelected() and other.component_id < component.component_id:
+                    continue
                 wire.update_position()
                 wire_count += 1
 


### PR DESCRIPTION
## Summary
- In `reroute_connected_wires()`, when both endpoints of a wire are co-selected (group drag), only the endpoint with the lower `component_id` triggers the reroute
- Combined with #189 (timer path removal), this reduces wire reroutes from 4x to 1x per drag event for co-selected wires
- Added 5 mock-based tests verifying the skip logic, tiebreaker, and non-selected edge cases

## Test plan
- [x] All 1119 tests pass (5 new)
- [x] Lint clean
- [ ] Manual: select 2+ connected components, drag together, verify wires reroute once (check for performance improvement / no flicker)

Fixes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)