### PR TITLE
Add integration tests for MVC observer pattern

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -140,9 +140,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             new_pos = component.position
             # Only create a command if the component actually moved
             if old_pos[0] != new_pos[0] or old_pos[1] != new_pos[1]:
-                cmd = MoveComponentCommand(
-                    controller, comp_id, new_pos, old_position=old_pos
-                )
+                cmd = MoveComponentCommand(controller, comp_id, new_pos, old_position=old_pos)
                 move_commands.append(cmd)
 
         self._drag_start_positions = {}
@@ -155,9 +153,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             controller.undo_manager._undo_stack.append(move_commands[0])
             controller.undo_manager._redo_stack.clear()
         else:
-            compound = CompoundCommand(
-                move_commands, f"Move {len(move_commands)} components"
-            )
+            compound = CompoundCommand(move_commands, f"Move {len(move_commands)} components")
             controller.undo_manager._undo_stack.append(compound)
             controller.undo_manager._redo_stack.clear()
 
@@ -209,9 +205,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         )
 
         if ok and new_value:
-            is_valid, error_msg = validate_component_value(
-                new_value, self.component_type
-            )
+            is_valid, error_msg = validate_component_value(new_value, self.component_type)
             if not is_valid:
                 QMessageBox.warning(None, "Invalid Value", error_msg)
                 return
@@ -336,19 +330,9 @@ class ComponentGraphicsItem(QGraphicsItem):
         self.draw_component_body(painter)
 
         # Draw label (check canvas visibility settings)
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))
@@ -368,10 +352,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             painter.drawEllipse(terminal, 3, 3)
 
     def itemChange(self, change, value):
-        if (
-            change == QGraphicsItem.GraphicsItemChange.ItemPositionChange
-            and self.scene()
-        ):
+        if change == QGraphicsItem.GraphicsItemChange.ItemPositionChange and self.scene():
             # Snap to grid
             new_pos = value
             grid_x = round(new_pos.x() / GRID_SIZE) * GRID_SIZE
@@ -434,9 +415,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         if self._position_update_timer is None:
             self._position_update_timer = QTimer()
             self._position_update_timer.setSingleShot(True)
-            self._position_update_timer.timeout.connect(
-                self._notify_controller_position
-            )
+            self._position_update_timer.timeout.connect(self._notify_controller_position)
         self._position_update_timer.start(50)  # 50ms debounce
 
     def _notify_controller_position(self):
@@ -646,9 +625,7 @@ class WaveformVoltageSource(ComponentGraphicsItem):
         # Draw sine wave symbol
         from models.component import COMPONENT_COLORS
 
-        painter.setPen(
-            QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2)
-        )
+        painter.setPen(QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2))
         from PyQt6.QtGui import QPainterPath
 
         path = QPainterPath()
@@ -688,19 +665,9 @@ class Ground(ComponentGraphicsItem):
         painter.setBrush(QBrush(color.lighter(150)))
         self.draw_component_body(painter)
 
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -53,9 +53,7 @@ class MenuBarMixin:
 
         export_netlist_action = QAction("Export &Netlist...", self)
         export_netlist_action.setShortcut(kb.get("file.export_netlist"))
-        export_netlist_action.setToolTip(
-            "Export the generated SPICE netlist to a .cir file"
-        )
+        export_netlist_action.setToolTip("Export the generated SPICE netlist to a .cir file")
         export_netlist_action.triggered.connect(self.export_netlist)
         file_menu.addAction(export_netlist_action)
 
@@ -70,9 +68,7 @@ class MenuBarMixin:
         file_menu.addAction(export_pdf_action)
 
         export_latex_action = QAction("Export as &LaTeX...", self)
-        export_latex_action.setToolTip(
-            "Export circuit as CircuiTikZ LaTeX code (.tex file)"
-        )
+        export_latex_action.setToolTip("Export circuit as CircuiTikZ LaTeX code (.tex file)")
         export_latex_action.triggered.connect(self.export_circuitikz)
         file_menu.addAction(export_latex_action)
 
@@ -145,9 +141,7 @@ class MenuBarMixin:
         edit_menu.addSeparator()
 
         copy_latex_action = QAction("Copy as La&TeX", self)
-        copy_latex_action.setToolTip(
-            "Copy the CircuiTikZ environment block to the clipboard"
-        )
+        copy_latex_action.setToolTip("Copy the CircuiTikZ environment block to the clipboard")
         copy_latex_action.triggered.connect(self.copy_circuitikz)
         edit_menu.addAction(copy_latex_action)
 
