### PR TITLE
Add unit tests for Monte Carlo dialogs

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -140,9 +140,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             new_pos = component.position
             # Only create a command if the component actually moved
             if old_pos[0] != new_pos[0] or old_pos[1] != new_pos[1]:
-                cmd = MoveComponentCommand(
-                    controller, comp_id, new_pos, old_position=old_pos
-                )
+                cmd = MoveComponentCommand(controller, comp_id, new_pos, old_position=old_pos)
                 move_commands.append(cmd)
 
         self._drag_start_positions = {}
@@ -155,9 +153,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             controller.undo_manager._undo_stack.append(move_commands[0])
             controller.undo_manager._redo_stack.clear()
         else:
-            compound = CompoundCommand(
-                move_commands, f"Move {len(move_commands)} components"
-            )
+            compound = CompoundCommand(move_commands, f"Move {len(move_commands)} components")
             controller.undo_manager._undo_stack.append(compound)
             controller.undo_manager._redo_stack.clear()
 
@@ -209,9 +205,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         )
 
         if ok and new_value:
-            is_valid, error_msg = validate_component_value(
-                new_value, self.component_type
-            )
+            is_valid, error_msg = validate_component_value(new_value, self.component_type)
             if not is_valid:
                 QMessageBox.warning(None, "Invalid Value", error_msg)
                 return
@@ -336,19 +330,9 @@ class ComponentGraphicsItem(QGraphicsItem):
         self.draw_component_body(painter)
 
         # Draw label (check canvas visibility settings)
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))
@@ -368,10 +352,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             painter.drawEllipse(terminal, 3, 3)
 
     def itemChange(self, change, value):
-        if (
-            change == QGraphicsItem.GraphicsItemChange.ItemPositionChange
-            and self.scene()
-        ):
+        if change == QGraphicsItem.GraphicsItemChange.ItemPositionChange and self.scene():
             # Snap to grid
             new_pos = value
             grid_x = round(new_pos.x() / GRID_SIZE) * GRID_SIZE
@@ -434,9 +415,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         if self._position_update_timer is None:
             self._position_update_timer = QTimer()
             self._position_update_timer.setSingleShot(True)
-            self._position_update_timer.timeout.connect(
-                self._notify_controller_position
-            )
+            self._position_update_timer.timeout.connect(self._notify_controller_position)
         self._position_update_timer.start(50)  # 50ms debounce
 
     def _notify_controller_position(self):
@@ -646,9 +625,7 @@ class WaveformVoltageSource(ComponentGraphicsItem):
         # Draw sine wave symbol
         from models.component import COMPONENT_COLORS
 
-        painter.setPen(
-            QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2)
-        )
+        painter.setPen(QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2))
         from PyQt6.QtGui import QPainterPath
 
         path = QPainterPath()
@@ -688,19 +665,9 @@ class Ground(ComponentGraphicsItem):
         painter.setBrush(QBrush(color.lighter(150)))
         self.draw_component_body(painter)
 
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -53,9 +53,7 @@ class MenuBarMixin:
 
         export_netlist_action = QAction("Export &Netlist...", self)
         export_netlist_action.setShortcut(kb.get("file.export_netlist"))
-        export_netlist_action.setToolTip(
-            "Export the generated SPICE netlist to a .cir file"
-        )
+        export_netlist_action.setToolTip("Export the generated SPICE netlist to a .cir file")
         export_netlist_action.triggered.connect(self.export_netlist)
         file_menu.addAction(export_netlist_action)
 
@@ -70,9 +68,7 @@ class MenuBarMixin:
         file_menu.addAction(export_pdf_action)
 
         export_latex_action = QAction("Export as &LaTeX...", self)
-        export_latex_action.setToolTip(
-            "Export circuit as CircuiTikZ LaTeX code (.tex file)"
-        )
+        export_latex_action.setToolTip("Export circuit as CircuiTikZ LaTeX code (.tex file)")
         export_latex_action.triggered.connect(self.export_circuitikz)
         file_menu.addAction(export_latex_action)
 
@@ -145,9 +141,7 @@ class MenuBarMixin:
         edit_menu.addSeparator()
 
         copy_latex_action = QAction("Copy as La&TeX", self)
-        copy_latex_action.setToolTip(
-            "Copy the CircuiTikZ environment block to the clipboard"
-        )
+        copy_latex_action.setToolTip("Copy the CircuiTikZ environment block to the clipboard")
         copy_latex_action.triggered.connect(self.copy_circuitikz)
         edit_menu.addAction(copy_latex_action)
 
@@ -214,9 +208,7 @@ class MenuBarMixin:
         self.probe_action = QAction("&Probe Tool", self)
         self.probe_action.setCheckable(True)
         self.probe_action.setShortcut(kb.get("tools.probe"))
-        self.probe_action.setToolTip(
-            "Click nodes or components to see voltage/current values"
-        )
+        self.probe_action.setToolTip("Click nodes or components to see voltage/current values")
         self.probe_action.triggered.connect(self._toggle_probe_mode)
         view_menu.addAction(self.probe_action)
 
@@ -274,9 +266,7 @@ class MenuBarMixin:
 
         self.monochrome_mode_action = QAction("&Monochrome", self)
         self.monochrome_mode_action.setCheckable(True)
-        self.monochrome_mode_action.triggered.connect(
-            lambda: self._set_color_mode("monochrome")
-        )
+        self.monochrome_mode_action.triggered.connect(lambda: self._set_color_mode("monochrome"))
         color_mode_menu.addAction(self.monochrome_mode_action)
 
         self.color_mode_group = QActionGroup(self)
@@ -371,9 +361,7 @@ class MenuBarMixin:
 
         mc_action = QAction("&Monte Carlo...", self)
         mc_action.setCheckable(True)
-        mc_action.setToolTip(
-            "Run Monte Carlo tolerance analysis with randomized component values"
-        )
+        mc_action.setToolTip("Run Monte Carlo tolerance analysis with randomized component values")
         mc_action.triggered.connect(self.set_analysis_monte_carlo)
         analysis_menu.addAction(mc_action)
 

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -127,11 +127,7 @@ class SettingsMixin:
         if reply == QMessageBox.StandardButton.Yes:
             source = self.file_ctrl.load_auto_save()
             if source is not None:
-                title = (
-                    f"Circuit Design GUI - {source}"
-                    if source
-                    else "Circuit Design GUI - (Recovered)"
-                )
+                title = f"Circuit Design GUI - {source}" if source else "Circuit Design GUI - (Recovered)"
                 self.setWindowTitle(title)
                 self._sync_analysis_menu()
                 statusBar = self.statusBar()

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -143,9 +143,7 @@ class ViewOperationsMixin:
         self.canvas.set_probe_mode(checked)
         if checked:
             if not self.canvas.node_voltages and self._last_results is None:
-                self.statusBar().showMessage(
-                    "Probe mode active. Run a simulation first to see values.", 3000
-                )
+                self.statusBar().showMessage("Probe mode active. Run a simulation first to see values.", 3000)
             else:
                 self.statusBar().showMessage(
                     "Probe mode active. Click nodes or components to see values. Press Escape to exit.",
@@ -158,9 +156,7 @@ class ViewOperationsMixin:
     def _on_probe_requested(self, signal_name, probe_type):
         """Handle probe click for sweep/transient analyses (no OP data on canvas)."""
         if self._last_results is None:
-            self.statusBar().showMessage(
-                "No simulation results available. Run a simulation first.", 3000
-            )
+            self.statusBar().showMessage("No simulation results available. Run a simulation first.", 3000)
             return
 
         analysis_type = self._last_results_type
@@ -171,9 +167,7 @@ class ViewOperationsMixin:
         elif analysis_type == "AC Sweep":
             self._probe_open_ac_sweep(signal_name, probe_type)
         else:
-            self.statusBar().showMessage(
-                f"Probe not supported for {analysis_type} analysis.", 3000
-            )
+            self.statusBar().showMessage(f"Probe not supported for {analysis_type} analysis.", 3000)
 
     def _probe_open_waveform(self, signal_name, probe_type):
         """Open waveform dialog focused on the probed signal."""
@@ -232,14 +226,10 @@ class ViewOperationsMixin:
         circuit_items = [
             item
             for item in scene.items()
-            if isinstance(
-                item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem)
-            )
+            if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
         ]
         if not circuit_items:
-            QMessageBox.information(
-                self, "Export Image", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export Image", "Nothing to export — the canvas is empty.")
             return
 
         source_rect = circuit_items[0].sceneBoundingRect()
@@ -256,9 +246,7 @@ class ViewOperationsMixin:
 
             generator = QSvgGenerator()
             generator.setFileName(filename)
-            generator.setSize(
-                QSize(int(source_rect.width()), int(source_rect.height()))
-            )
+            generator.setSize(QSize(int(source_rect.width()), int(source_rect.height())))
             generator.setViewBox(source_rect)
             generator.setTitle("SDM Spice Circuit")
 
@@ -285,9 +273,7 @@ class ViewOperationsMixin:
             painter.end()
             image.save(filename)
 
-        QMessageBox.information(
-            self, "Export Image", f"Circuit exported to:\n{filename}"
-        )
+        QMessageBox.information(self, "Export Image", f"Circuit exported to:\n{filename}")
 
     def export_circuitikz(self):
         """Export the circuit as a CircuiTikZ LaTeX file."""
@@ -299,9 +285,7 @@ class ViewOperationsMixin:
 
         model = self.circuit_ctrl.model
         if not model.components:
-            QMessageBox.information(
-                self, "Export LaTeX", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export LaTeX", "Nothing to export — the canvas is empty.")
             return
 
         # Show options dialog
@@ -319,11 +303,7 @@ class ViewOperationsMixin:
                 nodes=model.nodes,
                 terminal_to_node=model.terminal_to_node,
                 standalone=opts["standalone"],
-                circuit_name=(
-                    os.path.basename(self.file_ctrl.current_file)
-                    if self.file_ctrl.current_file
-                    else ""
-                ),
+                circuit_name=(os.path.basename(self.file_ctrl.current_file) if self.file_ctrl.current_file else ""),
                 scale=opts["scale"],
                 include_ids=opts["include_ids"],
                 include_values=opts["include_values"],
@@ -336,9 +316,7 @@ class ViewOperationsMixin:
 
         default_name = ""
         if hasattr(self, "file_ctrl") and self.file_ctrl.current_file:
-            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[
-                0
-            ]
+            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[0]
             default_name = base + ".tex"
 
         filename, _ = QFileDialog.getSaveFileName(

--- a/app/tests/unit/test_data_roundtrips_and_undo.py
+++ b/app/tests/unit/test_data_roundtrips_and_undo.py
@@ -1,0 +1,791 @@
+"""
+Tests for model/controller-level data round-trips and undo operations.
+
+Covers:
+- Serialization round-trips (flip, rotation, waveform, models, values)
+- Wire data persistence through save/load
+- Undo/redo stack via controller commands
+- FileController operations (new, save, load, dirty tracking)
+- Node consistency after wire add/remove
+
+Issue: #280
+"""
+
+import json
+
+import pytest
+from controllers.circuit_controller import CircuitController
+from controllers.commands import (
+    AddAnnotationCommand,
+    AddComponentCommand,
+    ChangeValueCommand,
+    DeleteAnnotationCommand,
+    DeleteComponentCommand,
+    EditAnnotationCommand,
+    FlipComponentCommand,
+    MoveComponentCommand,
+    RotateComponentCommand,
+)
+from controllers.file_controller import FileController
+from models.annotation import AnnotationData
+from models.circuit import CircuitModel
+from models.component import COMPONENT_TYPES, ComponentData
+from models.wire import WireData
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_circuit_with_all_fields():
+    """Build a circuit exercising every serializable field."""
+    model = CircuitModel()
+    r1 = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value="4.7k",
+        position=(100.0, 200.0),
+        rotation=90,
+        flip_h=True,
+        flip_v=False,
+    )
+    c1 = ComponentData(
+        component_id="C1",
+        component_type="Capacitor",
+        value="10u",
+        position=(200.0, 200.0),
+        rotation=180,
+        flip_h=False,
+        flip_v=True,
+    )
+    v1 = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value="12V",
+        position=(0.0, 0.0),
+    )
+    gnd = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(100.0, 300.0),
+    )
+    model.add_component(r1)
+    model.add_component(c1)
+    model.add_component(v1)
+    model.add_component(gnd)
+    model.component_counter = {"R": 1, "C": 1, "V": 1, "GND": 1}
+
+    model.add_wire(WireData("V1", 0, "R1", 0))
+    model.add_wire(WireData("R1", 1, "C1", 0))
+    model.add_wire(WireData("C1", 1, "GND1", 0))
+    model.add_wire(WireData("V1", 1, "GND1", 0))
+
+    model.analysis_type = "Transient"
+    model.analysis_params = {"step": "1m", "duration": "10m"}
+
+    # Add custom net name
+    node = model.terminal_to_node.get(("V1", 0))
+    if node:
+        node.set_custom_label("Vin")
+
+    # Add annotation
+    model.annotations.append(
+        AnnotationData(text="Test Label", x=50.0, y=50.0, font_size=14, bold=True, color="#FF0000")
+    )
+
+    return model
+
+
+# ===========================================================================
+# Serialization Round-Trips
+# ===========================================================================
+
+
+class TestSerializationRoundTrips:
+    """Verify that to_dict → from_dict produces identical data."""
+
+    def test_full_circuit_round_trip(self):
+        """Complete circuit with all field types survives round-trip."""
+        model = _build_circuit_with_all_fields()
+        data1 = model.to_dict()
+        model2 = CircuitModel.from_dict(data1)
+        data2 = model2.to_dict()
+        assert data1 == data2
+
+    @pytest.mark.parametrize("rotation", [0, 90, 180, 270])
+    def test_rotation_round_trip(self, rotation):
+        """Component rotation is preserved through serialization."""
+        comp = ComponentData("R1", "Resistor", "1k", (0, 0), rotation=rotation)
+        data = comp.to_dict()
+        restored = ComponentData.from_dict(data)
+        assert restored.rotation == rotation
+
+    @pytest.mark.parametrize("flip_h,flip_v", [(True, False), (False, True), (True, True)])
+    def test_flip_state_round_trip(self, flip_h, flip_v):
+        """Component flip states are preserved through serialization."""
+        comp = ComponentData("R1", "Resistor", "1k", (0, 0), flip_h=flip_h, flip_v=flip_v)
+        data = comp.to_dict()
+        restored = ComponentData.from_dict(data)
+        assert restored.flip_h == flip_h
+        assert restored.flip_v == flip_v
+
+    def test_waveform_source_round_trip(self):
+        """Waveform source with custom params survives round-trip."""
+        comp = ComponentData("VW1", "Waveform Source", "SIN(0 5 1k)", (0, 0))
+        # Customize SIN params
+        comp.waveform_params["SIN"]["amplitude"] = "10"
+        comp.waveform_params["SIN"]["frequency"] = "2k"
+        comp.waveform_type = "SIN"
+
+        data = comp.to_dict()
+        restored = ComponentData.from_dict(data)
+        assert restored.waveform_type == "SIN"
+        assert restored.waveform_params["SIN"]["amplitude"] == "10"
+        assert restored.waveform_params["SIN"]["frequency"] == "2k"
+
+    def test_waveform_pulse_params_round_trip(self):
+        """PULSE waveform type and params survive round-trip."""
+        comp = ComponentData("VW1", "Waveform Source", "PULSE(0 5 0 1n 1n 500u 1m)", (0, 0))
+        comp.waveform_type = "PULSE"
+        comp.waveform_params["PULSE"]["v2"] = "3.3"
+
+        data = comp.to_dict()
+        restored = ComponentData.from_dict(data)
+        assert restored.waveform_type == "PULSE"
+        assert restored.waveform_params["PULSE"]["v2"] == "3.3"
+
+    @pytest.mark.parametrize("model_name", ["Ideal", "LM741", "TL081", "LM358"])
+    def test_opamp_model_round_trip(self, model_name):
+        """Op-amp model names survive round-trip."""
+        comp = ComponentData("OA1", "Op-Amp", model_name, (0, 0))
+        data = comp.to_dict()
+        restored = ComponentData.from_dict(data)
+        assert restored.value == model_name
+        assert restored.component_type == "Op-Amp"
+
+    @pytest.mark.parametrize(
+        "comp_type,value",
+        [
+            ("MOSFET NMOS", "NMOS1"),
+            ("MOSFET PMOS", "PMOS1"),
+            ("BJT NPN", "2N3904"),
+            ("BJT PNP", "2N3906"),
+            ("Diode", "IS=1e-14 N=1"),
+            ("LED", "IS=1e-20 N=1.8 EG=1.9"),
+            ("Zener Diode", "IS=1e-14 N=1 BV=5.1 IBV=1e-3"),
+        ],
+    )
+    def test_semiconductor_model_round_trip(self, comp_type, value):
+        """Semiconductor component model values survive round-trip."""
+        comp = ComponentData("X1", comp_type, value, (0, 0))
+        data = comp.to_dict()
+        restored = ComponentData.from_dict(data)
+        assert restored.value == value
+        assert restored.component_type == comp_type
+
+    @pytest.mark.parametrize("comp_type", COMPONENT_TYPES)
+    def test_all_component_types_round_trip(self, comp_type):
+        """Every component type serializes and deserializes without error."""
+        comp = ComponentData("X1", comp_type, "test_val", (50.0, 75.0), rotation=90)
+        data = comp.to_dict()
+        restored = ComponentData.from_dict(data)
+        assert restored.component_type == comp_type
+        assert restored.position == (50.0, 75.0)
+        assert restored.rotation == 90
+
+    def test_analysis_settings_round_trip(self):
+        """Analysis type and params survive circuit round-trip."""
+        model = CircuitModel()
+        model.analysis_type = "AC Sweep"
+        model.analysis_params = {"variation": "dec", "points": "10", "fstart": "1", "fstop": "1e6"}
+
+        data = model.to_dict()
+        restored = CircuitModel.from_dict(data)
+        assert restored.analysis_type == "AC Sweep"
+        assert restored.analysis_params == model.analysis_params
+
+    def test_default_analysis_omitted_from_dict(self):
+        """Default analysis type (DC Operating Point) is not stored in dict."""
+        model = CircuitModel()
+        data = model.to_dict()
+        assert "analysis_type" not in data
+        assert "analysis_params" not in data
+
+    def test_annotation_round_trip(self):
+        """Annotation data survives circuit round-trip."""
+        model = CircuitModel()
+        model.annotations.append(AnnotationData(text="Note", x=10.0, y=20.0, font_size=16, bold=True, color="#00FF00"))
+        data = model.to_dict()
+        restored = CircuitModel.from_dict(data)
+        assert len(restored.annotations) == 1
+        ann = restored.annotations[0]
+        assert ann.text == "Note"
+        assert ann.x == 10.0
+        assert ann.y == 20.0
+        assert ann.font_size == 16
+        assert ann.bold is True
+        assert ann.color == "#00FF00"
+
+    def test_empty_circuit_round_trip(self):
+        """Empty circuit serializes and deserializes cleanly."""
+        model = CircuitModel()
+        data = model.to_dict()
+        restored = CircuitModel.from_dict(data)
+        assert len(restored.components) == 0
+        assert len(restored.wires) == 0
+        assert len(restored.nodes) == 0
+
+
+# ===========================================================================
+# Wire Data Persistence
+# ===========================================================================
+
+
+class TestWireDataPersistence:
+    """Verify wire data survives save/load cycles."""
+
+    def test_wire_round_trip(self):
+        """Wire start/end component IDs and terminals survive round-trip."""
+        wire = WireData("V1", 0, "R1", 1)
+        data = wire.to_dict()
+        restored = WireData.from_dict(data)
+        assert restored.start_component_id == "V1"
+        assert restored.start_terminal == 0
+        assert restored.end_component_id == "R1"
+        assert restored.end_terminal == 1
+
+    def test_wire_deletion_persists_through_save_load(self, tmp_path):
+        """Deleting a wire and saving/loading preserves the deletion."""
+        model = CircuitModel()
+        r1 = ComponentData("R1", "Resistor", "1k", (0, 0))
+        r2 = ComponentData("R2", "Resistor", "2k", (100, 0))
+        gnd = ComponentData("GND1", "Ground", "0V", (0, 100))
+        model.add_component(r1)
+        model.add_component(r2)
+        model.add_component(gnd)
+        model.component_counter = {"R": 2, "GND": 1}
+
+        model.add_wire(WireData("R1", 0, "R2", 0))
+        model.add_wire(WireData("R2", 1, "GND1", 0))
+        assert len(model.wires) == 2
+
+        # Delete first wire
+        model.remove_wire(0)
+        assert len(model.wires) == 1
+
+        # Save and reload
+        ctrl = FileController(model)
+        filepath = tmp_path / "test.json"
+        ctrl.save_circuit(filepath)
+
+        ctrl2 = FileController()
+        ctrl2.load_circuit(filepath)
+        assert len(ctrl2.model.wires) == 1
+        assert ctrl2.model.wires[0].start_component_id == "R2"
+
+    def test_net_label_survives_save_load(self, tmp_path):
+        """Custom node labels (net names) survive save/load cycle."""
+        model = CircuitModel()
+        v1 = ComponentData("V1", "Voltage Source", "5V", (0, 0))
+        r1 = ComponentData("R1", "Resistor", "1k", (100, 0))
+        model.add_component(v1)
+        model.add_component(r1)
+        model.component_counter = {"V": 1, "R": 1}
+        model.add_wire(WireData("V1", 0, "R1", 0))
+
+        # Set custom label
+        node = model.terminal_to_node[("V1", 0)]
+        node.set_custom_label("Vout")
+
+        ctrl = FileController(model)
+        filepath = tmp_path / "net_names.json"
+        ctrl.save_circuit(filepath)
+
+        ctrl2 = FileController()
+        ctrl2.load_circuit(filepath)
+        node2 = ctrl2.model.terminal_to_node[("V1", 0)]
+        assert node2.custom_label == "Vout"
+        assert node2.get_label() == "Vout"
+
+    def test_wire_count_preserved_through_save_load(self, tmp_path):
+        """The exact number of wires is preserved through save/load."""
+        model = CircuitModel()
+        v1 = ComponentData("V1", "Voltage Source", "5V", (0, 0))
+        r1 = ComponentData("R1", "Resistor", "1k", (100, 0))
+        r2 = ComponentData("R2", "Resistor", "2k", (200, 0))
+        gnd = ComponentData("GND1", "Ground", "0V", (200, 100))
+        for c in [v1, r1, r2, gnd]:
+            model.add_component(c)
+        model.component_counter = {"V": 1, "R": 2, "GND": 1}
+
+        model.add_wire(WireData("V1", 0, "R1", 0))
+        model.add_wire(WireData("R1", 1, "R2", 0))
+        model.add_wire(WireData("R2", 1, "GND1", 0))
+        model.add_wire(WireData("V1", 1, "GND1", 0))
+
+        ctrl = FileController(model)
+        filepath = tmp_path / "wires.json"
+        ctrl.save_circuit(filepath)
+
+        ctrl2 = FileController()
+        ctrl2.load_circuit(filepath)
+        assert len(ctrl2.model.wires) == 4
+
+
+# ===========================================================================
+# Undo/Redo Stack
+# ===========================================================================
+
+
+class TestUndoRedoWorkflows:
+    """Test undo/redo through CircuitController command execution."""
+
+    def test_add_component_undo_redo(self):
+        """Place component → undo removes it → redo restores a component."""
+        ctrl = CircuitController()
+        cmd = AddComponentCommand(ctrl, "Resistor", (100, 100))
+        ctrl.execute_command(cmd)
+
+        assert len(ctrl.model.components) == 1
+
+        ctrl.undo()
+        assert len(ctrl.model.components) == 0
+
+        ctrl.redo()
+        assert len(ctrl.model.components) == 1
+
+    def test_delete_component_undo_restores(self):
+        """Delete component → undo restores it with wires."""
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Resistor", (0, 0))
+        comp2 = ctrl.add_component("Resistor", (100, 0))
+        ctrl.add_wire(comp.component_id, 0, comp2.component_id, 0)
+
+        assert len(ctrl.model.wires) == 1
+
+        cmd = DeleteComponentCommand(ctrl, comp.component_id)
+        ctrl.execute_command(cmd)
+        assert comp.component_id not in ctrl.model.components
+        assert len(ctrl.model.wires) == 0
+
+        ctrl.undo()
+        assert comp.component_id in ctrl.model.components
+        assert len(ctrl.model.wires) == 1
+
+    def test_move_undo_reverts_position(self):
+        """Move → undo reverts to original position."""
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Resistor", (0, 0))
+        original_pos = comp.position
+
+        cmd = MoveComponentCommand(ctrl, comp.component_id, (200, 300))
+        ctrl.execute_command(cmd)
+        assert ctrl.model.components[comp.component_id].position == (200, 300)
+
+        ctrl.undo()
+        assert ctrl.model.components[comp.component_id].position == original_pos
+
+    def test_flip_undo_reverts_flip_state(self):
+        """Flip → undo reverts flip state."""
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Resistor", (0, 0))
+        assert comp.flip_h is False
+
+        cmd = FlipComponentCommand(ctrl, comp.component_id, horizontal=True)
+        ctrl.execute_command(cmd)
+        assert ctrl.model.components[comp.component_id].flip_h is True
+
+        ctrl.undo()
+        assert ctrl.model.components[comp.component_id].flip_h is False
+
+    def test_flip_vertical_undo(self):
+        """Vertical flip → undo reverts."""
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Capacitor", (0, 0))
+        assert comp.flip_v is False
+
+        cmd = FlipComponentCommand(ctrl, comp.component_id, horizontal=False)
+        ctrl.execute_command(cmd)
+        assert ctrl.model.components[comp.component_id].flip_v is True
+
+        ctrl.undo()
+        assert ctrl.model.components[comp.component_id].flip_v is False
+
+    def test_rotate_undo(self):
+        """Rotate → undo reverts rotation."""
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Inductor", (0, 0))
+        assert comp.rotation == 0
+
+        cmd = RotateComponentCommand(ctrl, comp.component_id, clockwise=True)
+        ctrl.execute_command(cmd)
+        assert ctrl.model.components[comp.component_id].rotation == 90
+
+        ctrl.undo()
+        assert ctrl.model.components[comp.component_id].rotation == 0
+
+    def test_change_value_undo(self):
+        """Change value → undo restores old value."""
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Resistor", (0, 0))
+        old_value = comp.value
+
+        cmd = ChangeValueCommand(ctrl, comp.component_id, "4.7k")
+        ctrl.execute_command(cmd)
+        assert ctrl.model.components[comp.component_id].value == "4.7k"
+
+        ctrl.undo()
+        assert ctrl.model.components[comp.component_id].value == old_value
+
+    def test_annotation_add_undo_redo(self):
+        """Add annotation → undo removes → redo restores."""
+        ctrl = CircuitController()
+        ann = AnnotationData(text="Test", x=10, y=20)
+        cmd = AddAnnotationCommand(ctrl, ann)
+        ctrl.execute_command(cmd)
+        assert len(ctrl.model.annotations) == 1
+
+        ctrl.undo()
+        assert len(ctrl.model.annotations) == 0
+
+        ctrl.redo()
+        assert len(ctrl.model.annotations) == 1
+        assert ctrl.model.annotations[0].text == "Test"
+
+    def test_annotation_delete_undo(self):
+        """Delete annotation → undo restores it."""
+        ctrl = CircuitController()
+        ann = AnnotationData(text="Important", x=5, y=10)
+        ctrl.add_annotation(ann)
+        assert len(ctrl.model.annotations) == 1
+
+        cmd = DeleteAnnotationCommand(ctrl, 0)
+        ctrl.execute_command(cmd)
+        assert len(ctrl.model.annotations) == 0
+
+        ctrl.undo()
+        assert len(ctrl.model.annotations) == 1
+        assert ctrl.model.annotations[0].text == "Important"
+
+    def test_annotation_edit_undo(self):
+        """Edit annotation text → undo restores old text."""
+        ctrl = CircuitController()
+        ann = AnnotationData(text="Original")
+        ctrl.add_annotation(ann)
+
+        cmd = EditAnnotationCommand(ctrl, 0, "Modified")
+        ctrl.execute_command(cmd)
+        assert ctrl.model.annotations[0].text == "Modified"
+
+        ctrl.undo()
+        assert ctrl.model.annotations[0].text == "Original"
+
+    def test_multiple_undos_in_sequence(self):
+        """Multiple operations can be undone in correct LIFO order."""
+        ctrl = CircuitController()
+        cmd1 = AddComponentCommand(ctrl, "Resistor", (0, 0))
+        ctrl.execute_command(cmd1)
+        cmd2 = AddComponentCommand(ctrl, "Capacitor", (100, 0))
+        ctrl.execute_command(cmd2)
+
+        assert len(ctrl.model.components) == 2
+
+        ctrl.undo()  # undo capacitor
+        assert len(ctrl.model.components) == 1
+        assert cmd1.component_id in ctrl.model.components
+
+        ctrl.undo()  # undo resistor
+        assert len(ctrl.model.components) == 0
+
+    def test_redo_cleared_after_new_command(self):
+        """Executing a new command after undo clears the redo stack."""
+        ctrl = CircuitController()
+        cmd1 = AddComponentCommand(ctrl, "Resistor", (0, 0))
+        ctrl.execute_command(cmd1)
+
+        ctrl.undo()
+        assert ctrl.can_redo()
+
+        cmd2 = AddComponentCommand(ctrl, "Capacitor", (100, 0))
+        ctrl.execute_command(cmd2)
+        assert not ctrl.can_redo()
+
+
+# ===========================================================================
+# FileController Operations
+# ===========================================================================
+
+
+class TestFileControllerOperations:
+    """Test FileController save/load/new behavior."""
+
+    def test_new_circuit_clears_model(self):
+        """new_circuit() clears all model data."""
+        model = _build_circuit_with_all_fields()
+        ctrl = FileController(model)
+        ctrl.new_circuit()
+
+        assert len(ctrl.model.components) == 0
+        assert len(ctrl.model.wires) == 0
+        assert len(ctrl.model.nodes) == 0
+        assert len(ctrl.model.annotations) == 0
+        assert ctrl.model.analysis_type == "DC Operating Point"
+        assert ctrl.model.analysis_params == {}
+        assert ctrl.current_file is None
+
+    def test_save_sets_current_file(self, tmp_path):
+        """save_circuit() updates current_file."""
+        model = CircuitModel()
+        ctrl = FileController(model)
+        filepath = tmp_path / "test.json"
+        ctrl.save_circuit(filepath)
+
+        assert ctrl.current_file == filepath
+        assert ctrl.has_file()
+
+    def test_load_updates_current_file(self, tmp_path):
+        """load_circuit() updates current_file."""
+        model = CircuitModel()
+        ctrl = FileController(model)
+        filepath = tmp_path / "test.json"
+        ctrl.save_circuit(filepath)
+
+        ctrl2 = FileController()
+        ctrl2.load_circuit(filepath)
+        assert ctrl2.current_file == filepath
+
+    def test_new_circuit_clears_file_path(self, tmp_path):
+        """new_circuit() after save clears the current_file."""
+        model = CircuitModel()
+        ctrl = FileController(model)
+        filepath = tmp_path / "test.json"
+        ctrl.save_circuit(filepath)
+        assert ctrl.has_file()
+
+        ctrl.new_circuit()
+        assert not ctrl.has_file()
+        assert ctrl.current_file is None
+
+    def test_load_preserves_model_reference(self, tmp_path):
+        """load_circuit() updates model in place, preserving the reference."""
+        model = CircuitModel()
+        ctrl = FileController(model)
+
+        # Save a non-empty circuit
+        model2 = _build_circuit_with_all_fields()
+        ctrl2 = FileController(model2)
+        filepath = tmp_path / "full.json"
+        ctrl2.save_circuit(filepath)
+
+        # Load into original controller
+        model_ref = ctrl.model
+        ctrl.load_circuit(filepath)
+        assert ctrl.model is model_ref  # same object
+        assert len(ctrl.model.components) > 0
+
+    def test_save_load_round_trip_full(self, tmp_path):
+        """Full circuit save → load preserves all data."""
+        model = _build_circuit_with_all_fields()
+        ctrl = FileController(model)
+        filepath = tmp_path / "full.json"
+        ctrl.save_circuit(filepath)
+
+        ctrl2 = FileController()
+        ctrl2.load_circuit(filepath)
+
+        assert set(ctrl2.model.components.keys()) == set(model.components.keys())
+        assert len(ctrl2.model.wires) == len(model.wires)
+        assert ctrl2.model.analysis_type == "Transient"
+        assert ctrl2.model.analysis_params["step"] == "1m"
+        assert len(ctrl2.model.annotations) == 1
+        assert ctrl2.model.annotations[0].text == "Test Label"
+
+    def test_save_load_preserves_flip_state(self, tmp_path):
+        """Component flip_h and flip_v survive save/load."""
+        model = CircuitModel()
+        comp = ComponentData("R1", "Resistor", "1k", (0, 0), flip_h=True, flip_v=True)
+        model.add_component(comp)
+        model.component_counter = {"R": 1}
+
+        ctrl = FileController(model)
+        filepath = tmp_path / "flip.json"
+        ctrl.save_circuit(filepath)
+
+        ctrl2 = FileController()
+        ctrl2.load_circuit(filepath)
+        restored = ctrl2.model.components["R1"]
+        assert restored.flip_h is True
+        assert restored.flip_v is True
+
+    def test_save_load_preserves_rotation(self, tmp_path):
+        """Component rotation survives save/load."""
+        model = CircuitModel()
+        comp = ComponentData("C1", "Capacitor", "10u", (0, 0), rotation=270)
+        model.add_component(comp)
+        model.component_counter = {"C": 1}
+
+        ctrl = FileController(model)
+        filepath = tmp_path / "rot.json"
+        ctrl.save_circuit(filepath)
+
+        ctrl2 = FileController()
+        ctrl2.load_circuit(filepath)
+        assert ctrl2.model.components["C1"].rotation == 270
+
+    def test_save_produces_valid_json(self, tmp_path):
+        """Saved file is valid JSON."""
+        model = _build_circuit_with_all_fields()
+        ctrl = FileController(model)
+        filepath = tmp_path / "valid.json"
+        ctrl.save_circuit(filepath)
+
+        with open(filepath) as f:
+            data = json.load(f)
+        assert "components" in data
+        assert "wires" in data
+
+
+# ===========================================================================
+# Node Consistency
+# ===========================================================================
+
+
+class TestNodeConsistency:
+    """Verify terminal-to-node mapping stays valid after operations."""
+
+    def test_terminal_to_node_valid_after_wire_add(self):
+        """Adding a wire updates terminal-to-node mapping correctly."""
+        model = CircuitModel()
+        r1 = ComponentData("R1", "Resistor", "1k", (0, 0))
+        r2 = ComponentData("R2", "Resistor", "2k", (100, 0))
+        model.add_component(r1)
+        model.add_component(r2)
+
+        model.add_wire(WireData("R1", 0, "R2", 0))
+
+        # Both terminals should map to the same node
+        node1 = model.terminal_to_node[("R1", 0)]
+        node2 = model.terminal_to_node[("R2", 0)]
+        assert node1 is node2
+        assert ("R1", 0) in node1.terminals
+        assert ("R2", 0) in node1.terminals
+
+    def test_node_merge_on_connect(self):
+        """Connecting two existing nodes merges them."""
+        model = CircuitModel()
+        r1 = ComponentData("R1", "Resistor", "1k", (0, 0))
+        r2 = ComponentData("R2", "Resistor", "2k", (100, 0))
+        r3 = ComponentData("R3", "Resistor", "3k", (200, 0))
+        model.add_component(r1)
+        model.add_component(r2)
+        model.add_component(r3)
+
+        # Create two separate nodes
+        model.add_wire(WireData("R1", 0, "R2", 0))
+        model.add_wire(WireData("R2", 1, "R3", 0))
+
+        # R1:0 and R2:0 are in one node
+        # R2:1 and R3:0 are in another node
+        node_a = model.terminal_to_node[("R1", 0)]
+        node_b = model.terminal_to_node[("R2", 1)]
+        assert node_a is not node_b
+
+        # Now bridge R1:1 → R2:1 to merge nodes
+        model.add_wire(WireData("R1", 1, "R2", 1))
+        merged = model.terminal_to_node[("R1", 1)]
+        assert model.terminal_to_node[("R2", 1)] is merged
+        assert model.terminal_to_node[("R3", 0)] is merged
+
+    def test_node_splitting_on_wire_remove(self):
+        """Removing a wire can split a node into two."""
+        model = CircuitModel()
+        r1 = ComponentData("R1", "Resistor", "1k", (0, 0))
+        r2 = ComponentData("R2", "Resistor", "2k", (100, 0))
+        r3 = ComponentData("R3", "Resistor", "3k", (200, 0))
+        model.add_component(r1)
+        model.add_component(r2)
+        model.add_component(r3)
+
+        # Chain: R1:1 -- R2:0, R2:1 -- R3:0
+        model.add_wire(WireData("R1", 1, "R2", 0))
+        model.add_wire(WireData("R2", 0, "R3", 0))
+
+        # All three terminals should be in the same node
+        node = model.terminal_to_node[("R1", 1)]
+        assert ("R2", 0) in node.terminals
+        assert ("R3", 0) in node.terminals
+
+        # Remove the bridge wire
+        model.remove_wire(0)  # R1:1 -- R2:0
+
+        # R2:0 and R3:0 should still be connected, R1:1 should be separate
+        node_r2 = model.terminal_to_node.get(("R2", 0))
+        # After wire removal, R1:1 has no wires connecting it, so it won't have a node
+        # R2:0 and R3:0 still share a node
+        assert node_r2 is not None
+        assert ("R3", 0) in node_r2.terminals
+
+    def test_ground_node_assignment_persists(self):
+        """Ground nodes are correctly identified and persist."""
+        model = CircuitModel()
+        gnd = ComponentData("GND1", "Ground", "0V", (0, 0))
+        r1 = ComponentData("R1", "Resistor", "1k", (100, 0))
+        model.add_component(gnd)
+        model.add_component(r1)
+        model.add_wire(WireData("GND1", 0, "R1", 1))
+
+        node = model.terminal_to_node[("GND1", 0)]
+        assert node.is_ground
+        assert ("R1", 1) in node.terminals
+
+    def test_ground_node_persists_through_rebuild(self):
+        """rebuild_nodes() preserves ground status."""
+        model = CircuitModel()
+        gnd = ComponentData("GND1", "Ground", "0V", (0, 0))
+        r1 = ComponentData("R1", "Resistor", "1k", (100, 0))
+        model.add_component(gnd)
+        model.add_component(r1)
+        model.add_wire(WireData("GND1", 0, "R1", 1))
+
+        model.rebuild_nodes()
+
+        node = model.terminal_to_node[("GND1", 0)]
+        assert node.is_ground
+
+    def test_custom_label_preserved_through_rebuild(self):
+        """Custom net labels survive rebuild_nodes()."""
+        model = CircuitModel()
+        r1 = ComponentData("R1", "Resistor", "1k", (0, 0))
+        r2 = ComponentData("R2", "Resistor", "2k", (100, 0))
+        model.add_component(r1)
+        model.add_component(r2)
+        model.add_wire(WireData("R1", 0, "R2", 0))
+
+        node = model.terminal_to_node[("R1", 0)]
+        node.set_custom_label("MyNet")
+
+        model.rebuild_nodes()
+
+        rebuilt_node = model.terminal_to_node[("R1", 0)]
+        assert rebuilt_node.custom_label == "MyNet"
+
+    def test_node_count_matches_topology(self):
+        """Simple series circuit has the expected number of nodes."""
+        model = CircuitModel()
+        v1 = ComponentData("V1", "Voltage Source", "5V", (0, 0))
+        r1 = ComponentData("R1", "Resistor", "1k", (100, 0))
+        gnd = ComponentData("GND1", "Ground", "0V", (100, 100))
+        model.add_component(v1)
+        model.add_component(r1)
+        model.add_component(gnd)
+
+        model.add_wire(WireData("V1", 0, "R1", 0))
+        model.add_wire(WireData("R1", 1, "GND1", 0))
+        model.add_wire(WireData("V1", 1, "GND1", 0))
+
+        # V1:0 + R1:0 = nodeA, R1:1 + GND1:0 + V1:1 = ground
+        assert len(model.nodes) == 2
+
+        ground_nodes = [n for n in model.nodes if n.is_ground]
+        assert len(ground_nodes) == 1

