### PR TITLE
add .meas measurement directive support

### DIFF
--- a/app/GUI/main_window_simulation.py
+++ b/app/GUI/main_window_simulation.py
@@ -171,6 +171,10 @@ class SimulationMixin:
         if handler:
             handler(result)
 
+        # Display .meas measurement results if present
+        if result.measurements:
+            self._display_measurement_results(result.measurements)
+
         self.results_text.append("=" * 70)
 
         if self._last_results is not None:
@@ -203,6 +207,20 @@ class SimulationMixin:
             "Circuit Validation",
             "\n\n".join(popup_lines),
         )
+
+    def _display_measurement_results(self, measurements):
+        """Display .meas measurement results."""
+        from simulation.result_parser import format_si
+
+        self.results_text.append("\nMEASUREMENTS:")
+        self.results_text.append("-" * 40)
+        for name, value in sorted(measurements.items()):
+            if value is None:
+                self.results_text.append(f"  {name:20s} : FAILED")
+            else:
+                formatted = format_si(value)
+                self.results_text.append(f"  {name:20s} : {formatted}")
+        self.results_text.append("-" * 40)
 
     def _display_op_results(self, result):
         """Display DC Operating Point results."""

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -31,6 +31,7 @@ class SimulationResult:
     raw_output: str = ""
     output_file: str = ""
     wrdata_filepath: str = ""
+    measurements: Optional[dict] = None
 
 
 class SimulationController:
@@ -83,6 +84,7 @@ class SimulationController:
         self,
         wrdata_filepath: Optional[str] = None,
         spice_options: Optional[dict] = None,
+        measurements: Optional[list] = None,
     ) -> str:
         """Generate a SPICE netlist from the current circuit model."""
         from simulation import NetlistGenerator
@@ -97,6 +99,7 @@ class SimulationController:
             analysis_params=self.model.analysis_params,
             wrdata_filepath=wrdata_filepath or "transient_data.txt",
             spice_options=spice_options,
+            measurements=measurements,
         )
         return generator.generate()
 
@@ -122,9 +125,13 @@ class SimulationController:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         wrdata_filepath = os.path.join(self.runner.output_dir, f"wrdata_{timestamp}.txt")
 
-        # 3. Generate netlist
+        # 3. Generate netlist (include .meas directives if configured)
+        meas_directives = self.model.analysis_params.get("measurements", [])
         try:
-            netlist = self.generate_netlist(wrdata_filepath=wrdata_filepath)
+            netlist = self.generate_netlist(
+                wrdata_filepath=wrdata_filepath,
+                measurements=meas_directives,
+            )
         except (ValueError, KeyError, TypeError) as e:
             result = SimulationResult(
                 success=False,
@@ -247,6 +254,9 @@ class SimulationController:
                     error=f"Unknown analysis type: {analysis}",
                 )
 
+            # Parse any .meas measurement results from stdout
+            meas_results = ResultParser.parse_measurement_results(raw_output)
+
             return SimulationResult(
                 success=True,
                 analysis_type=analysis,
@@ -256,6 +266,7 @@ class SimulationController:
                 output_file=output_file or "",
                 wrdata_filepath=wrdata_filepath,
                 warnings=warnings,
+                measurements=meas_results,
             )
 
         except (ValueError, IndexError, KeyError, OSError) as e:

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -26,6 +26,7 @@ class NetlistGenerator:
         analysis_params,
         wrdata_filepath="transient_data.txt",
         spice_options=None,
+        measurements=None,
     ):
         """
         Args:
@@ -37,6 +38,7 @@ class NetlistGenerator:
             analysis_params: dict
             wrdata_filepath: str - path for wrdata output file
             spice_options: Optional[dict[str, str]] - extra .options key=value pairs
+            measurements: Optional[list[str]] - .meas directive strings
         """
         self.components = components
         self.wires = wires
@@ -46,6 +48,7 @@ class NetlistGenerator:
         self.analysis_params = analysis_params
         self.wrdata_filepath = wrdata_filepath
         self.spice_options = spice_options or {}
+        self.measurements = measurements or []
 
     def generate(self):
         """Generate complete SPICE netlist"""
@@ -279,6 +282,16 @@ class NetlistGenerator:
         if self.spice_options:
             pairs = " ".join(f"{k}={v}" for k, v in self.spice_options.items())
             lines.append(f".options {pairs}")
+
+        # Add .meas measurement directives
+        if self.measurements:
+            lines.append("")
+            lines.append("* Measurement Directives")
+            for meas in self.measurements:
+                directive = meas.strip()
+                if not directive.lower().startswith(".meas"):
+                    directive = f".meas {directive}"
+                lines.append(directive)
 
         # Add analysis command
         lines.extend(self._generate_analysis_commands(node_labels, node_map))

