### PR TITLE
Add unit tests for annotation_item and parameter_sweep_plot_dialog

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -140,9 +140,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             new_pos = component.position
             # Only create a command if the component actually moved
             if old_pos[0] != new_pos[0] or old_pos[1] != new_pos[1]:
-                cmd = MoveComponentCommand(
-                    controller, comp_id, new_pos, old_position=old_pos
-                )
+                cmd = MoveComponentCommand(controller, comp_id, new_pos, old_position=old_pos)
                 move_commands.append(cmd)
 
         self._drag_start_positions = {}
@@ -155,9 +153,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             controller.undo_manager._undo_stack.append(move_commands[0])
             controller.undo_manager._redo_stack.clear()
         else:
-            compound = CompoundCommand(
-                move_commands, f"Move {len(move_commands)} components"
-            )
+            compound = CompoundCommand(move_commands, f"Move {len(move_commands)} components")
             controller.undo_manager._undo_stack.append(compound)
             controller.undo_manager._redo_stack.clear()
 
@@ -209,9 +205,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         )
 
         if ok and new_value:
-            is_valid, error_msg = validate_component_value(
-                new_value, self.component_type
-            )
+            is_valid, error_msg = validate_component_value(new_value, self.component_type)
             if not is_valid:
                 QMessageBox.warning(None, "Invalid Value", error_msg)
                 return
@@ -336,19 +330,9 @@ class ComponentGraphicsItem(QGraphicsItem):
         self.draw_component_body(painter)
 
         # Draw label (check canvas visibility settings)
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))
@@ -368,10 +352,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             painter.drawEllipse(terminal, 3, 3)
 
     def itemChange(self, change, value):
-        if (
-            change == QGraphicsItem.GraphicsItemChange.ItemPositionChange
-            and self.scene()
-        ):
+        if change == QGraphicsItem.GraphicsItemChange.ItemPositionChange and self.scene():
             # Snap to grid
             new_pos = value
             grid_x = round(new_pos.x() / GRID_SIZE) * GRID_SIZE
@@ -434,9 +415,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         if self._position_update_timer is None:
             self._position_update_timer = QTimer()
             self._position_update_timer.setSingleShot(True)
-            self._position_update_timer.timeout.connect(
-                self._notify_controller_position
-            )
+            self._position_update_timer.timeout.connect(self._notify_controller_position)
         self._position_update_timer.start(50)  # 50ms debounce
 
     def _notify_controller_position(self):
@@ -646,9 +625,7 @@ class WaveformVoltageSource(ComponentGraphicsItem):
         # Draw sine wave symbol
         from models.component import COMPONENT_COLORS
 
-        painter.setPen(
-            QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2)
-        )
+        painter.setPen(QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2))
         from PyQt6.QtGui import QPainterPath
 
         path = QPainterPath()
@@ -688,19 +665,9 @@ class Ground(ComponentGraphicsItem):
         painter.setBrush(QBrush(color.lighter(150)))
         self.draw_component_body(painter)
 
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -53,9 +53,7 @@ class MenuBarMixin:
 
         export_netlist_action = QAction("Export &Netlist...", self)
         export_netlist_action.setShortcut(kb.get("file.export_netlist"))
-        export_netlist_action.setToolTip(
-            "Export the generated SPICE netlist to a .cir file"
-        )
+        export_netlist_action.setToolTip("Export the generated SPICE netlist to a .cir file")
         export_netlist_action.triggered.connect(self.export_netlist)
         file_menu.addAction(export_netlist_action)
 
@@ -70,9 +68,7 @@ class MenuBarMixin:
         file_menu.addAction(export_pdf_action)
 
         export_latex_action = QAction("Export as &LaTeX...", self)
-        export_latex_action.setToolTip(
-            "Export circuit as CircuiTikZ LaTeX code (.tex file)"
-        )
+        export_latex_action.setToolTip("Export circuit as CircuiTikZ LaTeX code (.tex file)")
         export_latex_action.triggered.connect(self.export_circuitikz)
         file_menu.addAction(export_latex_action)
 
