### PR TITLE
Add noise analysis support (#233)

### DIFF
--- a/app/GUI/analysis_dialog.py
+++ b/app/GUI/analysis_dialog.py
@@ -84,6 +84,25 @@ class AnalysisDialog(QDialog):
                 "tempStep": "Temperature increment between sweep points (\u00b0C)",
             },
         },
+        "Noise": {
+            "fields": [
+                ("Output Node", "output_node", "text", "out"),
+                ("Input Source", "source", "text", "V1"),
+                ("Start Frequency (Hz)", "fStart", "float", "1"),
+                ("Stop Frequency (Hz)", "fStop", "float", "1e6"),
+                ("Points per Decade", "points", "int", "100"),
+                ("Sweep Type", "sweepType", "combo", ["dec", "oct", "lin"], "dec"),
+            ],
+            "description": ("Noise spectral density analysis — computes output and input-referred noise vs. frequency"),
+            "tooltips": {
+                "output_node": "Node name (or number) where output noise is measured, e.g. 'out' or '2'",
+                "source": "Name of the input source used as noise reference (e.g. V1)",
+                "fStart": "Starting frequency for the noise sweep (Hz)",
+                "fStop": "Ending frequency for the noise sweep (Hz)",
+                "points": "Number of frequency points per decade (log scale)",
+                "sweepType": "Frequency scale: dec (decade/log), oct (octave), lin (linear)",
+            },
+        },
     }
 
     def __init__(self, analysis_type=None, parent=None, preset_manager=None):
@@ -247,6 +266,15 @@ class AnalysisDialog(QDialog):
             tstop = params.get("tempStop", 85)
             tstep = params.get("tempStep", 25)
             return f".step temp {tstart} {tstop} {tstep}"
+
+        elif self.analysis_type == "Noise":
+            output = params.get("output_node", "out")
+            source = params.get("source", "V1")
+            fstart = params.get("fStart", 1)
+            fstop = params.get("fStop", 1e6)
+            points = params.get("points", 100)
+            sweep_type = params.get("sweepType", "dec")
+            return f".noise v({output}) {source} {sweep_type} {points} {fstart} {fstop}"
 
         return ""
 

--- a/app/GUI/main_window_analysis.py
+++ b/app/GUI/main_window_analysis.py
@@ -96,6 +96,25 @@ class AnalysisSettingsMixin:
         else:
             self.op_action.setChecked(True)
 