--- a/app/tests/unit/test_monte_carlo_dialogs.py
+++ b/app/tests/unit/test_monte_carlo_dialogs.py
@@ -1,0 +1,315 @@
+"""Unit tests for Monte Carlo configuration and results dialogs.
+
+Tests MonteCarloDialog (app/GUI/monte_carlo_dialog.py) and
+MonteCarloResultsDialog (app/GUI/monte_carlo_results_dialog.py).
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+QtWidgets = pytest.importorskip("PyQt6.QtWidgets")
+
+from GUI.monte_carlo_dialog import MC_BASE_ANALYSIS_TYPES, MonteCarloDialog
+from GUI.monte_carlo_results_dialog import MonteCarloResultsDialog
+from models.component import ComponentData
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_components(*specs):
+    """Build a components dict from (id, type, value) tuples."""
+    return {
+        cid: ComponentData(
+            component_id=cid,
+            component_type=ctype,
+            value=val,
+            position=(0.0, 0.0),
+        )
+        for cid, ctype, val in specs
+    }
+
+
+@dataclass
+class FakeSimResult:
+    """Minimal stand-in for SimulationResult."""
+
+    success: bool = True
+    data: Any = None
+
+
+# ---------------------------------------------------------------------------
+# MonteCarloDialog — initialization
+# ---------------------------------------------------------------------------
+
+
+class TestMonteCarloDialogInit:
+    def test_opens_without_crash(self, qtbot):
+        comps = _make_components(("R1", "Resistor", "1k"))
+        dlg = MonteCarloDialog(comps)
+        qtbot.addWidget(dlg)
+
+    def test_window_title(self, qtbot):
+        dlg = MonteCarloDialog(_make_components(("R1", "Resistor", "1k")))
+        qtbot.addWidget(dlg)
+        assert "Monte Carlo" in dlg.windowTitle()
+
+    def test_default_num_runs(self, qtbot):
+        dlg = MonteCarloDialog(_make_components(("R1", "Resistor", "1k")))
+        qtbot.addWidget(dlg)
+        assert dlg.num_runs_spin.value() == 20
+
+    def test_num_runs_range(self, qtbot):
+        dlg = MonteCarloDialog(_make_components(("R1", "Resistor", "1k")))
+        qtbot.addWidget(dlg)
+        assert dlg.num_runs_spin.minimum() == 2
+        assert dlg.num_runs_spin.maximum() == 1000
+
+    def test_analysis_combo_has_four_types(self, qtbot):
+        dlg = MonteCarloDialog(_make_components(("R1", "Resistor", "1k")))
+        qtbot.addWidget(dlg)
+        items = [dlg.analysis_combo.itemText(i) for i in range(dlg.analysis_combo.count())]
+        assert items == MC_BASE_ANALYSIS_TYPES
+
+    def test_tolerance_table_row_count_matches_eligible(self, qtbot):
+        comps = _make_components(
+            ("R1", "Resistor", "1k"),
+            ("C1", "Capacitor", "100n"),
+            ("V1", "Voltage Source", "5V"),
+        )
+        dlg = MonteCarloDialog(comps)
+        qtbot.addWidget(dlg)
+        assert dlg.tol_table is not None
+        assert dlg.tol_table.rowCount() == 3
+
+    def test_empty_circuit_shows_no_eligible_label(self, qtbot):
+        # Only a Diode — not in MC_ELIGIBLE_TYPES
+        comps = _make_components(("D1", "Diode", "1N4148"))
+        dlg = MonteCarloDialog(comps)
+        qtbot.addWidget(dlg)
+        assert dlg.tol_table is None
+
+    def test_default_tolerances_match_constants(self, qtbot):
+        from simulation.monte_carlo import DEFAULT_TOLERANCES
+
+        comps = _make_components(("R1", "Resistor", "1k"), ("C1", "Capacitor", "10u"))
+        dlg = MonteCarloDialog(comps)
+        qtbot.addWidget(dlg)
+
+        for row in range(dlg.tol_table.rowCount()):
+            comp_type = dlg.tol_table.item(row, 1).text()
+            tol_spin = dlg.tol_table.cellWidget(row, 2)
+            expected = DEFAULT_TOLERANCES.get(comp_type, 5.0)
+            assert tol_spin.value() == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# MonteCarloDialog — analysis type switching
+# ---------------------------------------------------------------------------
+
+
+class TestMonteCarloDialogAnalysisSwitch:
+    def test_switching_type_rebuilds_base_form(self, qtbot):
+        dlg = MonteCarloDialog(_make_components(("R1", "Resistor", "1k")))
+        qtbot.addWidget(dlg)
+
+        # Start at DC OP (no extra fields)
+        dlg.analysis_combo.setCurrentText("DC Operating Point")
+        count_dcop = dlg._base_form.count()
+
+        # Switch to Transient (has fields)
+        dlg.analysis_combo.setCurrentText("Transient")
+        count_tran = dlg._base_form.count()
+        assert count_tran > count_dcop
+
+
+# ---------------------------------------------------------------------------
+# MonteCarloDialog — get_parameters
+# ---------------------------------------------------------------------------
+
+
+class TestMonteCarloDialogGetParameters:
+    def test_returns_correct_structure(self, qtbot):
+        comps = _make_components(("R1", "Resistor", "1k"))
+        dlg = MonteCarloDialog(comps)
+        qtbot.addWidget(dlg)
+
+        params = dlg.get_parameters()
+        assert params is not None
+        assert "num_runs" in params
+        assert "base_analysis_type" in params
+        assert "base_params" in params
+        assert "tolerances" in params
+        assert params["num_runs"] == 20
+
+    def test_returns_none_when_all_tolerances_zero(self, qtbot):
+        comps = _make_components(("R1", "Resistor", "1k"))
+        dlg = MonteCarloDialog(comps)
+        qtbot.addWidget(dlg)
+
+        # Set all tolerances to 0
+        for row in range(dlg.tol_table.rowCount()):
+            dlg.tol_table.cellWidget(row, 2).setValue(0.0)
+
+        assert dlg.get_parameters() is None
+
+    def test_tolerances_contain_component_ids(self, qtbot):
+        comps = _make_components(("R1", "Resistor", "1k"), ("C1", "Capacitor", "10u"))
+        dlg = MonteCarloDialog(comps)
+        qtbot.addWidget(dlg)
+
+        params = dlg.get_parameters()
+        assert params is not None
+        for cid in params["tolerances"]:
+            assert cid in comps
+
+    def test_tolerance_has_pct_and_distribution(self, qtbot):
+        comps = _make_components(("R1", "Resistor", "1k"))
+        dlg = MonteCarloDialog(comps)
+        qtbot.addWidget(dlg)
+
+        params = dlg.get_parameters()
+        tol = list(params["tolerances"].values())[0]
+        assert "tolerance_pct" in tol
+        assert "distribution" in tol
+        assert tol["distribution"] in ("gaussian", "uniform")
+
+
+# ---------------------------------------------------------------------------
+# MonteCarloResultsDialog
+# ---------------------------------------------------------------------------
+
+
+def _dc_op_mc_data(n_runs=5):
+    """Build fake MC data for DC Operating Point analysis."""
+    results = []
+    for i in range(n_runs):
+        results.append(
+            FakeSimResult(
+                success=True,
+                data={"node_voltages": {"out": 4.9 + i * 0.05, "in": 5.0}},
+            )
+        )
+    return {
+        "base_analysis_type": "DC Operating Point",
+        "results": results,
+    }
+
+
+def _transient_mc_data(n_runs=3):
+    """Build fake MC data for Transient analysis."""
+    results = []
+    for i in range(n_runs):
+        results.append(
+            FakeSimResult(
+                success=True,
+                data=[
+                    {"time": 0.0, "out": 0.0},
+                    {"time": 0.5e-3, "out": 2.5 + i * 0.1},
+                    {"time": 1e-3, "out": 5.0 + i * 0.2},
+                ],
+            )
+        )
+    return {
+        "base_analysis_type": "Transient",
+        "results": results,
+    }
+
+
+class TestMonteCarloResultsDialog:
+    def test_opens_with_dc_op_data(self, qtbot):
+        dlg = MonteCarloResultsDialog(_dc_op_mc_data())
+        qtbot.addWidget(dlg)
+        assert "Monte Carlo" in dlg.windowTitle()
+
+    def test_metric_combo_populated(self, qtbot):
+        dlg = MonteCarloResultsDialog(_dc_op_mc_data())
+        qtbot.addWidget(dlg)
+        assert dlg._metric_combo.count() >= 1
+
+    def test_summary_contains_statistics(self, qtbot):
+        dlg = MonteCarloResultsDialog(_dc_op_mc_data())
+        qtbot.addWidget(dlg)
+        text = dlg._summary.toPlainText()
+        assert "Mean" in text
+        assert "Std" in text
+
+    def test_histogram_updates_on_metric_change(self, qtbot):
+        dlg = MonteCarloResultsDialog(_dc_op_mc_data())
+        qtbot.addWidget(dlg)
+
+        if dlg._metric_combo.count() >= 2:
+            dlg._metric_combo.setCurrentIndex(1)
+            text = dlg._summary.toPlainText()
+            assert "Mean" in text
+
+    def test_opens_with_transient_data(self, qtbot):
+        dlg = MonteCarloResultsDialog(_transient_mc_data())
+        qtbot.addWidget(dlg)
+        assert dlg._metric_combo.count() >= 1
+
+    def test_empty_results_handled(self, qtbot):
+        mc_data = {"base_analysis_type": "DC Operating Point", "results": []}
+        dlg = MonteCarloResultsDialog(mc_data)
+        qtbot.addWidget(dlg)
+        assert dlg._metric_combo.count() == 0
+        assert "No metric data" in dlg._summary.toPlainText()
+
+    def test_failed_results_skipped(self, qtbot):
+        results = [FakeSimResult(success=False, data=None) for _ in range(3)]
+        mc_data = {"base_analysis_type": "DC Operating Point", "results": results}
+        dlg = MonteCarloResultsDialog(mc_data)
+        qtbot.addWidget(dlg)
+        assert dlg._metric_combo.count() == 0
+
+    def test_close_event_cleans_up_figures(self, qtbot):
+        dlg = MonteCarloResultsDialog(_dc_op_mc_data())
+        qtbot.addWidget(dlg)
+
+        import matplotlib.pyplot as plt
+
+        with patch.object(plt, "close") as mock_close:
+            dlg.close()
+            assert mock_close.call_count >= 2
+
+    def test_dc_sweep_mc_data(self, qtbot):
+        results = []
+        for i in range(3):
+            results.append(
+                FakeSimResult(
+                    success=True,
+                    data={
+                        "headers": ["idx", "v-sweep", "V(out)"],
+                        "data": [
+                            [0, 0.0, 0.0 + i * 0.1],
+                            [1, 5.0, 2.5 + i * 0.1],
+                            [2, 10.0, 5.0 + i * 0.1],
+                        ],
+                    },
+                )
+            )
+        mc_data = {"base_analysis_type": "DC Sweep", "results": results}
+        dlg = MonteCarloResultsDialog(mc_data)
+        qtbot.addWidget(dlg)
+        assert dlg._metric_combo.count() >= 1
+
+    def test_ac_sweep_mc_data(self, qtbot):
+        results = []
+        for i in range(3):
+            results.append(
+                FakeSimResult(
+                    success=True,
+                    data={
+                        "frequencies": [100.0, 1000.0, 10000.0],
+                        "magnitude": {"out": [1.0, 0.7 + i * 0.01, 0.3]},
+                    },
+                )
+            )
+        mc_data = {"base_analysis_type": "AC Sweep", "results": results}
+        dlg = MonteCarloResultsDialog(mc_data)
+        qtbot.addWidget(dlg)
+        assert dlg._metric_combo.count() >= 1

--- a/app/tests/unit/test_symbol_style.py
+++ b/app/tests/unit/test_symbol_style.py
@@ -191,9 +191,7 @@ class TestIEEEDrawDispatch:
         called = []
         comp._draw_ieee = lambda painter: called.append(True)
         comp.draw_component_body(None)
-        assert (
-            called
-        ), f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
+        assert called, f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
 
 
 class TestObstacleShapeDispatch:


### PR DESCRIPTION
## Summary
- Adds 23 unit tests for `MonteCarloDialog` and `MonteCarloResultsDialog`
- Tests dialog initialization, analysis type switching, parameter extraction, tolerance validation
- Results dialog tested with DC OP, Transient, DC Sweep, AC Sweep data plus empty/failed edge cases

## Test plan
- [x] `python -m pytest app/tests/unit/test_monte_carlo_dialogs.py -v` — 23/23 pass
- [x] `make format && make lint` — clean

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)