### PR TITLE
Add unit tests for ngspice_runner.py

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -140,9 +140,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             new_pos = component.position
             # Only create a command if the component actually moved
             if old_pos[0] != new_pos[0] or old_pos[1] != new_pos[1]:
-                cmd = MoveComponentCommand(
-                    controller, comp_id, new_pos, old_position=old_pos
-                )
+                cmd = MoveComponentCommand(controller, comp_id, new_pos, old_position=old_pos)
                 move_commands.append(cmd)
 
         self._drag_start_positions = {}
@@ -155,9 +153,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             controller.undo_manager._undo_stack.append(move_commands[0])
             controller.undo_manager._redo_stack.clear()
         else:
-            compound = CompoundCommand(
-                move_commands, f"Move {len(move_commands)} components"
-            )
+            compound = CompoundCommand(move_commands, f"Move {len(move_commands)} components")
             controller.undo_manager._undo_stack.append(compound)
             controller.undo_manager._redo_stack.clear()
 
@@ -209,9 +205,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         )
 
         if ok and new_value:
-            is_valid, error_msg = validate_component_value(
-                new_value, self.component_type
-            )
+            is_valid, error_msg = validate_component_value(new_value, self.component_type)
             if not is_valid:
                 QMessageBox.warning(None, "Invalid Value", error_msg)
                 return
@@ -336,19 +330,9 @@ class ComponentGraphicsItem(QGraphicsItem):
         self.draw_component_body(painter)
 
         # Draw label (check canvas visibility settings)
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))
@@ -368,10 +352,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             painter.drawEllipse(terminal, 3, 3)
 
     def itemChange(self, change, value):
-        if (
-            change == QGraphicsItem.GraphicsItemChange.ItemPositionChange
-            and self.scene()
-        ):
+        if change == QGraphicsItem.GraphicsItemChange.ItemPositionChange and self.scene():
             # Snap to grid
             new_pos = value
             grid_x = round(new_pos.x() / GRID_SIZE) * GRID_SIZE
@@ -434,9 +415,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         if self._position_update_timer is None:
             self._position_update_timer = QTimer()
             self._position_update_timer.setSingleShot(True)
-            self._position_update_timer.timeout.connect(
-                self._notify_controller_position
-            )
+            self._position_update_timer.timeout.connect(self._notify_controller_position)
         self._position_update_timer.start(50)  # 50ms debounce
 
     def _notify_controller_position(self):
@@ -646,9 +625,7 @@ class WaveformVoltageSource(ComponentGraphicsItem):
         # Draw sine wave symbol
         from models.component import COMPONENT_COLORS
 
-        painter.setPen(
-            QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2)
-        )
+        painter.setPen(QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2))
         from PyQt6.QtGui import QPainterPath
 
         path = QPainterPath()
@@ -688,19 +665,9 @@ class Ground(ComponentGraphicsItem):
         painter.setBrush(QBrush(color.lighter(150)))
         self.draw_component_body(painter)
 
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -53,9 +53,7 @@ class MenuBarMixin:
 
         export_netlist_action = QAction("Export &Netlist...", self)
         export_netlist_action.setShortcut(kb.get("file.export_netlist"))
-        export_netlist_action.setToolTip(
-            "Export the generated SPICE netlist to a .cir file"
-        )
+        export_netlist_action.setToolTip("Export the generated SPICE netlist to a .cir file")
         export_netlist_action.triggered.connect(self.export_netlist)
         file_menu.addAction(export_netlist_action)
 
@@ -70,9 +68,7 @@ class MenuBarMixin:
         file_menu.addAction(export_pdf_action)
 
         export_latex_action = QAction("Export as &LaTeX...", self)
-        export_latex_action.setToolTip(
-            "Export circuit as CircuiTikZ LaTeX code (.tex file)"
-        )
+        export_latex_action.setToolTip("Export circuit as CircuiTikZ LaTeX code (.tex file)")
         export_latex_action.triggered.connect(self.export_circuitikz)
         file_menu.addAction(export_latex_action)
 
