### PR TITLE
add circuit template system with save, load, and built-in templates

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -140,9 +140,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             new_pos = component.position
             # Only create a command if the component actually moved
             if old_pos[0] != new_pos[0] or old_pos[1] != new_pos[1]:
-                cmd = MoveComponentCommand(
-                    controller, comp_id, new_pos, old_position=old_pos
-                )
+                cmd = MoveComponentCommand(controller, comp_id, new_pos, old_position=old_pos)
                 move_commands.append(cmd)
 
         self._drag_start_positions = {}
@@ -155,9 +153,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             controller.undo_manager._undo_stack.append(move_commands[0])
             controller.undo_manager._redo_stack.clear()
         else:
-            compound = CompoundCommand(
-                move_commands, f"Move {len(move_commands)} components"
-            )
+            compound = CompoundCommand(move_commands, f"Move {len(move_commands)} components")
             controller.undo_manager._undo_stack.append(compound)
             controller.undo_manager._redo_stack.clear()
 
@@ -209,9 +205,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         )
 
         if ok and new_value:
-            is_valid, error_msg = validate_component_value(
-                new_value, self.component_type
-            )
+            is_valid, error_msg = validate_component_value(new_value, self.component_type)
             if not is_valid:
                 QMessageBox.warning(None, "Invalid Value", error_msg)
                 return
@@ -336,19 +330,9 @@ class ComponentGraphicsItem(QGraphicsItem):
         self.draw_component_body(painter)
 
         # Draw label (check canvas visibility settings)
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))
@@ -368,10 +352,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             painter.drawEllipse(terminal, 3, 3)
 
     def itemChange(self, change, value):
-        if (
-            change == QGraphicsItem.GraphicsItemChange.ItemPositionChange
-            and self.scene()
-        ):
+        if change == QGraphicsItem.GraphicsItemChange.ItemPositionChange and self.scene():
             # Snap to grid
             new_pos = value
             grid_x = round(new_pos.x() / GRID_SIZE) * GRID_SIZE
@@ -434,9 +415,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         if self._position_update_timer is None:
             self._position_update_timer = QTimer()
             self._position_update_timer.setSingleShot(True)
-            self._position_update_timer.timeout.connect(
-                self._notify_controller_position
-            )
+            self._position_update_timer.timeout.connect(self._notify_controller_position)
         self._position_update_timer.start(50)  # 50ms debounce
 
     def _notify_controller_position(self):
@@ -646,9 +625,7 @@ class WaveformVoltageSource(ComponentGraphicsItem):
         # Draw sine wave symbol
         from models.component import COMPONENT_COLORS
 
-        painter.setPen(
-            QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2)
-        )
+        painter.setPen(QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2))
         from PyQt6.QtGui import QPainterPath
 
         path = QPainterPath()
@@ -688,19 +665,9 @@ class Ground(ComponentGraphicsItem):
         painter.setBrush(QBrush(color.lighter(150)))
         self.draw_component_body(painter)
 
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -34,6 +34,10 @@ class MenuBarMixin:
         self.examples_menu = file_menu.addMenu("Open &Example")
         self._populate_examples_menu()
 
+        # Templates
+        self.templates_menu = file_menu.addMenu("New from &Template")
+        self._populate_templates_menu()
+
         save_action = QAction("&Save", self)
         save_action.setShortcut(kb.get("file.save"))
         save_action.triggered.connect(self._on_save)
@@ -44,6 +48,10 @@ class MenuBarMixin:
         save_as_action.triggered.connect(self._on_save_as)
         file_menu.addAction(save_as_action)
 
+        save_template_action = QAction("Save as Tem&plate...", self)
+        save_template_action.triggered.connect(self._on_save_as_template)
+        file_menu.addAction(save_template_action)
+
         file_menu.addSeparator()
 
         import_netlist_action = QAction("&Import SPICE Netlist...", self)
@@ -53,9 +61,7 @@ class MenuBarMixin:
 
         export_netlist_action = QAction("Export &Netlist...", self)
         export_netlist_action.setShortcut(kb.get("file.export_netlist"))
-        export_netlist_action.setToolTip(
-            "Export the generated SPICE netlist to a .cir file"
-        )
+        export_netlist_action.setToolTip("Export the generated SPICE netlist to a .cir file")
         export_netlist_action.triggered.connect(self.export_netlist)
         file_menu.addAction(export_netlist_action)
 
@@ -70,9 +76,7 @@ class MenuBarMixin:
         file_menu.addAction(export_pdf_action)
 
         export_latex_action = QAction("Export as &LaTeX...", self)
-        export_latex_action.setToolTip(
-            "Export circuit as CircuiTikZ LaTeX code (.tex file)"
-        )
+        export_latex_action.setToolTip("Export circuit as CircuiTikZ LaTeX code (.tex file)")
         export_latex_action.triggered.connect(self.export_circuitikz)
         file_menu.addAction(export_latex_action)
 
@@ -145,9 +149,7 @@ class MenuBarMixin:
         edit_menu.addSeparator()
 
         copy_latex_action = QAction("Copy as La&TeX", self)
-        copy_latex_action.setToolTip(
-            "Copy the CircuiTikZ environment block to the clipboard"
-        )
+        copy_latex_action.setToolTip("Copy the CircuiTikZ environment block to the clipboard")
         copy_latex_action.triggered.connect(self.copy_circuitikz)
         edit_menu.addAction(copy_latex_action)
 
@@ -214,9 +216,7 @@ class MenuBarMixin:
         self.probe_action = QAction("&Probe Tool", self)
         self.probe_action.setCheckable(True)
         self.probe_action.setShortcut(kb.get("tools.probe"))
-        self.probe_action.setToolTip(
-            "Click nodes or components to see voltage/current values"
-        )
+        self.probe_action.setToolTip("Click nodes or components to see voltage/current values")
         self.probe_action.triggered.connect(self._toggle_probe_mode)
         view_menu.addAction(self.probe_action)
 
@@ -274,9 +274,7 @@ class MenuBarMixin:
 
         self.monochrome_mode_action = QAction("&Monochrome", self)
         self.monochrome_mode_action.setCheckable(True)
-        self.monochrome_mode_action.triggered.connect(
-            lambda: self._set_color_mode("monochrome")
-        )
+        self.monochrome_mode_action.triggered.connect(lambda: self._set_color_mode("monochrome"))
         color_mode_menu.addAction(self.monochrome_mode_action)
 
         self.color_mode_group = QActionGroup(self)
@@ -371,9 +369,7 @@ class MenuBarMixin:
 
         mc_action = QAction("&Monte Carlo...", self)
         mc_action.setCheckable(True)
-        mc_action.setToolTip(
-            "Run Monte Carlo tolerance analysis with randomized component values"
-        )
+        mc_action.setToolTip("Run Monte Carlo tolerance analysis with randomized component values")
         mc_action.triggered.connect(self.set_analysis_monte_carlo)
         analysis_menu.addAction(mc_action)
 

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -127,11 +127,7 @@ class SettingsMixin:
         if reply == QMessageBox.StandardButton.Yes:
             source = self.file_ctrl.load_auto_save()
             if source is not None:
