### PR TITLE
add instructor grading panel UI with visual feedback annotations

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -140,9 +140,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             new_pos = component.position
             # Only create a command if the component actually moved
             if old_pos[0] != new_pos[0] or old_pos[1] != new_pos[1]:
-                cmd = MoveComponentCommand(
-                    controller, comp_id, new_pos, old_position=old_pos
-                )
+                cmd = MoveComponentCommand(controller, comp_id, new_pos, old_position=old_pos)
                 move_commands.append(cmd)
 
         self._drag_start_positions = {}
@@ -155,9 +153,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             controller.undo_manager._undo_stack.append(move_commands[0])
             controller.undo_manager._redo_stack.clear()
         else:
-            compound = CompoundCommand(
-                move_commands, f"Move {len(move_commands)} components"
-            )
+            compound = CompoundCommand(move_commands, f"Move {len(move_commands)} components")
             controller.undo_manager._undo_stack.append(compound)
             controller.undo_manager._redo_stack.clear()
 
@@ -209,9 +205,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         )
 
         if ok and new_value:
-            is_valid, error_msg = validate_component_value(
-                new_value, self.component_type
-            )
+            is_valid, error_msg = validate_component_value(new_value, self.component_type)
             if not is_valid:
                 QMessageBox.warning(None, "Invalid Value", error_msg)
                 return
@@ -336,19 +330,9 @@ class ComponentGraphicsItem(QGraphicsItem):
         self.draw_component_body(painter)
 
         # Draw label (check canvas visibility settings)
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))
@@ -368,10 +352,7 @@ class ComponentGraphicsItem(QGraphicsItem):
             painter.drawEllipse(terminal, 3, 3)
 
     def itemChange(self, change, value):
-        if (
-            change == QGraphicsItem.GraphicsItemChange.ItemPositionChange
-            and self.scene()
-        ):
+        if change == QGraphicsItem.GraphicsItemChange.ItemPositionChange and self.scene():
             # Snap to grid
             new_pos = value
             grid_x = round(new_pos.x() / GRID_SIZE) * GRID_SIZE
@@ -434,9 +415,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         if self._position_update_timer is None:
             self._position_update_timer = QTimer()
             self._position_update_timer.setSingleShot(True)
-            self._position_update_timer.timeout.connect(
-                self._notify_controller_position
-            )
+            self._position_update_timer.timeout.connect(self._notify_controller_position)
         self._position_update_timer.start(50)  # 50ms debounce
 
     def _notify_controller_position(self):
@@ -646,9 +625,7 @@ class WaveformVoltageSource(ComponentGraphicsItem):
         # Draw sine wave symbol
         from models.component import COMPONENT_COLORS
 
-        painter.setPen(
-            QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2)
-        )
+        painter.setPen(QPen(QColor(COMPONENT_COLORS.get(self.component_type, "#E91E63")), 2))
         from PyQt6.QtGui import QPainterPath
 
         path = QPainterPath()
@@ -688,19 +665,9 @@ class Ground(ComponentGraphicsItem):
         painter.setBrush(QBrush(color.lighter(150)))
         self.draw_component_body(painter)
 
-        canvas = (
-            self.scene().views()[0] if self.scene() and self.scene().views() else None
-        )
-        show_label = (
-            canvas.show_component_labels
-            if canvas and hasattr(canvas, "show_component_labels")
-            else True
-        )
-        show_value = (
-            canvas.show_component_values
-            if canvas and hasattr(canvas, "show_component_values")
-            else True
-        )
+        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
+        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
+        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
 
         if show_label or show_value:
             painter.setPen(QPen(Qt.GlobalColor.black))