@@ -145,9 +141,7 @@ class MenuBarMixin:
         edit_menu.addSeparator()
 
         copy_latex_action = QAction("Copy as La&TeX", self)
-        copy_latex_action.setToolTip(
-            "Copy the CircuiTikZ environment block to the clipboard"
-        )
+        copy_latex_action.setToolTip("Copy the CircuiTikZ environment block to the clipboard")
         copy_latex_action.triggered.connect(self.copy_circuitikz)
         edit_menu.addAction(copy_latex_action)
 
@@ -214,9 +208,7 @@ class MenuBarMixin:
         self.probe_action = QAction("&Probe Tool", self)
         self.probe_action.setCheckable(True)
         self.probe_action.setShortcut(kb.get("tools.probe"))
-        self.probe_action.setToolTip(
-            "Click nodes or components to see voltage/current values"
-        )
+        self.probe_action.setToolTip("Click nodes or components to see voltage/current values")
         self.probe_action.triggered.connect(self._toggle_probe_mode)
         view_menu.addAction(self.probe_action)
 
@@ -274,9 +266,7 @@ class MenuBarMixin:
 
         self.monochrome_mode_action = QAction("&Monochrome", self)
         self.monochrome_mode_action.setCheckable(True)
-        self.monochrome_mode_action.triggered.connect(
-            lambda: self._set_color_mode("monochrome")
-        )
+        self.monochrome_mode_action.triggered.connect(lambda: self._set_color_mode("monochrome"))
         color_mode_menu.addAction(self.monochrome_mode_action)
 
         self.color_mode_group = QActionGroup(self)
@@ -371,9 +361,7 @@ class MenuBarMixin:
 
         mc_action = QAction("&Monte Carlo...", self)
         mc_action.setCheckable(True)
-        mc_action.setToolTip(
-            "Run Monte Carlo tolerance analysis with randomized component values"
-        )
+        mc_action.setToolTip("Run Monte Carlo tolerance analysis with randomized component values")
         mc_action.triggered.connect(self.set_analysis_monte_carlo)
         analysis_menu.addAction(mc_action)
 

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -127,11 +127,7 @@ class SettingsMixin:
         if reply == QMessageBox.StandardButton.Yes:
             source = self.file_ctrl.load_auto_save()
             if source is not None:
-                title = (
-                    f"Circuit Design GUI - {source}"
-                    if source
-                    else "Circuit Design GUI - (Recovered)"
-                )
+                title = f"Circuit Design GUI - {source}" if source else "Circuit Design GUI - (Recovered)"
                 self.setWindowTitle(title)
                 self._sync_analysis_menu()
                 statusBar = self.statusBar()

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -143,9 +143,7 @@ class ViewOperationsMixin:
         self.canvas.set_probe_mode(checked)
         if checked:
             if not self.canvas.node_voltages and self._last_results is None:
-                self.statusBar().showMessage(
-                    "Probe mode active. Run a simulation first to see values.", 3000
-                )
+                self.statusBar().showMessage("Probe mode active. Run a simulation first to see values.", 3000)
             else:
                 self.statusBar().showMessage(
                     "Probe mode active. Click nodes or components to see values. Press Escape to exit.",
@@ -158,9 +156,7 @@ class ViewOperationsMixin:
     def _on_probe_requested(self, signal_name, probe_type):
         """Handle probe click for sweep/transient analyses (no OP data on canvas)."""
         if self._last_results is None:
-            self.statusBar().showMessage(
-                "No simulation results available. Run a simulation first.", 3000
-            )
+            self.statusBar().showMessage("No simulation results available. Run a simulation first.", 3000)
             return
 
         analysis_type = self._last_results_type
@@ -171,9 +167,7 @@ class ViewOperationsMixin:
         elif analysis_type == "AC Sweep":
             self._probe_open_ac_sweep(signal_name, probe_type)
         else:
-            self.statusBar().showMessage(
-                f"Probe not supported for {analysis_type} analysis.", 3000
-            )
+            self.statusBar().showMessage(f"Probe not supported for {analysis_type} analysis.", 3000)
 
     def _probe_open_waveform(self, signal_name, probe_type):
         """Open waveform dialog focused on the probed signal."""
@@ -232,14 +226,10 @@ class ViewOperationsMixin:
         circuit_items = [
             item
             for item in scene.items()
-            if isinstance(
-                item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem)
-            )
+            if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
         ]
         if not circuit_items:
