### PR TITLE
add symbol style system and monochrome color mode

### DIFF
--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -53,7 +53,9 @@ class MenuBarMixin:
 
         export_netlist_action = QAction("Export &Netlist...", self)
         export_netlist_action.setShortcut(kb.get("file.export_netlist"))
-        export_netlist_action.setToolTip("Export the generated SPICE netlist to a .cir file")
+        export_netlist_action.setToolTip(
+            "Export the generated SPICE netlist to a .cir file"
+        )
         export_netlist_action.triggered.connect(self.export_netlist)
         file_menu.addAction(export_netlist_action)
 
@@ -68,7 +70,9 @@ class MenuBarMixin:
         file_menu.addAction(export_pdf_action)
 
         export_latex_action = QAction("Export as &LaTeX...", self)
-        export_latex_action.setToolTip("Export circuit as CircuiTikZ LaTeX code (.tex file)")
+        export_latex_action.setToolTip(
+            "Export circuit as CircuiTikZ LaTeX code (.tex file)"
+        )
         export_latex_action.triggered.connect(self.export_circuitikz)
         file_menu.addAction(export_latex_action)
 
@@ -141,7 +145,9 @@ class MenuBarMixin:
         edit_menu.addSeparator()
 
         copy_latex_action = QAction("Copy as La&TeX", self)
-        copy_latex_action.setToolTip("Copy the CircuiTikZ environment block to the clipboard")
+        copy_latex_action.setToolTip(
+            "Copy the CircuiTikZ environment block to the clipboard"
+        )
         copy_latex_action.triggered.connect(self.copy_circuitikz)
         edit_menu.addAction(copy_latex_action)
 
@@ -208,7 +214,9 @@ class MenuBarMixin:
         self.probe_action = QAction("&Probe Tool", self)
         self.probe_action.setCheckable(True)
         self.probe_action.setShortcut(kb.get("tools.probe"))
-        self.probe_action.setToolTip("Click nodes or components to see voltage/current values")
+        self.probe_action.setToolTip(
+            "Click nodes or components to see voltage/current values"
+        )
         self.probe_action.triggered.connect(self._toggle_probe_mode)
         view_menu.addAction(self.probe_action)
 
@@ -238,6 +246,42 @@ class MenuBarMixin:
         self.theme_group = QActionGroup(self)
         self.theme_group.addAction(self.light_theme_action)
         self.theme_group.addAction(self.dark_theme_action)
+
+        # Symbol Style submenu
+        symbol_style_menu = view_menu.addMenu("&Symbol Style")
+        self.ieee_style_action = QAction("&IEEE / ANSI (American)", self)
+        self.ieee_style_action.setCheckable(True)
+        self.ieee_style_action.setChecked(True)
+        self.ieee_style_action.triggered.connect(lambda: self._set_symbol_style("ieee"))
+        symbol_style_menu.addAction(self.ieee_style_action)
+
+        self.iec_style_action = QAction("I&EC (European)", self)
+        self.iec_style_action.setCheckable(True)
+        self.iec_style_action.triggered.connect(lambda: self._set_symbol_style("iec"))
+        symbol_style_menu.addAction(self.iec_style_action)
+
+        self.symbol_style_group = QActionGroup(self)
+        self.symbol_style_group.addAction(self.ieee_style_action)
+        self.symbol_style_group.addAction(self.iec_style_action)
+
+        # Component Colors submenu
+        color_mode_menu = view_menu.addMenu("Component &Colors")
+        self.color_mode_action = QAction("&Color (per component type)", self)
+        self.color_mode_action.setCheckable(True)
+        self.color_mode_action.setChecked(True)
+        self.color_mode_action.triggered.connect(lambda: self._set_color_mode("color"))
+        color_mode_menu.addAction(self.color_mode_action)
+
+        self.monochrome_mode_action = QAction("&Monochrome", self)
+        self.monochrome_mode_action.setCheckable(True)
+        self.monochrome_mode_action.triggered.connect(
+            lambda: self._set_color_mode("monochrome")
+        )
+        color_mode_menu.addAction(self.monochrome_mode_action)
+
+        self.color_mode_group = QActionGroup(self)
+        self.color_mode_group.addAction(self.color_mode_action)
+        self.color_mode_group.addAction(self.monochrome_mode_action)
 
         view_menu.addSeparator()
 
@@ -327,7 +371,9 @@ class MenuBarMixin:
 
         mc_action = QAction("&Monte Carlo...", self)
         mc_action.setCheckable(True)
