### PR TITLE
Add tooltips to analysis dialog parameters

### DIFF
--- a/app/GUI/analysis_dialog.py
+++ b/app/GUI/analysis_dialog.py
@@ -23,6 +23,7 @@ class AnalysisDialog(QDialog):
         "DC Operating Point": {
             "fields": [],
             "description": "Calculate DC operating point of the circuit",
+            "tooltips": {},
         },
         "DC Sweep": {
             "fields": [
@@ -32,6 +33,12 @@ class AnalysisDialog(QDialog):
                 ("Step Size (V)", "step", "float", "0.1"),
             ],
             "description": "Sweep a voltage source and measure circuit response",
+            "tooltips": {
+                "source": "Name of the voltage source to sweep (e.g., V1)",
+                "min": "Starting voltage for the DC sweep (V)",
+                "max": "Ending voltage for the DC sweep (V)",
+                "step": "Voltage increment between sweep points (V)",
+            },
         },
         "AC Sweep": {
             "fields": [
@@ -41,6 +48,12 @@ class AnalysisDialog(QDialog):
                 ("Sweep Type", "sweepType", "combo", ["dec", "oct", "lin"], "dec"),
             ],
             "description": "Frequency domain analysis",
+            "tooltips": {
+                "fStart": "Starting frequency for the AC sweep (Hz)",
+                "fStop": "Ending frequency for the AC sweep (Hz)",
+                "points": "Number of frequency points per decade (log scale)",
+                "sweepType": "Frequency scale: dec (decade/log), oct (octave), lin (linear)",
+            },
         },
         "Transient": {
             "fields": [
@@ -49,6 +62,11 @@ class AnalysisDialog(QDialog):
                 ("Start Time", "startTime", "float", "0"),
             ],
             "description": "Time domain analysis",
+            "tooltips": {
+                "duration": "Total simulation time (supports SI prefixes: 10m = 10 ms, 100u = 100 \u00b5s)",
+                "step": "Maximum time step for the simulation (supports SI prefixes: 1u = 1 \u00b5s)",
+                "startTime": "Time at which to start recording output data (default: 0)",
+            },
         },
         "Temperature Sweep": {
             "fields": [
@@ -60,6 +78,11 @@ class AnalysisDialog(QDialog):
                 "Sweep temperature and run a DC operating point analysis "
                 "at each temperature to see how circuit behavior changes"
             ),
+            "tooltips": {
+                "tempStart": "Starting temperature in degrees Celsius",
+                "tempStop": "Ending temperature in degrees Celsius",
+                "tempStep": "Temperature increment between sweep points (\u00b0C)",
+            },
         },
     }
 
@@ -81,6 +104,7 @@ class AnalysisDialog(QDialog):
         # Analysis type selector (if not provided)
         if self.analysis_type is None:
             self.type_combo = QComboBox()
+            self.type_combo.setToolTip("Select the type of circuit analysis to perform")
             self.type_combo.addItems(self.ANALYSIS_CONFIGS.keys())
             self.type_combo.currentTextChanged.connect(self._on_type_changed)
             layout.addWidget(QLabel("Analysis Type:"))
@@ -96,6 +120,7 @@ class AnalysisDialog(QDialog):
         preset_layout = QHBoxLayout()
         preset_layout.addWidget(QLabel("Preset:"))
         self.preset_combo = QComboBox()
+        self.preset_combo.setToolTip("Load a saved parameter preset")
         self.preset_combo.setMinimumWidth(180)
         self.preset_combo.currentIndexChanged.connect(self._on_preset_selected)
         preset_layout.addWidget(self.preset_combo, 1)
@@ -146,6 +171,7 @@ class AnalysisDialog(QDialog):
         self.desc_label.setText(config["description"])
 
         # Build fields
+        tooltips = config.get("tooltips", {})
         for field_config in config["fields"]:
             # Unpack based on field type
             if field_config[2] == "combo":  # (label, key, "combo", options, default)
@@ -156,6 +182,10 @@ class AnalysisDialog(QDialog):
             else:  # (label, key, type, default)
                 label, key, field_type, default = field_config
                 widget = QLineEdit(str(default))