--- a/app/GUI/grading_panel.py
+++ b/app/GUI/grading_panel.py
@@ -1,0 +1,324 @@
+"""Instructor grading panel - displays rubric results with visual feedback."""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from models.circuit import CircuitModel
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import (
+    QFileDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+if TYPE_CHECKING:
+    from grading.grader import GradingResult
+    from grading.rubric import Rubric
+
+logger = logging.getLogger(__name__)
+
+
+class GradingPanel(QWidget):
+    """Panel for grading student circuits against rubrics.
+
+    Shows rubric check results with pass/fail indicators, scores,
+    and feedback. Supports loading student files and rubrics,
+    running the grader, and exporting results.
+    """
+
+    def __init__(self, model: CircuitModel, parent=None):
+        super().__init__(parent)
+        self._model = model
+        self._grader = None  # Lazy-initialized to avoid circular import
+        self._rubric: Optional[Rubric] = None
+        self._student_circuit: Optional[CircuitModel] = None
+        self._student_file: str = ""
+        self._result: Optional[GradingResult] = None
+        self._highlighted_components: list = []
+
+        self._init_ui()
+
+    def _init_ui(self):
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(5, 5, 5, 5)
+
+        title = QLabel("Instructor Grading")
+        title.setStyleSheet("font-weight: bold; font-size: 14px;")
+        outer.addWidget(title)
+
+        # --- Action buttons ---
+        btn_layout = QHBoxLayout()
+
+        self.load_student_btn = QPushButton("Load Student...")
+        self.load_student_btn.setToolTip("Load a student circuit file to grade")
+        self.load_student_btn.clicked.connect(self._on_load_student)
+        btn_layout.addWidget(self.load_student_btn)
+
+        self.load_rubric_btn = QPushButton("Load Rubric...")
+        self.load_rubric_btn.setToolTip("Load a grading rubric (.spice-rubric)")
+        self.load_rubric_btn.clicked.connect(self._on_load_rubric)
+        btn_layout.addWidget(self.load_rubric_btn)
+
+        outer.addLayout(btn_layout)
+
+        btn_layout2 = QHBoxLayout()
+
+        self.grade_btn = QPushButton("Grade")
+        self.grade_btn.setToolTip("Run the rubric against the loaded student circuit")
+        self.grade_btn.setEnabled(False)
+        self.grade_btn.clicked.connect(self._on_grade)
+        btn_layout2.addWidget(self.grade_btn)
+
+        self.export_btn = QPushButton("Export CSV")
+        self.export_btn.setToolTip("Export grading results as CSV")
+        self.export_btn.setEnabled(False)
+        self.export_btn.clicked.connect(self._on_export_csv)
+        btn_layout2.addWidget(self.export_btn)
+
+        outer.addLayout(btn_layout2)
+
+        # --- Status labels ---
+        status_group = QGroupBox("Status")
+        status_layout = QVBoxLayout(status_group)
+
+        self.student_label = QLabel("Student: (none loaded)")
+        status_layout.addWidget(self.student_label)
+
+        self.rubric_label = QLabel("Rubric: (none loaded)")
+        status_layout.addWidget(self.rubric_label)
+
+        outer.addWidget(status_group)
+
+        # --- Score display ---
+        self.score_label = QLabel("")
+        self.score_label.setStyleSheet("font-size: 16px; font-weight: bold;")
+        self.score_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        outer.addWidget(self.score_label)
+
+        # --- Check results list ---
+        results_group = QGroupBox("Check Results")
+        results_layout = QVBoxLayout(results_group)
+
+        self.results_list = QListWidget()
+        self.results_list.setAlternatingRowColors(True)
+        self.results_list.currentItemChanged.connect(self._on_check_selected)
+        results_layout.addWidget(self.results_list)
+
+        self.feedback_label = QLabel("")
+        self.feedback_label.setWordWrap(True)
+        self.feedback_label.setStyleSheet("padding: 4px;")
+        results_layout.addWidget(self.feedback_label)
+
+        outer.addWidget(results_group)
+
+    # --- Load operations ---
+
+    def _on_load_student(self):
+        """Load a student circuit file."""
+        from controllers.file_controller import validate_circuit_data
+
+        filename, _ = QFileDialog.getOpenFileName(
+            self,
+            "Load Student Circuit",
+            "",
+            "Circuit Files (*.json);;Template Files (*.spice-template);;All Files (*)",
+        )
+        if not filename:
+            return
+
+        try:
+            with open(filename, "r") as f:
+                data = json.load(f)
+
+            # Handle template files (extract starter_circuit)
+            if "template_version" in data and "starter_circuit" in data:
+                if data["starter_circuit"] is not None:
+                    validate_circuit_data(data["starter_circuit"])
+                    self._student_circuit = CircuitModel.from_dict(data["starter_circuit"])
+                else:
+                    self._student_circuit = CircuitModel()
+            else:
+                validate_circuit_data(data)
+                self._student_circuit = CircuitModel.from_dict(data)
+
+            self._student_file = Path(filename).name
+            self.student_label.setText(f"Student: {self._student_file}")
+            self._update_grade_button()
+        except (json.JSONDecodeError, ValueError, OSError) as e:
+            QMessageBox.critical(self, "Error", f"Failed to load student file:\n{e}")
+
+    def _on_load_rubric(self):
+        """Load a grading rubric."""
+        filename, _ = QFileDialog.getOpenFileName(
+            self,
+            "Load Grading Rubric",
+            "",
+            "Rubric Files (*.spice-rubric);;All Files (*)",
+        )
+        if not filename:
+            return
+
+        try:
+            from grading.rubric import load_rubric
+
+            self._rubric = load_rubric(filename)
+            self.rubric_label.setText(f"Rubric: {self._rubric.title}")
+            self._update_grade_button()
+        except (json.JSONDecodeError, ValueError, OSError) as e:
+            QMessageBox.critical(self, "Error", f"Failed to load rubric:\n{e}")
+
+    def _update_grade_button(self):
+        """Enable grade button when both student and rubric are loaded."""
+        self.grade_btn.setEnabled(self._student_circuit is not None and self._rubric is not None)
+
+    # --- Grading ---
+
+    def _on_grade(self):
+        """Run the grading engine and display results."""
+        if self._student_circuit is None or self._rubric is None:
+            return
+
+        if self._grader is None:
+            from grading.grader import CircuitGrader
+
+            self._grader = CircuitGrader()
+
+        self._result = self._grader.grade(
+            student_circuit=self._student_circuit,
+            rubric=self._rubric,
+            reference_circuit=self._model,
+            student_file=self._student_file,
+        )
+
+        self._display_results(self._result)
+        self.export_btn.setEnabled(True)
+
+    def _display_results(self, result: GradingResult):
+        """Populate the results list with check outcomes."""
+        self.results_list.clear()
+        self._highlighted_components.clear()
+
+        # Score header
+        pct = result.percentage
+        self.score_label.setText(f"{result.earned_points}/{result.total_points} — {pct:.0f}%")
+        if pct >= 90:
+            self.score_label.setStyleSheet("font-size: 16px; font-weight: bold; color: green;")
+        elif pct >= 70:
+            self.score_label.setStyleSheet("font-size: 16px; font-weight: bold; color: #CC8800;")
+        else:
+            self.score_label.setStyleSheet("font-size: 16px; font-weight: bold; color: red;")
+
+        # Check results
+        for cr in result.check_results:
+            if cr.passed:
+                icon = "\u2714"  # checkmark
+                text = f"{icon} {cr.check_id}: +{cr.points_earned}/{cr.points_possible}"
+            else:
+                icon = "\u2718"  # X mark
+                text = f"{icon} {cr.check_id}: 0/{cr.points_possible}"
+
+            item = QListWidgetItem(text)
+            item.setData(Qt.ItemDataRole.UserRole, cr)
+
+            if cr.passed:
+                item.setForeground(QColor("green"))
+            else:
+                item.setForeground(QColor("red"))
+
+            self.results_list.addItem(item)
+
+        self.feedback_label.setText("Click a check to see feedback")
+
+    def _on_check_selected(self, current, previous):
+        """Show feedback for the selected check."""
+        if current is None:
+            self.feedback_label.setText("")
+            return
+
+        cr = current.data(Qt.ItemDataRole.UserRole)
+        if cr is None:
+            return
+
+        self.feedback_label.setText(cr.feedback)
+
+    # --- Export ---
+
+    def _on_export_csv(self):
+        """Export grading results as CSV."""
+        if self._result is None:
+            return
+
+        filename, _ = QFileDialog.getSaveFileName(
+            self,
+            "Export Grading Results",
+            "",
+            "CSV Files (*.csv);;All Files (*)",
+        )
+        if not filename:
+            return
+
+        try:
+            self._export_result_csv(self._result, filename)
+            QMessageBox.information(self, "Exported", f"Results saved to {filename}")
+        except OSError as e:
+            QMessageBox.critical(self, "Error", f"Failed to export:\n{e}")
+
+    @staticmethod
+    def _export_result_csv(result: GradingResult, filepath: str):
+        """Write a single student's grading result to CSV."""
+        with open(filepath, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["Student File", "Rubric", "Score", "Percentage"])
+            writer.writerow(
+                [
+                    result.student_file,
+                    result.rubric_title,
+                    f"{result.earned_points}/{result.total_points}",
+                    f"{result.percentage:.1f}%",
+                ]
+            )
+            writer.writerow([])
+            writer.writerow(["Check ID", "Passed", "Points Earned", "Points Possible", "Feedback"])
+            for cr in result.check_results:
+                writer.writerow(
+                    [
+                        cr.check_id,
+                        "Yes" if cr.passed else "No",
+                        cr.points_earned,
+                        cr.points_possible,
+                        cr.feedback,
+                    ]
+                )
+
+    # --- Public API ---
+
+    def clear_results(self):
+        """Clear all grading results and reset the panel."""
+        self._result = None
+        self._student_circuit = None
+        self._student_file = ""
+        self._rubric = None
+        self.results_list.clear()
+        self.score_label.setText("")
+        self.feedback_label.setText("")
+        self.student_label.setText("Student: (none loaded)")
+        self.rubric_label.setText("Rubric: (none loaded)")
+        self.grade_btn.setEnabled(False)
+        self.export_btn.setEnabled(False)
+
+    def get_result(self) -> Optional[GradingResult]:
+        """Return the current grading result, or None."""
+        return self._result

--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -33,6 +33,7 @@ from PyQt6.QtWidgets import (
 from .circuit_canvas import CircuitCanvasView
 from .circuit_statistics_panel import CircuitStatisticsPanel
 from .component_palette import ComponentPalette
+from .grading_panel import GradingPanel
 from .keybindings import KeybindingsRegistry
 from .main_window_analysis import AnalysisSettingsMixin
 from .main_window_file_ops import FileOperationsMixin
@@ -208,6 +209,11 @@ class MainWindow(
         self.statistics_panel = CircuitStatisticsPanel(self.model, self.circuit_ctrl, self.simulation_ctrl)
         self.statistics_panel.setVisible(False)
         right_panel_layout.addWidget(self.statistics_panel)
+
+        # Instructor grading panel
+        self.grading_panel = GradingPanel(self.model, self)
+        self.grading_panel.setVisible(False)
+        right_panel_layout.addWidget(self.grading_panel)
 
         right_panel_layout.addStretch()
         right_panel_layout.addWidget(QLabel("Actions"))

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -53,9 +53,7 @@ class MenuBarMixin:
 
         export_netlist_action = QAction("Export &Netlist...", self)
         export_netlist_action.setShortcut(kb.get("file.export_netlist"))
-        export_netlist_action.setToolTip(
-            "Export the generated SPICE netlist to a .cir file"
-        )
+        export_netlist_action.setToolTip("Export the generated SPICE netlist to a .cir file")
         export_netlist_action.triggered.connect(self.export_netlist)
         file_menu.addAction(export_netlist_action)
 
@@ -70,9 +68,7 @@ class MenuBarMixin:
         file_menu.addAction(export_pdf_action)
 
         export_latex_action = QAction("Export as &LaTeX...", self)
-        export_latex_action.setToolTip(
-            "Export circuit as CircuiTikZ LaTeX code (.tex file)"
-        )
+        export_latex_action.setToolTip("Export circuit as CircuiTikZ LaTeX code (.tex file)")
         export_latex_action.triggered.connect(self.export_circuitikz)
         file_menu.addAction(export_latex_action)
 
@@ -145,9 +141,7 @@ class MenuBarMixin:
         edit_menu.addSeparator()
 
         copy_latex_action = QAction("Copy as La&TeX", self)
-        copy_latex_action.setToolTip(
-            "Copy the CircuiTikZ environment block to the clipboard"
-        )
+        copy_latex_action.setToolTip("Copy the CircuiTikZ environment block to the clipboard")
         copy_latex_action.triggered.connect(self.copy_circuitikz)
         edit_menu.addAction(copy_latex_action)
 
@@ -214,9 +208,7 @@ class MenuBarMixin:
         self.probe_action = QAction("&Probe Tool", self)
         self.probe_action.setCheckable(True)
         self.probe_action.setShortcut(kb.get("tools.probe"))
-        self.probe_action.setToolTip(
-            "Click nodes or components to see voltage/current values"
-        )
+        self.probe_action.setToolTip("Click nodes or components to see voltage/current values")
         self.probe_action.triggered.connect(self._toggle_probe_mode)
         view_menu.addAction(self.probe_action)
 
@@ -274,9 +266,7 @@ class MenuBarMixin:
 
         self.monochrome_mode_action = QAction("&Monochrome", self)
         self.monochrome_mode_action.setCheckable(True)
-        self.monochrome_mode_action.triggered.connect(
-            lambda: self._set_color_mode("monochrome")
-        )
+        self.monochrome_mode_action.triggered.connect(lambda: self._set_color_mode("monochrome"))
         color_mode_menu.addAction(self.monochrome_mode_action)
 
         self.color_mode_group = QActionGroup(self)
@@ -371,9 +361,7 @@ class MenuBarMixin:
 
         mc_action = QAction("&Monte Carlo...", self)
         mc_action.setCheckable(True)
-        mc_action.setToolTip(
-            "Run Monte Carlo tolerance analysis with randomized component values"
-        )
+        mc_action.setToolTip("Run Monte Carlo tolerance analysis with randomized component values")
         mc_action.triggered.connect(self.set_analysis_monte_carlo)
         analysis_menu.addAction(mc_action)
 
@@ -428,6 +416,14 @@ class MenuBarMixin:
             "sim.run": run_action,
             "tools.probe": self.probe_action,
         }
+
+        # Instructor menu
+        instructor_menu = menubar.addMenu("&Instructor")
+        if instructor_menu:
+            grade_action = QAction("&Grade Student Circuit...", self)
+            grade_action.setToolTip("Open the grading panel to grade a student submission")
+            grade_action.triggered.connect(self._toggle_grading_panel)
+            instructor_menu.addAction(grade_action)
 
         # Settings menu
         settings_menu = menubar.addMenu("Se&ttings")

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -127,11 +127,7 @@ class SettingsMixin:
         if reply == QMessageBox.StandardButton.Yes:
             source = self.file_ctrl.load_auto_save()
             if source is not None:
-                title = (
-                    f"Circuit Design GUI - {source}"
-                    if source
-                    else "Circuit Design GUI - (Recovered)"
-                )
+                title = f"Circuit Design GUI - {source}" if source else "Circuit Design GUI - (Recovered)"
                 self.setWindowTitle(title)
                 self._sync_analysis_menu()
                 statusBar = self.statusBar()

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -81,6 +81,11 @@ class ViewOperationsMixin:
         if checked:
             self.statistics_panel.refresh()
 
+    def _toggle_grading_panel(self):
+        """Toggle the instructor grading panel visibility."""
+        visible = not self.grading_panel.isVisible()
+        self.grading_panel.setVisible(visible)
+
     # Dirty flag (unsaved changes indicator)
 
     def _on_dirty_change(self, event: str, data) -> None:
@@ -143,9 +148,7 @@ class ViewOperationsMixin:
         self.canvas.set_probe_mode(checked)
         if checked:
             if not self.canvas.node_voltages and self._last_results is None:
-                self.statusBar().showMessage(
-                    "Probe mode active. Run a simulation first to see values.", 3000
-                )
+                self.statusBar().showMessage("Probe mode active. Run a simulation first to see values.", 3000)
             else:
                 self.statusBar().showMessage(
                     "Probe mode active. Click nodes or components to see values. Press Escape to exit.",
@@ -158,9 +161,7 @@ class ViewOperationsMixin:
     def _on_probe_requested(self, signal_name, probe_type):
         """Handle probe click for sweep/transient analyses (no OP data on canvas)."""
         if self._last_results is None:
-            self.statusBar().showMessage(
-                "No simulation results available. Run a simulation first.", 3000
-            )
+            self.statusBar().showMessage("No simulation results available. Run a simulation first.", 3000)
             return
 
         analysis_type = self._last_results_type
@@ -171,9 +172,7 @@ class ViewOperationsMixin:
         elif analysis_type == "AC Sweep":
             self._probe_open_ac_sweep(signal_name, probe_type)
         else:
-            self.statusBar().showMessage(
-                f"Probe not supported for {analysis_type} analysis.", 3000
-            )
+            self.statusBar().showMessage(f"Probe not supported for {analysis_type} analysis.", 3000)
 
     def _probe_open_waveform(self, signal_name, probe_type):
         """Open waveform dialog focused on the probed signal."""
@@ -232,14 +231,10 @@ class ViewOperationsMixin:
         circuit_items = [
             item
             for item in scene.items()
-            if isinstance(
-                item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem)
-            )
+            if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
         ]
         if not circuit_items:
-            QMessageBox.information(
-                self, "Export Image", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export Image", "Nothing to export — the canvas is empty.")
             return
 
         source_rect = circuit_items[0].sceneBoundingRect()
@@ -256,9 +251,7 @@ class ViewOperationsMixin:
 
             generator = QSvgGenerator()
             generator.setFileName(filename)
-            generator.setSize(
-                QSize(int(source_rect.width()), int(source_rect.height()))
-            )
+            generator.setSize(QSize(int(source_rect.width()), int(source_rect.height())))
             generator.setViewBox(source_rect)
             generator.setTitle("SDM Spice Circuit")
 
@@ -285,9 +278,7 @@ class ViewOperationsMixin:
             painter.end()
             image.save(filename)
 
-        QMessageBox.information(
-            self, "Export Image", f"Circuit exported to:\n{filename}"
-        )
+        QMessageBox.information(self, "Export Image", f"Circuit exported to:\n{filename}")
 
     def export_circuitikz(self):
         """Export the circuit as a CircuiTikZ LaTeX file."""
@@ -299,9 +290,7 @@ class ViewOperationsMixin:
 
         model = self.circuit_ctrl.model
         if not model.components:
-            QMessageBox.information(
-                self, "Export LaTeX", "Nothing to export — the canvas is empty."
-            )
+            QMessageBox.information(self, "Export LaTeX", "Nothing to export — the canvas is empty.")
             return
 
         # Show options dialog
@@ -319,11 +308,7 @@ class ViewOperationsMixin:
                 nodes=model.nodes,
                 terminal_to_node=model.terminal_to_node,
                 standalone=opts["standalone"],
-                circuit_name=(
-                    os.path.basename(self.file_ctrl.current_file)
-                    if self.file_ctrl.current_file
-                    else ""
-                ),
+                circuit_name=(os.path.basename(self.file_ctrl.current_file) if self.file_ctrl.current_file else ""),
                 scale=opts["scale"],
                 include_ids=opts["include_ids"],
                 include_values=opts["include_values"],
@@ -336,9 +321,7 @@ class ViewOperationsMixin:
 
         default_name = ""
         if hasattr(self, "file_ctrl") and self.file_ctrl.current_file:
-            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[
-                0
-            ]
+            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[0]
             default_name = base + ".tex"
 
         filename, _ = QFileDialog.getSaveFileName(

--- a/app/grading/circuit_comparer.py
+++ b/app/grading/circuit_comparer.py
@@ -1,0 +1,399 @@
+"""Circuit comparison engine for structural and parametric checks.
+
+Compares two CircuitModel instances to identify differences in components,
+values, topology, and analysis settings. Foundation for automated grading.
+
+No Qt dependencies — pure Python module.
+"""
+
+from dataclasses import dataclass, field
+
+from models.circuit import CircuitModel
+from simulation.monte_carlo import parse_spice_value
+
+
+@dataclass
+class CheckResult:
+    """Result of a single comparison check."""
+
+    check_type: str
+    component_id: str
+    passed: bool
+    expected: str
+    actual: str
+    message: str
+
+
+@dataclass
+class ComparisonResult:
+    """Aggregated result of comparing two circuits."""
+
+    matches: list[CheckResult] = field(default_factory=list)
+    mismatches: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def score(self) -> float:
+        """Overall match ratio (0.0–1.0)."""
+        total = len(self.matches) + len(self.mismatches)
+        if total == 0:
+            return 1.0
+        return len(self.matches) / total
+
+    @property
+    def all_results(self) -> list[CheckResult]:
+        """All check results in order."""
+        return self.matches + self.mismatches
+
+    def add(self, result: CheckResult) -> None:
+        """Add a check result to the appropriate list."""
+        if result.passed:
+            self.matches.append(result)
+        else:
+            self.mismatches.append(result)
+
+
+def compare_values(expected_str: str, actual_str: str, tolerance_pct: float = 0.0) -> bool:
+    """Compare two SPICE value strings with optional tolerance.
+
+    Args:
+        expected_str: Expected value (e.g., "1k", "4.7u").
+        actual_str: Actual value to check.
+        tolerance_pct: Allowed deviation in percent (0 = exact match).
+
+    Returns:
+        True if values match within tolerance, False otherwise.
+        Returns False if either value cannot be parsed.
+    """
+    expected = parse_spice_value(expected_str)
+    actual = parse_spice_value(actual_str)
+
+    if expected is None or actual is None:
+        return expected_str.strip() == actual_str.strip()
+
+    if expected == 0:
+        return actual == 0
+
+    deviation = abs(actual - expected) / abs(expected) * 100
+    return deviation <= tolerance_pct
+
+
+class CircuitComparer:
+    """Compares two CircuitModel instances structurally and parametrically."""
+
+    def compare(self, reference: CircuitModel, student: CircuitModel) -> ComparisonResult:
+        """Run all comparison checks between reference and student circuits.
+
+        Args:
+            reference: The instructor's solution circuit.
+            student: The student's submitted circuit.
+
+        Returns:
+            ComparisonResult with all check outcomes.
+        """
+        result = ComparisonResult()
+        self._check_component_existence(reference, student, result)
+        self._check_component_values(reference, student, result)
+        self._check_component_counts(reference, student, result)
+        self._check_topology(reference, student, result)
+        self._check_ground(reference, student, result)
+        self._check_analysis(reference, student, result)
+        return result
+
+    def check_component_exists(self, student: CircuitModel, component_id: str, component_type: str) -> CheckResult:
+        """Check if a specific component exists in the student circuit.
+
+        Args:
+            student: The student's circuit.
+            component_id: Expected component ID (e.g., "R1").
+            component_type: Expected component type (e.g., "Resistor").
+
+        Returns:
+            CheckResult for this single check.
+        """
+        comp = student.components.get(component_id)
+        if comp is None:
+            return CheckResult(
+                check_type="component_exists",
+                component_id=component_id,
+                passed=False,
+                expected=f"{component_type} {component_id}",
+                actual="not found",
+                message=f"Missing {component_type} '{component_id}'",
+            )
+        if comp.component_type != component_type:
+            return CheckResult(
+                check_type="component_exists",
+                component_id=component_id,
+                passed=False,
+                expected=component_type,
+                actual=comp.component_type,
+                message=f"'{component_id}' is a {comp.component_type}, expected {component_type}",
+            )
+        return CheckResult(
+            check_type="component_exists",
+            component_id=component_id,
+            passed=True,
+            expected=f"{component_type} {component_id}",
+            actual=f"{comp.component_type} {component_id}",
+            message=f"{component_type} '{component_id}' present",
+        )
+
+    def check_component_value(
+        self,
+        student: CircuitModel,
+        component_id: str,
+        expected_value: str,
+        tolerance_pct: float = 0.0,
+    ) -> CheckResult:
+        """Check if a component has the expected value.
+
+        Args:
+            student: The student's circuit.
+            component_id: Component to check.
+            expected_value: Expected value string (e.g., "1k").
+            tolerance_pct: Allowed deviation in percent.
+
+        Returns:
+            CheckResult for this single check.
+        """
+        comp = student.components.get(component_id)
+        if comp is None:
+            return CheckResult(
+                check_type="component_value",
+                component_id=component_id,
+                passed=False,
+                expected=expected_value,
+                actual="component not found",
+                message=f"Cannot check value — '{component_id}' not found",
+            )
+
+        passed = compare_values(expected_value, comp.value, tolerance_pct)
+        if passed:
+            msg = f"'{component_id}' value correct ({comp.value})"
+        else:
+            msg = f"'{component_id}' value is {comp.value}, expected {expected_value}"
+            if tolerance_pct > 0:
+                msg += f" (within {tolerance_pct}%)"
+
+        return CheckResult(
+            check_type="component_value",
+            component_id=component_id,
+            passed=passed,
+            expected=expected_value,
+            actual=comp.value,
+            message=msg,
+        )
+
+    def check_topology(
+        self,
+        circuit: CircuitModel,
+        component_a: str,
+        component_b: str,
+    ) -> CheckResult:
+        """Check if two components share a node (are directly connected).
+
+        Args:
+            circuit: Circuit to check.
+            component_a: First component ID.
+            component_b: Second component ID.
+
+        Returns:
+            CheckResult indicating whether they share a node.
+        """
+        connected = _components_share_node(circuit, component_a, component_b)
+
+        if connected:
+            return CheckResult(
+                check_type="topology",
+                component_id=f"{component_a}-{component_b}",
+                passed=True,
+                expected="connected",
+                actual="connected",
+                message=f"'{component_a}' and '{component_b}' are connected",
+            )
+        return CheckResult(
+            check_type="topology",
+            component_id=f"{component_a}-{component_b}",
+            passed=False,
+            expected="connected",
+            actual="not connected",
+            message=f"'{component_a}' and '{component_b}' should share a node",
+        )
+
+    def check_analysis_type(self, student: CircuitModel, expected_type: str) -> CheckResult:
+        """Check if the analysis type matches.
+
+        Args:
+            student: The student's circuit.
+            expected_type: Expected analysis type string.
+
+        Returns:
+            CheckResult for analysis type check.
+        """
+        passed = student.analysis_type == expected_type
+        return CheckResult(
+            check_type="analysis_type",
+            component_id="",
+            passed=passed,
+            expected=expected_type,
+            actual=student.analysis_type,
+            message=(
+                f"Analysis type correct ({expected_type})"
+                if passed
+                else f"Analysis type is '{student.analysis_type}', expected '{expected_type}'"
+            ),
+        )
+
+    # -- Internal comparison methods for compare() --
+
+    def _check_component_existence(
+        self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult
+    ) -> None:
+        """Check that all reference components exist in the student circuit."""
+        for comp_id, comp in reference.components.items():
+            if comp.component_type == "Ground":
+                continue
+            result.add(self.check_component_exists(student, comp_id, comp.component_type))
+
+    def _check_component_values(self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult) -> None:
+        """Check that matching components have the same values."""
+        for comp_id, ref_comp in reference.components.items():
+            if ref_comp.component_type == "Ground":
+                continue
+            student_comp = student.components.get(comp_id)
+            if student_comp is None:
+                continue  # Already reported by existence check
+            if student_comp.component_type != ref_comp.component_type:
+                continue  # Already reported by existence check
+            result.add(self.check_component_value(student, comp_id, ref_comp.value))
+
+    def _check_component_counts(self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult) -> None:
+        """Check that the count of each component type matches."""
+        ref_counts = _count_by_type(reference)
+        student_counts = _count_by_type(student)
+
+        for comp_type, expected_count in ref_counts.items():
+            actual_count = student_counts.get(comp_type, 0)
+            passed = actual_count == expected_count
+            result.add(
+                CheckResult(
+                    check_type="component_count",
+                    component_id="",
+                    passed=passed,
+                    expected=f"{expected_count} {comp_type}(s)",
+                    actual=f"{actual_count} {comp_type}(s)",
+                    message=(
+                        f"Correct number of {comp_type}s ({expected_count})"
+                        if passed
+                        else f"Expected {expected_count} {comp_type}(s), found {actual_count}"
+                    ),
+                )
+            )
+
+    def _check_topology(self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult) -> None:
+        """Check that components sharing nodes in the reference also share them in the student."""
+        # Find pairs of non-ground components that share a node in the reference
+        pairs_checked = set()
+        for node in reference.nodes:
+            comp_ids = {t[0] for t in node.terminals}
+            # Filter to non-ground components
+            comp_ids = {
+                cid
+                for cid in comp_ids
+                if cid in reference.components and reference.components[cid].component_type != "Ground"
+            }
+            for a in sorted(comp_ids):
+                for b in sorted(comp_ids):
+                    if a >= b:
+                        continue
+                    pair = (a, b)
+                    if pair in pairs_checked:
+                        continue
+                    pairs_checked.add(pair)
+                    # Only check if both exist in student
+                    if a in student.components and b in student.components:
+                        result.add(self.check_topology(student, a, b))
+
+    def _check_ground(self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult) -> None:
+        """Check that ground is present and connects the expected components."""
+        ref_ground_comps = set()
+        student_ground_comps = set()
+
+        for node in reference.nodes:
+            if node.is_ground:
+                ref_ground_comps = {t[0] for t in node.terminals}
+                break
+
+        has_ground = False
+        for node in student.nodes:
+            if node.is_ground:
+                student_ground_comps = {t[0] for t in node.terminals}
+                has_ground = True
+                break
+
+        if ref_ground_comps and not has_ground:
+            result.add(
+                CheckResult(
+                    check_type="ground",
+                    component_id="GND",
+                    passed=False,
+                    expected="ground node present",
+                    actual="no ground node",
+                    message="Circuit is missing a ground connection",
+                )
+            )
+            return
+
+        if ref_ground_comps and has_ground:
+            # Check that ground connects the same non-Ground components
+            ref_connected = {
+                cid
+                for cid in ref_ground_comps
+                if cid in reference.components and reference.components[cid].component_type != "Ground"
+            }
+            student_connected = {
+                cid
+                for cid in student_ground_comps
+                if cid in student.components and student.components[cid].component_type != "Ground"
+            }
+
+            for cid in ref_connected:
+                if cid in student.components:
+                    passed = cid in student_connected
+                    result.add(
+                        CheckResult(
+                            check_type="ground",
+                            component_id=cid,
+                            passed=passed,
+                            expected=f"'{cid}' connected to ground",
+                            actual=f"'{cid}' {'connected' if passed else 'not connected'} to ground",
+                            message=(
+                                f"'{cid}' correctly connected to ground"
+                                if passed
+                                else f"'{cid}' should be connected to ground"
+                            ),
+                        )
+                    )
+
+    def _check_analysis(self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult) -> None:
+        """Check that analysis type and parameters match."""
+        result.add(self.check_analysis_type(student, reference.analysis_type))
+
+
+def _components_share_node(circuit: CircuitModel, comp_a: str, comp_b: str) -> bool:
+    """Check if two components share at least one node in the circuit."""
+    for node in circuit.nodes:
+        comp_ids = {t[0] for t in node.terminals}
+        if comp_a in comp_ids and comp_b in comp_ids:
+            return True
+    return False
+
+
+def _count_by_type(circuit: CircuitModel) -> dict[str, int]:
+    """Count components by type, excluding Ground."""
+    counts: dict[str, int] = {}
+    for comp in circuit.components.values():
+        if comp.component_type == "Ground":
+            continue
+        counts[comp.component_type] = counts.get(comp.component_type, 0) + 1
+    return counts

--- a/app/grading/grader.py
+++ b/app/grading/grader.py
@@ -1,0 +1,227 @@
+"""Grading engine that executes rubric checks against student circuits.
+
+Orchestrates the CircuitComparer to run each rubric check and produces
+a scored GradingResult.
+
+No Qt dependencies — pure Python module.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from grading.circuit_comparer import CircuitComparer
+from grading.rubric import Rubric, RubricCheck
+from models.circuit import CircuitModel
+
+
+@dataclass
+class CheckGradeResult:
+    """Result of a single rubric check."""
+
+    check_id: str
+    passed: bool
+    points_earned: int
+    points_possible: int
+    feedback: str
+
+
+@dataclass
+class GradingResult:
+    """Aggregated grading result for a student submission."""
+
+    student_file: str
+    rubric_title: str
+    total_points: int
+    earned_points: int
+    check_results: list[CheckGradeResult] = field(default_factory=list)
+
+    @property
+    def percentage(self) -> float:
+        if self.total_points == 0:
+            return 100.0
+        return (self.earned_points / self.total_points) * 100.0
+
+
+class CircuitGrader:
+    """Executes rubric checks against a student circuit."""
+
+    def __init__(self):
+        self._comparer = CircuitComparer()
+
+    def grade(
+        self,
+        student_circuit: CircuitModel,
+        rubric: Rubric,
+        reference_circuit: Optional[CircuitModel] = None,
+        student_file: str = "",
+    ) -> GradingResult:
+        """Grade a student circuit against a rubric.
+
+        Args:
+            student_circuit: The student's submitted circuit.
+            rubric: The grading rubric to apply.
+            reference_circuit: Optional reference solution (used by some checks).
+            student_file: Filename for the result record.
+
+        Returns:
+            GradingResult with per-check scores and feedback.
+        """
+        result = GradingResult(
+            student_file=student_file,
+            rubric_title=rubric.title,
+            total_points=rubric.total_points,
+            earned_points=0,
+        )
+
+        for check in rubric.checks:
+            check_result = self._execute_check(check, student_circuit, reference_circuit)
+            result.check_results.append(check_result)
+            result.earned_points += check_result.points_earned
+
+        return result
+
+    def _execute_check(
+        self,
+        check: RubricCheck,
+        student: CircuitModel,
+        reference: Optional[CircuitModel],
+    ) -> CheckGradeResult:
+        """Execute a single rubric check and return the graded result."""
+        handler = _CHECK_HANDLERS.get(check.check_type)
+        if handler is None:
+            return CheckGradeResult(
+                check_id=check.check_id,
+                passed=False,
+                points_earned=0,
+                points_possible=check.points,
+                feedback=f"Unknown check type: {check.check_type}",
+            )
+        return handler(self, check, student, reference)
+
+    def _check_component_exists(
+        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+    ) -> CheckGradeResult:
+        component_id = check.params.get("component_id", "")
+        component_type = check.params.get("component_type", "")
+
+        if component_id:
+            cr = self._comparer.check_component_exists(student, component_id, component_type)
+            passed = cr.passed
+        elif component_type:
+            # Check by type count
+            min_count = check.params.get("min_count", 1)
+            count = sum(1 for c in student.components.values() if c.component_type == component_type)
+            passed = count >= min_count
+        else:
+            passed = False
+
+        return CheckGradeResult(
+            check_id=check.check_id,
+            passed=passed,
+            points_earned=check.points if passed else 0,
+            points_possible=check.points,
+            feedback=check.feedback_pass if passed else check.feedback_fail,
+        )
+
+    def _check_component_value(
+        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+    ) -> CheckGradeResult:
+        component_id = check.params.get("component_id", "")
+        expected_value = check.params.get("expected_value", "")
+        tolerance_pct = check.params.get("tolerance_pct", 0.0)
+
+        cr = self._comparer.check_component_value(student, component_id, expected_value, tolerance_pct)
+
+        return CheckGradeResult(
+            check_id=check.check_id,
+            passed=cr.passed,
+            points_earned=check.points if cr.passed else 0,
+            points_possible=check.points,
+            feedback=check.feedback_pass if cr.passed else check.feedback_fail,
+        )
+
+    def _check_component_count(
+        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+    ) -> CheckGradeResult:
+        component_type = check.params.get("component_type", "")
+        expected_count = check.params.get("expected_count", 0)
+
+        actual_count = sum(1 for c in student.components.values() if c.component_type == component_type)
+        passed = actual_count == expected_count
+
+        return CheckGradeResult(
+            check_id=check.check_id,
+            passed=passed,
+            points_earned=check.points if passed else 0,
+            points_possible=check.points,
+            feedback=check.feedback_pass if passed else check.feedback_fail,
+        )
+
+    def _check_topology(
+        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+    ) -> CheckGradeResult:
+        component_a = check.params.get("component_a", "")
+        component_b = check.params.get("component_b", "")
+
+        cr = self._comparer.check_topology(student, component_a, component_b)
+        expected_connected = check.params.get("shared_node", True)
+        passed = cr.passed == expected_connected
+
+        return CheckGradeResult(
+            check_id=check.check_id,
+            passed=passed,
+            points_earned=check.points if passed else 0,
+            points_possible=check.points,
+            feedback=check.feedback_pass if passed else check.feedback_fail,
+        )
+
+    def _check_ground(
+        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+    ) -> CheckGradeResult:
+        has_ground = any(n.is_ground for n in student.nodes)
+        component_id = check.params.get("component_id", "")
+
+        if component_id:
+            # Check that a specific component is connected to ground
+            passed = False
+            for node in student.nodes:
+                if node.is_ground:
+                    comp_ids = {t[0] for t in node.terminals}
+                    if component_id in comp_ids:
+                        passed = True
+                    break
+        else:
+            passed = has_ground
+
+        return CheckGradeResult(
+            check_id=check.check_id,
+            passed=passed,
+            points_earned=check.points if passed else 0,
+            points_possible=check.points,
+            feedback=check.feedback_pass if passed else check.feedback_fail,
+        )
+
+    def _check_analysis_type(
+        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+    ) -> CheckGradeResult:
+        expected_type = check.params.get("expected_type", "")
+        cr = self._comparer.check_analysis_type(student, expected_type)
+
+        return CheckGradeResult(
+            check_id=check.check_id,
+            passed=cr.passed,
+            points_earned=check.points if cr.passed else 0,
+            points_possible=check.points,
+            feedback=check.feedback_pass if cr.passed else check.feedback_fail,
+        )
+
+
+# Map check types to handler methods
+_CHECK_HANDLERS = {
+    "component_exists": CircuitGrader._check_component_exists,
+    "component_value": CircuitGrader._check_component_value,
+    "component_count": CircuitGrader._check_component_count,
+    "topology": CircuitGrader._check_topology,
+    "ground": CircuitGrader._check_ground,
+    "analysis_type": CircuitGrader._check_analysis_type,
+}

--- a/app/grading/rubric.py
+++ b/app/grading/rubric.py
@@ -1,0 +1,150 @@
+"""Rubric data model for automated circuit grading.
+
+A rubric defines a set of checks to run against a student circuit,
+each worth a certain number of points. Rubrics are serialized as
+.spice-rubric JSON files.
+
+No Qt dependencies — pure Python module.
+"""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+RUBRIC_EXTENSION = ".spice-rubric"
+
+VALID_CHECK_TYPES = frozenset(
+    {
+        "component_exists",
+        "component_value",
+        "component_count",
+        "topology",
+        "ground",
+        "analysis_type",
+    }
+)
+
+
+@dataclass
+class RubricCheck:
+    """A single check in a grading rubric."""
+
+    check_id: str
+    check_type: str
+    points: int
+    params: dict = field(default_factory=dict)
+    feedback_pass: str = ""
+    feedback_fail: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "check_id": self.check_id,
+            "check_type": self.check_type,
+            "points": self.points,
+            "params": dict(self.params),
+            "feedback_pass": self.feedback_pass,
+            "feedback_fail": self.feedback_fail,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "RubricCheck":
+        return cls(
+            check_id=data["check_id"],
+            check_type=data["check_type"],
+            points=data["points"],
+            params=dict(data.get("params", {})),
+            feedback_pass=data.get("feedback_pass", ""),
+            feedback_fail=data.get("feedback_fail", ""),
+        )
+
+
+@dataclass
+class Rubric:
+    """A complete grading rubric with title and checks."""
+
+    title: str
+    total_points: int
+    checks: list[RubricCheck] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "title": self.title,
+            "total_points": self.total_points,
+            "checks": [c.to_dict() for c in self.checks],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Rubric":
+        return cls(
+            title=data["title"],
+            total_points=data["total_points"],
+            checks=[RubricCheck.from_dict(c) for c in data.get("checks", [])],
+        )
+
+
+def validate_rubric(data: dict) -> None:
+    """Validate rubric JSON structure.
+
+    Raises ValueError if the rubric is malformed.
+    """
+    if not isinstance(data, dict):
+        raise ValueError("Rubric must be a JSON object.")
+
+    if not data.get("title"):
+        raise ValueError("Rubric must have a non-empty 'title'.")
+
+    if "total_points" not in data or not isinstance(data["total_points"], (int, float)):
+        raise ValueError("Rubric must have a numeric 'total_points'.")
+
+    if "checks" not in data or not isinstance(data["checks"], list):
+        raise ValueError("Rubric must have a 'checks' list.")
+
+    if len(data["checks"]) == 0:
+        raise ValueError("Rubric must have at least one check.")
+
+    check_ids = set()
+    points_sum = 0
+    for i, check in enumerate(data["checks"]):
+        if not isinstance(check, dict):
+            raise ValueError(f"Check #{i + 1} must be a JSON object.")
+
+        for required in ("check_id", "check_type", "points"):
+            if required not in check:
+                raise ValueError(f"Check #{i + 1} is missing required field '{required}'.")
+
+        if check["check_type"] not in VALID_CHECK_TYPES:
+            raise ValueError(
+                f"Check '{check['check_id']}' has invalid type '{check['check_type']}'. "
+                f"Valid types: {', '.join(sorted(VALID_CHECK_TYPES))}"
+            )
+
+        if check["check_id"] in check_ids:
+            raise ValueError(f"Duplicate check_id '{check['check_id']}'.")
+        check_ids.add(check["check_id"])
+
+        points_sum += check["points"]
+
+    if points_sum != data["total_points"]:
+        raise ValueError(f"Check points sum to {points_sum}, but total_points is {data['total_points']}.")
+
+
+def save_rubric(rubric: Rubric, filepath) -> None:
+    """Save a rubric to a .spice-rubric JSON file."""
+    filepath = Path(filepath)
+    with open(filepath, "w") as f:
+        json.dump(rubric.to_dict(), f, indent=2)
+
+
+def load_rubric(filepath) -> Rubric:
+    """Load and validate a rubric from a .spice-rubric JSON file.
+
+    Raises:
+        json.JSONDecodeError: If file is not valid JSON.
+        ValueError: If rubric structure is invalid.
+        OSError: If the file cannot be read.
+    """
+    filepath = Path(filepath)
+    with open(filepath, "r") as f:
+        data = json.load(f)
+    validate_rubric(data)
+    return Rubric.from_dict(data)

--- a/app/tests/unit/test_circuit_comparer.py
+++ b/app/tests/unit/test_circuit_comparer.py
@@ -1,0 +1,458 @@
+"""Tests for the circuit comparison engine."""
+
+import pytest
+from grading.circuit_comparer import CheckResult, CircuitComparer, ComparisonResult, compare_values
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from models.wire import WireData
+
+# --- Helpers ---
+
+
+def _build_voltage_divider(r1_value="1k", r2_value="2k", source_value="5V"):
+    """Build a V1-R1-R2-GND voltage divider circuit."""
+    model = CircuitModel()
+    model.components["V1"] = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value=source_value,
+        position=(0.0, 0.0),
+    )
+    model.components["R1"] = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value=r1_value,
+        position=(100.0, 0.0),
+    )
+    model.components["R2"] = ComponentData(
+        component_id="R2",
+        component_type="Resistor",
+        value=r2_value,
+        position=(100.0, 100.0),
+    )
+    model.components["GND1"] = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(0.0, 100.0),
+    )
+    model.wires = [
+        # V1 terminal 1 -> R1 terminal 0
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        # R1 terminal 1 -> R2 terminal 0
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="R2",
+            end_terminal=0,
+        ),
+        # R2 terminal 1 -> GND
+        WireData(
+            start_component_id="R2",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        # V1 terminal 0 -> GND
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+    ]
+    model.component_counter = {"V": 1, "R": 2, "GND": 1}
+    model.rebuild_nodes()
+    return model
+
+
+def _build_rc_filter(r_value="1k", c_value="100n"):
+    """Build a V1-R1-C1-GND RC low-pass filter."""
+    model = CircuitModel()
+    model.components["V1"] = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value="5V",
+        position=(0.0, 0.0),
+    )
+    model.components["R1"] = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value=r_value,
+        position=(100.0, 0.0),
+    )
+    model.components["C1"] = ComponentData(
+        component_id="C1",
+        component_type="Capacitor",
+        value=c_value,
+        position=(200.0, 0.0),
+    )
+    model.components["GND1"] = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(0.0, 100.0),
+    )
+    model.wires = [
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="C1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="C1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+    ]
+    model.component_counter = {"V": 1, "R": 1, "C": 1, "GND": 1}
+    model.analysis_type = "AC Sweep"
+    model.analysis_params = {"fStart": 20, "fStop": 20000}
+    model.rebuild_nodes()
+    return model
+
+
+# --- Tests: compare_values ---
+
+
+class TestCompareValues:
+    def test_exact_match(self):
+        assert compare_values("1k", "1k") is True
+
+    def test_equal_numeric_values(self):
+        assert compare_values("1000", "1k") is True
+
+    def test_within_tolerance(self):
+        assert compare_values("1k", "1.05k", tolerance_pct=10) is True
+
+    def test_outside_tolerance(self):
+        assert compare_values("1k", "1.2k", tolerance_pct=10) is False
+
+    def test_zero_tolerance_exact(self):
+        assert compare_values("1k", "1k", tolerance_pct=0) is True
+
+    def test_zero_tolerance_different(self):
+        assert compare_values("1k", "1.001k", tolerance_pct=0) is False
+
+    @pytest.mark.parametrize(
+        "value_str,expected_float",
+        [
+            ("1k", 1000.0),
+            ("4.7u", 4.7e-6),
+            ("100m", 0.1),
+            ("10MEG", 1e7),
+            ("22p", 22e-12),
+            ("100n", 1e-7),
+            ("1.5", 1.5),
+            ("100", 100.0),
+        ],
+    )
+    def test_engineering_notation_parsing(self, value_str, expected_float):
+        """Verify value parsing by comparing against itself."""
+        assert compare_values(value_str, value_str) is True
+
+    def test_unparseable_values_string_compare(self):
+        assert compare_values("SIN(0 5 1k)", "SIN(0 5 1k)") is True
+
+    def test_unparseable_values_mismatch(self):
+        assert compare_values("SIN(0 5 1k)", "SIN(0 10 1k)") is False
+
+    def test_zero_expected_zero_actual(self):
+        assert compare_values("0", "0") is True
+
+    def test_zero_expected_nonzero_actual(self):
+        assert compare_values("0", "1") is False
+
+    def test_negative_values(self):
+        assert compare_values("-5", "-5") is True
+
+    def test_units_stripped(self):
+        assert compare_values("5V", "5V") is True
+        assert compare_values("5V", "5") is True
+
+
+# --- Tests: CircuitComparer individual checks ---
+
+
+class TestCheckComponentExists:
+    def test_component_present(self):
+        circuit = _build_voltage_divider()
+        comparer = CircuitComparer()
+        result = comparer.check_component_exists(circuit, "R1", "Resistor")
+        assert result.passed is True
+
+    def test_component_missing(self):
+        circuit = _build_voltage_divider()
+        comparer = CircuitComparer()
+        result = comparer.check_component_exists(circuit, "C1", "Capacitor")
+        assert result.passed is False
+        assert "not found" in result.actual
+
+    def test_wrong_type(self):
+        circuit = _build_voltage_divider()
+        comparer = CircuitComparer()
+        result = comparer.check_component_exists(circuit, "R1", "Capacitor")
+        assert result.passed is False
+        assert "Resistor" in result.actual
+
+
+class TestCheckComponentValue:
+    def test_correct_value(self):
+        circuit = _build_voltage_divider(r1_value="1k")
+        comparer = CircuitComparer()
+        result = comparer.check_component_value(circuit, "R1", "1k")
+        assert result.passed is True
+
+    def test_wrong_value(self):
+        circuit = _build_voltage_divider(r1_value="2k")
+        comparer = CircuitComparer()
+        result = comparer.check_component_value(circuit, "R1", "1k")
+        assert result.passed is False
+        assert result.actual == "2k"
+
+    def test_value_within_tolerance(self):
+        circuit = _build_voltage_divider(r1_value="1.05k")
+        comparer = CircuitComparer()
+        result = comparer.check_component_value(circuit, "R1", "1k", tolerance_pct=10)
+        assert result.passed is True
+
+    def test_value_outside_tolerance(self):
+        circuit = _build_voltage_divider(r1_value="1.5k")
+        comparer = CircuitComparer()
+        result = comparer.check_component_value(circuit, "R1", "1k", tolerance_pct=10)
+        assert result.passed is False
+
+    def test_missing_component(self):
+        circuit = _build_voltage_divider()
+        comparer = CircuitComparer()
+        result = comparer.check_component_value(circuit, "C1", "100n")
+        assert result.passed is False
+        assert "not found" in result.message
+
+
+class TestCheckTopology:
+    def test_connected_components(self):
+        circuit = _build_voltage_divider()
+        comparer = CircuitComparer()
+        # R1 and R2 share a node in the voltage divider
+        result = comparer.check_topology(circuit, "R1", "R2")
+        assert result.passed is True
+
+    def test_not_connected_components(self):
+        """R1 and V1 don't share a node in the voltage divider (V1-R1 connection is terminal 1-0 but they should share)."""
+        circuit = _build_voltage_divider()
+        comparer = CircuitComparer()
+        # V1 terminal 1 connects to R1 terminal 0, so they DO share a node
+        result = comparer.check_topology(circuit, "V1", "R1")
+        assert result.passed is True
+
+    def test_unconnected_components(self):
+        """Create a circuit where two components are NOT connected."""
+        model = CircuitModel()
+        model.components["R1"] = ComponentData(
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(0.0, 0.0),
+        )
+        model.components["R2"] = ComponentData(
+            component_id="R2",
+            component_type="Resistor",
+            value="2k",
+            position=(100.0, 0.0),
+        )
+        # No wires connecting them
+        model.rebuild_nodes()
+
+        comparer = CircuitComparer()
+        result = comparer.check_topology(model, "R1", "R2")
+        assert result.passed is False
+
+
+class TestCheckAnalysisType:
+    def test_correct_analysis(self):
+        circuit = _build_rc_filter()
+        comparer = CircuitComparer()
+        result = comparer.check_analysis_type(circuit, "AC Sweep")
+        assert result.passed is True
+
+    def test_wrong_analysis(self):
+        circuit = _build_rc_filter()
+        comparer = CircuitComparer()
+        result = comparer.check_analysis_type(circuit, "Transient")
+        assert result.passed is False
+        assert result.actual == "AC Sweep"
+
+
+# --- Tests: Full comparison ---
+
+
+class TestFullComparison:
+    def test_identical_circuits(self):
+        ref = _build_voltage_divider()
+        student = _build_voltage_divider()
+        comparer = CircuitComparer()
+        result = comparer.compare(ref, student)
+        assert result.score == 1.0
+        assert len(result.mismatches) == 0
+
+    def test_missing_component(self):
+        ref = _build_voltage_divider()
+        student = _build_voltage_divider()
+        del student.components["R2"]
+        student.rebuild_nodes()
+
+        comparer = CircuitComparer()
+        result = comparer.compare(ref, student)
+        assert result.score < 1.0
+        # Should have mismatches for R2 existence and component count
+        mismatch_types = {m.check_type for m in result.mismatches}
+        assert "component_exists" in mismatch_types
+
+    def test_wrong_values(self):
+        ref = _build_voltage_divider(r1_value="1k", r2_value="2k")
+        student = _build_voltage_divider(r1_value="10k", r2_value="2k")
+
+        comparer = CircuitComparer()
+        result = comparer.compare(ref, student)
+        assert result.score < 1.0
+        value_mismatches = [m for m in result.mismatches if m.check_type == "component_value"]
+        assert len(value_mismatches) == 1
+        assert value_mismatches[0].component_id == "R1"
+
+    def test_wrong_analysis_type(self):
+        ref = _build_rc_filter()
+        student = _build_rc_filter()
+        student.analysis_type = "Transient"
+
+        comparer = CircuitComparer()
+        result = comparer.compare(ref, student)
+        analysis_mismatches = [m for m in result.mismatches if m.check_type == "analysis_type"]
+        assert len(analysis_mismatches) == 1
+
+    def test_topology_mismatch(self):
+        ref = _build_voltage_divider()
+        # Build a student circuit where R1 and R2 are NOT connected
+        student = CircuitModel()
+        student.components["V1"] = ComponentData(
+            component_id="V1",
+            component_type="Voltage Source",
+            value="5V",
+            position=(0.0, 0.0),
+        )
+        student.components["R1"] = ComponentData(
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(100.0, 0.0),
+        )
+        student.components["R2"] = ComponentData(
+            component_id="R2",
+            component_type="Resistor",
+            value="2k",
+            position=(200.0, 0.0),
+        )
+        student.components["GND1"] = ComponentData(
+            component_id="GND1",
+            component_type="Ground",
+            value="0V",
+            position=(0.0, 100.0),
+        )
+        # Wire V1-R1 and V1-R2 but NOT R1-R2
+        student.wires = [
+            WireData(
+                start_component_id="V1",
+                start_terminal=1,
+                end_component_id="R1",
+                end_terminal=0,
+            ),
+            WireData(
+                start_component_id="V1",
+                start_terminal=0,
+                end_component_id="R2",
+                end_terminal=0,
+            ),
+            WireData(
+                start_component_id="R2",
+                start_terminal=1,
+                end_component_id="GND1",
+                end_terminal=0,
+            ),
+        ]
+        student.component_counter = {"V": 1, "R": 2, "GND": 1}
+        student.rebuild_nodes()
+
+        comparer = CircuitComparer()
+        result = comparer.compare(ref, student)
+        topology_mismatches = [m for m in result.mismatches if m.check_type == "topology"]
+        # R1 and R2 should be reported as not connected
+        assert any("R1" in m.component_id and "R2" in m.component_id for m in topology_mismatches)
+
+
+class TestComparisonResult:
+    def test_score_all_pass(self):
+        result = ComparisonResult()
+        result.add(CheckResult("test", "", True, "", "", ""))
+        result.add(CheckResult("test", "", True, "", "", ""))
+        assert result.score == 1.0
+
+    def test_score_all_fail(self):
+        result = ComparisonResult()
+        result.add(CheckResult("test", "", False, "", "", ""))
+        result.add(CheckResult("test", "", False, "", "", ""))
+        assert result.score == 0.0
+
+    def test_score_half(self):
+        result = ComparisonResult()
+        result.add(CheckResult("test", "", True, "", "", ""))
+        result.add(CheckResult("test", "", False, "", "", ""))
+        assert result.score == 0.5
+
+    def test_empty_score(self):
+        result = ComparisonResult()
+        assert result.score == 1.0
+
+    def test_all_results_combines(self):
+        result = ComparisonResult()
+        result.add(CheckResult("a", "", True, "", "", ""))
+        result.add(CheckResult("b", "", False, "", "", ""))
+        assert len(result.all_results) == 2
+
+
+class TestRealisticScenarios:
+    def test_rc_filter_correct(self):
+        """Student builds the correct RC filter."""
+        ref = _build_rc_filter(r_value="1k", c_value="100n")
+        student = _build_rc_filter(r_value="1k", c_value="100n")
+        comparer = CircuitComparer()
+        result = comparer.compare(ref, student)
+        assert result.score == 1.0
+
+    def test_rc_filter_wrong_capacitor(self):
+        """Student uses wrong capacitor value."""
+        ref = _build_rc_filter(r_value="1k", c_value="100n")
+        student = _build_rc_filter(r_value="1k", c_value="10u")
+        comparer = CircuitComparer()
+        result = comparer.compare(ref, student)
+        assert result.score < 1.0
+        value_mismatches = [m for m in result.mismatches if m.check_type == "component_value"]
+        assert any(m.component_id == "C1" for m in value_mismatches)

--- a/app/tests/unit/test_grading_panel.py
+++ b/app/tests/unit/test_grading_panel.py
@@ -1,0 +1,250 @@
+"""Tests for the instructor grading panel."""
+
+import csv
+import json
+
+import pytest
+from grading.grader import CheckGradeResult, GradingResult
+from grading.rubric import Rubric, RubricCheck, save_rubric
+from GUI.grading_panel import GradingPanel
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from models.wire import WireData
+from PyQt6.QtCore import Qt
+
+
+def _build_rc_filter(r_value="1k", c_value="100n"):
+    """Build a V1-R1-C1-GND RC low-pass filter."""
+    model = CircuitModel()
+    model.components["V1"] = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value="5V",
+        position=(0.0, 0.0),
+    )
+    model.components["R1"] = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value=r_value,
+        position=(100.0, 0.0),
+    )
+    model.components["C1"] = ComponentData(
+        component_id="C1",
+        component_type="Capacitor",
+        value=c_value,
+        position=(200.0, 0.0),
+    )
+    model.components["GND1"] = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(0.0, 100.0),
+    )
+    model.wires = [
+        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
+        WireData(start_component_id="R1", start_terminal=1, end_component_id="C1", end_terminal=0),
+        WireData(start_component_id="C1", start_terminal=1, end_component_id="GND1", end_terminal=0),
+        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+    ]
+    model.component_counter = {"V": 1, "R": 1, "C": 1, "GND": 1}
+    model.analysis_type = "AC Sweep"
+    model.rebuild_nodes()
+    return model
+
+
+def _build_rubric():
+    return Rubric(
+        title="RC Filter Test",
+        total_points=50,
+        checks=[
+            RubricCheck(
+                check_id="r1_exists",
+                check_type="component_exists",
+                points=25,
+                params={"component_id": "R1", "component_type": "Resistor"},
+                feedback_pass="R1 present",
+                feedback_fail="R1 missing",
+            ),
+            RubricCheck(
+                check_id="r1_value",
+                check_type="component_value",
+                points=25,
+                params={"component_id": "R1", "expected_value": "1k", "tolerance_pct": 10},
+                feedback_pass="R1 value OK",
+                feedback_fail="R1 value wrong",
+            ),
+        ],
+    )
+
+
+class TestGradingPanelStructure:
+    def test_creates_with_expected_widgets(self, qtbot):
+        model = CircuitModel()
+        panel = GradingPanel(model)
+        qtbot.addWidget(panel)
+
+        assert panel.load_student_btn is not None
+        assert panel.load_rubric_btn is not None
+        assert panel.grade_btn is not None
+        assert panel.export_btn is not None
+        assert panel.results_list is not None
+        assert panel.score_label is not None
+
+    def test_grade_button_initially_disabled(self, qtbot):
+        panel = GradingPanel(CircuitModel())
+        qtbot.addWidget(panel)
+        assert not panel.grade_btn.isEnabled()
+
+    def test_export_button_initially_disabled(self, qtbot):
+        panel = GradingPanel(CircuitModel())
+        qtbot.addWidget(panel)
+        assert not panel.export_btn.isEnabled()
+
+
+class TestGradingPanelGrading:
+    def test_grade_populates_results(self, qtbot):
+        model = _build_rc_filter()
+        panel = GradingPanel(model)
+        qtbot.addWidget(panel)
+
+        panel._student_circuit = _build_rc_filter()
+        panel._rubric = _build_rubric()
+        panel._student_file = "test_student.json"
+        panel._on_grade()
+
+        assert panel.results_list.count() == 2
+        assert panel._result is not None
+        assert panel._result.earned_points == 50
+
+    def test_grade_shows_score(self, qtbot):
+        model = _build_rc_filter()
+        panel = GradingPanel(model)
+        qtbot.addWidget(panel)
+
+        panel._student_circuit = _build_rc_filter()
+        panel._rubric = _build_rubric()
+        panel._on_grade()
+
+        assert "50/50" in panel.score_label.text()
+
+    def test_grade_with_wrong_value(self, qtbot):
+        model = _build_rc_filter()
+        panel = GradingPanel(model)
+        qtbot.addWidget(panel)
+
+        panel._student_circuit = _build_rc_filter(r_value="10k")
+        panel._rubric = _build_rubric()
+        panel._on_grade()
+
+        assert panel._result.earned_points == 25  # Only existence check passes
+        assert "25/50" in panel.score_label.text()
+
+    def test_grade_enables_export(self, qtbot):
+        model = _build_rc_filter()
+        panel = GradingPanel(model)
+        qtbot.addWidget(panel)
+
+        panel._student_circuit = _build_rc_filter()
+        panel._rubric = _build_rubric()
+        panel._on_grade()
+
+        assert panel.export_btn.isEnabled()
+
+
+class TestGradingPanelCheckSelection:
+    def test_selecting_check_shows_feedback(self, qtbot):
+        model = _build_rc_filter()
+        panel = GradingPanel(model)
+        qtbot.addWidget(panel)
+
+        panel._student_circuit = _build_rc_filter()
+        panel._rubric = _build_rubric()
+        panel._on_grade()
+
+        # Select first item
+        panel.results_list.setCurrentRow(0)
+        assert panel.feedback_label.text() == "R1 present"
+
+
+class TestGradingPanelClear:
+    def test_clear_results(self, qtbot):
+        model = _build_rc_filter()
+        panel = GradingPanel(model)
+        qtbot.addWidget(panel)
+
+        panel._student_circuit = _build_rc_filter()
+        panel._rubric = _build_rubric()
+        panel._on_grade()
+
+        panel.clear_results()
+        assert panel.results_list.count() == 0
+        assert panel.score_label.text() == ""
+        assert not panel.grade_btn.isEnabled()
+        assert not panel.export_btn.isEnabled()
+
+
+class TestGradingPanelExport:
+    def test_export_csv(self, qtbot, tmp_path):
+        model = _build_rc_filter()
+        panel = GradingPanel(model)
+        qtbot.addWidget(panel)
+
+        panel._student_circuit = _build_rc_filter()
+        panel._rubric = _build_rubric()
+        panel._student_file = "student1.json"
+        panel._on_grade()
+
+        filepath = tmp_path / "results.csv"
+        panel._export_result_csv(panel._result, str(filepath))
+
+        assert filepath.exists()
+        content = filepath.read_text()
+        assert "student1.json" in content
+        assert "RC Filter Test" in content
+        assert "r1_exists" in content
+
+
+class TestGradingPanelLoadStudent:
+    def test_load_student_json(self, qtbot, tmp_path):
+        model = CircuitModel()
+        panel = GradingPanel(model)
+        qtbot.addWidget(panel)
+
+        # Create a circuit file
+        circuit = _build_rc_filter()
+        filepath = tmp_path / "student.json"
+        with open(filepath, "w") as f:
+            json.dump(circuit.to_dict(), f)
+
+        # Simulate loading (bypass file dialog)
+        from controllers.file_controller import validate_circuit_data
+
+        with open(filepath, "r") as f:
+            data = json.load(f)
+        validate_circuit_data(data)
+        panel._student_circuit = CircuitModel.from_dict(data)
+        panel._student_file = "student.json"
+        panel.student_label.setText("Student: student.json")
+
+        assert panel._student_circuit is not None
+        assert "R1" in panel._student_circuit.components
+
+
+class TestGradingPanelLoadRubric:
+    def test_load_rubric_file(self, qtbot, tmp_path):
+        model = CircuitModel()
+        panel = GradingPanel(model)
+        qtbot.addWidget(panel)
+
+        rubric = _build_rubric()
+        filepath = tmp_path / "test.spice-rubric"
+        save_rubric(rubric, filepath)
+
+        # Simulate loading (bypass file dialog)
+        from grading.rubric import load_rubric
+
+        panel._rubric = load_rubric(filepath)
+        panel.rubric_label.setText(f"Rubric: {panel._rubric.title}")
+
+        assert panel._rubric is not None
+        assert panel._rubric.title == "RC Filter Test"

--- a/app/tests/unit/test_rubric_grader.py
+++ b/app/tests/unit/test_rubric_grader.py
@@ -1,0 +1,491 @@
+"""Tests for rubric data model and grading engine."""
+
+import json
+
+import pytest
+from grading.grader import CircuitGrader, GradingResult
+from grading.rubric import Rubric, RubricCheck, load_rubric, save_rubric, validate_rubric
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from models.wire import WireData
+
+# --- Helpers ---
+
+
+def _build_rc_filter(r_value="1k", c_value="100n", analysis="AC Sweep"):
+    """Build a V1-R1-C1-GND RC low-pass filter."""
+    model = CircuitModel()
+    model.components["V1"] = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value="5V",
+        position=(0.0, 0.0),
+    )
+    model.components["R1"] = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value=r_value,
+        position=(100.0, 0.0),
+    )
+    model.components["C1"] = ComponentData(
+        component_id="C1",
+        component_type="Capacitor",
+        value=c_value,
+        position=(200.0, 0.0),
+    )
+    model.components["GND1"] = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(0.0, 100.0),
+    )
+    model.wires = [
+        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
+        WireData(start_component_id="R1", start_terminal=1, end_component_id="C1", end_terminal=0),
+        WireData(start_component_id="C1", start_terminal=1, end_component_id="GND1", end_terminal=0),
+        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+    ]
+    model.component_counter = {"V": 1, "R": 1, "C": 1, "GND": 1}
+    model.analysis_type = analysis
+    model.rebuild_nodes()
+    return model
+
+
+def _build_rc_rubric():
+    """Build a rubric for an RC low-pass filter assignment."""
+    return Rubric(
+        title="RC Low-Pass Filter",
+        total_points=100,
+        checks=[
+            RubricCheck(
+                check_id="r1_exists",
+                check_type="component_exists",
+                points=15,
+                params={"component_id": "R1", "component_type": "Resistor"},
+                feedback_pass="Resistor R1 present",
+                feedback_fail="Missing resistor R1",
+            ),
+            RubricCheck(
+                check_id="c1_exists",
+                check_type="component_exists",
+                points=15,
+                params={"component_id": "C1", "component_type": "Capacitor"},
+                feedback_pass="Capacitor C1 present",
+                feedback_fail="Missing capacitor C1",
+            ),
+            RubricCheck(
+                check_id="r1_value",
+                check_type="component_value",
+                points=20,
+                params={"component_id": "R1", "expected_value": "1k", "tolerance_pct": 10},
+                feedback_pass="R1 value correct",
+                feedback_fail="R1 value should be approximately 1k",
+            ),
+            RubricCheck(
+                check_id="rc_connected",
+                check_type="topology",
+                points=25,
+                params={"component_a": "R1", "component_b": "C1", "shared_node": True},
+                feedback_pass="R1 and C1 are connected",
+                feedback_fail="R1 and C1 must share a node",
+            ),
+            RubricCheck(
+                check_id="has_ground",
+                check_type="ground",
+                points=10,
+                params={},
+                feedback_pass="Ground present",
+                feedback_fail="Circuit needs a ground connection",
+            ),
+            RubricCheck(
+                check_id="ac_sweep",
+                check_type="analysis_type",
+                points=15,
+                params={"expected_type": "AC Sweep"},
+                feedback_pass="AC Sweep selected",
+                feedback_fail="Use AC Sweep for frequency response",
+            ),
+        ],
+    )
+
+
+# --- Tests: Rubric data model ---
+
+
+class TestRubricCheck:
+    def test_to_dict(self):
+        check = RubricCheck(
+            check_id="r1",
+            check_type="component_exists",
+            points=10,
+            params={"component_id": "R1"},
+            feedback_pass="OK",
+            feedback_fail="Missing",
+        )
+        d = check.to_dict()
+        assert d["check_id"] == "r1"
+        assert d["points"] == 10
+        assert d["params"]["component_id"] == "R1"
+
+    def test_from_dict_round_trip(self):
+        check = RubricCheck(
+            check_id="r1",
+            check_type="component_value",
+            points=20,
+            params={"expected_value": "1k", "tolerance_pct": 5},
+            feedback_pass="OK",
+            feedback_fail="Wrong",
+        )
+        restored = RubricCheck.from_dict(check.to_dict())
+        assert restored.check_id == "r1"
+        assert restored.check_type == "component_value"
+        assert restored.params["tolerance_pct"] == 5
+
+
+class TestRubric:
+    def test_to_dict(self):
+        rubric = _build_rc_rubric()
+        d = rubric.to_dict()
+        assert d["title"] == "RC Low-Pass Filter"
+        assert d["total_points"] == 100
+        assert len(d["checks"]) == 6
+
+    def test_from_dict_round_trip(self):
+        rubric = _build_rc_rubric()
+        restored = Rubric.from_dict(rubric.to_dict())
+        assert restored.title == rubric.title
+        assert restored.total_points == rubric.total_points
+        assert len(restored.checks) == len(rubric.checks)
+        assert restored.checks[0].check_id == "r1_exists"
+
+
+class TestValidateRubric:
+    def test_valid_rubric(self):
+        rubric = _build_rc_rubric()
+        validate_rubric(rubric.to_dict())  # Should not raise
+
+    def test_not_a_dict(self):
+        with pytest.raises(ValueError, match="JSON object"):
+            validate_rubric([])
+
+    def test_missing_title(self):
+        with pytest.raises(ValueError, match="title"):
+            validate_rubric({"total_points": 10, "checks": []})
+
+    def test_missing_total_points(self):
+        with pytest.raises(ValueError, match="total_points"):
+            validate_rubric({"title": "Test", "checks": []})
+
+    def test_empty_checks(self):
+        with pytest.raises(ValueError, match="at least one"):
+            validate_rubric({"title": "Test", "total_points": 10, "checks": []})
+
+    def test_invalid_check_type(self):
+        data = {
+            "title": "Test",
+            "total_points": 10,
+            "checks": [
+                {"check_id": "x", "check_type": "invalid_type", "points": 10},
+            ],
+        }
+        with pytest.raises(ValueError, match="invalid type"):
+            validate_rubric(data)
+
+    def test_duplicate_check_ids(self):
+        data = {
+            "title": "Test",
+            "total_points": 20,
+            "checks": [
+                {"check_id": "dup", "check_type": "ground", "points": 10},
+                {"check_id": "dup", "check_type": "ground", "points": 10},
+            ],
+        }
+        with pytest.raises(ValueError, match="Duplicate"):
+            validate_rubric(data)
+
+    def test_points_sum_mismatch(self):
+        data = {
+            "title": "Test",
+            "total_points": 50,
+            "checks": [
+                {"check_id": "a", "check_type": "ground", "points": 10},
+            ],
+        }
+        with pytest.raises(ValueError, match="sum to 10"):
+            validate_rubric(data)
+
+    def test_missing_check_field(self):
+        data = {
+            "title": "Test",
+            "total_points": 10,
+            "checks": [
+                {"check_id": "a", "check_type": "ground"},  # missing points
+            ],
+        }
+        with pytest.raises(ValueError, match="points"):
+            validate_rubric(data)
+
+
+class TestRubricSaveLoad:
+    def test_save_creates_file(self, tmp_path):
+        rubric = _build_rc_rubric()
+        filepath = tmp_path / "test.spice-rubric"
+        save_rubric(rubric, filepath)
+        assert filepath.exists()
+
+    def test_round_trip(self, tmp_path):
+        rubric = _build_rc_rubric()
+        filepath = tmp_path / "test.spice-rubric"
+        save_rubric(rubric, filepath)
+        loaded = load_rubric(filepath)
+        assert loaded.title == rubric.title
+        assert loaded.total_points == rubric.total_points
+        assert len(loaded.checks) == len(rubric.checks)
+
+    def test_load_invalid_json_raises(self, tmp_path):
+        filepath = tmp_path / "bad.spice-rubric"
+        filepath.write_text("not json")
+        with pytest.raises(json.JSONDecodeError):
+            load_rubric(filepath)
+
+    def test_load_invalid_rubric_raises(self, tmp_path):
+        filepath = tmp_path / "bad.spice-rubric"
+        filepath.write_text(json.dumps({"title": "", "total_points": 0, "checks": []}))
+        with pytest.raises(ValueError):
+            load_rubric(filepath)
+
+
+# --- Tests: Grading engine ---
+
+
+class TestCircuitGraderFullMarks:
+    def test_correct_circuit_gets_full_marks(self):
+        student = _build_rc_filter(r_value="1k", c_value="100n", analysis="AC Sweep")
+        rubric = _build_rc_rubric()
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric, student_file="student.json")
+        assert result.earned_points == 100
+        assert result.percentage == 100.0
+        assert all(cr.passed for cr in result.check_results)
+
+    def test_result_metadata(self):
+        student = _build_rc_filter()
+        rubric = _build_rc_rubric()
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric, student_file="test.json")
+        assert result.student_file == "test.json"
+        assert result.rubric_title == "RC Low-Pass Filter"
+        assert result.total_points == 100
+
+
+class TestCircuitGraderPartialMarks:
+    def test_missing_component_loses_points(self):
+        student = _build_rc_filter()
+        del student.components["C1"]
+        student.rebuild_nodes()
+
+        rubric = _build_rc_rubric()
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+
+        # C1 existence check should fail
+        c1_result = next(cr for cr in result.check_results if cr.check_id == "c1_exists")
+        assert c1_result.passed is False
+        assert c1_result.points_earned == 0
+
+        # Total should be less than 100
+        assert result.earned_points < 100
+
+    def test_wrong_value_loses_points(self):
+        student = _build_rc_filter(r_value="10k")  # Wrong value
+        rubric = _build_rc_rubric()
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+
+        r1_value = next(cr for cr in result.check_results if cr.check_id == "r1_value")
+        assert r1_value.passed is False
+        assert r1_value.feedback == "R1 value should be approximately 1k"
+
+    def test_value_within_tolerance_passes(self):
+        student = _build_rc_filter(r_value="1.05k")  # Within 10%
+        rubric = _build_rc_rubric()
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+
+        r1_value = next(cr for cr in result.check_results if cr.check_id == "r1_value")
+        assert r1_value.passed is True
+
+    def test_wrong_analysis_loses_points(self):
+        student = _build_rc_filter(analysis="Transient")
+        rubric = _build_rc_rubric()
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+
+        ac_check = next(cr for cr in result.check_results if cr.check_id == "ac_sweep")
+        assert ac_check.passed is False
+        assert ac_check.points_earned == 0
+
+
+class TestCircuitGraderTopology:
+    def test_disconnected_topology_fails(self):
+        """R1 and C1 not connected should fail topology check."""
+        model = CircuitModel()
+        model.components["V1"] = ComponentData(
+            component_id="V1", component_type="Voltage Source", value="5V", position=(0.0, 0.0)
+        )
+        model.components["R1"] = ComponentData(
+            component_id="R1", component_type="Resistor", value="1k", position=(100.0, 0.0)
+        )
+        model.components["C1"] = ComponentData(
+            component_id="C1", component_type="Capacitor", value="100n", position=(200.0, 0.0)
+        )
+        model.components["GND1"] = ComponentData(
+            component_id="GND1", component_type="Ground", value="0V", position=(0.0, 100.0)
+        )
+        # Wire V1-R1 and C1-GND but NOT R1-C1
+        model.wires = [
+            WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
+            WireData(start_component_id="C1", start_terminal=1, end_component_id="GND1", end_terminal=0),
+            WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        ]
+        model.analysis_type = "AC Sweep"
+        model.rebuild_nodes()
+
+        rubric = _build_rc_rubric()
+        grader = CircuitGrader()
+        result = grader.grade(model, rubric)
+
+        topo_check = next(cr for cr in result.check_results if cr.check_id == "rc_connected")
+        assert topo_check.passed is False
+
+
+class TestCircuitGraderGround:
+    def test_missing_ground_fails(self):
+        model = CircuitModel()
+        model.components["R1"] = ComponentData(
+            component_id="R1", component_type="Resistor", value="1k", position=(0.0, 0.0)
+        )
+        model.rebuild_nodes()
+
+        rubric = Rubric(
+            title="Ground Test",
+            total_points=10,
+            checks=[
+                RubricCheck(
+                    check_id="gnd",
+                    check_type="ground",
+                    points=10,
+                    params={},
+                    feedback_pass="OK",
+                    feedback_fail="No ground",
+                )
+            ],
+        )
+        grader = CircuitGrader()
+        result = grader.grade(model, rubric)
+        assert result.check_results[0].passed is False
+
+    def test_ground_with_component_check(self):
+        student = _build_rc_filter()
+        rubric = Rubric(
+            title="Ground Component Test",
+            total_points=10,
+            checks=[
+                RubricCheck(
+                    check_id="c1_grounded",
+                    check_type="ground",
+                    points=10,
+                    params={"component_id": "C1"},
+                    feedback_pass="C1 grounded",
+                    feedback_fail="C1 not grounded",
+                )
+            ],
+        )
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        # C1 terminal 1 connects to GND in _build_rc_filter
+        assert result.check_results[0].passed is True
+
+
+class TestCircuitGraderComponentCount:
+    def test_correct_count(self):
+        student = _build_rc_filter()
+        rubric = Rubric(
+            title="Count Test",
+            total_points=10,
+            checks=[
+                RubricCheck(
+                    check_id="one_resistor",
+                    check_type="component_count",
+                    points=10,
+                    params={"component_type": "Resistor", "expected_count": 1},
+                    feedback_pass="OK",
+                    feedback_fail="Wrong count",
+                )
+            ],
+        )
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        assert result.check_results[0].passed is True
+
+    def test_wrong_count(self):
+        student = _build_rc_filter()
+        rubric = Rubric(
+            title="Count Test",
+            total_points=10,
+            checks=[
+                RubricCheck(
+                    check_id="two_resistors",
+                    check_type="component_count",
+                    points=10,
+                    params={"component_type": "Resistor", "expected_count": 2},
+                    feedback_pass="OK",
+                    feedback_fail="Expected 2 resistors",
+                )
+            ],
+        )
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        assert result.check_results[0].passed is False
+
+
+class TestCircuitGraderExistsByType:
+    def test_exists_by_type_min_count(self):
+        student = _build_rc_filter()
+        rubric = Rubric(
+            title="Type Test",
+            total_points=10,
+            checks=[
+                RubricCheck(
+                    check_id="has_resistor",
+                    check_type="component_exists",
+                    points=10,
+                    params={"component_type": "Resistor", "min_count": 1},
+                    feedback_pass="OK",
+                    feedback_fail="Missing",
+                )
+            ],
+        )
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        assert result.check_results[0].passed is True
+
+
+class TestGradingResult:
+    def test_percentage_zero_total(self):
+        result = GradingResult(
+            student_file="",
+            rubric_title="",
+            total_points=0,
+            earned_points=0,
+        )
+        assert result.percentage == 100.0
+
+    def test_percentage_calculation(self):
+        result = GradingResult(
+            student_file="",
+            rubric_title="",
+            total_points=100,
+            earned_points=75,
+        )
+        assert result.percentage == 75.0

--- a/app/tests/unit/test_symbol_style.py
+++ b/app/tests/unit/test_symbol_style.py
@@ -191,9 +191,7 @@ class TestIEEEDrawDispatch:
         called = []
         comp._draw_ieee = lambda painter: called.append(True)
         comp.draw_component_body(None)
-        assert (
-            called
-        ), f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
+        assert called, f"{cls.type_name} draw_component_body did not dispatch to _draw_ieee"
 
 
 class TestObstacleShapeDispatch:


### PR DESCRIPTION
## Summary

- Add `GradingPanel` QWidget with load student/rubric, grade, and export CSV workflow
- Integrate grading panel into MainWindow right panel (hidden by default)
- Add **Instructor** top-level menu with "Grade Student Circuit..." toggle
- Uses lazy imports (`from __future__ import annotations` + `TYPE_CHECKING`) to avoid circular dependency through grading modules
- 12 qtbot tests covering structure, grading workflow, check selection, clear, export, and loading

## Test plan

- [x] All 12 grading panel tests pass
- [x] Full suite (1548 tests) passes
- [x] Lint clean
- [ ] Human testing: open grading panel, load student file and rubric, verify grade results display correctly

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)