--- a/app/simulation/result_parser.py
+++ b/app/simulation/result_parser.py
@@ -339,3 +339,36 @@ class ResultParser:
             data_rows.append(" | ".join(row_list))
 
         return f"{header_str}\n{separator}\n" + "\n".join(data_rows)
+
+    @staticmethod
+    def parse_measurement_results(stdout):
+        """Parse .meas measurement results from ngspice stdout.
+
+        ngspice prints measurement results in the format:
+            name  =  value
+        or:
+            name  =  failed
+
+        Returns a dict mapping measurement names to float values,
+        or None if no measurements found.  Failed measurements are
+        included with value None.
+        """
+        if not stdout:
+            return None
+
+        results = {}
+        for line in stdout.split("\n"):
+            # Match: "  rise_time  =  1.23456e-06"
+            match = re.match(r"^\s*(\w+)\s*=\s*([-+]?[\d.]+(?:e[-+]?\d+)?)\s*$", line, re.IGNORECASE)
+            if match:
+                name = match.group(1)
+                value = float(match.group(2))
+                results[name] = value
+                continue
+
+            # Match failed measurement: "  rise_time  =  failed"
+            fail_match = re.match(r"^\s*(\w+)\s*=\s*failed\s*$", line, re.IGNORECASE)
+            if fail_match:
+                results[fail_match.group(1)] = None
+
+        return results if results else None