+
+            tooltip = tooltips.get(key)
+            if tooltip:
+                widget.setToolTip(tooltip)
 
             self.field_widgets[key] = (widget, field_type)
             self.form_layout.addRow(f"{label}:", widget)

--- a/app/GUI/parameter_sweep_dialog.py
+++ b/app/GUI/parameter_sweep_dialog.py
@@ -160,6 +160,7 @@ class ParameterSweepDialog(QDialog):
         analysis_type = self.analysis_combo.currentText()
         config = AnalysisDialog.ANALYSIS_CONFIGS.get(analysis_type, {})
 
+        tooltips = config.get("tooltips", {})
         for field_config in config.get("fields", []):
             if field_config[2] == "combo":
                 label, key, _, options, default = field_config
@@ -169,6 +170,10 @@ class ParameterSweepDialog(QDialog):
             else:
                 label, key, field_type, default = field_config
                 widget = QLineEdit(str(default))
+
+            tooltip = tooltips.get(key)
+            if tooltip:
+                widget.setToolTip(tooltip)
 
             self._base_field_widgets[key] = (widget, field_config[2])
             self._base_form.addRow(f"{label}:", widget)

--- a/app/tests/unit/test_analysis_tooltips.py
+++ b/app/tests/unit/test_analysis_tooltips.py
@@ -1,0 +1,218 @@
+"""Tests for analysis dialog tooltips (issue #231).
+
+Verifies that all input fields across the analysis dialogs have
+descriptive tooltips to guide users.
+"""
+
+import pytest
+from GUI.analysis_dialog import AnalysisDialog
+
+
+class TestAnalysisConfigTooltips:
+    """Every field in ANALYSIS_CONFIGS should have a corresponding tooltip."""
+
+    def test_dc_sweep_fields_have_tooltips(self):
+        """All DC Sweep fields should have tooltip entries."""
+        config = AnalysisDialog.ANALYSIS_CONFIGS["DC Sweep"]
+        tooltips = config["tooltips"]
+        for field_config in config["fields"]:
+            key = field_config[1]
+            assert key in tooltips, f"DC Sweep field '{key}' missing tooltip"
+            assert len(tooltips[key]) > 0
+
+    def test_ac_sweep_fields_have_tooltips(self):
+        """All AC Sweep fields should have tooltip entries."""
+        config = AnalysisDialog.ANALYSIS_CONFIGS["AC Sweep"]
+        tooltips = config["tooltips"]
+        for field_config in config["fields"]:
+            key = field_config[1]
+            assert key in tooltips, f"AC Sweep field '{key}' missing tooltip"
+            assert len(tooltips[key]) > 0
+
+    def test_transient_fields_have_tooltips(self):
+        """All Transient fields should have tooltip entries."""
+        config = AnalysisDialog.ANALYSIS_CONFIGS["Transient"]
+        tooltips = config["tooltips"]
+        for field_config in config["fields"]:
+            key = field_config[1]
+            assert key in tooltips, f"Transient field '{key}' missing tooltip"
+            assert len(tooltips[key]) > 0
+
+    def test_temperature_sweep_fields_have_tooltips(self):
+        """All Temperature Sweep fields should have tooltip entries."""
+        config = AnalysisDialog.ANALYSIS_CONFIGS["Temperature Sweep"]
+        tooltips = config["tooltips"]
+        for field_config in config["fields"]:
+            key = field_config[1]
+            assert key in tooltips, f"Temperature Sweep field '{key}' missing tooltip"
+            assert len(tooltips[key]) > 0
+
+    def test_dc_operating_point_has_empty_tooltips(self):
+        """DC Operating Point has no fields, so tooltips should be empty."""
+        config = AnalysisDialog.ANALYSIS_CONFIGS["DC Operating Point"]
+        assert config["tooltips"] == {}
+
+    def test_all_configs_have_tooltips_key(self):
+        """Every analysis config should have a 'tooltips' key."""
+        for name, config in AnalysisDialog.ANALYSIS_CONFIGS.items():
+            assert "tooltips" in config, f"Config '{name}' missing 'tooltips' key"
+
+    def test_no_orphan_tooltip_keys(self):
+        """Tooltip keys should match actual field keys (no stale entries)."""
+        for name, config in AnalysisDialog.ANALYSIS_CONFIGS.items():
+            field_keys = {fc[1] for fc in config["fields"]}
+            tooltip_keys = set(config.get("tooltips", {}).keys())
+            orphans = tooltip_keys - field_keys
+            assert not orphans, f"Config '{name}' has orphan tooltip keys: {orphans}"
+
+
+class TestAnalysisDialogWidgetTooltips:
+    """Verify tooltips are applied to actual QWidget instances."""
+
+    @pytest.fixture
+    def dialog(self, qtbot):
+        dlg = AnalysisDialog(analysis_type="DC Sweep")
+        qtbot.addWidget(dlg)
+        return dlg
+
+    def test_dc_sweep_source_widget_has_tooltip(self, dialog):
+        """The 'source' QLineEdit should have a non-empty tooltip."""
+        widget, _ = dialog.field_widgets["source"]
+        assert widget.toolTip() != ""
+
+    def test_dc_sweep_all_widgets_have_tooltips(self, dialog):
+        """All DC Sweep field widgets should have tooltips."""
+        for key, (widget, _) in dialog.field_widgets.items():
+            assert widget.toolTip() != "", f"Widget for '{key}' has no tooltip"
+
+    def test_ac_sweep_widgets_have_tooltips(self, qtbot):
+        """All AC Sweep field widgets should have tooltips."""
+        dlg = AnalysisDialog(analysis_type="AC Sweep")
+        qtbot.addWidget(dlg)
+        for key, (widget, _) in dlg.field_widgets.items():
+            assert widget.toolTip() != "", f"Widget for '{key}' has no tooltip"
+
+    def test_transient_widgets_have_tooltips(self, qtbot):
+        """All Transient field widgets should have tooltips."""
+        dlg = AnalysisDialog(analysis_type="Transient")
+        qtbot.addWidget(dlg)
+        for key, (widget, _) in dlg.field_widgets.items():
+            assert widget.toolTip() != "", f"Widget for '{key}' has no tooltip"
+
+    def test_temperature_sweep_widgets_have_tooltips(self, qtbot):
+        """All Temperature Sweep field widgets should have tooltips."""
+        dlg = AnalysisDialog(analysis_type="Temperature Sweep")
+        qtbot.addWidget(dlg)
+        for key, (widget, _) in dlg.field_widgets.items():
+            assert widget.toolTip() != "", f"Widget for '{key}' has no tooltip"
+
+    def test_type_combo_has_tooltip(self, qtbot):
+        """The analysis type combo (when no type preset) should have a tooltip."""
+        dlg = AnalysisDialog()
+        qtbot.addWidget(dlg)
+        assert dlg.type_combo.toolTip() != ""
+
+    def test_preset_combo_has_tooltip(self, dialog):
+        """The preset combo should have a tooltip."""
+        assert dialog.preset_combo.toolTip() != ""
+
+    def test_save_preset_button_has_tooltip(self, dialog):
+        """The save preset button should have a tooltip."""
+        assert dialog.save_preset_btn.toolTip() != ""
+
+    def test_delete_preset_button_has_tooltip(self, dialog):
+        """The delete preset button should have a tooltip."""
+        assert dialog.delete_preset_btn.toolTip() != ""
+
+
+class TestParameterSweepDialogTooltips:
+    """Verify tooltips on ParameterSweepDialog widgets."""
+
+    @pytest.fixture
+    def dialog(self, qtbot):
+        from GUI.parameter_sweep_dialog import ParameterSweepDialog
+        from models.component import ComponentData
+
+        components = {
+            "R1": ComponentData(
+                component_id="R1",
+                component_type="Resistor",
+                value="1k",
+                position=(0, 0),
+            ),
+        }
+        dlg = ParameterSweepDialog(components)
+        qtbot.addWidget(dlg)
+        return dlg
+
+    def test_component_combo_has_tooltip(self, dialog):
+        assert dialog.component_combo.toolTip() != ""
+
+    def test_start_edit_has_tooltip(self, dialog):
+        assert dialog.start_edit.toolTip() != ""
+
+    def test_stop_edit_has_tooltip(self, dialog):
+        assert dialog.stop_edit.toolTip() != ""
+
+    def test_steps_spin_has_tooltip(self, dialog):
+        assert dialog.steps_spin.toolTip() != ""
+
+    def test_analysis_combo_has_tooltip(self, dialog):
+        assert dialog.analysis_combo.toolTip() != ""
+
+    def test_base_form_fields_get_tooltips_on_type_change(self, dialog):
+        """Changing base analysis type should apply tooltips to new fields."""
+        dialog.analysis_combo.setCurrentText("Transient")
+        for key, (widget, _) in dialog._base_field_widgets.items():
+            assert widget.toolTip() != "", f"Base field '{key}' has no tooltip"
+
+
+class TestMonteCarloDialogTooltips:
+    """Verify tooltips on MonteCarloDialog widgets."""
+
+    @pytest.fixture
+    def dialog(self, qtbot):
+        from GUI.monte_carlo_dialog import MonteCarloDialog
+        from models.component import ComponentData
+
+        components = {
+            "R1": ComponentData(
+                component_id="R1",
+                component_type="Resistor",
+                value="1k",
+                position=(0, 0),
+            ),
+        }
+        dlg = MonteCarloDialog(components)
+        qtbot.addWidget(dlg)
+        return dlg
+
+    def test_num_runs_spin_has_tooltip(self, dialog):
+        assert dialog.num_runs_spin.toolTip() != ""
+
+    def test_analysis_combo_has_tooltip(self, dialog):
+        assert dialog.analysis_combo.toolTip() != ""
+
+    def test_tolerance_table_has_tooltip(self, dialog):
+        assert dialog.tol_table is not None
+        assert dialog.tol_table.toolTip() != ""
+
+    def test_tolerance_spin_has_tooltip(self, dialog):
+        """Each tolerance spin box should have a tooltip."""
+        assert dialog.tol_table is not None
+        for row in range(dialog.tol_table.rowCount()):
+            tol_spin = dialog.tol_table.cellWidget(row, 2)
+            assert tol_spin.toolTip() != "", f"Row {row} tolerance spin has no tooltip"
+
+    def test_distribution_combo_has_tooltip(self, dialog):
+        """Each distribution combo should have a tooltip."""
+        assert dialog.tol_table is not None
+        for row in range(dialog.tol_table.rowCount()):
+            dist_combo = dialog.tol_table.cellWidget(row, 3)
+            assert dist_combo.toolTip() != "", f"Row {row} dist combo has no tooltip"
+
+    def test_base_form_fields_get_tooltips(self, dialog):
+        """Changing base analysis type should apply tooltips to base fields."""
+        dialog.analysis_combo.setCurrentText("AC Sweep")
+        for key, (widget, _) in dialog._base_field_widgets.items():
+            assert widget.toolTip() != "", f"Base field '{key}' has no tooltip"


### PR DESCRIPTION
## Summary
- Adds descriptive tooltips to all input fields across the three analysis dialogs: `AnalysisDialog`, `ParameterSweepDialog`, and `MonteCarloDialog`
- Centralizes tooltip text in `ANALYSIS_CONFIGS["tooltips"]` dict so all three dialogs share the same tooltip definitions for base analysis fields
- Fixes pre-existing PyQt6 compatibility bug in `monte_carlo_dialog.py` where `ItemFlag` enum was ANDed with int literal `0x2` (crashes on PyQt6 6.9+)

Closes #231

## Test plan
- [x] 28 new tests in `test_analysis_tooltips.py` covering all dialogs/fields
- [x] All 1121 unit tests pass
- [x] Full lint passes (ruff + black + isort)
- [ ] Manual: hover over fields in Analysis, Parameter Sweep, and Monte Carlo dialogs to verify tooltip text

🤖 Generated with [Claude Code](https://claude.com/claude-code)