@@ -145,9 +141,7 @@ class MenuBarMixin:
         edit_menu.addSeparator()
 
         copy_latex_action = QAction("Copy as La&TeX", self)
-        copy_latex_action.setToolTip(
-            "Copy the CircuiTikZ environment block to the clipboard"
-        )
+        copy_latex_action.setToolTip("Copy the CircuiTikZ environment block to the clipboard")
         copy_latex_action.triggered.connect(self.copy_circuitikz)
         edit_menu.addAction(copy_latex_action)
 
@@ -214,9 +208,7 @@ class MenuBarMixin:
         self.probe_action = QAction("&Probe Tool", self)
         self.probe_action.setCheckable(True)
         self.probe_action.setShortcut(kb.get("tools.probe"))
-        self.probe_action.setToolTip(
-            "Click nodes or components to see voltage/current values"
-        )
+        self.probe_action.setToolTip("Click nodes or components to see voltage/current values")
         self.probe_action.triggered.connect(self._toggle_probe_mode)
         view_menu.addAction(self.probe_action)
 
@@ -274,9 +266,7 @@ class MenuBarMixin:
 
         self.monochrome_mode_action = QAction("&Monochrome", self)
         self.monochrome_mode_action.setCheckable(True)
-        self.monochrome_mode_action.triggered.connect(
-            lambda: self._set_color_mode("monochrome")
-        )
+        self.monochrome_mode_action.triggered.connect(lambda: self._set_color_mode("monochrome"))
         color_mode_menu.addAction(self.monochrome_mode_action)
 
         self.color_mode_group = QActionGroup(self)
@@ -371,9 +361,7 @@ class MenuBarMixin:
 
         mc_action = QAction("&Monte Carlo...", self)
         mc_action.setCheckable(True)
-        mc_action.setToolTip(
-            "Run Monte Carlo tolerance analysis with randomized component values"
-        )
+        mc_action.setToolTip("Run Monte Carlo tolerance analysis with randomized component values")
         mc_action.triggered.connect(self.set_analysis_monte_carlo)
         analysis_menu.addAction(mc_action)
 

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -127,11 +127,7 @@ class SettingsMixin:
         if reply == QMessageBox.StandardButton.Yes:
             source = self.file_ctrl.load_auto_save()
             if source is not None:
-                title = (
-                    f"Circuit Design GUI - {source}"
-                    if source
-                    else "Circuit Design GUI - (Recovered)"
-                )
+                title = f"Circuit Design GUI - {source}" if source else "Circuit Design GUI - (Recovered)"
                 self.setWindowTitle(title)
                 self._sync_analysis_menu()
                 statusBar = self.statusBar()

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -143,9 +143,7 @@ class ViewOperationsMixin:
         self.canvas.set_probe_mode(checked)
         if checked:
             if not self.canvas.node_voltages and self._last_results is None:
-                self.statusBar().showMessage(
-                    "Probe mode active. Run a simulation first to see values.", 3000
-                )
+                self.statusBar().showMessage("Probe mode active. Run a simulation first to see values.", 3000)
             else:
                 self.statusBar().showMessage(
                     "Probe mode active. Click nodes or components to see values. Press Escape to exit.",
@@ -158,9 +156,7 @@ class ViewOperationsMixin:
     def _on_probe_requested(self, signal_name, probe_type):
         """Handle probe click for sweep/transient analyses (no OP data on canvas)."""
         if self._last_results is None:
-            self.statusBar().showMessage(
-                "No simulation results available. Run a simulation first.", 3000
-            )
+            self.statusBar().showMessage("No simulation results available. Run a simulation first.", 3000)
             return
 
         analysis_type = self._last_results_type
@@ -171,9 +167,7 @@ class ViewOperationsMixin:
         elif analysis_type == "AC Sweep":
             self._probe_open_ac_sweep(signal_name, probe_type)
         else:
-            self.statusBar().showMessage(
-                f"Probe not supported for {analysis_type} analysis.", 3000
-            )
+            self.statusBar().showMessage(f"Probe not supported for {analysis_type} analysis.", 3000)
 
     def _probe_open_waveform(self, signal_name, probe_type):
         """Open waveform dialog focused on the probed signal."""
@@ -232,14 +226,10 @@ class ViewOperationsMixin:
         circuit_items = [
             item
             for item in scene.items()
-            if isinstance(
-                item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem)
-            )
+            if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
         ]
         if not circuit_items:
-            QMessageBox.information(
-                self, "Export Image", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export Image", "Nothing to export — the canvas is empty.")
             return
 
         source_rect = circuit_items[0].sceneBoundingRect()
@@ -256,9 +246,7 @@ class ViewOperationsMixin:
 
             generator = QSvgGenerator()
             generator.setFileName(filename)
-            generator.setSize(
-                QSize(int(source_rect.width()), int(source_rect.height()))
-            )
+            generator.setSize(QSize(int(source_rect.width()), int(source_rect.height())))
             generator.setViewBox(source_rect)
             generator.setTitle("SDM Spice Circuit")
 
@@ -285,9 +273,7 @@ class ViewOperationsMixin:
             painter.end()
             image.save(filename)
 
-        QMessageBox.information(
-            self, "Export Image", f"Circuit exported to:\n{filename}"
-        )
+        QMessageBox.information(self, "Export Image", f"Circuit exported to:\n{filename}")
 
     def export_circuitikz(self):
         """Export the circuit as a CircuiTikZ LaTeX file."""
@@ -299,9 +285,7 @@ class ViewOperationsMixin:
 
         model = self.circuit_ctrl.model
         if not model.components:
-            QMessageBox.information(
-                self, "Export LaTeX", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export LaTeX", "Nothing to export — the canvas is empty.")
             return
 
         # Show options dialog
@@ -319,11 +303,7 @@ class ViewOperationsMixin:
                 nodes=model.nodes,
                 terminal_to_node=model.terminal_to_node,
                 standalone=opts["standalone"],
-                circuit_name=(
-                    os.path.basename(self.file_ctrl.current_file)
-                    if self.file_ctrl.current_file
-                    else ""
-                ),
+                circuit_name=(os.path.basename(self.file_ctrl.current_file) if self.file_ctrl.current_file else ""),
                 scale=opts["scale"],
                 include_ids=opts["include_ids"],
                 include_values=opts["include_values"],
@@ -336,9 +316,7 @@ class ViewOperationsMixin:
 
         default_name = ""
         if hasattr(self, "file_ctrl") and self.file_ctrl.current_file:
-            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[
-                0
-            ]
+            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[0]
             default_name = base + ".tex"
 
         filename, _ = QFileDialog.getSaveFileName(

--- a/app/tests/unit/test_annotation_item_and_sweep_plot.py
+++ b/app/tests/unit/test_annotation_item_and_sweep_plot.py
@@ -1,0 +1,213 @@
+"""Unit tests for AnnotationItem and ParameterSweepPlotDialog.
+
+Tests app/GUI/annotation_item.py (serialization, flags, styling) and
+app/GUI/parameter_sweep_plot_dialog.py (plot routing per analysis type).
+"""
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+QtWidgets = pytest.importorskip("PyQt6.QtWidgets")
+
+from GUI.annotation_item import AnnotationItem
+from GUI.parameter_sweep_plot_dialog import ParameterSweepPlotDialog
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import QGraphicsItem
+
+# ---------------------------------------------------------------------------
+# AnnotationItem
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotationItemCreation:
+    def test_default_creation(self, qtbot):
+        item = AnnotationItem()
+        assert item.toPlainText() == "Annotation"
+
+    def test_custom_text(self, qtbot):
+        item = AnnotationItem(text="Hello World")
+        assert item.toPlainText() == "Hello World"
+
+    def test_position(self, qtbot):
+        item = AnnotationItem(x=100.0, y=200.0)
+        assert item.pos().x() == pytest.approx(100.0)
+        assert item.pos().y() == pytest.approx(200.0)
+
+    def test_font_size(self, qtbot):
+        item = AnnotationItem(font_size=14)
+        assert item.font().pointSize() == 14
+
+    def test_bold(self, qtbot):
+        item = AnnotationItem(bold=True)
+        assert item.font().bold() is True
+
+    def test_not_bold_by_default(self, qtbot):
+        item = AnnotationItem()
+        assert item.font().bold() is False
+
+    def test_color(self, qtbot):
+        item = AnnotationItem(color="#FF0000")
+        assert item.defaultTextColor() == QColor("#FF0000")
+
+    def test_z_value(self, qtbot):
+        item = AnnotationItem()
+        assert item.zValue() == 90
+
+
+class TestAnnotationItemFlags:
+    def test_is_movable(self, qtbot):
+        item = AnnotationItem()
+        assert item.flags() & QGraphicsItem.GraphicsItemFlag.ItemIsMovable
+
+    def test_is_selectable(self, qtbot):
+        item = AnnotationItem()
+        assert item.flags() & QGraphicsItem.GraphicsItemFlag.ItemIsSelectable
+
+    def test_sends_geometry_changes(self, qtbot):
+        item = AnnotationItem()
+        assert item.flags() & QGraphicsItem.GraphicsItemFlag.ItemSendsGeometryChanges
+
+
+class TestAnnotationItemSerialization:
+    def test_to_dict_keys(self, qtbot):
+        item = AnnotationItem(text="Test", x=10, y=20, font_size=12, bold=True, color="#00FF00")
+        d = item.to_dict()
+        assert set(d.keys()) == {"text", "x", "y", "font_size", "bold", "color"}
+
+    def test_to_dict_values(self, qtbot):
+        item = AnnotationItem(text="Test", x=10.0, y=20.0, font_size=12, bold=True, color="#00FF00")
+        d = item.to_dict()
+        assert d["text"] == "Test"
+        assert d["x"] == pytest.approx(10.0)
+        assert d["y"] == pytest.approx(20.0)
+        assert d["font_size"] == 12
+        assert d["bold"] is True
+        assert d["color"] == "#00FF00"
+
+    def test_from_dict_roundtrip(self, qtbot):
+        original = AnnotationItem(text="Round Trip", x=55.5, y=66.6, font_size=16, bold=True, color="#AABBCC")
+        d = original.to_dict()
+        restored = AnnotationItem.from_dict(d)
+
+        assert restored.toPlainText() == "Round Trip"
+        assert restored.pos().x() == pytest.approx(55.5)
+        assert restored.pos().y() == pytest.approx(66.6)
+        assert restored.font().pointSize() == 16
+        assert restored.font().bold() is True
+        assert restored._color_hex == "#AABBCC"
+
+    def test_from_dict_defaults(self, qtbot):
+        restored = AnnotationItem.from_dict({})
+        assert restored.toPlainText() == "Annotation"
+        assert restored.pos().x() == pytest.approx(0.0)
+        assert restored.font().pointSize() == 10
+        assert restored.font().bold() is False
+
+
+# ---------------------------------------------------------------------------
+# ParameterSweepPlotDialog — helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeResult:
+    success: bool = True
+    data: Any = None
+
+
+def _sweep_data(base_type, results, **kwargs):
+    return {
+        "component_id": "R1",
+        "base_analysis_type": base_type,
+        "sweep_values": [1000, 2000, 3000],
+        "sweep_labels": ["1k", "2k", "3k"],
+        "results": results,
+        **kwargs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# ParameterSweepPlotDialog
+# ---------------------------------------------------------------------------
+
+
+class TestParameterSweepPlotDialog:
+    def test_dc_op_sweep(self, qtbot):
+        results = [FakeResult(success=True, data={"out": 4.9 + i * 0.1}) for i in range(3)]
+        dlg = ParameterSweepPlotDialog(_sweep_data("DC Operating Point", results))
+        qtbot.addWidget(dlg)
+        assert "R1" in dlg.windowTitle()
+        assert "DC Operating Point" in dlg.windowTitle()
+
+    def test_transient_sweep(self, qtbot):
+        results = [
+            FakeResult(
+                success=True,
+                data=[
+                    {"time": 0.0, "out": 0.0},
+                    {"time": 0.5e-3, "out": 2.5 + i * 0.1},
+                    {"time": 1e-3, "out": 5.0},
+                ],
+            )
+            for i in range(3)
+        ]
+        dlg = ParameterSweepPlotDialog(_sweep_data("Transient", results))
+        qtbot.addWidget(dlg)
+        assert "Transient" in dlg.windowTitle()
+
+    def test_ac_sweep(self, qtbot):
+        results = [
+            FakeResult(
+                success=True,
+                data={
+                    "frequencies": [100, 1000, 10000],
+                    "magnitude": {"out": [1.0, 0.7, 0.3]},
+                    "phase": {"out": [-10, -45, -80]},
+                },
+            )
+            for _ in range(3)
+        ]
+        dlg = ParameterSweepPlotDialog(_sweep_data("AC Sweep", results))
+        qtbot.addWidget(dlg)
+        assert "AC Sweep" in dlg.windowTitle()
+
+    def test_dc_sweep(self, qtbot):
+        results = [
+            FakeResult(
+                success=True,
+                data={
+                    "headers": ["idx", "v-sweep", "V(out)"],
+                    "data": [[0, 0.0, 0.0], [1, 5.0, 2.5], [2, 10.0, 5.0]],
+                },
+            )
+            for _ in range(3)
+        ]
+        dlg = ParameterSweepPlotDialog(_sweep_data("DC Sweep", results))
+        qtbot.addWidget(dlg)
+        assert "DC Sweep" in dlg.windowTitle()
+
+    def test_unknown_base_type_fallback(self, qtbot):
+        results = [FakeResult(success=True, data={})]
+        dlg = ParameterSweepPlotDialog(_sweep_data("Unknown Analysis", results))
+        qtbot.addWidget(dlg)
+        assert "Unknown Analysis" in dlg.windowTitle()
+
+    def test_canvas_widget_exists(self, qtbot):
+        results = [FakeResult(success=True, data={"out": 5.0})]
+        dlg = ParameterSweepPlotDialog(_sweep_data("DC Operating Point", results))
+        qtbot.addWidget(dlg)
+        assert dlg._canvas is not None
+
+    def test_close_event_cleans_up(self, qtbot):
+        import matplotlib.pyplot as plt
+
+        results = [FakeResult(success=True, data={"out": 5.0})]
+        dlg = ParameterSweepPlotDialog(_sweep_data("DC Operating Point", results))
+        qtbot.addWidget(dlg)
+
+        with patch.object(plt, "close") as mock_close:
+            dlg.close()
+            mock_close.assert_called_once()

--- a/app/tests/unit/test_symbol_style.py
+++ b/app/tests/unit/test_symbol_style.py
@@ -191,9 +191,7 @@ class TestIEEEDrawDispatch:
         called = []
         comp._draw_ieee = lambda painter: called.append(True)
         comp.draw_component_body(None)
-        assert (
-            called
-        ), f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
+        assert called, f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
 
 
 class TestObstacleShapeDispatch:


### PR DESCRIPTION
## Summary
- Adds 22 unit tests covering `AnnotationItem` (creation, flags, serialization round-trip) and `ParameterSweepPlotDialog` (plot routing for all 4 analysis types plus unknown fallback)
- Tests use qtbot fixture and fake simulation results

## Test plan
- [x] `python -m pytest app/tests/unit/test_annotation_item_and_sweep_plot.py -v` — 22/22 pass
- [x] `make format && make lint` — clean

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)