-            QMessageBox.information(
-                self, "Export Image", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export Image", "Nothing to export — the canvas is empty.")
             return
 
         source_rect = circuit_items[0].sceneBoundingRect()
@@ -256,9 +246,7 @@ class ViewOperationsMixin:
 
             generator = QSvgGenerator()
             generator.setFileName(filename)
-            generator.setSize(
-                QSize(int(source_rect.width()), int(source_rect.height()))
-            )
+            generator.setSize(QSize(int(source_rect.width()), int(source_rect.height())))
             generator.setViewBox(source_rect)
             generator.setTitle("SDM Spice Circuit")
 
@@ -285,9 +273,7 @@ class ViewOperationsMixin:
             painter.end()
             image.save(filename)
 
-        QMessageBox.information(
-            self, "Export Image", f"Circuit exported to:\n{filename}"
-        )
+        QMessageBox.information(self, "Export Image", f"Circuit exported to:\n{filename}")
 
     def export_circuitikz(self):
         """Export the circuit as a CircuiTikZ LaTeX file."""
@@ -299,9 +285,7 @@ class ViewOperationsMixin:
 
         model = self.circuit_ctrl.model
         if not model.components:
-            QMessageBox.information(
-                self, "Export LaTeX", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export LaTeX", "Nothing to export — the canvas is empty.")
             return
 
         # Show options dialog
@@ -319,11 +303,7 @@ class ViewOperationsMixin:
                 nodes=model.nodes,
                 terminal_to_node=model.terminal_to_node,
                 standalone=opts["standalone"],
-                circuit_name=(
-                    os.path.basename(self.file_ctrl.current_file)
-                    if self.file_ctrl.current_file
-                    else ""
-                ),
+                circuit_name=(os.path.basename(self.file_ctrl.current_file) if self.file_ctrl.current_file else ""),
                 scale=opts["scale"],
                 include_ids=opts["include_ids"],
                 include_values=opts["include_values"],
@@ -336,9 +316,7 @@ class ViewOperationsMixin:
 
         default_name = ""
         if hasattr(self, "file_ctrl") and self.file_ctrl.current_file:
-            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[
-                0
-            ]
+            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[0]
             default_name = base + ".tex"
 
         filename, _ = QFileDialog.getSaveFileName(

--- a/app/tests/unit/test_ngspice_runner.py
+++ b/app/tests/unit/test_ngspice_runner.py
@@ -1,0 +1,277 @@
+"""Unit tests for simulation/ngspice_runner.py — NgspiceRunner.
+
+All subprocess and filesystem interactions are mocked so no ngspice
+installation is required.
+"""
+
+import os
+import subprocess
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+from simulation.ngspice_runner import NgspiceRunner
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+class TestNgspiceRunnerInit:
+    def test_creates_output_dir(self, tmp_path):
+        out = tmp_path / "sim_output"
+        NgspiceRunner(output_dir=str(out))
+        assert out.is_dir()
+
+    def test_stores_output_dir(self, tmp_path):
+        out = tmp_path / "sim_output"
+        runner = NgspiceRunner(output_dir=str(out))
+        assert runner.output_dir == str(out)
+
+    def test_ngspice_cmd_initially_none(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path / "out"))
+        assert runner.ngspice_cmd is None
+
+    def test_existing_dir_ok(self, tmp_path):
+        out = tmp_path / "existing"
+        out.mkdir()
+        runner = NgspiceRunner(output_dir=str(out))
+        assert runner.output_dir == str(out)
+
+
+# ---------------------------------------------------------------------------
+# find_ngspice
+# ---------------------------------------------------------------------------
+
+
+class TestFindNgspice:
+    def test_found_via_which(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        with patch("simulation.ngspice_runner.shutil.which", return_value="/usr/bin/ngspice"):
+            result = runner.find_ngspice()
+        assert result == "/usr/bin/ngspice"
+        assert runner.ngspice_cmd == "/usr/bin/ngspice"
+
+    def test_fallback_linux(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        with (
+            patch("simulation.ngspice_runner.shutil.which", return_value=None),
+            patch("simulation.ngspice_runner.platform.system", return_value="Linux"),
+            patch("simulation.ngspice_runner.os.path.exists", side_effect=lambda p: p == "/usr/local/bin/ngspice"),
+        ):
+            result = runner.find_ngspice()
+        assert result == "/usr/local/bin/ngspice"
+        assert runner.ngspice_cmd == "/usr/local/bin/ngspice"
+
+    def test_fallback_windows(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        expected = r"C:\Program Files\ngspice\bin\ngspice.exe"
+        with (
+            patch("simulation.ngspice_runner.shutil.which", return_value=None),
+            patch("simulation.ngspice_runner.platform.system", return_value="Windows"),
+            patch("simulation.ngspice_runner.os.path.exists", side_effect=lambda p: p == expected),
+        ):
+            result = runner.find_ngspice()
+        assert result == expected
+
+    def test_fallback_darwin(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        with (
+            patch("simulation.ngspice_runner.shutil.which", return_value=None),
+            patch("simulation.ngspice_runner.platform.system", return_value="Darwin"),
+            patch("simulation.ngspice_runner.os.path.exists", side_effect=lambda p: p == "/opt/homebrew/bin/ngspice"),
+        ):
+            result = runner.find_ngspice()
+        assert result == "/opt/homebrew/bin/ngspice"
+
+    def test_not_found_anywhere(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        with (
+            patch("simulation.ngspice_runner.shutil.which", return_value=None),
+            patch("simulation.ngspice_runner.platform.system", return_value="Linux"),
+            patch("simulation.ngspice_runner.os.path.exists", return_value=False),
+        ):
+            result = runner.find_ngspice()
+        assert result is None
+        assert runner.ngspice_cmd is None
+
+    def test_unknown_platform_no_fallbacks(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        with (
+            patch("simulation.ngspice_runner.shutil.which", return_value=None),
+            patch("simulation.ngspice_runner.platform.system", return_value="FreeBSD"),
+        ):
+            result = runner.find_ngspice()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# run_simulation
+# ---------------------------------------------------------------------------
+
+
+class TestRunSimulation:
+    def test_success(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/usr/bin/ngspice"
+
+        mock_result = MagicMock()
+        mock_result.stdout = "sim stdout"
+        mock_result.stderr = ""
+
+        with (
+            patch("simulation.ngspice_runner.subprocess.run", return_value=mock_result),
+            patch("simulation.ngspice_runner.os.path.exists", return_value=True),
+        ):
+            success, outfile, stdout, stderr = runner.run_simulation("* test netlist\n.end")
+
+        assert success is True
+        assert outfile is not None
+        assert stdout == "sim stdout"
+
+    def test_output_file_not_created(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/usr/bin/ngspice"
+
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.stderr = "error occurred"
+
+        with (
+            patch("simulation.ngspice_runner.subprocess.run", return_value=mock_result),
+            patch("simulation.ngspice_runner.os.path.exists", return_value=False),
+        ):
+            success, outfile, stdout, stderr = runner.run_simulation("* test\n.end")
+
+        assert success is False
+        assert outfile is None
+        assert stderr == "error occurred"
+
+    def test_output_file_not_created_empty_stderr(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/usr/bin/ngspice"
+
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with (
+            patch("simulation.ngspice_runner.subprocess.run", return_value=mock_result),
+            patch("simulation.ngspice_runner.os.path.exists", return_value=False),
+        ):
+            success, outfile, stdout, stderr = runner.run_simulation("* test\n.end")
+
+        assert success is False
+        assert stderr == "Output file not created"
+
+    def test_timeout(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/usr/bin/ngspice"
+
+        with patch(
+            "simulation.ngspice_runner.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="ngspice", timeout=60),
+        ):
+            success, outfile, stdout, stderr = runner.run_simulation("* test\n.end")
+
+        assert success is False
+        assert outfile is None
+        assert "timed out" in stderr.lower()
+
+    def test_oserror_on_subprocess(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/usr/bin/ngspice"
+
+        with patch(
+            "simulation.ngspice_runner.subprocess.run",
+            side_effect=OSError("exec failed"),
+        ):
+            success, outfile, stdout, stderr = runner.run_simulation("* test\n.end")
+
+        assert success is False
+        assert "exec failed" in stderr
+
+    def test_oserror_on_netlist_write(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/usr/bin/ngspice"
+
+        with patch("builtins.open", side_effect=OSError("permission denied")):
+            success, outfile, stdout, stderr = runner.run_simulation("* test\n.end")
+
+        assert success is False
+        assert "permission denied" in stderr.lower()
+
+    def test_auto_finds_ngspice_when_cmd_is_none(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        assert runner.ngspice_cmd is None
+
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with (
+            patch("simulation.ngspice_runner.shutil.which", return_value="/usr/bin/ngspice"),
+            patch("simulation.ngspice_runner.subprocess.run", return_value=mock_result),
+            patch("simulation.ngspice_runner.os.path.exists", return_value=True),
+        ):
+            success, outfile, stdout, stderr = runner.run_simulation("* test\n.end")
+
+        assert success is True
+        assert runner.ngspice_cmd == "/usr/bin/ngspice"
+
+    def test_returns_error_when_ngspice_not_found(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        assert runner.ngspice_cmd is None
+
+        with (
+            patch("simulation.ngspice_runner.shutil.which", return_value=None),
+            patch("simulation.ngspice_runner.platform.system", return_value="Linux"),
+            patch("simulation.ngspice_runner.os.path.exists", return_value=False),
+        ):
+            success, outfile, stdout, stderr = runner.run_simulation("* test\n.end")
+
+        assert success is False
+        assert "not found" in stderr.lower()
+
+    def test_subprocess_called_with_correct_args(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/usr/bin/ngspice"
+
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with (
+            patch("simulation.ngspice_runner.subprocess.run", return_value=mock_result) as mock_run,
+            patch("simulation.ngspice_runner.os.path.exists", return_value=True),
+        ):
+            runner.run_simulation("* test netlist\n.end")
+
+        mock_run.assert_called_once()
+        args = mock_run.call_args
+        cmd_list = args[0][0]
+        assert cmd_list[0] == "/usr/bin/ngspice"
+        assert "-b" in cmd_list
+        assert "-o" in cmd_list
+        assert args[1]["capture_output"] is True
+        assert args[1]["text"] is True
+        assert args[1]["timeout"] == 60  # SIMULATION_TIMEOUT
+
+
+# ---------------------------------------------------------------------------
+# read_output
+# ---------------------------------------------------------------------------
+
+
+class TestReadOutput:
+    def test_reads_existing_file(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        out_file = tmp_path / "result.txt"
+        out_file.write_text("simulation results here")
+
+        result = runner.read_output(str(out_file))
+        assert result == "simulation results here"
+
+    def test_missing_file(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        result = runner.read_output(str(tmp_path / "nonexistent.txt"))
+        assert "Error reading output" in result

--- a/app/tests/unit/test_symbol_style.py
+++ b/app/tests/unit/test_symbol_style.py
@@ -191,9 +191,7 @@ class TestIEEEDrawDispatch:
         called = []
         comp._draw_ieee = lambda painter: called.append(True)
         comp.draw_component_body(None)
-        assert (
-            called
-        ), f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
+        assert called, f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
 
 
 class TestObstacleShapeDispatch:


### PR DESCRIPTION
## Summary
- Adds 21 unit tests for `app/simulation/ngspice_runner.py` covering `__init__`, `find_ngspice`, `run_simulation`, and `read_output`
- Tests platform-specific fallback paths (Linux, Windows, macOS)
- All subprocess and filesystem calls are mocked — no ngspice installation required

## Test plan
- [x] `python -m pytest app/tests/unit/test_ngspice_runner.py -v` — 21/21 pass
- [x] `make format && make lint` — clean

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)