### PR TITLE
add convergence error diagnostics and auto-retry

### DIFF
--- a/app/simulation/__init__.py
+++ b/app/simulation/__init__.py
@@ -1,4 +1,4 @@
-from . import circuitikz_exporter, csv_exporter
+from . import circuitikz_exporter, convergence, csv_exporter
 from .circuit_validator import validate_circuit
 from .netlist_generator import NetlistGenerator
 from .ngspice_runner import NgspiceRunner
@@ -11,4 +11,5 @@ __all__ = [
     "ResultParser",
     "csv_exporter",
     "circuitikz_exporter",
+    "convergence",
 ]

--- a/app/simulation/convergence.py
+++ b/app/simulation/convergence.py
@@ -1,0 +1,203 @@
+"""
+simulation/convergence.py
+
+Classifies ngspice simulation errors and provides retry strategies
+with relaxed tolerances for convergence failures.
+"""
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ErrorCategory(Enum):
+    """Categories of ngspice simulation failures."""
+
+    DC_CONVERGENCE = "dc_convergence"
+    TIMESTEP_TOO_SMALL = "timestep_too_small"
+    SINGULAR_MATRIX = "singular_matrix"
+    SOURCE_STEPPING_FAILED = "source_stepping_failed"
+    UNKNOWN = "unknown"
+
+
+# Patterns matched against combined stdout+stderr (case-insensitive)
+_ERROR_PATTERNS: list[tuple[re.Pattern, ErrorCategory]] = [
+    (re.compile(r"singular matrix", re.IGNORECASE), ErrorCategory.SINGULAR_MATRIX),
+    (
+        re.compile(r"no convergence in dc operating point", re.IGNORECASE),
+        ErrorCategory.DC_CONVERGENCE,
+    ),
+    (
+        re.compile(r"doAnalyses:.*timestep too small", re.IGNORECASE),
+        ErrorCategory.TIMESTEP_TOO_SMALL,
+    ),
+    (
+        re.compile(r"source stepping failed", re.IGNORECASE),
+        ErrorCategory.SOURCE_STEPPING_FAILED,
+    ),
+    (
+        re.compile(r"no convergence", re.IGNORECASE),
+        ErrorCategory.DC_CONVERGENCE,
+    ),
+]
+
+
+@dataclass
+class ErrorDiagnosis:
+    """Structured diagnosis of a simulation failure."""
+
+    category: ErrorCategory
+    message: str
+    causes: list[str]
+    suggestions: list[str]
+
+
+_DIAGNOSES: dict[ErrorCategory, ErrorDiagnosis] = {
+    ErrorCategory.DC_CONVERGENCE: ErrorDiagnosis(
+        category=ErrorCategory.DC_CONVERGENCE,
+        message=("The simulator could not find a stable DC operating point for your circuit."),
+        causes=[
+            "A node is not connected to ground (floating node)",
+            "Component values are unrealistic (e.g. 0 ohm resistor, extremely large gain)",
+            "Positive feedback loop without a stable bias point",
+        ],
+        suggestions=[
+            "Check that every node has a DC path to ground",
+            "Add a large resistor (e.g. 1G) from floating nodes to ground",
+            "Verify component values are within realistic ranges",
+        ],
+    ),
+    ErrorCategory.TIMESTEP_TOO_SMALL: ErrorDiagnosis(
+        category=ErrorCategory.TIMESTEP_TOO_SMALL,
+        message=("The transient simulation could not advance in time — the required timestep became too small."),
+        causes=[
+            "Very fast switching edges combined with large time constants",
+            "Numerical oscillation in a feedback loop",
+            "Unrealistic component values causing stiff equations",
+        ],
+        suggestions=[
+            "Increase the simulation time step in the analysis settings",
+            "Reduce the simulation duration or avoid very fast signal edges",
+            "Check for unrealistic component values (very small capacitors with very large resistors)",
+        ],
+    ),
+    ErrorCategory.SINGULAR_MATRIX: ErrorDiagnosis(
+        category=ErrorCategory.SINGULAR_MATRIX,
+        message="The circuit equations could not be solved — the matrix is singular.",
+        causes=[
+            "Two voltage sources are connected in parallel",
+            "A loop of voltage sources and/or inductors with no resistance",
+            "A node is completely disconnected from the rest of the circuit",
+        ],
+        suggestions=[
+            "Ensure no two voltage sources are directly in parallel",
+            "Add a small series resistor (e.g. 1m ohm) to inductor or voltage-source loops",
+            "Check for disconnected nodes or components",
+        ],
+    ),
+    ErrorCategory.SOURCE_STEPPING_FAILED: ErrorDiagnosis(
+        category=ErrorCategory.SOURCE_STEPPING_FAILED,
+        message=("The simulator tried ramping sources gradually but still could not converge."),
+        causes=[
+            "Circuit has a very sensitive operating point",
+            "Non-linear devices (diodes, transistors) with difficult bias conditions",
+        ],
+        suggestions=[
+            "Simplify the circuit and add components back one at a time",
+            "Check transistor bias conditions — ensure they are in the expected region",
+            "Try different initial conditions or component values",
+        ],
+    ),
+    ErrorCategory.UNKNOWN: ErrorDiagnosis(
+        category=ErrorCategory.UNKNOWN,
+        message="The simulation failed for an unexpected reason.",
+        causes=[],
+        suggestions=[
+            "Check the netlist for syntax errors",
+            "Verify all components are connected properly",
+            "Try a simpler circuit to isolate the problem",
+        ],
+    ),
+}
+
+# Convergence-related categories that benefit from relaxed tolerances
+_RETRIABLE_CATEGORIES = {
+    ErrorCategory.DC_CONVERGENCE,
+    ErrorCategory.TIMESTEP_TOO_SMALL,
+    ErrorCategory.SOURCE_STEPPING_FAILED,
+}
+
+# Relaxed SPICE options for retry attempts
+RELAXED_OPTIONS = {
+    "reltol": "0.01",
+    "abstol": "1e-10",
+    "vntol": "1e-4",
+    "itl1": "500",
+    "itl4": "200",
+}
+
+
+def classify_error(stderr: str, stdout: str = "") -> ErrorCategory:
+    """Classify an ngspice error from its stderr/stdout output.
+
+    Checks stderr first, then stdout, returning the first matching category.
+    """
+    for text in (stderr, stdout):
+        if not text:
+            continue
+        for pattern, category in _ERROR_PATTERNS:
+            if pattern.search(text):
+                return category
+    return ErrorCategory.UNKNOWN
+
+
+def diagnose_error(stderr: str, stdout: str = "") -> ErrorDiagnosis:
+    """Classify and return a full diagnosis for a simulation failure."""
+    category = classify_error(stderr, stdout)
+    return _DIAGNOSES[category]
+
+
+def is_retriable(category: ErrorCategory) -> bool:
+    """Return True if this error category may benefit from relaxed tolerances."""
+    return category in _RETRIABLE_CATEGORIES
+
+
+def format_options_lines(options: dict[str, str] | None = None) -> list[str]:
+    """Format a dict of SPICE options as netlist lines.
+
+    Returns a list like [".options reltol=0.01 abstol=1e-10 ..."].
+    If *options* is None, uses the default RELAXED_OPTIONS.
+    If *options* is an empty dict, returns [].
+    """
+    if options is None:
+        options = RELAXED_OPTIONS
+    if not options:
+        return []
+    pairs = " ".join(f"{k}={v}" for k, v in options.items())
+    return [f".options {pairs}"]
+
+
+def format_user_message(diagnosis: ErrorDiagnosis, relaxed: bool = False) -> str:
+    """Build a student-friendly error message string.
+
+    If *relaxed* is True, prepend a note that relaxed tolerances were used.
+    """
+    parts = [diagnosis.message]
+
+    if diagnosis.causes:
+        parts.append("\nCommon causes:")
+        for cause in diagnosis.causes:
+            parts.append(f"  - {cause}")
+
+    if diagnosis.suggestions:
+        parts.append("\nSuggestions:")
+        for suggestion in diagnosis.suggestions:
+            parts.append(f"  - {suggestion}")
+
+    if relaxed:
+        parts.insert(
+            0,
+            "Simulation converged with relaxed tolerances (results may be less accurate).\n",
+        )
+
+    return "\n".join(parts)

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -25,6 +25,7 @@ class NetlistGenerator:
         analysis_type,
         analysis_params,
         wrdata_filepath="transient_data.txt",