+    def set_analysis_noise(self):
+        """Set analysis type to Noise with parameters"""
+        dialog = AnalysisDialog("Noise", self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            params = dialog.get_parameters()
+            if params:
+                self.simulation_ctrl.set_analysis("Noise", params)
+                statusBar = self.statusBar()
+                if statusBar:
+                    statusBar.showMessage(
+                        f"Analysis: Noise (v({params['output_node']}), {params['fStart']}Hz to {params['fStop']}Hz)",
+                        3000,
+                    )
+            else:
+                QMessageBox.warning(self, "Invalid Parameters", "Please enter valid numeric values.")
+                self.op_action.setChecked(True)
+        else:
+            self.op_action.setChecked(True)
+
     def set_analysis_parameter_sweep(self):
         """Set analysis type to Parameter Sweep with configuration dialog"""
         if not self.model.components:
@@ -176,5 +195,7 @@ class AnalysisSettingsMixin:
             self.tran_action.setChecked(True)
         elif analysis_type == "Temperature Sweep":
             self.temp_action.setChecked(True)
+        elif analysis_type == "Noise":
+            self.noise_action.setChecked(True)
         elif analysis_type == "Parameter Sweep":
             self.sweep_action.setChecked(True)

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -304,6 +304,14 @@ class MenuBarMixin:
         sweep_action.triggered.connect(self.set_analysis_parameter_sweep)
         analysis_menu.addAction(sweep_action)
 
+        noise_action = QAction("&Noise...", self)
+        noise_action.setCheckable(True)
+        noise_action.setToolTip("Noise spectral density analysis (.noise)")
+        noise_action.triggered.connect(self.set_analysis_noise)
+        analysis_menu.addAction(noise_action)
+
+        analysis_menu.addSeparator()
+
         mc_action = QAction("&Monte Carlo...", self)
         mc_action.setCheckable(True)
         mc_action.setToolTip("Run Monte Carlo tolerance analysis with randomized component values")
@@ -317,6 +325,7 @@ class MenuBarMixin:
         self.analysis_group.addAction(ac_action)
         self.analysis_group.addAction(tran_action)
         self.analysis_group.addAction(temp_action)
+        self.analysis_group.addAction(noise_action)
         self.analysis_group.addAction(sweep_action)
         self.analysis_group.addAction(mc_action)
 
@@ -325,6 +334,7 @@ class MenuBarMixin:
         self.ac_action = ac_action
         self.tran_action = tran_action
         self.temp_action = temp_action
+        self.noise_action = noise_action
         self.sweep_action = sweep_action
 
         # Store action references for keybinding re-application

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -201,6 +201,9 @@ class SimulationController:
                 # Temperature sweep runs DC OP at each temp; parse as OP
                 output = self.runner.read_output(output_file)
                 data = ResultParser.parse_op_results(output)
+            elif analysis == "Noise":
+                output = self.runner.read_output(output_file)
+                data = ResultParser.parse_noise_results(output)
             else:
                 return SimulationResult(
                     success=False,

--- a/app/simulation/csv_exporter.py
+++ b/app/simulation/csv_exporter.py
@@ -150,6 +150,48 @@ def export_transient_results(tran_data, circuit_name=""):
     return output.getvalue()
 
 
+def export_noise_results(noise_data, circuit_name=""):
+    """
+    Export Noise analysis results to CSV string.
+
+    Args:
+        noise_data: dict with 'frequencies', 'onoise_spectrum', 'inoise_spectrum'
+        circuit_name: optional circuit filename
+
+    Returns:
+        str: CSV content
+    """
+    output = io.StringIO()
+    writer = csv.writer(output)
+
+    writer.writerow(["# Analysis Type", "Noise"])
+    writer.writerow(["# Date", datetime.now().strftime("%Y-%m-%d %H:%M:%S")])
+    if circuit_name:
+        writer.writerow(["# Circuit", circuit_name])
+    writer.writerow([])
+
+    frequencies = noise_data.get("frequencies", [])
+    onoise = noise_data.get("onoise_spectrum", [])
+    inoise = noise_data.get("inoise_spectrum", [])
+
+    headers = ["Frequency (Hz)"]
+    if onoise:
+        headers.append("Output Noise (V/sqrt(Hz))")
+    if inoise:
+        headers.append("Input Noise (V/sqrt(Hz))")
+    writer.writerow(headers)
+
+    for i, freq in enumerate(frequencies):
+        row = [freq]
+        if onoise:
+            row.append(onoise[i] if i < len(onoise) else "")
+        if inoise:
+            row.append(inoise[i] if i < len(inoise) else "")
+        writer.writerow(row)
+
+    return output.getvalue()
+
+
 def write_csv(csv_content, filepath):
     """
     Write CSV content string to a file.

--- a/app/simulation/preset_manager.py
+++ b/app/simulation/preset_manager.py
@@ -39,6 +39,32 @@ BUILTIN_PRESETS = [
         "builtin": True,
         "params": {"tempStart": -40, "tempStop": 85, "tempStep": 25},
     },
+    {
+        "name": "Audio Band Noise",
+        "analysis_type": "Noise",
+        "builtin": True,
+        "params": {
+            "output_node": "out",
+            "source": "V1",
+            "fStart": 20,
+            "fStop": 20000,
+            "points": 100,
+            "sweepType": "dec",
+        },
+    },
+    {
+        "name": "Wideband Noise",
+        "analysis_type": "Noise",
+        "builtin": True,
+        "params": {
+            "output_node": "out",
+            "source": "V1",
+            "fStart": 1,
+            "fStop": 1e9,
+            "points": 100,
+            "sweepType": "dec",
+        },
+    },
 ]
 
 

--- a/app/tests/unit/test_noise_analysis.py
+++ b/app/tests/unit/test_noise_analysis.py
@@ -1,0 +1,376 @@
+"""Tests for noise analysis support (#233).
+
+Covers the full noise analysis pipeline: dialog configuration,
+netlist generation, result parsing, display routing, menu
+infrastructure, preset availability, and CSV export.
+"""
+
+import inspect
+
+import pytest
+from controllers.simulation_controller import SimulationController
+from GUI.analysis_dialog import AnalysisDialog
+from models.circuit import CircuitModel
+
+
+class TestNoiseAnalysisDialog:
+    """Test noise analysis dialog configuration."""
+
+    def test_noise_in_analysis_configs(self):
+        """Noise should be a recognized analysis type."""
+        assert "Noise" in AnalysisDialog.ANALYSIS_CONFIGS
+
+    def test_noise_has_six_fields(self, qtbot):
+        """Noise dialog should have output_node, source, fStart, fStop, points, sweepType."""
+        dialog = AnalysisDialog(analysis_type="Noise")
+        qtbot.addWidget(dialog)
+        expected = {"output_node", "source", "fStart", "fStop", "points", "sweepType"}
+        assert set(dialog.field_widgets.keys()) == expected
+
+    def test_noise_description_set(self, qtbot):
+        """Noise dialog should have a description label."""
+        dialog = AnalysisDialog(analysis_type="Noise")
+        qtbot.addWidget(dialog)
+        assert dialog.desc_label.text() != ""
+        assert "noise" in dialog.desc_label.text().lower()
+
+    def test_noise_default_values(self, qtbot):
+        """Noise fields should have sensible defaults."""
+        dialog = AnalysisDialog(analysis_type="Noise")
+        qtbot.addWidget(dialog)
+        params = dialog.get_parameters()
+        assert params is not None
+        assert params["output_node"] == "out"
+        assert params["source"] == "V1"
+        assert params["fStart"] == 1.0
+        assert params["fStop"] == 1e6
+        assert params["points"] == 100
+        assert params["sweepType"] == "dec"
+
+    def test_noise_get_parameters_returns_analysis_type(self, qtbot):
+        """get_parameters() should include analysis_type key."""
+        dialog = AnalysisDialog(analysis_type="Noise")
+        qtbot.addWidget(dialog)
+        params = dialog.get_parameters()
+        assert params["analysis_type"] == "Noise"
+
+    def test_noise_tooltips_present(self):
+        """All noise fields should have tooltips."""
+        config = AnalysisDialog.ANALYSIS_CONFIGS["Noise"]
+        tooltips = config.get("tooltips", {})
+        field_keys = {f[1] for f in config["fields"]}
+        assert field_keys == set(tooltips.keys())
+
+
+class TestNoiseNgspiceCommand:
+    """Test NGSPICE command generation for noise analysis."""
+
+    def test_noise_generates_dot_noise_command(self, qtbot):
+        """get_ngspice_command() should produce a .noise directive."""
+        dialog = AnalysisDialog(analysis_type="Noise")
+        qtbot.addWidget(dialog)
+        cmd = dialog.get_ngspice_command()
+        assert cmd is not None
+        assert cmd.startswith(".noise")
+
+    def test_noise_command_contains_output_node(self, qtbot):
+        """Command should reference the output node."""
+        dialog = AnalysisDialog(analysis_type="Noise")
+        qtbot.addWidget(dialog)
+        cmd = dialog.get_ngspice_command()
+        assert "v(out)" in cmd
+
+    def test_noise_command_contains_source(self, qtbot):
+        """Command should reference the input source."""
+        dialog = AnalysisDialog(analysis_type="Noise")
+        qtbot.addWidget(dialog)
+        cmd = dialog.get_ngspice_command()
+        assert "V1" in cmd
+
+    def test_noise_command_contains_sweep_params(self, qtbot):
+        """Command should include sweep type and frequency range."""
+        dialog = AnalysisDialog(analysis_type="Noise")
+        qtbot.addWidget(dialog)
+        cmd = dialog.get_ngspice_command()
+        assert "dec" in cmd
+        assert "100" in cmd
+
+
+class TestNoiseNetlistGeneration:
+    """Test netlist generation for noise analysis."""
+
+    def _make_circuit(self):
+        """Build a simple circuit with voltage source and resistor."""
+        model = CircuitModel()
+        from controllers.circuit_controller import CircuitController
+
+        ctrl = CircuitController(model)
+        v1 = ctrl.add_component("Voltage Source", (0, 0))
+        r1 = ctrl.add_component("Resistor", (100, 0))
+        gnd = ctrl.add_component("Ground", (0, 100))
+        ctrl.add_wire(v1.component_id, 0, r1.component_id, 0)
+        ctrl.add_wire(r1.component_id, 1, gnd.component_id, 0)
+        ctrl.add_wire(v1.component_id, 1, gnd.component_id, 0)
+        return model, ctrl
+
+    def test_noise_netlist_contains_dot_noise(self):
+        """Generated netlist should contain .noise directive."""
+        model, ctrl = self._make_circuit()
+        sim = SimulationController(model, circuit_ctrl=ctrl)
+        sim.set_analysis(
+            "Noise",
+            {
+                "output_node": "1",
+                "source": "V1",
+                "fStart": 1,
+                "fStop": 1e6,
+                "points": 100,
+                "sweepType": "dec",
+            },
+        )
+        netlist = sim.generate_netlist()
+        assert ".noise" in netlist.lower()
+
+    def test_noise_netlist_contains_output_node(self):
+        """Netlist .noise line should reference the output node."""
+        model, ctrl = self._make_circuit()
+        sim = SimulationController(model, circuit_ctrl=ctrl)
+        sim.set_analysis(
+            "Noise",
+            {
+                "output_node": "2",
+                "source": "V1",
+                "fStart": 10,
+                "fStop": 100000,
+                "points": 50,
+                "sweepType": "dec",
+            },
+        )
+        netlist = sim.generate_netlist()
+        assert "v(2)" in netlist.lower()
+
+    def test_noise_netlist_prints_onoise_inoise(self):
+        """Noise netlist control block should print onoise_spectrum and inoise_spectrum."""
+        model, ctrl = self._make_circuit()
+        sim = SimulationController(model, circuit_ctrl=ctrl)
+        sim.set_analysis(
+            "Noise",
+            {
+                "output_node": "1",
+                "source": "V1",
+                "fStart": 1,
+                "fStop": 1e6,
+                "points": 100,
+                "sweepType": "dec",
+            },
+        )
+        netlist = sim.generate_netlist()
+        assert "onoise_spectrum" in netlist
+        assert "inoise_spectrum" in netlist
+
+    def test_noise_netlist_uses_setplot(self):
+        """Noise control block should switch to noise1 plot."""
+        model, ctrl = self._make_circuit()
+        sim = SimulationController(model, circuit_ctrl=ctrl)
+        sim.set_analysis(
+            "Noise",
+            {
+                "output_node": "1",
+                "source": "V1",
+                "fStart": 1,
+                "fStop": 1e6,
+                "points": 100,
+                "sweepType": "dec",
+            },
+        )
+        netlist = sim.generate_netlist()
+        assert "setplot noise1" in netlist
+
+
+class TestNoiseResultParser:
+    """Test noise result parsing."""
+
+    def test_parse_noise_empty_output(self):
+        """Parsing empty output should return None."""
+        from simulation.result_parser import ResultParser
+
+        result = ResultParser.parse_noise_results("")
+        assert result is None
+
+    def test_parse_noise_valid_output(self):
+        """Parser should extract frequencies and spectral densities."""
+        from simulation.result_parser import ResultParser
+
+        output = (
+            "Index   frequency       onoise_spectrum inoise_spectrum\n"
+            "0       1.000000e+00    3.200000e-09    1.600000e-09\n"
+            "1       1.000000e+01    3.100000e-09    1.550000e-09\n"
+            "2       1.000000e+02    3.000000e-09    1.500000e-09\n"
+        )
+        result = ResultParser.parse_noise_results(output)
+        assert result is not None
+        assert len(result["frequencies"]) == 3
+        assert len(result["onoise_spectrum"]) == 3
+        assert len(result["inoise_spectrum"]) == 3
+        assert result["frequencies"][0] == pytest.approx(1.0)
+        assert result["frequencies"][2] == pytest.approx(100.0)
+
+    def test_parse_noise_onoise_values(self):
+        """Output noise values should be parsed correctly."""
+        from simulation.result_parser import ResultParser
+
+        output = (
+            "Index   frequency       onoise_spectrum inoise_spectrum\n"
+            "0       1.000000e+00    5.000000e-08    2.500000e-08\n"
+        )
+        result = ResultParser.parse_noise_results(output)
+        assert result is not None
+        assert result["onoise_spectrum"][0] == pytest.approx(5e-8)
+        assert result["inoise_spectrum"][0] == pytest.approx(2.5e-8)
+
+    def test_parse_noise_no_matching_header(self):
+        """Output without noise headers should return None."""
+        from simulation.result_parser import ResultParser
+
+        output = "some random text\nwithout noise data\n"
+        result = ResultParser.parse_noise_results(output)
+        assert result is None
+
+
+class TestNoiseSimulationController:
+    """Test simulation controller handles noise analysis type."""
+
+    def test_set_analysis_noise(self):
+        """set_analysis should store Noise type."""
+        model = CircuitModel()
+        sim = SimulationController(model)
+        sim.set_analysis("Noise", {"output_node": "out", "source": "V1"})
+        assert model.analysis_type == "Noise"
+        assert model.analysis_params["output_node"] == "out"
+
+    def test_parse_results_has_noise_branch(self):
+        """_parse_results should handle 'Noise' analysis type."""
+        source = inspect.getsource(SimulationController._parse_results)
+        assert '"Noise"' in source
+
+
+class TestNoiseMenuIntegration:
+    """Test menu infrastructure for noise analysis."""
+
+    def test_analysis_menu_has_noise_action(self):
+        """MenuBarMixin should create a noise_action."""
+        from GUI.main_window_menus import MenuBarMixin
+
+        source = inspect.getsource(MenuBarMixin.create_menu_bar)
+        assert "noise_action" in source
+        assert "set_analysis_noise" in source
+
+    def test_analysis_settings_has_noise_method(self):
+        """AnalysisSettingsMixin should have set_analysis_noise."""
+        from GUI.main_window_analysis import AnalysisSettingsMixin
+
+        assert hasattr(AnalysisSettingsMixin, "set_analysis_noise")
+
+    def test_sync_analysis_menu_handles_noise(self):
+        """_sync_analysis_menu should check for 'Noise' type."""
+        from GUI.main_window_analysis import AnalysisSettingsMixin
+
+        source = inspect.getsource(AnalysisSettingsMixin._sync_analysis_menu)
+        assert '"Noise"' in source
+
+    def test_display_handlers_include_noise(self):
+        """SimulationMixin handlers dict should include Noise."""
+        from GUI.main_window_simulation import SimulationMixin
+
+        source = inspect.getsource(SimulationMixin._display_simulation_results)
+        assert '"Noise"' in source
+        assert "_display_noise_results" in source
+
+    def test_display_noise_results_method_exists(self):
+        """SimulationMixin should have _display_noise_results method."""
+        from GUI.main_window_simulation import SimulationMixin
+
+        assert hasattr(SimulationMixin, "_display_noise_results")
+
+
+class TestNoisePresets:
+    """Test noise analysis presets."""
+
+    def test_builtin_noise_presets_exist(self):
+        """There should be at least one built-in Noise preset."""
+        from simulation.preset_manager import BUILTIN_PRESETS
+
+        noise_presets = [p for p in BUILTIN_PRESETS if p["analysis_type"] == "Noise"]
+        assert len(noise_presets) >= 1
+
+    def test_audio_band_noise_preset_params(self):
+        """Audio Band Noise preset should have correct frequency range."""
+        from simulation.preset_manager import BUILTIN_PRESETS
+
+        audio = next(p for p in BUILTIN_PRESETS if p["name"] == "Audio Band Noise")
+        assert audio["params"]["fStart"] == 20
+        assert audio["params"]["fStop"] == 20000
+
+    def test_noise_preset_has_required_keys(self):
+        """All noise presets should have required parameter keys."""
+        from simulation.preset_manager import BUILTIN_PRESETS
+
+        required = {"output_node", "source", "fStart", "fStop", "points", "sweepType"}
+        for preset in BUILTIN_PRESETS:
+            if preset["analysis_type"] == "Noise":
+                assert required <= set(preset["params"].keys()), f"Preset {preset['name']} missing keys"
+
+
+class TestNoiseCSVExport:
+    """Test noise CSV export."""
+
+    def test_export_noise_results_function_exists(self):
+        """csv_exporter should have export_noise_results."""
+        from simulation.csv_exporter import export_noise_results
+
+        assert callable(export_noise_results)
+
+    def test_export_noise_csv_content(self):
+        """Noise CSV export should contain frequency and noise columns."""
+        from simulation.csv_exporter import export_noise_results
+
+        data = {
+            "frequencies": [1.0, 10.0, 100.0],
+            "onoise_spectrum": [3.2e-9, 3.1e-9, 3.0e-9],
+            "inoise_spectrum": [1.6e-9, 1.5e-9, 1.4e-9],
+        }
+        csv = export_noise_results(data, "test_circuit")
+        assert "Noise" in csv
+        assert "Frequency" in csv
+        assert "Output Noise" in csv
+        assert "Input Noise" in csv
+
+    def test_csv_export_handles_noise_type(self):
+        """main_window_simulation CSV export should route noise results."""
+        from GUI.main_window_simulation import SimulationMixin
+
+        source = inspect.getsource(SimulationMixin.export_results_csv)
+        assert "export_noise_results" in source
+        assert '"Noise"' in source
+
+
+class TestNoiseModelSerialization:
+    """Test that Noise analysis type survives save/load."""
+
+    def test_noise_analysis_roundtrip(self):
+        """Circuit with Noise analysis should serialize and deserialize."""
+        model = CircuitModel()
+        model.analysis_type = "Noise"
+        model.analysis_params = {
+            "output_node": "out",
+            "source": "V1",
+            "fStart": 1,
+            "fStop": 1e6,
+            "points": 100,
+            "sweepType": "dec",
+        }
+        data = model.to_dict()
+        restored = CircuitModel.from_dict(data)
+        assert restored.analysis_type == "Noise"
+        assert restored.analysis_params["output_node"] == "out"
+        assert restored.analysis_params["fStop"] == 1e6


### PR DESCRIPTION
## Summary
- Adds `.noise` analysis as a new analysis type across the full simulation pipeline
- Noise dialog with output node, input source, and frequency sweep parameters
- Netlist generation produces `.noise v(output) source dec pts fstart fstop` directive
- Result parser extracts `onoise_spectrum` and `inoise_spectrum` from ngspice output
- Display handler shows noise spectral density table in results panel
- CSV export support for noise data
- Two built-in presets: Audio Band Noise (20 Hz - 20 kHz) and Wideband Noise (1 Hz - 1 GHz)
- Menu integration with Analysis menu and mutual exclusion group
- 32 new tests covering dialog, command gen, netlist, parsing, menu, presets, CSV, serialization

## Files changed
- `app/GUI/analysis_dialog.py` - Noise config in ANALYSIS_CONFIGS + ngspice command
- `app/GUI/main_window_analysis.py` - `set_analysis_noise()` + menu sync
- `app/GUI/main_window_menus.py` - Noise action in Analysis menu
- `app/GUI/main_window_simulation.py` - `_display_noise_results()` + CSV routing
- `app/controllers/simulation_controller.py` - Noise branch in `_parse_results()`
- `app/simulation/netlist_generator.py` - `.noise` directive + noise control block
- `app/simulation/result_parser.py` - `parse_noise_results()` static method
- `app/simulation/csv_exporter.py` - `export_noise_results()` function
- `app/simulation/preset_manager.py` - Two built-in noise presets
- `app/tests/unit/test_noise_analysis.py` - 32 tests

## Test plan
- [x] All 32 new tests pass (`pytest -k test_noise`)
- [x] Full test suite passes (1252 tests, 0 failures)
- [x] Lint and format clean (`make lint`)
- [ ] Manual testing: Run noise analysis on a circuit with ngspice (requires ngspice installed)

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)