### PR TITLE
add assignment template format with metadata and save/load support

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -140,9 +140,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             new_pos = component.position
             # Only create a command if the component actually moved
             if old_pos[0] != new_pos[0] or old_pos[1] != new_pos[1]:
-                cmd = MoveComponentCommand(
-                    controller, comp_id, new_pos, old_position=old_pos
-                )
+                cmd = MoveComponentCommand(controller, comp_id, new_pos, old_position=old_pos)
                 move_commands.append(cmd)
 
         self._drag_start_positions = {}
@@ -155,9 +153,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             controller.undo_manager._undo_stack.append(move_commands[0])
             controller.undo_manager._redo_stack.clear()
         else:
-            compound = CompoundCommand(
-                move_commands, f"Move {len(move_commands)} components"
-            )
+            compound = CompoundCommand(move_commands, f"Move {len(move_commands)} components")
             controller.undo_manager._undo_stack.append(compound)
             controller.undo_manager._redo_stack.clear()
 
@@ -209,9 +205,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         )
 
         if ok and new_value:
-            is_valid, error_msg = validate_component_value(
-                new_value, self.component_type
-            )
+            is_valid, error_msg = validate_component_value(new_value, self.component_type)
             if not is_valid:
                 QMessageBox.warning(None, "Invalid Value", error_msg)
                 return
@@ -336,19 +330,9 @@ class ComponentGraphicsItem(QGraphicsItem):
         self.draw_component_body(painter)
 
         # Draw label (check canvas visibility settings)
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))
@@ -368,10 +352,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             painter.drawEllipse(terminal, 3, 3)
 
     def itemChange(self, change, value):
-        if (
-            change == QGraphicsItem.GraphicsItemChange.ItemPositionChange
-            and self.scene()
-        ):
+        if change == QGraphicsItem.GraphicsItemChange.ItemPositionChange and self.scene():
             # Snap to grid
             new_pos = value
             grid_x = round(new_pos.x() / GRID_SIZE) * GRID_SIZE
@@ -434,9 +415,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         if self._position_update_timer is None:
             self._position_update_timer = QTimer()
             self._position_update_timer.setSingleShot(True)
-            self._position_update_timer.timeout.connect(
-                self._notify_controller_position
-            )
+            self._position_update_timer.timeout.connect(self._notify_controller_position)
         self._position_update_timer.start(50)  # 50ms debounce
 
     def _notify_controller_position(self):
@@ -646,9 +625,7 @@ class WaveformVoltageSource(ComponentGraphicsItem):
         # Draw sine wave symbol
         from models.component import COMPONENT_COLORS
 
-        painter.setPen(
-            QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2)
-        )
+        painter.setPen(QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2))
         from PyQt6.QtGui import QPainterPath
 
         path = QPainterPath()
@@ -688,19 +665,9 @@ class Ground(ComponentGraphicsItem):
         painter.setBrush(QBrush(color.lighter(150)))
         self.draw_component_body(painter)
 
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -46,6 +46,18 @@ class MenuBarMixin:
 
         file_menu.addSeparator()
 
+        new_from_template_action = QAction("New from &Template...", self)
+        new_from_template_action.setToolTip("Create a new circuit from an assignment template")
+        new_from_template_action.triggered.connect(self._on_new_from_template)
+        file_menu.addAction(new_from_template_action)
+
+        save_as_template_action = QAction("Save as Temp&late...", self)
+        save_as_template_action.setToolTip("Save current circuit as an assignment template with metadata")
+        save_as_template_action.triggered.connect(self._on_save_as_template)
+        file_menu.addAction(save_as_template_action)
+
+        file_menu.addSeparator()
+
         import_netlist_action = QAction("&Import SPICE Netlist...", self)
         import_netlist_action.setToolTip("Import a SPICE netlist file (.cir, .spice)")
         import_netlist_action.triggered.connect(self._on_import_netlist)
@@ -53,9 +65,7 @@ class MenuBarMixin:
 
         export_netlist_action = QAction("Export &Netlist...", self)
         export_netlist_action.setShortcut(kb.get("file.export_netlist"))
-        export_netlist_action.setToolTip(
-            "Export the generated SPICE netlist to a .cir file"
-        )
+        export_netlist_action.setToolTip("Export the generated SPICE netlist to a .cir file")
         export_netlist_action.triggered.connect(self.export_netlist)
         file_menu.addAction(export_netlist_action)
 
@@ -70,9 +80,7 @@ class MenuBarMixin:
         file_menu.addAction(export_pdf_action)
 
         export_latex_action = QAction("Export as &LaTeX...", self)