-        mc_action.setToolTip("Run Monte Carlo tolerance analysis with randomized component values")
+        mc_action.setToolTip(
+            "Run Monte Carlo tolerance analysis with randomized component values"
+        )
         mc_action.triggered.connect(self.set_analysis_monte_carlo)
         analysis_menu.addAction(mc_action)
 

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -26,6 +26,8 @@ class SettingsMixin:
             settings.setValue("autosave/enabled", True)
         settings.setValue("view/show_statistics", self.statistics_panel.isVisible())
         settings.setValue("view/theme", theme_manager.current_theme.name)
+        settings.setValue("view/symbol_style", theme_manager.symbol_style)
+        settings.setValue("view/color_mode", theme_manager.color_mode)
 
     def _restore_settings(self):
         """Restore user preferences from QSettings"""
@@ -79,6 +81,14 @@ class SettingsMixin:
         if saved_theme == "Dark Theme":
             self._set_theme("dark")
 
+        saved_symbol_style = settings.value("view/symbol_style")
+        if saved_symbol_style in ("ieee", "iec"):
+            self._set_symbol_style(saved_symbol_style)
+
+        saved_color_mode = settings.value("view/color_mode")
+        if saved_color_mode in ("color", "monochrome"):
+            self._set_color_mode(saved_color_mode)
+
     def closeEvent(self, event):
         """Save settings before closing"""
         self._save_settings()
@@ -117,7 +127,11 @@ class SettingsMixin:
         if reply == QMessageBox.StandardButton.Yes:
             source = self.file_ctrl.load_auto_save()
             if source is not None:
-                title = f"Circuit Design GUI - {source}" if source else "Circuit Design GUI - (Recovered)"
+                title = (
+                    f"Circuit Design GUI - {source}"
+                    if source
+                    else "Circuit Design GUI - (Recovered)"
+                )
                 self.setWindowTitle(title)
                 self._sync_analysis_menu()
                 statusBar = self.statusBar()

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -57,6 +57,24 @@ class ViewOperationsMixin:
         # Refresh canvas (grid + components)
         self.canvas.refresh_theme()
 
+    def _set_symbol_style(self, style: str):
+        """Switch the component symbol drawing style."""
+        theme_manager.set_symbol_style(style)
+        if style == "iec":
+            self.iec_style_action.setChecked(True)
+        else:
+            self.ieee_style_action.setChecked(True)
+        self.canvas.scene.update()
+
+    def _set_color_mode(self, mode: str):
+        """Switch between per-type color and monochrome rendering."""
+        theme_manager.set_color_mode(mode)
+        if mode == "monochrome":
+            self.monochrome_mode_action.setChecked(True)
+        else:
+            self.color_mode_action.setChecked(True)
+        self.canvas.scene.update()
+
     def _toggle_statistics_panel(self, checked):
         """Toggle the circuit statistics panel visibility."""
         self.statistics_panel.setVisible(checked)
@@ -125,7 +143,9 @@ class ViewOperationsMixin:
         self.canvas.set_probe_mode(checked)
         if checked:
             if not self.canvas.node_voltages and self._last_results is None:
-                self.statusBar().showMessage("Probe mode active. Run a simulation first to see values.", 3000)
+                self.statusBar().showMessage(
+                    "Probe mode active. Run a simulation first to see values.", 3000
+                )
             else:
                 self.statusBar().showMessage(
                     "Probe mode active. Click nodes or components to see values. Press Escape to exit.",
@@ -138,7 +158,9 @@ class ViewOperationsMixin:
     def _on_probe_requested(self, signal_name, probe_type):
         """Handle probe click for sweep/transient analyses (no OP data on canvas)."""
         if self._last_results is None:
-            self.statusBar().showMessage("No simulation results available. Run a simulation first.", 3000)
+            self.statusBar().showMessage(
+                "No simulation results available. Run a simulation first.", 3000
+            )
             return
 
         analysis_type = self._last_results_type
@@ -149,7 +171,9 @@ class ViewOperationsMixin:
         elif analysis_type == "AC Sweep":
             self._probe_open_ac_sweep(signal_name, probe_type)
         else:
-            self.statusBar().showMessage(f"Probe not supported for {analysis_type} analysis.", 3000)
+            self.statusBar().showMessage(
+                f"Probe not supported for {analysis_type} analysis.", 3000
+            )
 
     def _probe_open_waveform(self, signal_name, probe_type):
         """Open waveform dialog focused on the probed signal."""
@@ -208,10 +232,14 @@ class ViewOperationsMixin:
         circuit_items = [
             item
             for item in scene.items()
-            if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
+            if isinstance(
+                item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem)
+            )
         ]
         if not circuit_items:
-            QMessageBox.information(self, "Export Image", "Nothing to export — the canvas is empty.")
+            QMessageBox.information(
+                self, "Export Image", "Nothing to export — the canvas is empty."
+            )
             return
 
         source_rect = circuit_items[0].sceneBoundingRect()
@@ -228,7 +256,9 @@ class ViewOperationsMixin:
 
             generator = QSvgGenerator()
             generator.setFileName(filename)
-            generator.setSize(QSize(int(source_rect.width()), int(source_rect.height())))
+            generator.setSize(
+                QSize(int(source_rect.width()), int(source_rect.height()))
+            )
             generator.setViewBox(source_rect)
             generator.setTitle("SDM Spice Circuit")
 
@@ -255,7 +285,9 @@ class ViewOperationsMixin:
             painter.end()
             image.save(filename)
 
-        QMessageBox.information(self, "Export Image", f"Circuit exported to:\n{filename}")
+        QMessageBox.information(
+            self, "Export Image", f"Circuit exported to:\n{filename}"
+        )
 
     def export_circuitikz(self):
         """Export the circuit as a CircuiTikZ LaTeX file."""
@@ -267,7 +299,9 @@ class ViewOperationsMixin:
 
         model = self.circuit_ctrl.model
         if not model.components:
-            QMessageBox.information(self, "Export LaTeX", "Nothing to export — the canvas is empty.")
+            QMessageBox.information(
+                self, "Export LaTeX", "Nothing to export — the canvas is empty."
+            )
             return
 
         # Show options dialog
@@ -285,7 +319,11 @@ class ViewOperationsMixin:
                 nodes=model.nodes,
                 terminal_to_node=model.terminal_to_node,
                 standalone=opts["standalone"],
-                circuit_name=os.path.basename(self.file_ctrl.current_file) if self.file_ctrl.current_file else "",
+                circuit_name=(
+                    os.path.basename(self.file_ctrl.current_file)
+                    if self.file_ctrl.current_file
+                    else ""
+                ),
                 scale=opts["scale"],
                 include_ids=opts["include_ids"],
                 include_values=opts["include_values"],
@@ -298,7 +336,9 @@ class ViewOperationsMixin:
 
         default_name = ""
         if hasattr(self, "file_ctrl") and self.file_ctrl.current_file:
-            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[0]
+            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[
+                0
+            ]
             default_name = base + ".tex"
 
         filename, _ = QFileDialog.getSaveFileName(

--- a/app/GUI/styles/__init__.py
+++ b/app/GUI/styles/__init__.py
@@ -51,7 +51,7 @@ from .light_theme import LightTheme
 
 # Theme system
 from .theme import BaseTheme, ThemeProtocol
-from .theme_manager import ThemeManager, theme_manager
+from .theme_manager import COLOR_MODES, SYMBOL_STYLES, ThemeManager, theme_manager
 
 __all__ = [
     # Constants
@@ -80,4 +80,6 @@ __all__ = [
     "theme_manager",
     "LightTheme",
     "DarkTheme",
+    "SYMBOL_STYLES",
+    "COLOR_MODES",
 ]

--- a/app/GUI/styles/theme_manager.py
+++ b/app/GUI/styles/theme_manager.py
@@ -1,7 +1,8 @@
 """
 theme_manager.py - Singleton theme manager.
 
-Provides global access to the current theme and enables runtime theme switching.
+Provides global access to the current theme, symbol style, and color mode.
+Enables runtime theme/style switching with observer notification.
 """
 
 import logging
@@ -12,10 +13,16 @@ from .theme import ThemeProtocol
 
 logger = logging.getLogger(__name__)
 
+# Valid symbol styles
+SYMBOL_STYLES = ("ieee", "iec")
+
+# Valid color modes
+COLOR_MODES = ("color", "monochrome")
+
 
 class ThemeManager:
     """
-    Singleton manager for application themes.
+    Singleton manager for application themes, symbol styles, and color modes.
 
     Usage:
         from app.GUI.styles import theme_manager
@@ -27,6 +34,14 @@ class ThemeManager:
         # Switch themes
         theme_manager.set_theme(DarkTheme())
 
+        # Symbol style
+        theme_manager.symbol_style  # "ieee" (default)
+        theme_manager.set_symbol_style("iec")
+
+        # Color mode
+        theme_manager.color_mode  # "color" (default)
+        theme_manager.set_color_mode("monochrome")
+
         # Subscribe to theme changes
         theme_manager.on_theme_changed(my_callback)
     """
@@ -34,18 +49,32 @@ class ThemeManager:
     _instance: Optional["ThemeManager"] = None
     _theme: ThemeProtocol
     _listeners: List[Callable[[ThemeProtocol], None]]
+    _symbol_style: str
+    _color_mode: str
 
     def __new__(cls) -> "ThemeManager":
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance._theme = LightTheme()
             cls._instance._listeners = []
+            cls._instance._symbol_style = "ieee"
+            cls._instance._color_mode = "color"
         return cls._instance
 
     @property
     def current_theme(self) -> ThemeProtocol:
         """Get the current theme."""
         return self._theme
+
+    @property
+    def symbol_style(self) -> str:
+        """Get the current symbol style ('ieee' or 'iec')."""
+        return self._symbol_style
+
+    @property
+    def color_mode(self) -> str:
+        """Get the current color mode ('color' or 'monochrome')."""
+        return self._color_mode
 
     def set_theme(self, theme: ThemeProtocol) -> None:
         """
@@ -57,9 +86,35 @@ class ThemeManager:
         self._theme = theme
         self._notify_listeners()
 
+    def set_symbol_style(self, style: str) -> None:
+        """Set the symbol drawing style and notify listeners.
+
+        Args:
+            style: 'ieee' for IEEE/ANSI or 'iec' for IEC 60617
+        """
+        if style not in SYMBOL_STYLES:
+            logger.warning("Unknown symbol style %r, ignoring", style)
+            return
+        if style != self._symbol_style:
+            self._symbol_style = style
+            self._notify_listeners()
+
+    def set_color_mode(self, mode: str) -> None:
+        """Set the component color mode and notify listeners.
+
+        Args:
+            mode: 'color' for per-type colors or 'monochrome' for single color
+        """
+        if mode not in COLOR_MODES:
+            logger.warning("Unknown color mode %r, ignoring", mode)
+            return
+        if mode != self._color_mode:
+            self._color_mode = mode
+            self._notify_listeners()
+
     def on_theme_changed(self, callback: Callable[[ThemeProtocol], None]) -> None:
         """
-        Register a callback to be notified when theme changes.
+        Register a callback to be notified when theme, style, or color mode changes.
 
         Args:
             callback: Function that takes the new theme as argument
@@ -109,11 +164,19 @@ class ThemeManager:
     # ===== Helper methods delegated to current theme =====
 
     def get_component_color(self, component_type: str):
-        """Get the themed color for a component type."""
+        """Get the themed color for a component type.
+
+        In monochrome mode, returns the theme's foreground color instead of
+        the per-type color.
+        """
+        if self._color_mode == "monochrome":
+            return self._theme.color("text_primary")
         return self._theme.get_component_color(component_type)
 
     def get_component_color_hex(self, component_type: str) -> str:
         """Get the hex color string for a component type."""
+        if self._color_mode == "monochrome":
+            return self._theme.color_hex("text_primary")
         return self._theme.get_component_color_hex(component_type)
 
     def get_algorithm_color(self, algorithm: str):

--- a/app/tests/unit/test_symbol_style.py
+++ b/app/tests/unit/test_symbol_style.py
@@ -1,0 +1,253 @@
+"""Tests for symbol style system (#283), IEC symbols (#284), and color modes (#285)."""
+
+import pytest
+from GUI.component_item import (
+    BJTNPN,
+    BJTPNP,
+    CCCS,
+    CCVS,
+    MOSFETNMOS,
+    MOSFETPMOS,
+    VCCS,
+    VCVS,
+    Capacitor,
+    CurrentSource,
+    Diode,
+    Ground,
+    Inductor,
+    LEDComponent,
+    OpAmp,
+    Resistor,
+    VCSwitch,
+    VoltageSource,
+    WaveformVoltageSource,
+    ZenerDiode,
+)
+from GUI.styles import LightTheme, theme_manager
+from GUI.styles.theme_manager import COLOR_MODES, SYMBOL_STYLES
+from PyQt6.QtGui import QColor
+
+
+@pytest.fixture(autouse=True)
+def reset_theme_manager():
+    """Reset theme manager to defaults after each test."""
+    yield
+    theme_manager.set_theme(LightTheme())
+    theme_manager._symbol_style = "ieee"
+    theme_manager._color_mode = "color"
+
+
+# ── Symbol style constants ──────────────────────────────────────────
+
+
+class TestSymbolStyleConstants:
+    def test_ieee_in_valid_styles(self):
+        assert "ieee" in SYMBOL_STYLES
+
+    def test_iec_in_valid_styles(self):
+        assert "iec" in SYMBOL_STYLES
+
+
+# ── ThemeManager symbol_style property ──────────────────────────────
+
+
+class TestSymbolStyleProperty:
+    def test_default_is_ieee(self):
+        assert theme_manager.symbol_style == "ieee"
+
+    def test_set_to_iec(self):
+        theme_manager.set_symbol_style("iec")
+        assert theme_manager.symbol_style == "iec"
+
+    def test_set_back_to_ieee(self):
+        theme_manager.set_symbol_style("iec")
+        theme_manager.set_symbol_style("ieee")
+        assert theme_manager.symbol_style == "ieee"
+
+    def test_invalid_style_ignored(self):
+        theme_manager.set_symbol_style("bogus")
+        assert theme_manager.symbol_style == "ieee"
+
+    def test_listener_notified_on_style_change(self):
+        received = []
+        theme_manager.on_theme_changed(lambda t: received.append("changed"))
+        theme_manager.set_symbol_style("iec")
+        assert received == ["changed"]
+        theme_manager.remove_listener(received.append)
+
+    def test_no_notification_when_same_style(self):
+        received = []
+        theme_manager.on_theme_changed(lambda t: received.append("changed"))
+        theme_manager.set_symbol_style("ieee")  # already ieee
+        assert received == []
+        theme_manager.remove_listener(received.append)
+
+
+# ── Color mode property ─────────────────────────────────────────────
+
+
+class TestColorModeProperty:
+    def test_default_is_color(self):
+        assert theme_manager.color_mode == "color"
+
+    def test_valid_modes(self):
+        assert "color" in COLOR_MODES
+        assert "monochrome" in COLOR_MODES
+
+    def test_set_monochrome(self):
+        theme_manager.set_color_mode("monochrome")
+        assert theme_manager.color_mode == "monochrome"
+
+    def test_set_back_to_color(self):
+        theme_manager.set_color_mode("monochrome")
+        theme_manager.set_color_mode("color")
+        assert theme_manager.color_mode == "color"
+
+    def test_invalid_mode_ignored(self):
+        theme_manager.set_color_mode("neon")
+        assert theme_manager.color_mode == "color"
+
+    def test_listener_notified_on_mode_change(self):
+        received = []
+        theme_manager.on_theme_changed(lambda t: received.append("changed"))
+        theme_manager.set_color_mode("monochrome")
+        assert received == ["changed"]
+        theme_manager.remove_listener(received.append)
+
+    def test_no_notification_when_same_mode(self):
+        received = []
+        theme_manager.on_theme_changed(lambda t: received.append("changed"))
+        theme_manager.set_color_mode("color")  # already color
+        assert received == []
+        theme_manager.remove_listener(received.append)
+
+
+# ── Monochrome color behavior ───────────────────────────────────────
+
+
+class TestMonochromeColors:
+    def test_color_mode_returns_per_type(self):
+        """In color mode, different component types get different colors."""
+        r = theme_manager.get_component_color("Resistor")
+        c = theme_manager.get_component_color("Capacitor")
+        assert r != c
+
+    def test_monochrome_returns_foreground(self):
+        """In monochrome mode, all components get the theme foreground."""
+        theme_manager.set_color_mode("monochrome")
+        fg = theme_manager.color("text_primary")
+        for comp_type in ("Resistor", "Capacitor", "Inductor", "Voltage Source"):
+            assert theme_manager.get_component_color(comp_type) == fg
+
+    def test_monochrome_hex_returns_foreground(self):
+        theme_manager.set_color_mode("monochrome")
+        fg_hex = theme_manager.color_hex("text_primary")
+        assert theme_manager.get_component_color_hex("Resistor") == fg_hex
+
+    def test_color_mode_hex_returns_per_type(self):
+        r_hex = theme_manager.get_component_color_hex("Resistor")
+        c_hex = theme_manager.get_component_color_hex("Capacitor")
+        assert r_hex != c_hex
+
+
+# ── Component draw dispatch (IEEE default) ──────────────────────────
+
+
+ALL_COMPONENT_CLASSES = [
+    Resistor,
+    Capacitor,
+    Inductor,
+    VoltageSource,
+    CurrentSource,
+    WaveformVoltageSource,
+    Ground,
+    OpAmp,
+    VCVS,
+    CCVS,
+    VCCS,
+    CCCS,
+    BJTNPN,
+    BJTPNP,
+    MOSFETNMOS,
+    MOSFETPMOS,
+    VCSwitch,
+    Diode,
+    LEDComponent,
+    ZenerDiode,
+]
+
+
+class TestIEEEDrawDispatch:
+    """Verify every component has a _draw_ieee method reachable via dispatch."""
+
+    @pytest.mark.parametrize("cls", ALL_COMPONENT_CLASSES, ids=lambda c: c.type_name)
+    def test_has_draw_ieee(self, cls):
+        assert hasattr(cls, "_draw_ieee"), f"{cls.type_name} missing _draw_ieee"
+
+    @pytest.mark.parametrize("cls", ALL_COMPONENT_CLASSES, ids=lambda c: c.type_name)
+    def test_draw_component_body_dispatches_ieee(self, cls):
+        """draw_component_body should call _draw_ieee when style is 'ieee'."""
+        comp = cls("T1")
+        called = []
+        comp._draw_ieee = lambda painter: called.append(True)
+        comp.draw_component_body(None)
+        assert (
+            called
+        ), f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
+
+
+class TestObstacleShapeDispatch:
+    """Verify obstacle shapes dispatch correctly."""
+
+    @pytest.mark.parametrize("cls", ALL_COMPONENT_CLASSES, ids=lambda c: c.type_name)
+    def test_obstacle_shape_returns_polygon(self, cls):
+        comp = cls("T1")
+        shape = comp.get_obstacle_shape()
+        assert isinstance(shape, list)
+        assert len(shape) >= 3, "Obstacle polygon must have ≥3 points"
+        for pt in shape:
+            assert len(pt) == 2, "Each point must be (x, y)"
+
+    def test_ieee_obstacle_shape_fallback(self):
+        """Unknown style falls back to _get_obstacle_shape_ieee."""
+        r = Resistor("R1")
+        ieee_shape = r._get_obstacle_shape_ieee()
+        theme_manager._symbol_style = "ieee"
+        assert r.get_obstacle_shape() == ieee_shape
+
+    def test_obstacle_dispatch_tries_style_specific(self):
+        """If a style-specific method exists, it's used."""
+        r = Resistor("R1")
+        custom = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
+        r._get_obstacle_shape_iec = lambda: custom
+        theme_manager.set_symbol_style("iec")
+        assert r.get_obstacle_shape() == custom
+
+    def test_obstacle_fallback_when_no_style_method(self):
+        """When no style-specific method exists, IEEE is used."""
+        d = Diode("D1")
+        theme_manager.set_symbol_style("iec")
+        # Diode has no _get_obstacle_shape_iec, so should fall back to ieee
+        assert d.get_obstacle_shape() == d._get_obstacle_shape_ieee()
+
+
+class TestDrawDispatchIEC:
+    """Verify draw dispatch falls back to IEEE when IEC is not implemented."""
+
+    def test_fallback_to_ieee_when_no_iec_method(self):
+        """Components without _draw_iec should use _draw_ieee."""
+        theme_manager.set_symbol_style("iec")
+        comp = Diode("D1")
+        called = []
+        comp._draw_ieee = lambda painter: called.append(True)
+        comp.draw_component_body(None)
+        assert called
+
+    def test_iec_method_used_when_available(self):
+        """If _draw_iec exists, it should be called."""
+        theme_manager.set_symbol_style("iec")
+        comp = Resistor("R1")
+        iec_called = []
+        comp._draw_iec = lambda painter: iec_called.append(True)
+        comp.draw_component_body(None)
+        assert iec_called


### PR DESCRIPTION
## Summary
- Adds configurable symbol style system with IEEE/ANSI as default (#283)
- Adds monochrome vs color component rendering preference (#285)
- Refactors all 20 component classes to use style-dispatched `_draw_ieee()` and `_get_obstacle_shape_ieee()` methods
- Adds `View > Symbol Style` and `View > Component Colors` submenus
- Persists preferences via QSettings across sessions
- 84 new tests (1447 total, all passing)

## Test plan
- [x] All 1447 tests pass (`python -m pytest`)
- [x] 84 new tests cover style dispatch, color modes, obstacle shapes
- [ ] Manual: Verify View > Symbol Style menu shows IEEE/ANSI option
- [ ] Manual: Verify View > Component Colors menu toggles monochrome mode
- [ ] Manual: Verify preferences persist across app restart

Closes #283
Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)