+        spice_options=None,
     ):
         """
         Args:
@@ -35,6 +36,7 @@ class NetlistGenerator:
             analysis_type: str
             analysis_params: dict
             wrdata_filepath: str - path for wrdata output file
+            spice_options: Optional[dict[str, str]] - extra .options key=value pairs
         """
         self.components = components
         self.wires = wires
@@ -43,6 +45,7 @@ class NetlistGenerator:
         self.analysis_type = analysis_type
         self.analysis_params = analysis_params
         self.wrdata_filepath = wrdata_filepath
+        self.spice_options = spice_options or {}
 
     def generate(self):
         """Generate complete SPICE netlist"""
@@ -271,6 +274,11 @@ class NetlistGenerator:
         lines.append("* Simulation Options")
         lines.append(".option TEMP=27")
         lines.append(".option TNOM=27")
+
+        # Add extra SPICE options (e.g. relaxed tolerances for convergence retry)
+        if self.spice_options:
+            pairs = " ".join(f"{k}={v}" for k, v in self.spice_options.items())
+            lines.append(f".options {pairs}")
 
         # Add analysis command
         lines.extend(self._generate_analysis_commands(node_labels, node_map))

--- a/app/tests/unit/test_convergence.py
+++ b/app/tests/unit/test_convergence.py
@@ -1,0 +1,134 @@
+"""Tests for simulation.convergence error classification and retry helpers."""
+
+import pytest
+from simulation.convergence import (
+    RELAXED_OPTIONS,
+    ErrorCategory,
+    ErrorDiagnosis,
+    classify_error,
+    diagnose_error,
+    format_options_lines,
+    format_user_message,
+    is_retriable,
+)
+
+
+class TestClassifyError:
+    """Test error classification from ngspice output."""
+
+    def test_dc_convergence_from_stderr(self):
+        stderr = "Error: no convergence in DC operating point"
+        assert classify_error(stderr) == ErrorCategory.DC_CONVERGENCE
+
+    def test_timestep_too_small(self):
+        stderr = "doAnalyses: TRAN:  Timestep too small; timestep = 1e-20"
+        assert classify_error(stderr) == ErrorCategory.TIMESTEP_TOO_SMALL
+
+    def test_singular_matrix(self):
+        stderr = "Error: singular matrix"
+        assert classify_error(stderr) == ErrorCategory.SINGULAR_MATRIX
+
+    def test_source_stepping_failed(self):
+        stderr = "Warning: source stepping failed"
+        assert classify_error(stderr) == ErrorCategory.SOURCE_STEPPING_FAILED
+
+    def test_unknown_error(self):
+        stderr = "some random error message"
+        assert classify_error(stderr) == ErrorCategory.UNKNOWN
+
+    def test_empty_stderr(self):
+        assert classify_error("") == ErrorCategory.UNKNOWN
+
+    def test_fallback_to_stdout(self):
+        stderr = ""
+        stdout = "Error: no convergence in DC operating point"
+        assert classify_error(stderr, stdout) == ErrorCategory.DC_CONVERGENCE
+
+    def test_case_insensitive(self):
+        stderr = "ERROR: SINGULAR MATRIX"
+        assert classify_error(stderr) == ErrorCategory.SINGULAR_MATRIX
+
+    def test_singular_matrix_takes_priority_over_convergence(self):
+        # Singular matrix appears before generic "no convergence" in pattern list
+        stderr = "singular matrix\nno convergence"
+        assert classify_error(stderr) == ErrorCategory.SINGULAR_MATRIX
+
+    def test_generic_no_convergence(self):
+        stderr = "Error(TRAN): no convergence in transient analysis"
+        assert classify_error(stderr) == ErrorCategory.DC_CONVERGENCE
+
+
+class TestDiagnoseError:
+    """Test full diagnosis generation."""
+
+    def test_returns_diagnosis_for_dc_convergence(self):
+        diag = diagnose_error("no convergence in DC operating point")
+        assert isinstance(diag, ErrorDiagnosis)
+        assert diag.category == ErrorCategory.DC_CONVERGENCE
+        assert "stable DC operating point" in diag.message
+        assert len(diag.causes) > 0
+        assert len(diag.suggestions) > 0
+
+    def test_returns_diagnosis_for_unknown(self):
+        diag = diagnose_error("something weird happened")
+        assert diag.category == ErrorCategory.UNKNOWN
+        assert "unexpected reason" in diag.message
+
+
+class TestIsRetriable:
+    """Test retriable classification."""
+
+    def test_dc_convergence_is_retriable(self):
+        assert is_retriable(ErrorCategory.DC_CONVERGENCE) is True
+
+    def test_timestep_is_retriable(self):
+        assert is_retriable(ErrorCategory.TIMESTEP_TOO_SMALL) is True
+
+    def test_source_stepping_is_retriable(self):
+        assert is_retriable(ErrorCategory.SOURCE_STEPPING_FAILED) is True
+
+    def test_singular_matrix_is_not_retriable(self):
+        assert is_retriable(ErrorCategory.SINGULAR_MATRIX) is False
+
+    def test_unknown_is_not_retriable(self):
+        assert is_retriable(ErrorCategory.UNKNOWN) is False
+
+
+class TestFormatOptionsLines:
+    """Test SPICE options line formatting."""
+
+    def test_default_relaxed_options(self):
+        lines = format_options_lines()
+        assert len(lines) == 1
+        assert lines[0].startswith(".options ")
+        assert "reltol=0.01" in lines[0]
+        assert "itl1=500" in lines[0]
+
+    def test_custom_options(self):
+        lines = format_options_lines({"reltol": "0.05"})
+        assert lines == [".options reltol=0.05"]
+
+    def test_empty_options(self):
+        lines = format_options_lines({})
+        assert lines == []
+
+
+class TestFormatUserMessage:
+    """Test student-friendly message formatting."""
+
+    def test_includes_message_and_causes(self):
+        diag = diagnose_error("singular matrix")
+        msg = format_user_message(diag)
+        assert "singular" in msg.lower()
+        assert "Common causes:" in msg
+        assert "Suggestions:" in msg
+
+    def test_relaxed_prefix(self):
+        diag = diagnose_error("no convergence in DC operating point")
+        msg = format_user_message(diag, relaxed=True)
+        assert msg.startswith("Simulation converged with relaxed tolerances")
+
+    def test_no_relaxed_prefix_by_default(self):
+        diag = diagnose_error("no convergence in DC operating point")
+        msg = format_user_message(diag, relaxed=False)
+        assert "relaxed tolerances" not in msg


### PR DESCRIPTION
## Summary
- Classifies ngspice simulation errors into 4 categories: DC convergence, timestep too small, singular matrix, source stepping failed
- Shows student-friendly error messages with common causes and suggested fixes instead of raw ngspice stderr
- Auto-retries retriable convergence failures with relaxed SPICE tolerances (reltol, abstol, vntol, itl1, itl4)
- Warns users when results were obtained with relaxed tolerances

## Test plan
- [x] 23 unit tests for error classification, diagnosis, retriable checks, options formatting, user messages
- [x] 3 integration tests for controller retry behavior (friendly messages, singular matrix non-retry, successful retry)
- [x] Full suite passes (1341 tests)
- [ ] Human testing: trigger a convergence error and verify the message is helpful

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)