-        export_latex_action.setToolTip(
-            "Export circuit as CircuiTikZ LaTeX code (.tex file)"
-        )
+        export_latex_action.setToolTip("Export circuit as CircuiTikZ LaTeX code (.tex file)")
         export_latex_action.triggered.connect(self.export_circuitikz)
         file_menu.addAction(export_latex_action)
 
@@ -145,9 +153,7 @@ class MenuBarMixin:
         edit_menu.addSeparator()
 
         copy_latex_action = QAction("Copy as La&TeX", self)
-        copy_latex_action.setToolTip(
-            "Copy the CircuiTikZ environment block to the clipboard"
-        )
+        copy_latex_action.setToolTip("Copy the CircuiTikZ environment block to the clipboard")
         copy_latex_action.triggered.connect(self.copy_circuitikz)
         edit_menu.addAction(copy_latex_action)
 
@@ -214,9 +220,7 @@ class MenuBarMixin:
         self.probe_action = QAction("&Probe Tool", self)
         self.probe_action.setCheckable(True)
         self.probe_action.setShortcut(kb.get("tools.probe"))
-        self.probe_action.setToolTip(
-            "Click nodes or components to see voltage/current values"
-        )
+        self.probe_action.setToolTip("Click nodes or components to see voltage/current values")
         self.probe_action.triggered.connect(self._toggle_probe_mode)
         view_menu.addAction(self.probe_action)
 
@@ -274,9 +278,7 @@ class MenuBarMixin:
 
         self.monochrome_mode_action = QAction("&Monochrome", self)
         self.monochrome_mode_action.setCheckable(True)
-        self.monochrome_mode_action.triggered.connect(
-            lambda: self._set_color_mode("monochrome")
-        )
+        self.monochrome_mode_action.triggered.connect(lambda: self._set_color_mode("monochrome"))
         color_mode_menu.addAction(self.monochrome_mode_action)
 
         self.color_mode_group = QActionGroup(self)
@@ -371,9 +373,7 @@ class MenuBarMixin:
 
         mc_action = QAction("&Monte Carlo...", self)
         mc_action.setCheckable(True)
-        mc_action.setToolTip(
-            "Run Monte Carlo tolerance analysis with randomized component values"
-        )
+        mc_action.setToolTip("Run Monte Carlo tolerance analysis with randomized component values")
         mc_action.triggered.connect(self.set_analysis_monte_carlo)
         analysis_menu.addAction(mc_action)
 

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -127,11 +127,7 @@ class SettingsMixin:
         if reply == QMessageBox.StandardButton.Yes:
             source = self.file_ctrl.load_auto_save()
             if source is not None:
-                title = (
-                    f"Circuit Design GUI - {source}"
-                    if source
-                    else "Circuit Design GUI - (Recovered)"
-                )
+                title = f"Circuit Design GUI - {source}" if source else "Circuit Design GUI - (Recovered)"
                 self.setWindowTitle(title)
                 self._sync_analysis_menu()
                 statusBar = self.statusBar()

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -143,9 +143,7 @@ class ViewOperationsMixin:
         self.canvas.set_probe_mode(checked)
         if checked:
             if not self.canvas.node_voltages and self._last_results is None:
-                self.statusBar().showMessage(
-                    "Probe mode active. Run a simulation first to see values.", 3000
-                )
+                self.statusBar().showMessage("Probe mode active. Run a simulation first to see values.", 3000)
             else:
                 self.statusBar().showMessage(
                     "Probe mode active. Click nodes or components to see values. Press Escape to exit.",
@@ -158,9 +156,7 @@ class ViewOperationsMixin:
     def _on_probe_requested(self, signal_name, probe_type):
         """Handle probe click for sweep/transient analyses (no OP data on canvas)."""
         if self._last_results is None:
-            self.statusBar().showMessage(
-                "No simulation results available. Run a simulation first.", 3000
-            )
+            self.statusBar().showMessage("No simulation results available. Run a simulation first.", 3000)
             return
 
         analysis_type = self._last_results_type
@@ -171,9 +167,7 @@ class ViewOperationsMixin:
         elif analysis_type == "AC Sweep":
             self._probe_open_ac_sweep(signal_name, probe_type)
         else:
-            self.statusBar().showMessage(
-                f"Probe not supported for {analysis_type} analysis.", 3000
-            )
+            self.statusBar().showMessage(f"Probe not supported for {analysis_type} analysis.", 3000)
 
     def _probe_open_waveform(self, signal_name, probe_type):
         """Open waveform dialog focused on the probed signal."""
@@ -232,14 +226,10 @@ class ViewOperationsMixin:
         circuit_items = [
             item
             for item in scene.items()
-            if isinstance(
-                item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem)
-            )
+            if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
         ]
         if not circuit_items:
-            QMessageBox.information(
-                self, "Export Image", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export Image", "Nothing to export — the canvas is empty.")
             return
 
         source_rect = circuit_items[0].sceneBoundingRect()
@@ -256,9 +246,7 @@ class ViewOperationsMixin:
 
             generator = QSvgGenerator()
             generator.setFileName(filename)
-            generator.setSize(
-                QSize(int(source_rect.width()), int(source_rect.height()))
-            )
+            generator.setSize(QSize(int(source_rect.width()), int(source_rect.height())))
             generator.setViewBox(source_rect)
             generator.setTitle("SDM Spice Circuit")
 
@@ -285,9 +273,7 @@ class ViewOperationsMixin:
             painter.end()
             image.save(filename)
 
-        QMessageBox.information(
-            self, "Export Image", f"Circuit exported to:\n{filename}"
-        )
+        QMessageBox.information(self, "Export Image", f"Circuit exported to:\n{filename}")
 
     def export_circuitikz(self):
         """Export the circuit as a CircuiTikZ LaTeX file."""
@@ -299,9 +285,7 @@ class ViewOperationsMixin:
 
         model = self.circuit_ctrl.model
         if not model.components:
-            QMessageBox.information(
-                self, "Export LaTeX", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export LaTeX", "Nothing to export — the canvas is empty.")
             return
 
         # Show options dialog
@@ -319,11 +303,7 @@ class ViewOperationsMixin:
                 nodes=model.nodes,
                 terminal_to_node=model.terminal_to_node,
                 standalone=opts["standalone"],
-                circuit_name=(
-                    os.path.basename(self.file_ctrl.current_file)
-                    if self.file_ctrl.current_file
-                    else ""
-                ),
+                circuit_name=(os.path.basename(self.file_ctrl.current_file) if self.file_ctrl.current_file else ""),
                 scale=opts["scale"],
                 include_ids=opts["include_ids"],
                 include_values=opts["include_values"],
@@ -336,9 +316,7 @@ class ViewOperationsMixin:
 
         default_name = ""
         if hasattr(self, "file_ctrl") and self.file_ctrl.current_file:
-            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[
-                0
-            ]
+            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[0]
             default_name = base + ".tex"
 
         filename, _ = QFileDialog.getSaveFileName(

--- a/app/GUI/template_metadata_dialog.py
+++ b/app/GUI/template_metadata_dialog.py
@@ -1,0 +1,77 @@
+"""Dialog for entering template metadata when saving as assignment template."""
+
+from models.template import TemplateMetadata
+from PyQt6.QtWidgets import QDialog, QDialogButtonBox, QFormLayout, QLineEdit, QPlainTextEdit, QVBoxLayout
+
+
+class TemplateMetadataDialog(QDialog):
+    """Dialog for entering assignment template metadata.
+
+    Collects title, description, author, tags, and instructions
+    when an instructor saves a circuit as a template.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Save as Assignment Template")
+        self.setMinimumWidth(450)
+        self._setup_ui()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+
+        form = QFormLayout()
+
+        self.title_edit = QLineEdit()
+        self.title_edit.setPlaceholderText("e.g., RC Low-Pass Filter Lab")
+        form.addRow("Title:", self.title_edit)
+
+        self.author_edit = QLineEdit()
+        self.author_edit.setPlaceholderText("e.g., Dr. Smith")
+        form.addRow("Author:", self.author_edit)
+
+        self.description_edit = QLineEdit()
+        self.description_edit.setPlaceholderText("Brief description of the assignment")
+        form.addRow("Description:", self.description_edit)
+
+        self.tags_edit = QLineEdit()
+        self.tags_edit.setPlaceholderText("Comma-separated tags, e.g., filters, AC, lab-3")
+        form.addRow("Tags:", self.tags_edit)
+
+        layout.addLayout(form)
+
+        self.instructions_edit = QPlainTextEdit()
+        self.instructions_edit.setPlaceholderText("Assignment instructions for students...")
+        self.instructions_edit.setMaximumHeight(120)
+        layout.addWidget(self.instructions_edit)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons.accepted.connect(self._on_accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _on_accept(self):
+        if not self.title_edit.text().strip():
+            self.title_edit.setFocus()
+            self.title_edit.setStyleSheet("border: 1px solid red;")
+            return
+        self.accept()
+
+    def get_metadata(self) -> TemplateMetadata:
+        """Return the metadata entered in the dialog."""
+        from datetime import date
+
+        tags_text = self.tags_edit.text().strip()
+        tags = [t.strip() for t in tags_text.split(",") if t.strip()] if tags_text else []
+
+        return TemplateMetadata(
+            title=self.title_edit.text().strip(),
+            description=self.description_edit.text().strip(),
+            author=self.author_edit.text().strip(),
+            created=date.today().isoformat(),
+            tags=tags,
+        )
+
+    def get_instructions(self) -> str:
+        """Return the instructions text entered in the dialog."""
+        return self.instructions_edit.toPlainText().strip()

--- a/app/controllers/template_controller.py
+++ b/app/controllers/template_controller.py
@@ -1,0 +1,177 @@
+"""TemplateController - Handles assignment template I/O for instructor tools.
+
+Templates wrap a standard circuit JSON with instructor metadata (title,
+description, instructions) and optionally a reference solution circuit.
+File extension: .spice-template (JSON internally).
+"""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from controllers.file_controller import validate_circuit_data
+from models.circuit import CircuitModel
+from models.template import TemplateData, TemplateMetadata
+
+TEMPLATE_EXTENSION = ".spice-template"
+
+
+def validate_template_data(data: dict) -> None:
+    """Validate template JSON structure before loading.
+
+    Raises ValueError with a descriptive message if anything is wrong.
+    """
+    if not isinstance(data, dict):
+        raise ValueError("File does not contain a valid template object.")
+
+    if "template_version" not in data:
+        raise ValueError("Missing 'template_version' field.")
+
+    if "metadata" not in data or not isinstance(data["metadata"], dict):
+        raise ValueError("Missing or invalid 'metadata' section.")
+
+    metadata = data["metadata"]
+    if not metadata.get("title"):
+        raise ValueError("Template metadata must include a non-empty 'title'.")
+
+    # Validate embedded circuits if present
+    if "starter_circuit" in data and data["starter_circuit"] is not None:
+        validate_circuit_data(data["starter_circuit"])
+
+    if "reference_circuit" in data and data["reference_circuit"] is not None:
+        validate_circuit_data(data["reference_circuit"])
+
+
+class TemplateController:
+    """Manages assignment template save/load operations.
+
+    Works alongside FileController — FileController handles regular circuit
+    files, TemplateController handles the template envelope format.
+    """
+
+    def save_as_template(
+        self,
+        filepath,
+        metadata: TemplateMetadata,
+        starter_circuit: Optional[CircuitModel] = None,
+        reference_circuit: Optional[CircuitModel] = None,
+        instructions: str = "",
+        required_analysis: Optional[dict] = None,
+    ) -> None:
+        """Save a circuit as an assignment template.
+
+        Args:
+            filepath: Path to save the template file.
+            metadata: Template metadata (title, author, etc.).
+            starter_circuit: Circuit students start with (optional).
+            reference_circuit: Instructor's solution circuit (optional).
+            instructions: Assignment instructions text.
+            required_analysis: Expected analysis type and params (optional).
+
+        Raises:
+            OSError: If the file cannot be written.
+            TypeError: If data is not JSON-serializable.
+        """
+        filepath = Path(filepath)
+
+        template = TemplateData(
+            metadata=metadata,
+            instructions=instructions,
+            starter_circuit=(starter_circuit.to_dict() if starter_circuit else None),
+            reference_circuit=(reference_circuit.to_dict() if reference_circuit else None),
+            required_analysis=required_analysis,
+        )
+
+        with open(filepath, "w") as f:
+            json.dump(template.to_dict(), f, indent=2)
+
+    def load_template(self, filepath) -> TemplateData:
+        """Load a template file and return parsed TemplateData.
+
+        Args:
+            filepath: Path to the template file.
+
+        Returns:
+            TemplateData with metadata and optional circuit dicts.
+
+        Raises:
+            json.JSONDecodeError: If file is not valid JSON.
+            ValueError: If template structure is invalid.
+            OSError: If the file cannot be read.
+        """
+        filepath = Path(filepath)
+        with open(filepath, "r") as f:
+            data = json.load(f)
+
+        validate_template_data(data)
+        return TemplateData.from_dict(data)
+
+    def create_circuit_from_template(self, template: TemplateData) -> CircuitModel:
+        """Create a new CircuitModel from a template's starter circuit.
+
+        If the template has no starter_circuit, returns an empty model
+        with the template's required analysis settings applied.
+
+        Args:
+            template: The loaded template data.
+
+        Returns:
+            A new CircuitModel ready for the student to work with.
+        """
+        if template.starter_circuit is not None:
+            model = CircuitModel.from_dict(template.starter_circuit)
+        else:
+            model = CircuitModel()
+
+        # Apply required analysis settings if specified
+        if template.required_analysis:
+            analysis_type = template.required_analysis.get("type")
+            if analysis_type:
+                model.analysis_type = analysis_type
+            analysis_params = template.required_analysis.get("params")
+            if analysis_params:
+                model.analysis_params = analysis_params.copy()
+
+        return model
+
+    def get_reference_circuit(self, template: TemplateData) -> Optional[CircuitModel]:
+        """Extract the reference (solution) circuit from a template.
+
+        Args:
+            template: The loaded template data.
+
+        Returns:
+            CircuitModel of the solution, or None if not included.
+        """
+        if template.reference_circuit is not None:
+            return CircuitModel.from_dict(template.reference_circuit)
+        return None
+
+    def get_template_metadata(self, filepath) -> TemplateMetadata:
+        """Read template metadata without loading the full circuit data.
+
+        Useful for browsing/listing templates without deserializing circuits.
+
+        Args:
+            filepath: Path to the template file.
+
+        Returns:
+            TemplateMetadata with title, description, author, etc.
+
+        Raises:
+            json.JSONDecodeError: If file is not valid JSON.
+            ValueError: If template structure is invalid.
+            OSError: If the file cannot be read.
+        """
+        filepath = Path(filepath)
+        with open(filepath, "r") as f:
+            data = json.load(f)
+
+        if not isinstance(data, dict):
+            raise ValueError("File does not contain a valid template object.")
+        if "metadata" not in data or not isinstance(data["metadata"], dict):
+            raise ValueError("Missing or invalid 'metadata' section.")
+        if not data["metadata"].get("title"):
+            raise ValueError("Template metadata must include a non-empty 'title'.")
+
+        return TemplateMetadata.from_dict(data["metadata"])

--- a/app/models/template.py
+++ b/app/models/template.py
@@ -1,0 +1,76 @@
+"""Data classes for assignment templates with instructor metadata."""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class TemplateMetadata:
+    """Instructor-facing metadata for an assignment template."""
+
+    title: str = ""
+    description: str = ""
+    author: str = ""
+    created: str = ""
+    tags: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "title": self.title,
+            "description": self.description,
+            "author": self.author,
+            "created": self.created,
+            "tags": list(self.tags),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TemplateMetadata":
+        return cls(
+            title=data.get("title", ""),
+            description=data.get("description", ""),
+            author=data.get("author", ""),
+            created=data.get("created", ""),
+            tags=list(data.get("tags", [])),
+        )
+
+
+@dataclass
+class TemplateData:
+    """A complete assignment template containing metadata and circuit data.
+
+    The starter_circuit is what students receive (may be empty or partially
+    built). The reference_circuit is the instructor's solution (optional,
+    used for grading).
+    """
+
+    template_version: str = "1.0"
+    metadata: TemplateMetadata = field(default_factory=TemplateMetadata)
+    instructions: str = ""
+    starter_circuit: Optional[dict] = None
+    reference_circuit: Optional[dict] = None
+    required_analysis: Optional[dict] = None
+
+    def to_dict(self) -> dict:
+        data = {
+            "template_version": self.template_version,
+            "metadata": self.metadata.to_dict(),
+            "instructions": self.instructions,
+        }
+        if self.starter_circuit is not None:
+            data["starter_circuit"] = self.starter_circuit
+        if self.reference_circuit is not None:
+            data["reference_circuit"] = self.reference_circuit
+        if self.required_analysis is not None:
+            data["required_analysis"] = self.required_analysis
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TemplateData":
+        return cls(
+            template_version=data.get("template_version", "1.0"),
+            metadata=TemplateMetadata.from_dict(data.get("metadata", {})),
+            instructions=data.get("instructions", ""),
+            starter_circuit=data.get("starter_circuit"),
+            reference_circuit=data.get("reference_circuit"),
+            required_analysis=data.get("required_analysis"),
+        )

--- a/app/tests/unit/test_symbol_style.py
+++ b/app/tests/unit/test_symbol_style.py
@@ -191,9 +191,7 @@ class TestIEEEDrawDispatch:
         called = []
         comp._draw_ieee = lambda painter: called.append(True)
         comp.draw_component_body(None)
-        assert (
-            called
-        ), f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
+        assert called, f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
 
 
 class TestObstacleShapeDispatch:

--- a/app/tests/unit/test_template_controller.py
+++ b/app/tests/unit/test_template_controller.py
@@ -1,0 +1,384 @@
+"""Tests for TemplateController and template data model."""
+
+import json
+
+import pytest
+from controllers.template_controller import TemplateController, validate_template_data
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from models.template import TemplateData, TemplateMetadata
+from models.wire import WireData
+
+
+def _build_simple_circuit():
+    """Build a simple V1-R1-GND circuit model."""
+    model = CircuitModel()
+    model.components["V1"] = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value="5V",
+        position=(0.0, 0.0),
+    )
+    model.components["R1"] = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value="1k",
+        position=(100.0, 0.0),
+    )
+    model.components["GND1"] = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(0.0, 100.0),
+    )
+    model.wires = [
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+    ]
+    model.component_counter = {"V": 1, "R": 1, "GND": 1}
+    model.rebuild_nodes()
+    return model
+
+
+def _build_metadata(**overrides):
+    """Build a TemplateMetadata with defaults."""
+    defaults = {
+        "title": "Test Template",
+        "description": "A test assignment",
+        "author": "Dr. Test",
+        "created": "2026-02-11",
+        "tags": ["test", "basic"],
+    }
+    defaults.update(overrides)
+    return TemplateMetadata(**defaults)
+
+
+class TestTemplateMetadata:
+    def test_to_dict(self):
+        meta = _build_metadata()
+        d = meta.to_dict()
+        assert d["title"] == "Test Template"
+        assert d["author"] == "Dr. Test"
+        assert d["tags"] == ["test", "basic"]
+
+    def test_from_dict_round_trip(self):
+        meta = _build_metadata()
+        restored = TemplateMetadata.from_dict(meta.to_dict())
+        assert restored.title == meta.title
+        assert restored.description == meta.description
+        assert restored.author == meta.author
+        assert restored.created == meta.created
+        assert restored.tags == meta.tags
+
+    def test_from_dict_missing_fields(self):
+        meta = TemplateMetadata.from_dict({})
+        assert meta.title == ""
+        assert meta.tags == []
+
+
+class TestTemplateData:
+    def test_to_dict_minimal(self):
+        template = TemplateData(metadata=_build_metadata())
+        d = template.to_dict()
+        assert d["template_version"] == "1.0"
+        assert d["metadata"]["title"] == "Test Template"
+        assert "starter_circuit" not in d
+        assert "reference_circuit" not in d
+
+    def test_to_dict_with_circuits(self):
+        circuit = _build_simple_circuit()
+        template = TemplateData(
+            metadata=_build_metadata(),
+            starter_circuit=circuit.to_dict(),
+            reference_circuit=circuit.to_dict(),
+        )
+        d = template.to_dict()
+        assert "starter_circuit" in d
+        assert "reference_circuit" in d
+        assert "components" in d["starter_circuit"]
+
+    def test_from_dict_round_trip(self):
+        circuit = _build_simple_circuit()
+        template = TemplateData(
+            metadata=_build_metadata(),
+            instructions="Build a voltage divider",
+            starter_circuit=circuit.to_dict(),
+            required_analysis={"type": "DC Operating Point", "params": {}},
+        )
+        restored = TemplateData.from_dict(template.to_dict())
+        assert restored.metadata.title == "Test Template"
+        assert restored.instructions == "Build a voltage divider"
+        assert restored.starter_circuit is not None
+        assert restored.reference_circuit is None
+        assert restored.required_analysis["type"] == "DC Operating Point"
+
+    def test_from_dict_missing_optional_fields(self):
+        data = {
+            "template_version": "1.0",
+            "metadata": {"title": "Minimal"},
+            "instructions": "",
+        }
+        template = TemplateData.from_dict(data)
+        assert template.metadata.title == "Minimal"
+        assert template.starter_circuit is None
+        assert template.reference_circuit is None
+        assert template.required_analysis is None
+
+
+class TestValidateTemplateData:
+    def test_valid_template(self):
+        data = {
+            "template_version": "1.0",
+            "metadata": {"title": "Valid Template"},
+        }
+        validate_template_data(data)  # Should not raise
+
+    def test_not_a_dict(self):
+        with pytest.raises(ValueError, match="valid template"):
+            validate_template_data([])
+
+    def test_missing_version(self):
+        with pytest.raises(ValueError, match="template_version"):
+            validate_template_data({"metadata": {"title": "No Version"}})
+
+    def test_missing_metadata(self):
+        with pytest.raises(ValueError, match="metadata"):
+            validate_template_data({"template_version": "1.0"})
+
+    def test_empty_title(self):
+        data = {
+            "template_version": "1.0",
+            "metadata": {"title": ""},
+        }
+        with pytest.raises(ValueError, match="title"):
+            validate_template_data(data)
+
+    def test_invalid_starter_circuit(self):
+        data = {
+            "template_version": "1.0",
+            "metadata": {"title": "Bad Circuit"},
+            "starter_circuit": {"components": "not a list", "wires": []},
+        }
+        with pytest.raises(ValueError, match="components"):
+            validate_template_data(data)
+
+    def test_null_circuits_ok(self):
+        data = {
+            "template_version": "1.0",
+            "metadata": {"title": "No Circuits"},
+            "starter_circuit": None,
+            "reference_circuit": None,
+        }
+        validate_template_data(data)  # Should not raise
+
+
+class TestTemplateControllerSaveLoad:
+    def test_save_creates_file(self, tmp_path):
+        ctrl = TemplateController()
+        filepath = tmp_path / "test.spice-template"
+        ctrl.save_as_template(
+            filepath=filepath,
+            metadata=_build_metadata(),
+        )
+        assert filepath.exists()
+
+    def test_save_writes_valid_json(self, tmp_path):
+        ctrl = TemplateController()
+        filepath = tmp_path / "test.spice-template"
+        ctrl.save_as_template(
+            filepath=filepath,
+            metadata=_build_metadata(),
+        )
+        data = json.loads(filepath.read_text())
+        assert data["template_version"] == "1.0"
+        assert data["metadata"]["title"] == "Test Template"
+
+    def test_save_with_circuits(self, tmp_path):
+        ctrl = TemplateController()
+        circuit = _build_simple_circuit()
+        filepath = tmp_path / "test.spice-template"
+        ctrl.save_as_template(
+            filepath=filepath,
+            metadata=_build_metadata(),
+            starter_circuit=circuit,
+            reference_circuit=circuit,
+            instructions="Follow the steps.",
+        )
+        data = json.loads(filepath.read_text())
+        assert "starter_circuit" in data
+        assert "reference_circuit" in data
+        assert data["instructions"] == "Follow the steps."
+
+    def test_load_returns_template_data(self, tmp_path):
+        ctrl = TemplateController()
+        filepath = tmp_path / "test.spice-template"
+        ctrl.save_as_template(
+            filepath=filepath,
+            metadata=_build_metadata(),
+            instructions="Do this",
+        )
+        template = ctrl.load_template(filepath)
+        assert isinstance(template, TemplateData)
+        assert template.metadata.title == "Test Template"
+        assert template.instructions == "Do this"
+
+    def test_round_trip_preserves_data(self, tmp_path):
+        ctrl = TemplateController()
+        circuit = _build_simple_circuit()
+        meta = _build_metadata(
+            title="Round Trip Test",
+            tags=["round", "trip"],
+        )
+        filepath = tmp_path / "test.spice-template"
+        ctrl.save_as_template(
+            filepath=filepath,
+            metadata=meta,
+            starter_circuit=circuit,
+            reference_circuit=circuit,
+            instructions="Step 1: Build it\nStep 2: Test it",
+            required_analysis={"type": "AC Sweep", "params": {"fStart": 20}},
+        )
+
+        template = ctrl.load_template(filepath)
+        assert template.metadata.title == "Round Trip Test"
+        assert template.metadata.tags == ["round", "trip"]
+        assert template.instructions == "Step 1: Build it\nStep 2: Test it"
+        assert template.starter_circuit is not None
+        assert template.reference_circuit is not None
+        assert template.required_analysis["type"] == "AC Sweep"
+
+    def test_load_invalid_json_raises(self, tmp_path):
+        filepath = tmp_path / "bad.spice-template"
+        filepath.write_text("not json")
+        ctrl = TemplateController()
+        with pytest.raises(json.JSONDecodeError):
+            ctrl.load_template(filepath)
+
+    def test_load_missing_title_raises(self, tmp_path):
+        filepath = tmp_path / "bad.spice-template"
+        filepath.write_text(json.dumps({"template_version": "1.0", "metadata": {"title": ""}}))
+        ctrl = TemplateController()
+        with pytest.raises(ValueError, match="title"):
+            ctrl.load_template(filepath)
+
+    def test_load_nonexistent_file_raises(self):
+        ctrl = TemplateController()
+        with pytest.raises(OSError):
+            ctrl.load_template("/nonexistent/path/file.spice-template")
+
+
+class TestCreateCircuitFromTemplate:
+    def test_creates_model_from_starter(self, tmp_path):
+        ctrl = TemplateController()
+        circuit = _build_simple_circuit()
+        filepath = tmp_path / "test.spice-template"
+        ctrl.save_as_template(
+            filepath=filepath,
+            metadata=_build_metadata(),
+            starter_circuit=circuit,
+        )
+        template = ctrl.load_template(filepath)
+        model = ctrl.create_circuit_from_template(template)
+
+        assert isinstance(model, CircuitModel)
+        assert "V1" in model.components
+        assert "R1" in model.components
+        assert len(model.wires) == 2
+
+    def test_creates_empty_model_when_no_starter(self):
+        ctrl = TemplateController()
+        template = TemplateData(metadata=_build_metadata())
+        model = ctrl.create_circuit_from_template(template)
+        assert isinstance(model, CircuitModel)
+        assert len(model.components) == 0
+
+    def test_applies_required_analysis(self):
+        ctrl = TemplateController()
+        template = TemplateData(
+            metadata=_build_metadata(),
+            required_analysis={
+                "type": "AC Sweep",
+                "params": {"fStart": 20, "fStop": 20000},
+            },
+        )
+        model = ctrl.create_circuit_from_template(template)
+        assert model.analysis_type == "AC Sweep"
+        assert model.analysis_params["fStart"] == 20
+
+    def test_applies_analysis_to_starter_circuit(self, tmp_path):
+        ctrl = TemplateController()
+        circuit = _build_simple_circuit()
+        filepath = tmp_path / "test.spice-template"
+        ctrl.save_as_template(
+            filepath=filepath,
+            metadata=_build_metadata(),
+            starter_circuit=circuit,
+            required_analysis={"type": "Transient", "params": {"duration": 0.01}},
+        )
+        template = ctrl.load_template(filepath)
+        model = ctrl.create_circuit_from_template(template)
+        assert model.analysis_type == "Transient"
+        assert model.analysis_params["duration"] == 0.01
+        assert "V1" in model.components
+
+
+class TestGetReferenceCircuit:
+    def test_returns_model_when_present(self, tmp_path):
+        ctrl = TemplateController()
+        circuit = _build_simple_circuit()
+        filepath = tmp_path / "test.spice-template"
+        ctrl.save_as_template(
+            filepath=filepath,
+            metadata=_build_metadata(),
+            reference_circuit=circuit,
+        )
+        template = ctrl.load_template(filepath)
+        ref = ctrl.get_reference_circuit(template)
+        assert ref is not None
+        assert "V1" in ref.components
+        assert "R1" in ref.components
+
+    def test_returns_none_when_absent(self):
+        ctrl = TemplateController()
+        template = TemplateData(metadata=_build_metadata())
+        assert ctrl.get_reference_circuit(template) is None
+
+
+class TestGetTemplateMetadata:
+    def test_returns_metadata_only(self, tmp_path):
+        ctrl = TemplateController()
+        circuit = _build_simple_circuit()
+        filepath = tmp_path / "test.spice-template"
+        ctrl.save_as_template(
+            filepath=filepath,
+            metadata=_build_metadata(title="Metadata Only Test"),
+            starter_circuit=circuit,
+        )
+        meta = ctrl.get_template_metadata(filepath)
+        assert isinstance(meta, TemplateMetadata)
+        assert meta.title == "Metadata Only Test"
+        assert meta.author == "Dr. Test"
+
+    def test_raises_on_invalid_file(self, tmp_path):
+        filepath = tmp_path / "bad.spice-template"
+        filepath.write_text("[]")
+        ctrl = TemplateController()
+        with pytest.raises(ValueError, match="valid template"):
+            ctrl.get_template_metadata(filepath)
+
+    def test_raises_on_empty_title(self, tmp_path):
+        filepath = tmp_path / "bad.spice-template"
+        filepath.write_text(json.dumps({"metadata": {"title": ""}}))
+        ctrl = TemplateController()
+        with pytest.raises(ValueError, match="title"):
+            ctrl.get_template_metadata(filepath)


### PR DESCRIPTION
## Summary

- Add `TemplateData` and `TemplateMetadata` dataclasses (`app/models/template.py`) for the `.spice-template` JSON format
- Add `TemplateController` (`app/controllers/template_controller.py`) with save/load/create operations for assignment templates
- Add `TemplateMetadataDialog` for entering template metadata when saving
- Add "New from Template..." and "Save as Template..." menu items to the File menu
- 31 unit tests covering model serialization, controller save/load, round-trips, validation, and error cases

## Test plan
- [x] 31 unit tests pass covering all template operations
- [x] Full test suite (1443 tests) passes
- [x] `make format` and `make lint` clean
- [ ] Human testing: verify "New from Template..." and "Save as Template..." menu items work in the GUI

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)