-                title = (
-                    f"Circuit Design GUI - {source}"
-                    if source
-                    else "Circuit Design GUI - (Recovered)"
-                )
+                title = f"Circuit Design GUI - {source}" if source else "Circuit Design GUI - (Recovered)"
                 self.setWindowTitle(title)
                 self._sync_analysis_menu()
                 statusBar = self.statusBar()

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -143,9 +143,7 @@ class ViewOperationsMixin:
         self.canvas.set_probe_mode(checked)
         if checked:
             if not self.canvas.node_voltages and self._last_results is None:
-                self.statusBar().showMessage(
-                    "Probe mode active. Run a simulation first to see values.", 3000
-                )
+                self.statusBar().showMessage("Probe mode active. Run a simulation first to see values.", 3000)
             else:
                 self.statusBar().showMessage(
                     "Probe mode active. Click nodes or components to see values. Press Escape to exit.",
@@ -158,9 +156,7 @@ class ViewOperationsMixin:
     def _on_probe_requested(self, signal_name, probe_type):
         """Handle probe click for sweep/transient analyses (no OP data on canvas)."""
         if self._last_results is None:
-            self.statusBar().showMessage(
-                "No simulation results available. Run a simulation first.", 3000
-            )
+            self.statusBar().showMessage("No simulation results available. Run a simulation first.", 3000)
             return
 
         analysis_type = self._last_results_type
@@ -171,9 +167,7 @@ class ViewOperationsMixin:
         elif analysis_type == "AC Sweep":
             self._probe_open_ac_sweep(signal_name, probe_type)
         else:
-            self.statusBar().showMessage(
-                f"Probe not supported for {analysis_type} analysis.", 3000
-            )
+            self.statusBar().showMessage(f"Probe not supported for {analysis_type} analysis.", 3000)
 
     def _probe_open_waveform(self, signal_name, probe_type):
         """Open waveform dialog focused on the probed signal."""
@@ -232,14 +226,10 @@ class ViewOperationsMixin:
         circuit_items = [
             item
             for item in scene.items()
-            if isinstance(
-                item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem)
-            )
+            if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
         ]
         if not circuit_items:
-            QMessageBox.information(
-                self, "Export Image", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export Image", "Nothing to export — the canvas is empty.")
             return
 
         source_rect = circuit_items[0].sceneBoundingRect()
@@ -256,9 +246,7 @@ class ViewOperationsMixin:
 
             generator = QSvgGenerator()
             generator.setFileName(filename)
-            generator.setSize(
-                QSize(int(source_rect.width()), int(source_rect.height()))
-            )
+            generator.setSize(QSize(int(source_rect.width()), int(source_rect.height())))
             generator.setViewBox(source_rect)
             generator.setTitle("SDM Spice Circuit")
 
@@ -285,9 +273,7 @@ class ViewOperationsMixin:
             painter.end()
             image.save(filename)
 
-        QMessageBox.information(
-            self, "Export Image", f"Circuit exported to:\n{filename}"
-        )
+        QMessageBox.information(self, "Export Image", f"Circuit exported to:\n{filename}")
 
     def export_circuitikz(self):
         """Export the circuit as a CircuiTikZ LaTeX file."""
@@ -299,9 +285,7 @@ class ViewOperationsMixin:
 
         model = self.circuit_ctrl.model
         if not model.components:
-            QMessageBox.information(
-                self, "Export LaTeX", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export LaTeX", "Nothing to export — the canvas is empty.")
             return
 
         # Show options dialog
@@ -319,11 +303,7 @@ class ViewOperationsMixin:
                 nodes=model.nodes,
                 terminal_to_node=model.terminal_to_node,
                 standalone=opts["standalone"],
-                circuit_name=(
-                    os.path.basename(self.file_ctrl.current_file)
-                    if self.file_ctrl.current_file
-                    else ""
-                ),
+                circuit_name=(os.path.basename(self.file_ctrl.current_file) if self.file_ctrl.current_file else ""),
                 scale=opts["scale"],
                 include_ids=opts["include_ids"],
                 include_values=opts["include_values"],
@@ -336,9 +316,7 @@ class ViewOperationsMixin:
 
         default_name = ""
         if hasattr(self, "file_ctrl") and self.file_ctrl.current_file:
-            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[
-                0
-            ]
+            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[0]
             default_name = base + ".tex"
 
         filename, _ = QFileDialog.getSaveFileName(

--- a/app/GUI/template_dialog.py
+++ b/app/GUI/template_dialog.py
@@ -1,0 +1,201 @@
+"""Dialogs for circuit template save and load."""
+
+from typing import Optional
+
+from controllers.template_manager import TemplateInfo, TemplateManager
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+)
+
+
+class NewFromTemplateDialog(QDialog):
+    """Dialog for creating a new circuit from a template."""
+
+    def __init__(self, template_manager: TemplateManager, parent=None):
+        super().__init__(parent)
+        self.template_manager = template_manager
+        self.selected_template: Optional[TemplateInfo] = None
+        self._setup_ui()
+        self._populate_templates()
+
+    def _setup_ui(self):
+        self.setWindowTitle("New from Template")
+        self.setMinimumSize(500, 400)
+
+        layout = QHBoxLayout(self)
+
+        # Left: template list
+        left = QVBoxLayout()
+        left.addWidget(QLabel("Templates:"))
+        self.template_list = QListWidget()
+        self.template_list.currentItemChanged.connect(self._on_selection_changed)
+        self.template_list.itemDoubleClicked.connect(self._on_double_click)
+        left.addWidget(self.template_list)
+
+        # Delete button for user templates
+        self.delete_btn = QPushButton("Delete Template")
+        self.delete_btn.setEnabled(False)
+        self.delete_btn.clicked.connect(self._on_delete)
+        left.addWidget(self.delete_btn)
+
+        layout.addLayout(left, stretch=2)
+
+        # Right: details
+        right = QVBoxLayout()
+        right.addWidget(QLabel("Details:"))
+
+        self.name_label = QLabel("")
+        self.name_label.setStyleSheet("font-weight: bold; font-size: 14px;")
+        self.name_label.setWordWrap(True)
+        right.addWidget(self.name_label)
+
+        self.category_label = QLabel("")
+        self.category_label.setStyleSheet("color: gray;")
+        right.addWidget(self.category_label)
+
+        self.description_label = QLabel("")
+        self.description_label.setWordWrap(True)
+        right.addWidget(self.description_label)
+
+        right.addStretch()
+
+        # OK / Cancel
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        self.ok_button = buttons.button(QDialogButtonBox.StandardButton.Ok)
+        self.ok_button.setEnabled(False)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        right.addWidget(buttons)
+
+        layout.addLayout(right, stretch=1)
+
+    def _populate_templates(self):
+        """Load and display all templates grouped by category."""
+        self.template_list.clear()
+        templates = self.template_manager.list_templates()
+
+        current_category = None
+        for template in templates:
+            if template.category != current_category:
+                current_category = template.category
+                header = QListWidgetItem(f"--- {current_category} ---")
+                header.setFlags(Qt.ItemFlag.NoItemFlags)
+                self.template_list.addItem(header)
+
+            label = template.name
+            if not template.is_builtin:
+                label += " (user)"
+            item = QListWidgetItem(label)
+            item.setData(Qt.ItemDataRole.UserRole, template)
+            item.setToolTip(template.description)
+            self.template_list.addItem(item)
+
+    def _on_selection_changed(self, current: Optional[QListWidgetItem], _previous):
+        if current is None:
+            self._clear_details()
+            return
+
+        template = current.data(Qt.ItemDataRole.UserRole)
+        if template is None:
+            self._clear_details()
+            return
+
+        self.selected_template = template
+        self.name_label.setText(template.name)
+        self.category_label.setText(f"Category: {template.category}")
+        self.description_label.setText(template.description or "(No description)")
+        self.ok_button.setEnabled(True)
+        self.delete_btn.setEnabled(not template.is_builtin)
+
+    def _clear_details(self):
+        self.selected_template = None
+        self.name_label.setText("")
+        self.category_label.setText("")
+        self.description_label.setText("")
+        self.ok_button.setEnabled(False)
+        self.delete_btn.setEnabled(False)
+
+    def _on_double_click(self, item: QListWidgetItem):
+        template = item.data(Qt.ItemDataRole.UserRole)
+        if template is not None:
+            self.selected_template = template
+            self.accept()
+
+    def _on_delete(self):
+        if self.selected_template is None or self.selected_template.is_builtin:
+            return
+
+        reply = QMessageBox.question(
+            self,
+            "Delete Template",
+            f'Delete user template "{self.selected_template.name}"?',
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            self.template_manager.delete_template(self.selected_template.filepath)
+            self._populate_templates()
+            self._clear_details()
+
+    def get_selected_template(self) -> Optional[TemplateInfo]:
+        return self.selected_template
+
+
+class SaveAsTemplateDialog(QDialog):
+    """Dialog for saving the current circuit as a template."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._setup_ui()
+
+    def _setup_ui(self):
+        self.setWindowTitle("Save as Template")
+        self.setMinimumWidth(400)
+
+        layout = QFormLayout(self)
+
+        self.name_edit = QLineEdit()
+        self.name_edit.setPlaceholderText("e.g. My RC Filter")
+        layout.addRow("Name:", self.name_edit)
+
+        self.description_edit = QTextEdit()
+        self.description_edit.setPlaceholderText("Optional description of the circuit template...")
+        self.description_edit.setMaximumHeight(80)
+        layout.addRow("Description:", self.description_edit)
+
+        self.category_edit = QLineEdit()
+        self.category_edit.setPlaceholderText("e.g. Filters, Amplifiers, Power (default: User)")
+        layout.addRow("Category:", self.category_edit)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        self.ok_button = buttons.button(QDialogButtonBox.StandardButton.Ok)
+        self.ok_button.setEnabled(False)
+        buttons.accepted.connect(self._validate_and_accept)
+        buttons.rejected.connect(self.reject)
+        layout.addRow(buttons)
+
+        self.name_edit.textChanged.connect(lambda text: self.ok_button.setEnabled(bool(text.strip())))
+
+    def _validate_and_accept(self):
+        if not self.name_edit.text().strip():
+            QMessageBox.warning(self, "Validation", "Template name is required.")
+            return
+        self.accept()
+
+    def get_values(self) -> tuple[str, str, str]:
+        """Return (name, description, category) entered by the user."""
+        name = self.name_edit.text().strip()
+        description = self.description_edit.toPlainText().strip()
+        category = self.category_edit.text().strip() or "User"
+        return name, description, category

--- a/app/controllers/template_manager.py
+++ b/app/controllers/template_manager.py
@@ -1,0 +1,210 @@
+"""
+TemplateManager - Handles circuit template discovery, save, and load.
+
+Templates are stored as JSON files with the same format as circuit files,
+plus metadata fields (name, description, category). Built-in templates
+ship with the application; user templates are saved to ~/.spice-gui/templates/.
+"""
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from controllers.file_controller import validate_circuit_data
+from models.circuit import CircuitModel
+
+logger = logging.getLogger(__name__)
+
+BUILTIN_TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+USER_TEMPLATES_DIR = Path.home() / ".spice-gui" / "templates"
+
+
+@dataclass
+class TemplateInfo:
+    """Metadata for a circuit template."""
+
+    name: str
+    description: str
+    category: str
+    filepath: Path
+    is_builtin: bool
+
+
+class TemplateManager:
+    """Manages circuit template discovery, saving, and loading."""
+
+    def __init__(
+        self,
+        builtin_dir: Optional[Path] = None,
+        user_dir: Optional[Path] = None,
+    ):
+        self.builtin_dir = builtin_dir or BUILTIN_TEMPLATES_DIR
+        self.user_dir = user_dir or USER_TEMPLATES_DIR
+
+    def _ensure_user_dir(self) -> None:
+        """Create user templates directory if it doesn't exist."""
+        self.user_dir.mkdir(parents=True, exist_ok=True)
+
+    def list_templates(self) -> list[TemplateInfo]:
+        """Return all available templates (built-in + user), sorted by category then name."""
+        templates = []
+        templates.extend(self._scan_directory(self.builtin_dir, is_builtin=True))
+        templates.extend(self._scan_directory(self.user_dir, is_builtin=False))
+
+        # Sort: category alphabetically, then name within category
+        templates.sort(key=lambda t: (t.category, t.name))
+        return templates
+
+    def _scan_directory(self, directory: Path, is_builtin: bool) -> list[TemplateInfo]:
+        """Scan a directory for template JSON files."""
+        templates = []
+        if not directory.exists():
+            return templates
+
+        for filepath in sorted(directory.glob("*.json")):
+            try:
+                with open(filepath, "r") as f:
+                    data = json.load(f)
+                templates.append(
+                    TemplateInfo(
+                        name=data.get("name", filepath.stem),
+                        description=data.get("description", ""),
+                        category=data.get("category", "Other"),
+                        filepath=filepath,
+                        is_builtin=is_builtin,
+                    )
+                )
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning("Failed to read template %s: %s", filepath, e)
+
+        return templates
+
+    def load_template(self, filepath: Path) -> CircuitModel:
+        """Load a template and return a CircuitModel with reset counters.
+
+        Component IDs are preserved from the template (R1, C1, etc.) but
+        the component_counter is recalculated to reflect the actual IDs
+        present, so new components added by the user continue from the
+        correct numbers.
+
+        Args:
+            filepath: Path to the template JSON file.
+
+        Returns:
+            A CircuitModel ready for editing.
+
+        Raises:
+            json.JSONDecodeError: If file is not valid JSON.
+            ValueError: If file structure is invalid.
+            OSError: If file cannot be read.
+        """
+        with open(filepath, "r") as f:
+            data = json.load(f)
+
+        validate_circuit_data(data)
+        model = CircuitModel.from_dict(data)
+
+        # Recalculate counters from the actual component IDs present
+        # so that new components continue with correct numbering
+        model.component_counter = self._calculate_counters(model)
+
+        return model
+
+    @staticmethod
+    def _calculate_counters(model: CircuitModel) -> dict[str, int]:
+        """Calculate component counters from actual component IDs.
+
+        Parses IDs like 'R1', 'R2', 'C1' to determine the highest
+        number used for each symbol prefix.
+        """
+        counters: dict[str, int] = {}
+        for comp_id in model.components:
+            # Split ID into prefix (letters) and suffix (digits)
+            prefix = ""
+            suffix = ""
+            for ch in comp_id:
+                if ch.isdigit() and prefix:
+                    suffix += ch
+                else:
+                    if suffix:
+                        break
+                    prefix += ch
+
+            if prefix and suffix:
+                num = int(suffix)
+                counters[prefix] = max(counters.get(prefix, 0), num)
+
+        return counters
+
+    def save_template(
+        self,
+        model: CircuitModel,
+        name: str,
+        description: str = "",
+        category: str = "User",
+    ) -> Path:
+        """Save the current circuit as a user template.
+
+        Args:
+            model: The circuit model to save.
+            name: Display name for the template.
+            description: Optional description text.
+            category: Category for grouping (default: "User").
+
+        Returns:
+            Path to the saved template file.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        self._ensure_user_dir()
+
+        data = model.to_dict()
+        data["name"] = name
+        data["description"] = description
+        data["category"] = category
+
+        # Generate a filename from the template name
+        filename = self._name_to_filename(name)
+        filepath = self.user_dir / filename
+
+        # Avoid overwriting: append a number if needed
+        counter = 1
+        while filepath.exists():
+            stem = self._name_to_filename(name).replace(".json", "")
+            filepath = self.user_dir / f"{stem}_{counter}.json"
+            counter += 1
+
+        with open(filepath, "w") as f:
+            json.dump(data, f, indent=2)
+
+        return filepath
+
+    def delete_template(self, filepath: Path) -> bool:
+        """Delete a user template. Cannot delete built-in templates.
+
+        Returns:
+            True if deleted, False if the template is built-in or doesn't exist.
+        """
+        if not filepath.exists():
+            return False
+
+        # Only allow deleting from user directory
+        try:
+            filepath.resolve().relative_to(self.user_dir.resolve())
+        except ValueError:
+            return False
+
+        filepath.unlink()
+        return True
+
+    @staticmethod
+    def _name_to_filename(name: str) -> str:
+        """Convert a template name to a safe filename."""
+        safe = "".join(c if c.isalnum() or c in " -_" else "" for c in name)
+        safe = safe.strip().replace(" ", "_").lower()
+        if not safe:
+            safe = "template"
+        return f"{safe}.json"

--- a/app/templates/common_emitter_amplifier.json
+++ b/app/templates/common_emitter_amplifier.json
@@ -1,0 +1,85 @@
+{
+  "name": "Common Emitter Amplifier",
+  "description": "BJT common-emitter amplifier with voltage divider bias. A fundamental single-transistor amplifier topology used in analog circuits.",
+  "components": [
+    {
+      "type": "VoltageSource",
+      "id": "V1",
+      "value": "12V",
+      "pos": {"x": 100.0, "y": 200.0},
+      "rotation": 0
+    },
+    {
+      "type": "VoltageSource",
+      "id": "V2",
+      "value": "0.1V",
+      "pos": {"x": 100.0, "y": 400.0},
+      "rotation": 0
+    },
+    {
+      "type": "Resistor",
+      "id": "R1",
+      "value": "56k",
+      "pos": {"x": 300.0, "y": 100.0},
+      "rotation": 90
+    },
+    {
+      "type": "Resistor",
+      "id": "R2",
+      "value": "12k",
+      "pos": {"x": 300.0, "y": 300.0},
+      "rotation": 90
+    },
+    {
+      "type": "Resistor",
+      "id": "R3",
+      "value": "4.7k",
+      "pos": {"x": 500.0, "y": 100.0},
+      "rotation": 90
+    },
+    {
+      "type": "Resistor",
+      "id": "R4",
+      "value": "1k",
+      "pos": {"x": 500.0, "y": 380.0},
+      "rotation": 90
+    },
+    {
+      "type": "Capacitor",
+      "id": "C1",
+      "value": "10u",
+      "pos": {"x": 200.0, "y": 250.0},
+      "rotation": 0
+    },
+    {
+      "type": "BJTNPN",
+      "id": "Q1",
+      "value": "2N3904",
+      "pos": {"x": 420.0, "y": 250.0},
+      "rotation": 0
+    },
+    {
+      "type": "Ground",
+      "id": "GND1",
+      "value": "0V",
+      "pos": {"x": 300.0, "y": 480.0},
+      "rotation": 0
+    }
+  ],
+  "wires": [
+    {"start_comp": "V1", "start_term": 0, "end_comp": "R1", "end_term": 0},
+    {"start_comp": "V1", "start_term": 0, "end_comp": "R3", "end_term": 0},
+    {"start_comp": "R1", "start_term": 1, "end_comp": "R2", "end_term": 0},
+    {"start_comp": "R1", "start_term": 1, "end_comp": "C1", "end_term": 1},
+    {"start_comp": "C1", "start_term": 0, "end_comp": "V2", "end_term": 0},
+    {"start_comp": "C1", "start_term": 1, "end_comp": "Q1", "end_term": 1},
+    {"start_comp": "R3", "start_term": 1, "end_comp": "Q1", "end_term": 0},
+    {"start_comp": "Q1", "start_term": 2, "end_comp": "R4", "end_term": 0},
+    {"start_comp": "R4", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+    {"start_comp": "R2", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+    {"start_comp": "V1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+    {"start_comp": "V2", "start_term": 1, "end_comp": "GND1", "end_term": 0}
+  ],
+  "counters": {"V": 2, "R": 4, "C": 1, "Q": 1, "GND": 1},
+  "category": "Amplifiers"
+}

--- a/app/templates/half_wave_rectifier.json
+++ b/app/templates/half_wave_rectifier.json
@@ -1,0 +1,67 @@
+{
+  "name": "Half-Wave Rectifier",
+  "description": "Diode half-wave rectifier with filter capacitor. Converts AC to pulsating DC. Use transient analysis to see the waveform.",
+  "category": "Power",
+  "analysis_type": "Transient",
+  "analysis_params": {
+    "step_time": "10u",
+    "stop_time": "50m"
+  },
+  "components": [
+    {
+      "type": "WaveformVoltageSource",
+      "id": "VW1",
+      "value": "SIN(0 10 60)",
+      "pos": {"x": 100.0, "y": 200.0},
+      "rotation": 0,
+      "waveform_type": "SIN",
+      "waveform_params": {
+        "SIN": {
+          "offset": "0",
+          "amplitude": "10",
+          "frequency": "60",
+          "delay": "0",
+          "theta": "0",
+          "phase": "0"
+        }
+      }
+    },
+    {
+      "type": "Diode",
+      "id": "D1",
+      "value": "IS=1e-14 N=1",
+      "pos": {"x": 250.0, "y": 100.0},
+      "rotation": 0
+    },
+    {
+      "type": "Resistor",
+      "id": "R1",
+      "value": "1k",
+      "pos": {"x": 400.0, "y": 200.0},
+      "rotation": 90
+    },
+    {
+      "type": "Capacitor",
+      "id": "C1",
+      "value": "100u",
+      "pos": {"x": 550.0, "y": 200.0},
+      "rotation": 90
+    },
+    {
+      "type": "Ground",
+      "id": "GND1",
+      "value": "0V",
+      "pos": {"x": 300.0, "y": 340.0},
+      "rotation": 0
+    }
+  ],
+  "wires": [
+    {"start_comp": "VW1", "start_term": 0, "end_comp": "D1", "end_term": 0},
+    {"start_comp": "D1", "start_term": 1, "end_comp": "R1", "end_term": 0},
+    {"start_comp": "D1", "start_term": 1, "end_comp": "C1", "end_term": 0},
+    {"start_comp": "R1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+    {"start_comp": "C1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+    {"start_comp": "VW1", "start_term": 1, "end_comp": "GND1", "end_term": 0}
+  ],
+  "counters": {"VW": 1, "D": 1, "R": 1, "C": 1, "GND": 1}
+}

--- a/app/templates/inverting_amplifier.json
+++ b/app/templates/inverting_amplifier.json
@@ -1,0 +1,51 @@
+{
+  "name": "Inverting Amplifier",
+  "description": "Op-amp inverting amplifier. Gain = -Rf/Rin = -100k/10k = -10. Output voltage is inverted and amplified by a factor of 10.",
+  "category": "Amplifiers",
+  "components": [
+    {
+      "type": "VoltageSource",
+      "id": "V1",
+      "value": "1V",
+      "pos": {"x": 100.0, "y": 150.0},
+      "rotation": 0
+    },
+    {
+      "type": "Resistor",
+      "id": "R1",
+      "value": "10k",
+      "pos": {"x": 250.0, "y": 100.0},
+      "rotation": 0
+    },
+    {
+      "type": "OpAmp",
+      "id": "OA1",
+      "value": "Ideal",
+      "pos": {"x": 400.0, "y": 150.0},
+      "rotation": 0
+    },
+    {
+      "type": "Resistor",
+      "id": "R2",
+      "value": "100k",
+      "pos": {"x": 400.0, "y": 50.0},
+      "rotation": 0
+    },
+    {
+      "type": "Ground",
+      "id": "GND1",
+      "value": "0V",
+      "pos": {"x": 250.0, "y": 280.0},
+      "rotation": 0
+    }
+  ],
+  "wires": [
+    {"start_comp": "V1", "start_term": 0, "end_comp": "R1", "end_term": 0},
+    {"start_comp": "R1", "start_term": 1, "end_comp": "OA1", "end_term": 0},
+    {"start_comp": "R1", "start_term": 1, "end_comp": "R2", "end_term": 0},
+    {"start_comp": "R2", "start_term": 1, "end_comp": "OA1", "end_term": 2},
+    {"start_comp": "V1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+    {"start_comp": "OA1", "start_term": 1, "end_comp": "GND1", "end_term": 0}
+  ],
+  "counters": {"V": 1, "R": 2, "OA": 1, "GND": 1}
+}

--- a/app/templates/non_inverting_amplifier.json
+++ b/app/templates/non_inverting_amplifier.json
@@ -1,0 +1,51 @@
+{
+  "name": "Non-Inverting Amplifier",
+  "description": "Op-amp non-inverting amplifier. Gain = 1 + Rf/R1 = 1 + 9k/1k = 10. Output is in phase with the input.",
+  "category": "Amplifiers",
+  "components": [
+    {
+      "type": "VoltageSource",
+      "id": "V1",
+      "value": "1V",
+      "pos": {"x": 100.0, "y": 200.0},
+      "rotation": 0
+    },
+    {
+      "type": "OpAmp",
+      "id": "OA1",
+      "value": "Ideal",
+      "pos": {"x": 350.0, "y": 150.0},
+      "rotation": 0
+    },
+    {
+      "type": "Resistor",
+      "id": "R1",
+      "value": "1k",
+      "pos": {"x": 350.0, "y": 280.0},
+      "rotation": 90
+    },
+    {
+      "type": "Resistor",
+      "id": "R2",
+      "value": "9k",
+      "pos": {"x": 350.0, "y": 50.0},
+      "rotation": 0
+    },
+    {
+      "type": "Ground",
+      "id": "GND1",
+      "value": "0V",
+      "pos": {"x": 250.0, "y": 380.0},
+      "rotation": 0
+    }
+  ],
+  "wires": [
+    {"start_comp": "V1", "start_term": 0, "end_comp": "OA1", "end_term": 1},
+    {"start_comp": "OA1", "start_term": 0, "end_comp": "R1", "end_term": 0},
+    {"start_comp": "OA1", "start_term": 0, "end_comp": "R2", "end_term": 0},
+    {"start_comp": "R2", "start_term": 1, "end_comp": "OA1", "end_term": 2},
+    {"start_comp": "R1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+    {"start_comp": "V1", "start_term": 1, "end_comp": "GND1", "end_term": 0}
+  ],
+  "counters": {"V": 1, "R": 2, "OA": 1, "GND": 1}
+}

--- a/app/templates/rc_high_pass_filter.json
+++ b/app/templates/rc_high_pass_filter.json
@@ -1,0 +1,49 @@
+{
+  "name": "RC High-Pass Filter",
+  "description": "First-order RC high-pass filter. Cutoff frequency fc = 1/(2*pi*R*C). With R=1k and C=1uF, fc ~ 159 Hz. Attenuates frequencies below the cutoff.",
+  "category": "Filters",
+  "analysis_type": "AC Sweep",
+  "analysis_params": {
+    "start_freq": "1",
+    "stop_freq": "100k",
+    "points": "100",
+    "variation": "Decade"
+  },
+  "components": [
+    {
+      "type": "VoltageSource",
+      "id": "V1",
+      "value": "1V",
+      "pos": {"x": 100.0, "y": 200.0},
+      "rotation": 0
+    },
+    {
+      "type": "Capacitor",
+      "id": "C1",
+      "value": "1u",
+      "pos": {"x": 250.0, "y": 100.0},
+      "rotation": 0
+    },
+    {
+      "type": "Resistor",
+      "id": "R1",
+      "value": "1k",
+      "pos": {"x": 400.0, "y": 200.0},
+      "rotation": 90
+    },
+    {
+      "type": "Ground",
+      "id": "GND1",
+      "value": "0V",
+      "pos": {"x": 250.0, "y": 340.0},
+      "rotation": 0
+    }
+  ],
+  "wires": [
+    {"start_comp": "V1", "start_term": 0, "end_comp": "C1", "end_term": 0},
+    {"start_comp": "C1", "start_term": 1, "end_comp": "R1", "end_term": 0},
+    {"start_comp": "R1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+    {"start_comp": "V1", "start_term": 1, "end_comp": "GND1", "end_term": 0}
+  ],
+  "counters": {"V": 1, "R": 1, "C": 1, "GND": 1}
+}

--- a/app/templates/rc_low_pass_filter.json
+++ b/app/templates/rc_low_pass_filter.json
@@ -1,0 +1,49 @@
+{
+  "name": "RC Low-Pass Filter",
+  "description": "First-order RC low-pass filter. Cutoff frequency fc = 1/(2*pi*R*C). With R=1k and C=1uF, fc ~ 159 Hz. Use AC sweep to see the frequency response.",
+  "category": "Filters",
+  "analysis_type": "AC Sweep",
+  "analysis_params": {
+    "start_freq": "1",
+    "stop_freq": "100k",
+    "points": "100",
+    "variation": "Decade"
+  },
+  "components": [
+    {
+      "type": "VoltageSource",
+      "id": "V1",
+      "value": "1V",
+      "pos": {"x": 100.0, "y": 200.0},
+      "rotation": 0
+    },
+    {
+      "type": "Resistor",
+      "id": "R1",
+      "value": "1k",
+      "pos": {"x": 250.0, "y": 100.0},
+      "rotation": 0
+    },
+    {
+      "type": "Capacitor",
+      "id": "C1",
+      "value": "1u",
+      "pos": {"x": 400.0, "y": 200.0},
+      "rotation": 90
+    },
+    {
+      "type": "Ground",
+      "id": "GND1",
+      "value": "0V",
+      "pos": {"x": 250.0, "y": 340.0},
+      "rotation": 0
+    }
+  ],
+  "wires": [
+    {"start_comp": "V1", "start_term": 0, "end_comp": "R1", "end_term": 0},
+    {"start_comp": "R1", "start_term": 1, "end_comp": "C1", "end_term": 0},
+    {"start_comp": "C1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+    {"start_comp": "V1", "start_term": 1, "end_comp": "GND1", "end_term": 0}
+  ],
+  "counters": {"V": 1, "R": 1, "C": 1, "GND": 1}
+}

--- a/app/templates/voltage_divider.json
+++ b/app/templates/voltage_divider.json
@@ -1,0 +1,42 @@
+{
+  "name": "Voltage Divider",
+  "description": "Resistive voltage divider. Output voltage is determined by R2/(R1+R2) ratio. A fundamental building block in analog circuit design.",
+  "category": "Passives",
+  "components": [
+    {
+      "type": "VoltageSource",
+      "id": "V1",
+      "value": "5V",
+      "pos": {"x": 100.0, "y": 200.0},
+      "rotation": 0
+    },
+    {
+      "type": "Resistor",
+      "id": "R1",
+      "value": "10k",
+      "pos": {"x": 250.0, "y": 100.0},
+      "rotation": 0
+    },
+    {
+      "type": "Resistor",
+      "id": "R2",
+      "value": "10k",
+      "pos": {"x": 400.0, "y": 200.0},
+      "rotation": 90
+    },
+    {
+      "type": "Ground",
+      "id": "GND1",
+      "value": "0V",
+      "pos": {"x": 250.0, "y": 340.0},
+      "rotation": 0
+    }
+  ],
+  "wires": [
+    {"start_comp": "V1", "start_term": 0, "end_comp": "R1", "end_term": 0},
+    {"start_comp": "R1", "start_term": 1, "end_comp": "R2", "end_term": 0},
+    {"start_comp": "R2", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+    {"start_comp": "V1", "start_term": 1, "end_comp": "GND1", "end_term": 0}
+  ],
+  "counters": {"V": 1, "R": 2, "GND": 1}
+}

--- a/app/tests/unit/test_symbol_style.py
+++ b/app/tests/unit/test_symbol_style.py
@@ -191,9 +191,7 @@ class TestIEEEDrawDispatch:
         called = []
         comp._draw_ieee = lambda painter: called.append(True)
         comp.draw_component_body(None)
-        assert (
-            called
-        ), f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
+        assert called, f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
 
 
 class TestObstacleShapeDispatch:

--- a/app/tests/unit/test_template_manager.py
+++ b/app/tests/unit/test_template_manager.py
@@ -1,0 +1,431 @@
+"""Tests for TemplateManager - template save/load/discovery."""
+
+import json
+
+import pytest
+from controllers.template_manager import TemplateManager
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from models.wire import WireData
+
+
+def _build_test_circuit():
+    """Build a simple V1-R1-R2-GND circuit for testing."""
+    model = CircuitModel()
+    model.components["V1"] = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value="5V",
+        position=(0.0, 0.0),
+    )
+    model.components["R1"] = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value="1k",
+        position=(100.0, 0.0),
+    )
+    model.components["R2"] = ComponentData(
+        component_id="R2",
+        component_type="Resistor",
+        value="2k",
+        position=(200.0, 0.0),
+    )
+    model.components["GND1"] = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(300.0, 0.0),
+    )
+    model.wires = [
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="R2",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R2",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+    ]
+    model.component_counter = {"V": 1, "R": 2, "GND": 1}
+    model.rebuild_nodes()
+    return model
+
+
+def _write_template(directory, filename, name, category="Test", description=""):
+    """Helper to write a template JSON file."""
+    data = {
+        "name": name,
+        "description": description,
+        "category": category,
+        "components": [
+            {
+                "id": "R1",
+                "type": "Resistor",
+                "value": "1k",
+                "pos": {"x": 0, "y": 0},
+            }
+        ],
+        "wires": [],
+        "counters": {"R": 1},
+    }
+    filepath = directory / filename
+    filepath.write_text(json.dumps(data))
+    return filepath
+
+
+class TestListTemplates:
+    def test_empty_directories(self, tmp_path):
+        builtin = tmp_path / "builtin"
+        user = tmp_path / "user"
+        builtin.mkdir()
+        user.mkdir()
+        mgr = TemplateManager(builtin_dir=builtin, user_dir=user)
+        assert mgr.list_templates() == []
+
+    def test_nonexistent_directories(self, tmp_path):
+        mgr = TemplateManager(
+            builtin_dir=tmp_path / "no_such_builtin",
+            user_dir=tmp_path / "no_such_user",
+        )
+        assert mgr.list_templates() == []
+
+    def test_discovers_builtin_templates(self, tmp_path):
+        builtin = tmp_path / "builtin"
+        builtin.mkdir()
+        _write_template(builtin, "divider.json", "Voltage Divider", "Passives")
+
+        mgr = TemplateManager(builtin_dir=builtin, user_dir=tmp_path / "user")
+        templates = mgr.list_templates()
+        assert len(templates) == 1
+        assert templates[0].name == "Voltage Divider"
+        assert templates[0].is_builtin is True
+
+    def test_discovers_user_templates(self, tmp_path):
+        user = tmp_path / "user"
+        user.mkdir()
+        _write_template(user, "my_filter.json", "My Filter", "User")
+
+        mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=user)
+        templates = mgr.list_templates()
+        assert len(templates) == 1
+        assert templates[0].name == "My Filter"
+        assert templates[0].is_builtin is False
+
+    def test_combines_builtin_and_user(self, tmp_path):
+        builtin = tmp_path / "builtin"
+        user = tmp_path / "user"
+        builtin.mkdir()
+        user.mkdir()
+        _write_template(builtin, "a.json", "Built-in A", "Passives")
+        _write_template(user, "b.json", "User B", "User")
+
+        mgr = TemplateManager(builtin_dir=builtin, user_dir=user)
+        templates = mgr.list_templates()
+        assert len(templates) == 2
+
+    def test_sorted_by_category_then_name(self, tmp_path):
+        builtin = tmp_path / "builtin"
+        builtin.mkdir()
+        _write_template(builtin, "z.json", "Zeta", "Zzz")
+        _write_template(builtin, "a.json", "Alpha", "Aaa")
+        _write_template(builtin, "b.json", "Beta", "Aaa")
+
+        mgr = TemplateManager(builtin_dir=builtin, user_dir=tmp_path / "user")
+        templates = mgr.list_templates()
+        assert [t.name for t in templates] == ["Alpha", "Beta", "Zeta"]
+
+    def test_skips_invalid_json(self, tmp_path):
+        builtin = tmp_path / "builtin"
+        builtin.mkdir()
+        (builtin / "bad.json").write_text("not json")
+        _write_template(builtin, "good.json", "Good One")
+
+        mgr = TemplateManager(builtin_dir=builtin, user_dir=tmp_path / "user")
+        templates = mgr.list_templates()
+        assert len(templates) == 1
+        assert templates[0].name == "Good One"
+
+
+class TestLoadTemplate:
+    def test_loads_components(self, tmp_path):
+        builtin = tmp_path / "builtin"
+        builtin.mkdir()
+
+        # Write a circuit with two resistors
+        data = {
+            "name": "Test",
+            "category": "Test",
+            "components": [
+                {"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}},
+                {"id": "R2", "type": "Resistor", "value": "2k", "pos": {"x": 100, "y": 0}},
+            ],
+            "wires": [],
+            "counters": {"R": 2},
+        }
+        filepath = builtin / "test.json"
+        filepath.write_text(json.dumps(data))
+
+        mgr = TemplateManager(builtin_dir=builtin, user_dir=tmp_path / "user")
+        model = mgr.load_template(filepath)
+        assert "R1" in model.components
+        assert "R2" in model.components
+
+    def test_recalculates_counters(self, tmp_path):
+        builtin = tmp_path / "builtin"
+        builtin.mkdir()
+
+        # Write template with counters that don't match component IDs
+        data = {
+            "name": "Test",
+            "category": "Test",
+            "components": [
+                {"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}},
+                {"id": "R3", "type": "Resistor", "value": "2k", "pos": {"x": 100, "y": 0}},
+                {"id": "V1", "type": "VoltageSource", "value": "5V", "pos": {"x": 200, "y": 0}},
+            ],
+            "wires": [],
+            "counters": {"R": 999, "V": 999},
+        }
+        filepath = builtin / "test.json"
+        filepath.write_text(json.dumps(data))
+
+        mgr = TemplateManager(builtin_dir=builtin, user_dir=tmp_path / "user")
+        model = mgr.load_template(filepath)
+
+        # Counter should reflect actual highest ID, not the stored value
+        assert model.component_counter["R"] == 3
+        assert model.component_counter["V"] == 1
+
+    def test_invalid_json_raises(self, tmp_path):
+        filepath = tmp_path / "bad.json"
+        filepath.write_text("not json")
+
+        mgr = TemplateManager(builtin_dir=tmp_path, user_dir=tmp_path / "user")
+        with pytest.raises(json.JSONDecodeError):
+            mgr.load_template(filepath)
+
+    def test_invalid_structure_raises(self, tmp_path):
+        filepath = tmp_path / "bad.json"
+        filepath.write_text(json.dumps({"no_components": True}))
+
+        mgr = TemplateManager(builtin_dir=tmp_path, user_dir=tmp_path / "user")
+        with pytest.raises(ValueError):
+            mgr.load_template(filepath)
+
+
+class TestSaveTemplate:
+    def test_saves_to_user_directory(self, tmp_path):
+        user = tmp_path / "user"
+        mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=user)
+
+        model = _build_test_circuit()
+        filepath = mgr.save_template(model, "My Circuit", "A test circuit", "Passives")
+
+        assert filepath.exists()
+        assert filepath.parent == user
+
+    def test_creates_user_directory(self, tmp_path):
+        user = tmp_path / "user" / "templates"
+        assert not user.exists()
+
+        mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=user)
+        mgr.save_template(_build_test_circuit(), "Test")
+
+        assert user.exists()
+
+    def test_saves_metadata(self, tmp_path):
+        user = tmp_path / "user"
+        mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=user)
+
+        filepath = mgr.save_template(_build_test_circuit(), "My Filter", "An RC filter", "Filters")
+
+        data = json.loads(filepath.read_text())
+        assert data["name"] == "My Filter"
+        assert data["description"] == "An RC filter"
+        assert data["category"] == "Filters"
+
+    def test_saves_circuit_data(self, tmp_path):
+        user = tmp_path / "user"
+        mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=user)
+
+        model = _build_test_circuit()
+        filepath = mgr.save_template(model, "Test")
+
+        data = json.loads(filepath.read_text())
+        assert "components" in data
+        assert "wires" in data
+        assert len(data["components"]) == 4
+        assert len(data["wires"]) == 3
+
+    def test_avoids_overwriting(self, tmp_path):
+        user = tmp_path / "user"
+        mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=user)
+
+        model = _build_test_circuit()
+        path1 = mgr.save_template(model, "Same Name")
+        path2 = mgr.save_template(model, "Same Name")
+
+        assert path1 != path2
+        assert path1.exists()
+        assert path2.exists()
+
+    def test_default_category_is_user(self, tmp_path):
+        user = tmp_path / "user"
+        mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=user)
+
+        filepath = mgr.save_template(_build_test_circuit(), "No Category")
+
+        data = json.loads(filepath.read_text())
+        assert data["category"] == "User"
+
+
+class TestSaveLoadRoundTrip:
+    def test_round_trip_preserves_components(self, tmp_path):
+        user = tmp_path / "user"
+        mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=user)
+
+        original = _build_test_circuit()
+        filepath = mgr.save_template(original, "Round Trip Test")
+        loaded = mgr.load_template(filepath)
+
+        assert set(loaded.components.keys()) == set(original.components.keys())
+
+    def test_round_trip_preserves_wires(self, tmp_path):
+        user = tmp_path / "user"
+        mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=user)
+
+        original = _build_test_circuit()
+        filepath = mgr.save_template(original, "Round Trip Test")
+        loaded = mgr.load_template(filepath)
+
+        assert len(loaded.wires) == len(original.wires)
+
+    def test_round_trip_recalculates_counters(self, tmp_path):
+        user = tmp_path / "user"
+        mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=user)
+
+        original = _build_test_circuit()
+        filepath = mgr.save_template(original, "Round Trip Test")
+        loaded = mgr.load_template(filepath)
+
+        # Counters should reflect actual component IDs
+        assert loaded.component_counter["R"] == 2
+        assert loaded.component_counter["V"] == 1
+        assert loaded.component_counter["GND"] == 1
+
+
+class TestDeleteTemplate:
+    def test_delete_user_template(self, tmp_path):
+        user = tmp_path / "user"
+        mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=user)
+
+        filepath = mgr.save_template(_build_test_circuit(), "To Delete")
+        assert filepath.exists()
+
+        result = mgr.delete_template(filepath)
+        assert result is True
+        assert not filepath.exists()
+
+    def test_cannot_delete_builtin(self, tmp_path):
+        builtin = tmp_path / "builtin"
+        builtin.mkdir()
+        filepath = _write_template(builtin, "builtin.json", "Built-in")
+
+        user = tmp_path / "user"
+        mgr = TemplateManager(builtin_dir=builtin, user_dir=user)
+
+        result = mgr.delete_template(filepath)
+        assert result is False
+        assert filepath.exists()
+
+    def test_delete_nonexistent_returns_false(self, tmp_path):
+        mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=tmp_path / "user")
+        result = mgr.delete_template(tmp_path / "nonexistent.json")
+        assert result is False
+
+
+class TestCalculateCounters:
+    def test_simple_ids(self):
+        model = CircuitModel()
+        model.components["R1"] = ComponentData("R1", "Resistor", "1k", (0, 0))
+        model.components["R2"] = ComponentData("R2", "Resistor", "2k", (100, 0))
+        model.components["C1"] = ComponentData("C1", "Capacitor", "1u", (200, 0))
+
+        counters = TemplateManager._calculate_counters(model)
+        assert counters == {"R": 2, "C": 1}
+
+    def test_multi_char_prefix(self):
+        model = CircuitModel()
+        model.components["OA1"] = ComponentData("OA1", "Op-Amp", "Ideal", (0, 0))
+        model.components["GND1"] = ComponentData("GND1", "Ground", "0V", (100, 0))
+        model.components["VW1"] = ComponentData("VW1", "Waveform Source", "SIN(0 5 1k)", (200, 0))
+
+        counters = TemplateManager._calculate_counters(model)
+        assert counters == {"OA": 1, "GND": 1, "VW": 1}
+
+    def test_gaps_in_numbering(self):
+        model = CircuitModel()
+        model.components["R1"] = ComponentData("R1", "Resistor", "1k", (0, 0))
+        model.components["R5"] = ComponentData("R5", "Resistor", "5k", (100, 0))
+
+        counters = TemplateManager._calculate_counters(model)
+        assert counters["R"] == 5  # Highest number, not count
+
+    def test_empty_model(self):
+        model = CircuitModel()
+        counters = TemplateManager._calculate_counters(model)
+        assert counters == {}
+
+
+class TestNameToFilename:
+    def test_simple_name(self):
+        assert TemplateManager._name_to_filename("My Circuit") == "my_circuit.json"
+
+    def test_special_characters(self):
+        result = TemplateManager._name_to_filename("RC Filter (1st Order)")
+        assert result == "rc_filter_1st_order.json"
+
+    def test_empty_name(self):
+        assert TemplateManager._name_to_filename("") == "template.json"
+
+    def test_whitespace_only(self):
+        assert TemplateManager._name_to_filename("   ") == "template.json"
+
+
+class TestBuiltinTemplatesValid:
+    """Validate that all shipped built-in templates are well-formed."""
+
+    def test_all_builtin_templates_load(self):
+        """Every JSON file in app/templates/ should load without error."""
+        mgr = TemplateManager()  # Uses default BUILTIN_TEMPLATES_DIR
+        if not mgr.builtin_dir.exists():
+            pytest.skip("Built-in templates directory not found")
+
+        templates = mgr._scan_directory(mgr.builtin_dir, is_builtin=True)
+        assert len(templates) >= 5, f"Expected at least 5 built-in templates, found {len(templates)}"
+
+        for template_info in templates:
+            model = mgr.load_template(template_info.filepath)
+            assert len(model.components) > 0, f"Template {template_info.name} has no components"
+            assert template_info.name, f"Template at {template_info.filepath} has no name"
+            assert template_info.category, f"Template {template_info.name} has no category"
+
+    def test_builtin_templates_have_descriptions(self):
+        """All built-in templates should have descriptions."""
+        mgr = TemplateManager()
+        if not mgr.builtin_dir.exists():
+            pytest.skip("Built-in templates directory not found")
+
+        templates = mgr._scan_directory(mgr.builtin_dir, is_builtin=True)
+        for t in templates:
+            assert t.description, f"Template {t.name} has no description"


### PR DESCRIPTION
## Summary
- Add `TemplateManager` controller for template discovery, save/load with automatic counter recalculation
- Add "New from Template" submenu and "Save as Template..." to File menu with a browse dialog (`NewFromTemplateDialog`, `SaveAsTemplateDialog`)
- Ship 7 built-in templates: voltage divider, RC low-pass/high-pass filters, inverting/non-inverting op-amp amplifiers, common emitter amplifier, half-wave rectifier
- User templates stored in `~/.spice-gui/templates/` and persist across sessions
- Component counters recalculated from actual IDs when loading templates so new components continue with correct numbering

## Test plan
- [x] 33 unit tests covering template save/load round-trip, counter calculation, file naming, deletion, built-in template validation
- [x] All 1445 existing tests still pass
- [x] Lint clean (ruff, black, isort)
- [ ] Manual: File > New from Template shows built-in templates grouped by category
- [ ] Manual: File > Save as Template saves current circuit as user template
- [ ] Manual: User templates appear in the submenu alongside built-in ones
- [ ] Manual: Loading a template resets the file state (no current file, dirty flag set)

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)