### PR TITLE
add testing policy, epic workflow, and branching ADRs

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -2,7 +2,7 @@ name: AI PR Review
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop, 'epic/**']
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop, 'epic/**']
   pull_request:
-    branches: [main]
+    branches: [main, develop, 'epic/**']
 
 jobs:
   lint:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,9 @@
 {
     "cSpell.words": [
+        "mgmt",
         "netlist",
         "ngspice",
+        "qtbot",
         "venv"
     ],
     "python.defaultInterpreterPath": "${workspaceFolder}/.venv/Scripts/python.exe"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,10 +33,30 @@ make format-check             # verify formatting without modifying files
 ### Testing Conventions
 - Use `tmp_path` (pytest fixture) for all file path tests — never hardcode paths like `/some/path` (Windows uses backslash separators)
 - Use `qtbot` fixture for Qt widget tests
-- Test count should increase by ≥5 for new features
 - Run tests from repo root: `python -m pytest` or `make test`
 - **MainWindow cannot be instantiated in offscreen test mode** — it hangs. Test with lower-level components (QGraphicsScene, QPrinter, keybinding registries) instead
 - Pre-existing GUI test errors (~46) in headless environments are expected (Qt display server issues)
+
+### Test Layer Priority
+
+The MVC architecture exists specifically to enable testing without the GUI (see `docs/adr/001-mvc-testability.md`). When writing tests, work down this list and stop at the first level that covers the behavior:
+
+1. **Model/controller test** — if the logic lives below the GUI, test it there (serialization, undo, node consistency, file operations)
+2. **Netlist snapshot test** — if it affects simulation output (component lines, analysis directives, model deduplication)
+3. **qtbot widget test** — if it's dialog, menu, or panel behavior (analysis dialogs, keybindings editor, palette search)
+4. **Structural assertion** — if it's about rendering (terminal positions, bounding boxes, z-order via `zValue()`)
+5. **Human testing item** — only if none of the above can verify it (drag feel, visual aesthetics, print dialogs, cross-session UX)
+
+### Test Expectations by Change Type
+
+| Change Type | Automated Tests | Human Testing Item? |
+|-------------|----------------|-------------------|
+| Bug fix | ≥1 regression test that reproduces the bug | Only if visual/interaction |
+| New feature | Tests covering core behavior at appropriate layer | Yes, for UI-visible behavior |
+| Refactor | Existing tests must pass, no new tests required | No |
+| UI-only | Structural assertions where applicable | Yes, always |
+
+Tests should cover the *behavior*, not just the *count*. A single test that exercises the real code path is worth more than five tests that assert obvious properties.
 
 ## Project Structure
 ```
@@ -62,8 +82,32 @@ CircuitModel(components={}, wires=[], nodes=[], terminal_to_node={}, component_c
 **Common mistakes**: `value` not `properties`, `start_terminal` not `start_terminal_index`, `component_id` not `id`.
 
 ## Git Conventions
-- Branch naming: `issue-<N>-short-description` (e.g. `issue-75-csv-export`)
-- Commit messages: lowercase imperative (e.g. "add CSV export", "fix wire rendering")
+
+### Branch Structure (see `docs/adr/003-branching-strategy.md`)
+
+```
+main                              <- always human-verified, student-safe
+├── develop                       <- integration branch, CI must pass
+│   ├── epic/<name>               <- grouped multi-issue feature work
+│   │   └── issue-<N>-<description>
+│   └── issue-<N>-<description>   <- standalone fixes/features
+└── release/vX.Y                  <- cut from develop for releases
+```
+
+| Branch | Base | PR Target | Who Merges | Protection |
+|--------|------|-----------|------------|------------|
+| `main` | — | — | Jeremy | Require PR, no direct push |
+| `develop` | `main` | `main` (via release) | PR mgmt agents + Jeremy | Require CI pass |
+| `epic/<name>` | `develop` | `develop` | Jeremy reviews | Require CI pass |
+| `issue-<N>-*` | epic or develop | epic or develop | Coding agents | — |
+
+### Branch Naming
+- Epic branches: `epic/<name>` (e.g., `epic/stability`, `epic/ui-customization`)
+- Issue branches: `issue-<N>-short-description` (e.g. `issue-75-csv-export`)
+- Release branches: `release/v<major>.<minor>` (e.g., `release/v1.0`)
+
+### Commit Messages
+- Lowercase imperative (e.g. "add CSV export", "fix wire rendering")
 - Co-author tag on all commits:
   ```
   Co-Authored-By: Claude <model> <noreply@anthropic.com>
@@ -132,6 +176,60 @@ gh project item-list 2 --owner SDSMT-Capstone-Spice-GUI-Team --format json --lim
   --jq '.items[] | {n: .content.number, s: .status}'
 ```
 
+## Epics
+
+Epics group related issues into goal-oriented swimlanes (see `docs/decisions/2026-02-10-epic-workflow-and-branch-strategy.md`). They serve three purposes:
+1. **Milestone** — track progress toward a larger goal
+2. **Swimlane** — partition work across agents to reduce merge conflicts
+3. **Context** — give agents the bigger picture when working on individual issues
+
+### Active Epics
+
+| Epic | Label | Branch | Priority | Description |
+|------|-------|--------|----------|-------------|
+| #209 | `epic:stability` | `epic/stability` | P0 | Bug fixes, test coverage, architectural improvements |
+| #210 | `epic:simulation` | `epic/simulation` | P1 | New analysis types, accuracy, error handling |
+| #211 | `epic:export` | `epic/export` | P1 | Export formats, sharing, templates |
+| #287 | `epic:ui-customization` | `epic/ui-customization` | P1 | Symbol styles, themes, color modes, preferences |
+| #212 | `epic:instructor` | `epic/instructor` | P2 | Instructor tools, grading, templates |
+| #213 | `epic:scripting` | `epic/scripting` | P2 | Python API, batch operations, plugins |
+
+### Epic Workflow
+- Issues carry an `epic:*` label linking them to their parent epic
+- When assigned to an epic, filter Ready queue by that label
+- Read the epic issue before starting work for goal context
+- Epic branches are created from `develop` by the first agent that picks up a labeled issue
+- Completing all issues in an epic is a precondition for promoting that epic's work to `main`
+
+## Human Testing
+
+Human testing board: [Project #3](https://github.com/orgs/SDSMT-Capstone-Spice-GUI-Team/projects/3)
+Testing guide: `docs/human-testing-guide.md`
+Quality model: `docs/adr/002-tiered-testing.md`
+
+### Filing Human Testing Items
+When a PR includes UI-visible behavior not covered by automated tests, add a checkbox item to the appropriate testing issue:
+
+| Feature Area | Issue |
+|-------------|-------|
+| Smoke Test | #269 |
+| Components | #270 |
+| Selection & Clipboard | #271 |
+| Wires | #272 |
+| Undo/Redo | #273 |
+| Annotations | #279 |
+| File Operations | #274 |
+| Simulation | #275 |
+| Plot Features | #276 |
+| User Interface | #277 |
+
+Format: `- [ ] Brief description (PR #NNN)`
+
+### Bugs from Human Testing
+- Bugs found during human testing get the `bug` label
+- They enter Project #2 board at Backlog until triaged
+- Reference the testing issue they came from (e.g., "Found during #270")
+
 ## Environment Setup
 
 ### Virtual Environment
@@ -183,11 +281,11 @@ Claude Code is authorized to work **fully autonomously** on Ready items.
 
 Before starting implementation on any issue, verify:
 
-1. **Start from Fresh Main**
+1. **Start from Fresh Develop**
    ```bash
-   git checkout main && git pull origin main
+   git checkout develop && git pull origin develop
    ```
-   - Ensures feature branches are based on the latest code
+   - Feature branches are based on `develop`, not `main`
    - Run this at session start and before creating each new feature branch
 
 2. **Virtual Environment**
@@ -224,13 +322,23 @@ Before starting implementation on any issue, verify:
 
 ### Work Loop
 1. Discover board IDs (see above — use `--jq` patterns from Board Query Patterns section)
-2. Query board for next **Ready** item (prefer P0 > P1 > P2, then lower issue number). If an item is already **In Progress**, skip it (another agent may own it).
+2. Query board for next **Ready** item. If assigned to an epic, filter by that epic's label. Otherwise prefer P0 > P1 > P2, then lower issue number. If an item is already **In Progress**, skip it (another agent may own it).
 3. **Triage**: Check issue comments and state (`gh issue view <N> --json state,comments`). If already resolved or closed, move to In Review/Done and skip to next Ready item.
-4. Move issue to **In Progress**
-5. Create branch `issue-<N>-short-description` from `main`
-6. Write a brief plan, assess complexity
-7. Implement the change
-8. **Format, test, and lint**
+4. **Read epic context**: If the issue has an `epic:*` label, read the epic issue for context on the larger goal before starting work.
+5. Move issue to **In Progress**
+6. **Resolve base branch and create issue branch**:
+   a. Read issue labels: `gh issue view <N> --json labels --jq '.labels[].name'`
+   b. Check for `epic:<name>` label
+   c. If epic label found: BASE = `epic/<name>`. If branch doesn't exist on remote, create it from `develop`.
+   d. If no epic label: BASE = `develop`
+   e. Create issue branch from BASE:
+      ```bash
+      git checkout <BASE> && git pull origin <BASE>
+      git checkout -b issue-<N>-short-description
+      ```
+7. Write a brief plan, assess complexity
+8. Implement the change
+9. **Format, test, and lint**
    ```bash
    # Auto-format first (black + isort + ruff --fix)
    make format
@@ -242,11 +350,9 @@ Before starting implementation on any issue, verify:
 
    **Requirements**:
    - ✅ Code is formatted (`make format` produces no diff)
-   - ✅ All new tests pass
+   - ✅ All new tests pass at the appropriate layer (see Test Layer Priority)
    - ✅ All existing tests still pass (no regressions)
    - ✅ Full lint passes: ruff + black --check + isort --check (`make lint`)
-   - ✅ Formatting verified: `make format-check` (optional — `make lint` also checks)
-   - ✅ Test count increased by ≥5 for new features
 
    **Troubleshooting**:
    - `ModuleNotFoundError`: Venv not activated or deps not installed
@@ -254,21 +360,23 @@ Before starting implementation on any issue, verify:
    - Formatting drift: Run `make format` then `make lint` to verify
    - Pre-commit hook missing: Run `make install-hooks`
 
-9. Commit changes
-10. Fetch and rebase on latest `origin/main` — resolves merge conflicts from PRs merged mid-session
-11. Re-run tests and linting after rebase to catch conflicts (e.g. duplicate imports from merged PRs)
-12. Push branch to remote
-13. Create PR targeting `main` (or push directly for small fixes)
-14. Close the GitHub issue (reference the commit/PR)
-15. Move issue to **In Review** on the board
-16. Log hours: comment `⏱️ Xh - description` on issue, update Hours field
-17. Pick next Ready item → repeat from step 2
+10. **File human testing items** if the change includes UI-visible behavior not covered by automated tests. Add a checkbox to the appropriate human testing issue (see Human Testing section). Format: `- [ ] Brief description (PR #NNN)`
+11. Commit changes
+12. Fetch and rebase on latest base branch (epic or `origin/develop`) — resolves merge conflicts from PRs merged mid-session
+13. Re-run tests and linting after rebase to catch conflicts (e.g. duplicate imports from merged PRs)
+14. Push branch to remote
+15. Create PR targeting the **base branch** (epic or `develop`). NEVER target `main` directly.
+16. Close the GitHub issue (reference the commit/PR)
+17. Move issue to **In Review** on the board
+18. Log hours: comment `⏱️ Xh - description` on issue, update Hours field
+19. Pick next Ready item → repeat from step 2
 
 **Post-issue checklist** (verify before picking next item):
-- [ ] PR created and linked to issue
+- [ ] PR created and linked to issue (targeting epic or `develop`, never `main`)
 - [ ] Issue closed (`gh issue close <N>`)
 - [ ] Board status updated to In Review
 - [ ] Hours logged (comment + field)
+- [ ] Human testing items filed (if UI-visible behavior not covered by automated tests)
 - [ ] MEMORY.md updated with issue/PR number
 
 ### Hours Estimates
@@ -289,7 +397,7 @@ Small: **0.5h** | Medium: **1–2h** | Large: **3h+**
 ### Edge Cases
 | Scenario | Action |
 |----------|--------|
-| Hard to test (UI, ngspice) | Implement, commit, flag manual testing needed in issue comment |
+| Hard to test (UI, ngspice) | Implement, commit, add human testing item to appropriate issue (#269-#279) |
 | Vague requirements | Make judgment call, note assumptions in commit/issue comment |
 | Conflicting issues | Move to Blocked with explanation, pick next Ready item |
 | Stale Ready item (already fixed/closed) | Verify via issue comments/state, move to In Review/Done, pick next Ready item |
@@ -331,9 +439,11 @@ Multiple Claude Code instances may run concurrently across different directories
 - **Never hold two issues simultaneously** — complete one before starting the next
 
 ### Work Partitioning
-To avoid race conditions where two agents claim the same Ready issue:
-- Assign agents to different **Epics** or **priority tiers** (P0 vs P1 vs P2)
-- Or partition by issue number (odd/even) when Epics aren't set up
+Agents are assigned to **Epics** to avoid merge conflicts and provide focus:
+- Each epic has a label (`epic:stability`, `epic:simulation`, etc.) and an `epic/<name>` branch
+- Agents filter Ready items by their assigned epic label
+- Before starting an issue, read the epic issue for context on the larger goal
+- If no epic is assigned, fall back to priority ordering (P0 > P1 > P2)
 - PR monitor agents never claim issues — they only merge and fix PRs
 
 ### PR Merge Ordering

--- a/docs/adr/001-mvc-testability.md
+++ b/docs/adr/001-mvc-testability.md
@@ -1,0 +1,57 @@
+# ADR-001: MVC Architecture for Testability
+
+**Date**: 2026-02-11
+**Status**: Accepted
+**Participants**: Jeremy (Software Architect), Claude Agent (Opus 4.6)
+
+## Decision
+
+The project uses a Model-View-Controller (MVC) pattern that separates data (models), business logic (controllers), and UI (GUI). This separation exists specifically to enable unit testing without the Qt GUI layer.
+
+## Context
+
+PyQt6's `MainWindow` hangs when instantiated in offscreen/CI test mode (`QT_QPA_PLATFORM=offscreen`). This means any test that requires `MainWindow` cannot run in CI. Without MVC separation, testing would require launching the full GUI — making automated testing impractical.
+
+The test suite has ~46 pre-existing GUI test failures in headless environments due to Qt display server limitations. These are expected and accepted.
+
+## Architecture
+
+```
+app/
+├── models/          # Data classes, no Qt dependency
+│                    # CircuitModel, ComponentData, WireData, NodeData
+│                    # → Testable with plain pytest
+│
+├── controllers/     # Business logic, minimal Qt dependency
+│                    # CircuitController, SimulationController, FileController
+│                    # → Testable with pytest + mock
+│
+├── GUI/             # PyQt6 views, depends on models + controllers
+│                    # MainWindow, CircuitCanvas, dialogs, graphics items
+│                    # → Testable with qtbot on individual widgets (never MainWindow)
+│
+├── simulation/      # ngspice pipeline, no Qt dependency
+│                    # Netlist generation, runner, parser, validator
+│                    # → Testable with pytest, mock ngspice for CI
+│
+└── tests/           # pytest suite
+    ├── unit/        # Model, controller, simulation tests
+    └── integration/ # Cross-layer tests (model → controller → file I/O)
+```
+
+## Test Layer Priority
+
+When deciding how to test a behavior, prefer the highest layer that can cover it without the GUI:
+
+1. **Model/controller test** — serialization, undo, node consistency, file operations
+2. **Netlist snapshot test** — component SPICE output, analysis directives, model deduplication
+3. **qtbot widget test** — dialogs, menus, panels (never MainWindow)
+4. **Structural assertion** — terminal positions, bounding boxes, z-order (`zValue()`)
+5. **Human testing item** — drag feel, visual aesthetics, print dialogs, cross-session UX
+
+## Consequences
+
+- Most new feature tests should target the model or controller layer
+- GUI tests use `qtbot` on individual widgets, dialogs, or `QGraphicsScene` — never `MainWindow`
+- Features that can only be verified visually get filed as human testing items on [Project #3](https://github.com/orgs/SDSMT-Capstone-Spice-GUI-Team/projects/3)
+- Test count grows primarily in `app/tests/unit/`, not GUI-dependent tests

--- a/docs/adr/002-tiered-testing.md
+++ b/docs/adr/002-tiered-testing.md
@@ -1,0 +1,74 @@
+# ADR-002: Tiered Testing Model
+
+**Date**: 2026-02-11
+**Status**: Accepted
+**Participants**: Jeremy (Software Architect), Claude Agent (Opus 4.6)
+
+## Decision
+
+Quality assurance uses a two-gate model that separates automated testing (blocks merge) from human testing (blocks release/promotion to `main`).
+
+## Context
+
+Claude Code agents develop features faster than humans can test them. During a single session, agents may complete 3-8 issues. This created a 132-item manual testing backlog. The project needs both rapid development throughput and verified quality.
+
+The solution is to decouple the merge gate (fast, automated) from the verification gate (slower, human-driven). Agents stay productive; humans maintain quality accountability.
+
+## Gate Model
+
+```
+Agent completes issue
+        │
+        ▼
+┌─────────────────────┐
+│   GATE 1: PR Merge   │  Automated, blocks merge to develop
+│                       │
+│  ✓ CI green (tests    │
+│    + lint + format)   │
+│  ✓ Tests added at     │
+│    appropriate layer  │
+│  ✓ Human testing item │
+│    filed if needed    │
+└───────────┬───────────┘
+            │
+            ▼
+┌─────────────────────┐
+│   GATE 2: Promotion  │  Human, blocks merge to main
+│                       │
+│  ✓ Human testing      │
+│    checklist passed   │
+│  ✓ Bugs filed and     │
+│    triaged            │
+└───────────────────────┘
+```
+
+## Test Expectations by Change Type
+
+| Change Type | Automated Tests | Human Testing Item? |
+|-------------|----------------|-------------------|
+| Bug fix | ≥1 regression test that reproduces the bug | Only if visual/interaction |
+| New feature | Tests covering core behavior at appropriate layer | Yes, for UI-visible behavior |
+| Refactor | Existing tests must pass, no new tests required | No |
+| UI-only | Structural assertions where applicable | Yes, always |
+
+Tests should cover the *behavior*, not just the *count*. A single test that exercises the real code path is worth more than five tests that assert obvious properties.
+
+## Human Testing Infrastructure
+
+- **Testing board**: [Project #3](https://github.com/orgs/SDSMT-Capstone-Spice-GUI-Team/projects/3) with columns: Ready to Test → Testing → Passed / Bugs Found
+- **Testing issues**: #269-#279 organized by feature area (Smoke Test, Components, Wires, etc.)
+- **Testing guide**: `docs/human-testing-guide.md` for non-engineer testers
+- **Bug flow**: failure → comment on testing issue → file separate `bug` issue → Backlog on dev board
+
+## Visual Testing Strategy
+
+- **Now**: Structural/geometric assertions (terminal positions, bounding boxes, z-order, scene membership). These survive visual redesigns.
+- **Deferred**: Pixel-baseline screenshot regression testing. Will be added after human testing feedback stabilizes visual preferences (component symbols, color schemes, theme styling).
+
+## Consequences
+
+- Agents stay fast — Gate 1 is fully automated
+- Human testing is decoupled from merge timing — no bottleneck on development
+- Release/promotion to `main` requires verified code — students always get tested builds
+- The human testing board is a living document — agents add items as they ship features
+- Bugs from human testing enter the dev board at Backlog for triage

--- a/docs/adr/003-branching-strategy.md
+++ b/docs/adr/003-branching-strategy.md
@@ -1,0 +1,60 @@
+# ADR-003: Branching Strategy (develop + main)
+
+**Date**: 2026-02-10 (formalized 2026-02-11)
+**Status**: Accepted
+**Participants**: Jeremy (Software Architect), Claude Agent (Opus 4.6)
+
+## Decision
+
+The project uses a `develop` + `main` branching model with ephemeral epic and issue branches. Agents develop against `develop`; only the project owner promotes code to `main` after human testing passes.
+
+## Context
+
+With up to 5 concurrent coding agents plus human contributors, all PRs targeting `main` caused frequent merge conflicts (especially in `main_window.py`, ~1700 lines). Students and EE team members needed a stable branch for testing that wouldn't break mid-session. The project needed to decouple "code-complete" from "human-verified."
+
+The solution adds one permanent branch (`develop`) as an integration point, with ephemeral `epic/<name>` branches to contain conflicts within related feature groups.
+
+## Branch Topology
+
+```
+main                              <- always human-verified, student-safe
+├── develop                       <- integration branch, CI must pass
+│   ├── epic/<name>               <- grouped multi-issue feature work
+│   │   └── issue-<N>-<description>
+│   └── issue-<N>-<description>   <- standalone fixes/features
+└── release/vX.Y                  <- cut from develop for releases
+```
+
+| Branch | Base | PR Target | Who Merges | Protection |
+|--------|------|-----------|------------|------------|
+| `main` | — | — | Jeremy | Require PR, no direct push |
+| `develop` | `main` | `main` (via release) | PR mgmt agents + Jeremy | Require CI pass |
+| `epic/<name>` | `develop` | `develop` | Jeremy reviews | Require CI pass |
+| `issue-<N>-*` | epic or develop | epic or develop | Coding agents | — |
+
+## Branch Resolution Algorithm
+
+Agents determine their base branch deterministically:
+
+1. Check issue body for explicit `Base-Branch: <branch>` override
+2. Check issue labels for `epic:<name>` — if found, base = `epic/<name>` (create from develop if it doesn't exist)
+3. Default: base = `develop`
+
+## Promotion Model
+
+- **Pre-production (current)**: Rolling promotion — Jeremy merges `develop` to `main` per-issue or in small batches after human testing passes
+- **Beta releases**: Cut `release/vX.Y` from `develop`, stabilize (bug fixes only), then merge to `main` and tag
+- **Gate**: Human testing on Project #3 board must pass before any promotion to `main`
+
+## Consequences
+
+- Agents target `develop` (or `epic/<name>`), never `main` directly
+- Merge conflicts are contained within epic branches instead of colliding on `main`
+- `main` is always safe for students and stakeholders to clone
+- Human testing is the gate between `develop` and `main` (see ADR-002)
+- One additional permanent branch (`develop`) to maintain — acceptable overhead for the team size
+- Epic branches are ephemeral (weeks) and cleaned up after merging to `develop`
+
+## Full Design Document
+
+For the complete analysis including options considered, team composition, role interactions, and implementation phases, see `docs/decisions/2026-02-10-epic-workflow-and-branch-strategy.md`.


### PR DESCRIPTION
## Summary
- Add test layer priority and test expectations by change type to CLAUDE.md
- Document develop + main branching model with epic branches and branch resolution algorithm
- Update work loop for epic filtering, human testing items, and branch-aware PR targeting
- Add Epics section (active epic table, epic workflow) and Human Testing section (issue table, filing format, bug flow) to CLAUDE.md
- Create 3 Architecture Decision Records: ADR-001 (MVC for testability), ADR-002 (tiered testing model), ADR-003 (branching strategy)
- Update CI and AI review GitHub Actions workflows to trigger on `develop` and `epic/**` branches

## Context
This formalizes the testing, epic, and branching decisions from a session discussion into the agent workflow (CLAUDE.md) and permanent architecture records (docs/adr/). The corresponding GitHub infrastructure (epic labels, `develop` branch, `main` branch protection, epic issues) was already set up during the session.

## Test plan
- [x] Verify CLAUDE.md renders correctly on GitHub and reads coherently end-to-end
- [x] Verify ADR-001, ADR-002, ADR-003 render correctly in `docs/adr/`
- [x] Verify CI triggers on push to `develop` branch
- [x] Verify an agent reading the updated CLAUDE.md would know to: target `develop`, filter by epic, test at the right layer, file human testing items

🤖 Generated with [Claude Code](https://claude.com/claude-code)