--- a/app/tests/unit/test_meas_directive.py
+++ b/app/tests/unit/test_meas_directive.py
@@ -1,0 +1,190 @@
+"""Tests for .meas measurement directive support — netlist generation and result parsing."""
+
+import pytest
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from models.wire import WireData
+from simulation import NetlistGenerator, ResultParser
+
+
+def _build_transient_circuit():
+    """Build a simple circuit with transient analysis for .meas testing."""
+    model = CircuitModel()
+    model.components["V1"] = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value="5V",
+        position=(0.0, 0.0),
+    )
+    model.components["R1"] = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value="1k",
+        position=(100.0, 0.0),
+    )
+    model.components["GND1"] = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(0.0, 100.0),
+    )
+    model.wires = [
+        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
+        WireData(start_component_id="R1", start_terminal=1, end_component_id="GND1", end_terminal=0),
+        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+    ]
+    model.analysis_type = "Transient"
+    model.analysis_params = {"step": "1u", "duration": "10m"}
+    model.rebuild_nodes()
+    return model
+
+
+class TestMeasNetlistGeneration:
+    """Test .meas directive generation in netlists."""
+
+    def test_single_meas_directive(self):
+        model = _build_transient_circuit()
+        gen = NetlistGenerator(
+            components=model.components,
+            wires=model.wires,
+            nodes=model.nodes,
+            terminal_to_node=model.terminal_to_node,
+            analysis_type=model.analysis_type,
+            analysis_params=model.analysis_params,
+            measurements=[".meas tran avg_out AVG V(1) FROM=1m TO=10m"],
+        )
+        netlist = gen.generate()
+        assert ".meas tran avg_out AVG V(1) FROM=1m TO=10m" in netlist
+        assert "* Measurement Directives" in netlist
+
+    def test_multiple_meas_directives(self):
+        model = _build_transient_circuit()
+        measurements = [
+            ".meas tran max_v MAX V(1)",
+            ".meas tran min_v MIN V(1)",
+            ".meas tran avg_v AVG V(1)",
+        ]
+        gen = NetlistGenerator(
+            components=model.components,
+            wires=model.wires,
+            nodes=model.nodes,
+            terminal_to_node=model.terminal_to_node,
+            analysis_type=model.analysis_type,
+            analysis_params=model.analysis_params,
+            measurements=measurements,
+        )
+        netlist = gen.generate()
+        for meas in measurements:
+            assert meas in netlist
+
+    def test_no_meas_directives(self):
+        model = _build_transient_circuit()
+        gen = NetlistGenerator(
+            components=model.components,
+            wires=model.wires,
+            nodes=model.nodes,
+            terminal_to_node=model.terminal_to_node,
+            analysis_type=model.analysis_type,
+            analysis_params=model.analysis_params,
+        )
+        netlist = gen.generate()
+        assert "* Measurement Directives" not in netlist
+
+    def test_auto_prefix_meas(self):
+        """If the directive doesn't start with .meas, it should be auto-prefixed."""
+        model = _build_transient_circuit()
+        gen = NetlistGenerator(
+            components=model.components,
+            wires=model.wires,
+            nodes=model.nodes,
+            terminal_to_node=model.terminal_to_node,
+            analysis_type=model.analysis_type,
+            analysis_params=model.analysis_params,
+            measurements=["tran avg_out AVG V(1)"],
+        )
+        netlist = gen.generate()
+        assert ".meas tran avg_out AVG V(1)" in netlist
+
+    def test_meas_appears_before_control_block(self):
+        model = _build_transient_circuit()
+        gen = NetlistGenerator(
+            components=model.components,
+            wires=model.wires,
+            nodes=model.nodes,
+            terminal_to_node=model.terminal_to_node,
+            analysis_type=model.analysis_type,
+            analysis_params=model.analysis_params,
+            measurements=[".meas tran avg_out AVG V(1)"],
+        )
+        netlist = gen.generate()
+        meas_pos = netlist.find(".meas")
+        control_pos = netlist.find(".control")
+        assert meas_pos < control_pos
+
+
+class TestParseMeasurementResults:
+    """Test parsing .meas output from ngspice stdout."""
+
+    def test_parse_single_measurement(self):
+        stdout = "avg_out  =  2.50000e+00\n"
+        results = ResultParser.parse_measurement_results(stdout)
+        assert results is not None
+        assert "avg_out" in results
+        assert results["avg_out"] == pytest.approx(2.5)
+
+    def test_parse_multiple_measurements(self):
+        stdout = "max_v  =  5.00000e+00\nmin_v  =  0.00000e+00\navg_v  =  2.50000e+00\n"
+        results = ResultParser.parse_measurement_results(stdout)
+        assert results is not None
+        assert len(results) == 3
+        assert results["max_v"] == pytest.approx(5.0)
+        assert results["min_v"] == pytest.approx(0.0)
+        assert results["avg_v"] == pytest.approx(2.5)
+
+    def test_parse_failed_measurement(self):
+        stdout = "rise_time  =  failed\n"
+        results = ResultParser.parse_measurement_results(stdout)
+        assert results is not None
+        assert results["rise_time"] is None
+
+    def test_parse_mixed_success_and_failure(self):
+        stdout = "avg_v  =  2.50000e+00\nrise_time  =  failed\n"
+        results = ResultParser.parse_measurement_results(stdout)
+        assert results is not None
+        assert results["avg_v"] == pytest.approx(2.5)
+        assert results["rise_time"] is None
+
+    def test_empty_stdout_returns_none(self):
+        assert ResultParser.parse_measurement_results("") is None
+
+    def test_no_measurements_returns_none(self):
+        stdout = "some random ngspice output\nno measurements here\n"
+        assert ResultParser.parse_measurement_results(stdout) is None
+
+    def test_negative_value(self):
+        stdout = "delay  =  -1.23456e-06\n"
+        results = ResultParser.parse_measurement_results(stdout)
+        assert results is not None
+        assert results["delay"] == pytest.approx(-1.23456e-6)
+
+    def test_ignores_non_measurement_lines(self):
+        stdout = (
+            "Circuit: My Test Circuit\nDoing transient analysis...\navg_v  =  2.50000e+00\nNo. of Data Rows : 100\n"
+        )
+        results = ResultParser.parse_measurement_results(stdout)
+        assert results is not None
+        assert len(results) == 1
+        assert "avg_v" in results
+
+
+class TestMeasControllerIntegration:
+    """Test measurement directives flow through the controller."""
+
+    def test_measurements_in_analysis_params_generate_directives(self):
+        from controllers.simulation_controller import SimulationController
+
+        model = _build_transient_circuit()
+        model.analysis_params["measurements"] = [".meas tran avg_v AVG V(1)"]
+        ctrl = SimulationController(model)
+        netlist = ctrl.generate_netlist(measurements=model.analysis_params.get("measurements"))
+        assert ".meas tran avg_v AVG V(1)" in netlist


### PR DESCRIPTION
## Summary
- Generates `.meas` directives in netlists (with auto-prefix for bare expressions)
- Parses measurement results from ngspice stdout (success values and failed measurements)
- Displays measurement results table in the simulation results panel with SI-prefix formatting
- Measurements passed via `analysis_params["measurements"]` list, works alongside any analysis type
- Adds `measurements` field to `SimulationResult` dataclass

## Test plan
- [x] 5 netlist generation tests (single/multiple directives, auto-prefix, ordering, no-meas)
- [x] 8 result parser tests (single/multiple/failed/mixed/negative/edge cases)
- [x] 1 controller integration test
- [x] Full suite passes (1355 tests)
- [ ] Human testing: configure measurements on a transient analysis and verify results display

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)