### PR TITLE
add IEC symbol style variants for resistor, capacitor, inductor

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -503,8 +503,17 @@ class Resistor(ComponentGraphicsItem):
         painter.drawLine(5, 8, 10, -8)
         painter.drawLine(10, -8, 15, 0)
 
+    def _draw_iec(self, painter):
+        if self.scene() is not None:
+            painter.drawLine(-30, 0, -15, 0)
+            painter.drawLine(15, 0, 30, 0)
+        painter.drawRect(-15, -8, 30, 16)
+
     def _get_obstacle_shape_ieee(self):
         return [(-18.0, -11.0), (18.0, -11.0), (18.0, 11.0), (-18.0, 11.0)]
+
+    def _get_obstacle_shape_iec(self):
+        return [(-18.0, -10.0), (18.0, -10.0), (18.0, 10.0), (-18.0, 10.0)]
 
 
 class Capacitor(ComponentGraphicsItem):
@@ -519,6 +528,14 @@ class Capacitor(ComponentGraphicsItem):
         if self.scene() is not None:
             painter.drawLine(-30, 0, -5, 0)
             painter.drawLine(5, 0, 30, 0)
+        painter.drawLine(-5, -12, -5, 12)
+        painter.drawLine(5, -12, 5, 12)
+
+    def _draw_iec(self, painter):
+        if self.scene() is not None:
+            painter.drawLine(-30, 0, -5, 0)
+            painter.drawLine(5, 0, 30, 0)
+        # IEC non-polarized: two parallel lines (same as IEEE)
         painter.drawLine(-5, -12, -5, 12)
         painter.drawLine(5, -12, 5, 12)
 
@@ -541,8 +558,19 @@ class Inductor(ComponentGraphicsItem):
         for i in range(-20, 20, 8):
             painter.drawArc(i, -5, 8, 10, 0, 180 * 16)
 
+    def _draw_iec(self, painter):
+        if self.scene() is not None:
+            painter.drawLine(-30, 0, -18, 0)
+            painter.drawLine(18, 0, 30, 0)
+        # IEC inductor: filled rectangular humps
+        painter.drawRect(-18, -8, 36, 8)
+        painter.drawLine(-18, 0, 18, 0)
+
     def _get_obstacle_shape_ieee(self):
         return [(-18.0, -11.0), (18.0, -11.0), (18.0, 11.0), (-18.0, 11.0)]
+
+    def _get_obstacle_shape_iec(self):
+        return [(-20.0, -10.0), (20.0, -10.0), (20.0, 2.0), (-20.0, 2.0)]
 
 
 class VoltageSource(ComponentGraphicsItem):


### PR DESCRIPTION
## Summary
- Adds `_draw_iec()` methods for Resistor (rectangle body), Capacitor (same as IEEE for non-polarized), and Inductor (rectangular humps)
- Adds `_get_obstacle_shape_iec()` for Resistor and Inductor where body dimensions differ
- 13 new tests for IEC draw methods and obstacle shapes

**Depends on:** PR #289 (#283 infrastructure)

## Test plan
- [x] All 1460 tests pass (`python -m pytest`)
- [x] 13 new IEC-specific tests
- [ ] Manual: Select IEC style in View > Symbol Style, verify resistor shows rectangle
- [ ] Manual: Switch back to IEEE, verify zigzag returns
- [ ] Manual: Verify wires still connect after style switch

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)