@@ -214,9 +208,7 @@ class MenuBarMixin:
         self.probe_action = QAction("&Probe Tool", self)
         self.probe_action.setCheckable(True)
         self.probe_action.setShortcut(kb.get("tools.probe"))
-        self.probe_action.setToolTip(
-            "Click nodes or components to see voltage/current values"
-        )
+        self.probe_action.setToolTip("Click nodes or components to see voltage/current values")
         self.probe_action.triggered.connect(self._toggle_probe_mode)
         view_menu.addAction(self.probe_action)
 
@@ -274,9 +266,7 @@ class MenuBarMixin:
 
         self.monochrome_mode_action = QAction("&Monochrome", self)
         self.monochrome_mode_action.setCheckable(True)
-        self.monochrome_mode_action.triggered.connect(
-            lambda: self._set_color_mode("monochrome")
-        )
+        self.monochrome_mode_action.triggered.connect(lambda: self._set_color_mode("monochrome"))
         color_mode_menu.addAction(self.monochrome_mode_action)
 
         self.color_mode_group = QActionGroup(self)
@@ -371,9 +361,7 @@ class MenuBarMixin:
 
         mc_action = QAction("&Monte Carlo...", self)
         mc_action.setCheckable(True)
-        mc_action.setToolTip(
-            "Run Monte Carlo tolerance analysis with randomized component values"
-        )
+        mc_action.setToolTip("Run Monte Carlo tolerance analysis with randomized component values")
         mc_action.triggered.connect(self.set_analysis_monte_carlo)
         analysis_menu.addAction(mc_action)
 

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -127,11 +127,7 @@ class SettingsMixin:
         if reply == QMessageBox.StandardButton.Yes:
             source = self.file_ctrl.load_auto_save()
             if source is not None:
-                title = (
-                    f"Circuit Design GUI - {source}"
-                    if source
-                    else "Circuit Design GUI - (Recovered)"
-                )
+                title = f"Circuit Design GUI - {source}" if source else "Circuit Design GUI - (Recovered)"
                 self.setWindowTitle(title)
                 self._sync_analysis_menu()
                 statusBar = self.statusBar()

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -143,9 +143,7 @@ class ViewOperationsMixin:
         self.canvas.set_probe_mode(checked)
         if checked:
             if not self.canvas.node_voltages and self._last_results is None:
-                self.statusBar().showMessage(
-                    "Probe mode active. Run a simulation first to see values.", 3000
-                )
+                self.statusBar().showMessage("Probe mode active. Run a simulation first to see values.", 3000)
             else:
                 self.statusBar().showMessage(
                     "Probe mode active. Click nodes or components to see values. Press Escape to exit.",
@@ -158,9 +156,7 @@ class ViewOperationsMixin:
     def _on_probe_requested(self, signal_name, probe_type):
         """Handle probe click for sweep/transient analyses (no OP data on canvas)."""
         if self._last_results is None:
-            self.statusBar().showMessage(
-                "No simulation results available. Run a simulation first.", 3000
-            )
+            self.statusBar().showMessage("No simulation results available. Run a simulation first.", 3000)
             return
 
         analysis_type = self._last_results_type
@@ -171,9 +167,7 @@ class ViewOperationsMixin:
         elif analysis_type == "AC Sweep":
             self._probe_open_ac_sweep(signal_name, probe_type)
         else:
-            self.statusBar().showMessage(
-                f"Probe not supported for {analysis_type} analysis.", 3000
-            )
+            self.statusBar().showMessage(f"Probe not supported for {analysis_type} analysis.", 3000)
 
     def _probe_open_waveform(self, signal_name, probe_type):
         """Open waveform dialog focused on the probed signal."""
@@ -232,14 +226,10 @@ class ViewOperationsMixin:
         circuit_items = [
             item
             for item in scene.items()
-            if isinstance(
-                item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem)
-            )
+            if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
         ]
         if not circuit_items:
-            QMessageBox.information(
-                self, "Export Image", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export Image", "Nothing to export — the canvas is empty.")
             return
 
         source_rect = circuit_items[0].sceneBoundingRect()
@@ -256,9 +246,7 @@ class ViewOperationsMixin:
 
             generator = QSvgGenerator()
             generator.setFileName(filename)
-            generator.setSize(
-                QSize(int(source_rect.width()), int(source_rect.height()))
-            )
+            generator.setSize(QSize(int(source_rect.width()), int(source_rect.height())))
             generator.setViewBox(source_rect)
             generator.setTitle("SDM Spice Circuit")
 
@@ -285,9 +273,7 @@ class ViewOperationsMixin:
             painter.end()
             image.save(filename)
 
-        QMessageBox.information(
-            self, "Export Image", f"Circuit exported to:\n{filename}"
-        )
+        QMessageBox.information(self, "Export Image", f"Circuit exported to:\n{filename}")
 
     def export_circuitikz(self):
         """Export the circuit as a CircuiTikZ LaTeX file."""
@@ -299,9 +285,7 @@ class ViewOperationsMixin:
 
         model = self.circuit_ctrl.model
         if not model.components:
-            QMessageBox.information(
-                self, "Export LaTeX", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export LaTeX", "Nothing to export — the canvas is empty.")
             return
 
         # Show options dialog
@@ -319,11 +303,7 @@ class ViewOperationsMixin:
                 nodes=model.nodes,
                 terminal_to_node=model.terminal_to_node,
                 standalone=opts["standalone"],
-                circuit_name=(
-                    os.path.basename(self.file_ctrl.current_file)
-                    if self.file_ctrl.current_file
-                    else ""
-                ),
+                circuit_name=(os.path.basename(self.file_ctrl.current_file) if self.file_ctrl.current_file else ""),
                 scale=opts["scale"],
                 include_ids=opts["include_ids"],
                 include_values=opts["include_values"],
@@ -336,9 +316,7 @@ class ViewOperationsMixin:
 
         default_name = ""
         if hasattr(self, "file_ctrl") and self.file_ctrl.current_file:
-            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[
-                0
-            ]
+            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[0]
             default_name = base + ".tex"
 
         filename, _ = QFileDialog.getSaveFileName(

--- a/app/tests/integration/test_mvc_observer_integration.py
+++ b/app/tests/integration/test_mvc_observer_integration.py
@@ -1,0 +1,422 @@
+"""Integration tests for MVC observer pattern and controller interactions.
+
+Covers:
+- Observer propagation (events fired for each mutation)
+- Cross-controller coordination (shared model reference)
+- Undo/redo across mixed operations
+- File round-trip with full controller state
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from controllers.circuit_controller import CircuitController
+from controllers.commands import (
+    AddComponentCommand,
+    AddWireCommand,
+    ChangeValueCommand,
+    CompoundCommand,
+    DeleteComponentCommand,
+    MoveComponentCommand,
+)
+from controllers.file_controller import FileController
+from controllers.simulation_controller import SimulationController
+from models.annotation import AnnotationData
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from models.wire import WireData
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class EventLog:
+    """Simple observer that records (event, data) tuples."""
+
+    def __init__(self):
+        self.events = []
+
+    def __call__(self, event, data):
+        self.events.append((event, data))
+
+    def count(self, event_name):
+        return sum(1 for e, _ in self.events if e == event_name)
+
+    def last(self):
+        return self.events[-1] if self.events else None
+
+    def clear(self):
+        self.events.clear()
+
+
+# ---------------------------------------------------------------------------
+# Observer propagation
+# ---------------------------------------------------------------------------
+
+
+class TestObserverPropagation:
+    def test_add_component_fires_event(self):
+        ctrl = CircuitController()
+        log = EventLog()
+        ctrl.add_observer(log)
+        ctrl.add_component("Resistor", (0, 0))
+        assert log.count("component_added") == 1
+
+    def test_remove_component_fires_event(self):
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Resistor", (0, 0))
+        log = EventLog()
+        ctrl.add_observer(log)
+        ctrl.remove_component(comp.component_id)
+        assert log.count("component_removed") == 1
+
+    def test_remove_component_fires_wire_removed_for_connected_wires(self):
+        ctrl = CircuitController()
+        c1 = ctrl.add_component("Resistor", (0, 0))
+        c2 = ctrl.add_component("Resistor", (100, 0))
+        ctrl.add_wire(c1.component_id, 0, c2.component_id, 0)
+
+        log = EventLog()
+        ctrl.add_observer(log)
+        ctrl.remove_component(c1.component_id)
+        assert log.count("wire_removed") == 1
+        assert log.count("component_removed") == 1
+
+    def test_move_component_fires_event(self):
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Resistor", (0, 0))
+        log = EventLog()
+        ctrl.add_observer(log)
+        ctrl.move_component(comp.component_id, (50, 50))
+        assert log.count("component_moved") == 1
+
+    def test_rotate_component_fires_event(self):
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Resistor", (0, 0))
+        log = EventLog()
+        ctrl.add_observer(log)
+        ctrl.rotate_component(comp.component_id)
+        assert log.count("component_rotated") == 1
+
+    def test_flip_component_fires_event(self):
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Resistor", (0, 0))
+        log = EventLog()
+        ctrl.add_observer(log)
+        ctrl.flip_component(comp.component_id, horizontal=True)
+        assert log.count("component_flipped") == 1
+
+    def test_value_change_fires_event(self):
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Resistor", (0, 0))
+        log = EventLog()
+        ctrl.add_observer(log)
+        ctrl.update_component_value(comp.component_id, "2k")
+        assert log.count("component_value_changed") == 1
+
+    def test_add_wire_fires_event(self):
+        ctrl = CircuitController()
+        c1 = ctrl.add_component("Resistor", (0, 0))
+        c2 = ctrl.add_component("Resistor", (100, 0))
+        log = EventLog()
+        ctrl.add_observer(log)
+        ctrl.add_wire(c1.component_id, 0, c2.component_id, 0)
+        assert log.count("wire_added") == 1
+
+    def test_clear_circuit_fires_event(self):
+        ctrl = CircuitController()
+        ctrl.add_component("Resistor", (0, 0))
+        log = EventLog()
+        ctrl.add_observer(log)
+        ctrl.clear_circuit()
+        assert log.count("circuit_cleared") == 1
+
+    def test_multiple_observers_all_receive_events(self):
+        ctrl = CircuitController()
+        log1 = EventLog()
+        log2 = EventLog()
+        ctrl.add_observer(log1)
+        ctrl.add_observer(log2)
+        ctrl.add_component("Resistor", (0, 0))
+        assert log1.count("component_added") == 1
+        assert log2.count("component_added") == 1
+
+    def test_remove_observer_stops_notifications(self):
+        ctrl = CircuitController()
+        log = EventLog()
+        ctrl.add_observer(log)
+        ctrl.add_component("Resistor", (0, 0))
+        assert log.count("component_added") == 1
+
+        ctrl.remove_observer(log)
+        ctrl.add_component("Resistor", (100, 0))
+        assert log.count("component_added") == 1  # still 1, not 2
+
+
+# ---------------------------------------------------------------------------
+# Cross-controller coordination
+# ---------------------------------------------------------------------------
+
+
+class TestCrossControllerCoordination:
+    def test_all_controllers_share_model(self):
+        model = CircuitModel()
+        cc = CircuitController(model)
+        sc = SimulationController(model)
+        fc = FileController(model)
+        assert cc.model is model
+        assert sc.model is model
+        assert fc.model is model
+
+    def test_circuit_changes_visible_to_simulation(self):
+        model = CircuitModel()
+        cc = CircuitController(model)
+        sc = SimulationController(model)
+        comp = cc.add_component("Resistor", (0, 0))
+        assert comp.component_id in sc.model.components
+
+    def test_file_load_updates_model_for_circuit_controller(self, tmp_path):
+        model = CircuitModel()
+        cc = CircuitController(model)
+        fc = FileController(model, circuit_ctrl=cc)
+
+        # Build and save a circuit
+        cc.add_component("Resistor", (0, 0))
+        filepath = tmp_path / "test.json"
+        fc.save_circuit(filepath)
+
+        # Create fresh controllers sharing a new model
+        model2 = CircuitModel()
+        cc2 = CircuitController(model2)
+        fc2 = FileController(model2, circuit_ctrl=cc2)
+
+        log = EventLog()
+        cc2.add_observer(log)
+
+        fc2.load_circuit(filepath)
+        assert len(model2.components) == 1
+        assert log.count("model_loaded") == 1
+
+    def test_clear_circuit_resets_for_all(self):
+        model = CircuitModel()
+        cc = CircuitController(model)
+        sc = SimulationController(model)
+        fc = FileController(model)
+
+        cc.add_component("Resistor", (0, 0))
+        assert len(model.components) == 1
+
+        cc.clear_circuit()
+        assert len(model.components) == 0
+        assert len(sc.model.components) == 0
+        assert len(fc.model.components) == 0
+
+
+# ---------------------------------------------------------------------------
+# Undo/redo across operations
+# ---------------------------------------------------------------------------
+
+
+class TestUndoRedoIntegration:
+    def test_mixed_operations_undo_in_correct_order(self):
+        ctrl = CircuitController()
+
+        # Add component via command
+        add_cmd = AddComponentCommand(ctrl, "Resistor", (0, 0))
+        ctrl.execute_command(add_cmd)
+        comp_id = add_cmd.component_id
+        assert comp_id in ctrl.model.components
+
+        # Move via command
+        move_cmd = MoveComponentCommand(ctrl, comp_id, (100, 100))
+        ctrl.execute_command(move_cmd)
+        assert ctrl.model.components[comp_id].position == (100, 100)
+
+        # Change value via command
+        val_cmd = ChangeValueCommand(ctrl, comp_id, "2k")
+        ctrl.execute_command(val_cmd)
+        assert ctrl.model.components[comp_id].value == "2k"
+
+        # Undo value change
+        ctrl.undo()
+        assert ctrl.model.components[comp_id].value == "1k"
+
+        # Undo move
+        ctrl.undo()
+        assert ctrl.model.components[comp_id].position == (0, 0)
+
+        # Undo add
+        ctrl.undo()
+        assert comp_id not in ctrl.model.components
+
+    def test_redo_stack_cleared_on_new_command(self):
+        ctrl = CircuitController()
+        add_cmd = AddComponentCommand(ctrl, "Resistor", (0, 0))
+        ctrl.execute_command(add_cmd)
+        ctrl.undo()
+        assert ctrl.can_redo()
+
+        # New command clears redo
+        add_cmd2 = AddComponentCommand(ctrl, "Capacitor", (100, 0))
+        ctrl.execute_command(add_cmd2)
+        assert not ctrl.can_redo()
+
+    def test_undo_depth_limit(self):
+        ctrl = CircuitController(max_undo_depth=5)
+        for i in range(10):
+            cmd = AddComponentCommand(ctrl, "Resistor", (i * 10, 0))
+            ctrl.execute_command(cmd)
+
+        assert ctrl.undo_manager.get_undo_count() == 5
+
+    def test_compound_command_undoes_atomically(self):
+        ctrl = CircuitController()
+
+        # Create compound: add two components
+        cmd1 = AddComponentCommand(ctrl, "Resistor", (0, 0))
+        cmd2 = AddComponentCommand(ctrl, "Capacitor", (100, 0))
+        compound = CompoundCommand([cmd1, cmd2], "Add pair")
+        ctrl.execute_command(compound)
+
+        assert len(ctrl.model.components) == 2
+
+        # Single undo removes both
+        ctrl.undo()
+        assert len(ctrl.model.components) == 0
+
+    def test_add_wire_undo(self):
+        ctrl = CircuitController()
+        c1 = ctrl.add_component("Resistor", (0, 0))
+        c2 = ctrl.add_component("Resistor", (100, 0))
+
+        wire_cmd = AddWireCommand(ctrl, c1.component_id, 0, c2.component_id, 0)
+        ctrl.execute_command(wire_cmd)
+        assert len(ctrl.model.wires) == 1
+
+        ctrl.undo()
+        assert len(ctrl.model.wires) == 0
+
+    def test_delete_component_undo_restores_wires(self):
+        ctrl = CircuitController()
+        c1 = ctrl.add_component("Resistor", (0, 0))
+        c2 = ctrl.add_component("Resistor", (100, 0))
+        ctrl.add_wire(c1.component_id, 0, c2.component_id, 0)
+
+        del_cmd = DeleteComponentCommand(ctrl, c1.component_id)
+        ctrl.execute_command(del_cmd)
+        assert c1.component_id not in ctrl.model.components
+        assert len(ctrl.model.wires) == 0
+
+        ctrl.undo()
+        assert c1.component_id in ctrl.model.components
+        assert len(ctrl.model.wires) == 1
+
+
+# ---------------------------------------------------------------------------
+# File round-trip with controller state
+# ---------------------------------------------------------------------------
+
+
+class TestFileRoundTrip:
+    def test_save_load_preserves_components_and_wires(self, tmp_path):
+        model = CircuitModel()
+        cc = CircuitController(model)
+        fc = FileController(model)
+
+        c1 = cc.add_component("Voltage Source", (0, 0))
+        c2 = cc.add_component("Resistor", (100, 0))
+        gnd = cc.add_component("Ground", (100, 100))
+        cc.add_wire(c1.component_id, 0, c2.component_id, 0)
+        cc.add_wire(c2.component_id, 1, gnd.component_id, 0)
+        cc.add_wire(c1.component_id, 1, gnd.component_id, 0)
+
+        filepath = tmp_path / "circuit.json"
+        fc.save_circuit(filepath)
+
+        model2 = CircuitModel()
+        fc2 = FileController(model2)
+        fc2.load_circuit(filepath)
+
+        assert len(model2.components) == 3
+        assert len(model2.wires) == 3
+        assert c1.component_id in model2.components
+        assert c2.component_id in model2.components
+        assert gnd.component_id in model2.components
+
+    def test_analysis_settings_survive_save_load(self, tmp_path):
+        model = CircuitModel()
+        sc = SimulationController(model)
+        fc = FileController(model)
+
+        sc.set_analysis("Transient", {"duration": "1ms", "step": "1us"})
+        filepath = tmp_path / "circuit.json"
+        fc.save_circuit(filepath)
+
+        model2 = CircuitModel()
+        fc2 = FileController(model2)
+        fc2.load_circuit(filepath)
+
+        assert model2.analysis_type == "Transient"
+        assert model2.analysis_params["duration"] == "1ms"
+        assert model2.analysis_params["step"] == "1us"
+
+    def test_annotation_state_persists(self, tmp_path):
+        model = CircuitModel()
+        cc = CircuitController(model)
+        fc = FileController(model)
+
+        cc.add_annotation(AnnotationData(text="Test Note", x=50.0, y=75.0, font_size=14, bold=True, color="#FF0000"))
+        filepath = tmp_path / "circuit.json"
+        fc.save_circuit(filepath)
+
+        model2 = CircuitModel()
+        fc2 = FileController(model2)
+        fc2.load_circuit(filepath)
+
+        assert len(model2.annotations) == 1
+        ann = model2.annotations[0]
+        assert ann.text == "Test Note"
+        assert ann.x == pytest.approx(50.0)
+        assert ann.y == pytest.approx(75.0)
+        assert ann.font_size == 14
+        assert ann.bold is True
+        assert ann.color == "#FF0000"
+
+    def test_new_circuit_resets_all_state(self):
+        model = CircuitModel()
+        cc = CircuitController(model)
+        sc = SimulationController(model)
+        fc = FileController(model)
+
+        cc.add_component("Resistor", (0, 0))
+        cc.add_annotation(AnnotationData(text="Note"))
+        sc.set_analysis("Transient", {"duration": "1ms"})
+
+        fc.new_circuit()
+
+        assert len(model.components) == 0
+        assert len(model.wires) == 0
+        assert len(model.annotations) == 0
+        assert fc.current_file is None
+
+    def test_component_values_preserved(self, tmp_path):
+        model = CircuitModel()
+        cc = CircuitController(model)
+        fc = FileController(model)
+
+        comp = cc.add_component("Resistor", (0, 0))
+        cc.update_component_value(comp.component_id, "4.7k")
+        cc.rotate_component(comp.component_id, clockwise=True)
+
+        filepath = tmp_path / "circuit.json"
+        fc.save_circuit(filepath)
+
+        model2 = CircuitModel()
+        fc2 = FileController(model2)
+        fc2.load_circuit(filepath)
+
+        restored = model2.components[comp.component_id]
+        assert restored.value == "4.7k"
+        assert restored.rotation == 90

--- a/app/tests/unit/test_symbol_style.py
+++ b/app/tests/unit/test_symbol_style.py
@@ -191,9 +191,7 @@ class TestIEEEDrawDispatch:
         called = []
         comp._draw_ieee = lambda painter: called.append(True)
         comp.draw_component_body(None)
-        assert (
-            called
-        ), f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
+        assert called, f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
 
 
 class TestObstacleShapeDispatch:


### PR DESCRIPTION
## Summary
- Adds 26 integration tests covering the MVC observer pattern and controller interactions
- Observer propagation: all mutation events fire correctly, multiple observers, removal stops notifications
- Cross-controller: shared model reference verified, file load triggers model_loaded event
- Undo/redo: mixed operations undo in correct order, compound commands atomic, depth limit
- File round-trip: components, wires, analysis settings, annotations, and modified values all preserved

## Test plan
- [x] `python -m pytest app/tests/integration/test_mvc_observer_integration.py -v` — 26/26 pass
- [x] `make format && make lint` — clean

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)