### PR TITLE
add batch grading with CSV gradebook export

### DIFF
--- a/app/GUI/batch_grading_dialog.py
+++ b/app/GUI/batch_grading_dialog.py
@@ -1,0 +1,210 @@
+"""Batch grading dialog for processing folders of student submissions."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QDialog,
+    QFileDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QVBoxLayout,
+)
+
+if TYPE_CHECKING:
+    from grading.batch_grader import BatchGradingResult
+
+logger = logging.getLogger(__name__)
+
+
+class BatchGradingDialog(QDialog):
+    """Dialog for batch grading a folder of student submissions."""
+
+    def __init__(self, reference_circuit=None, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Batch Grade Student Submissions")
+        self.setMinimumWidth(500)
+        self._reference_circuit = reference_circuit
+        self._rubric = None
+        self._batch_result: Optional[BatchGradingResult] = None
+        self._init_ui()
+
+    def _init_ui(self):
+        layout = QVBoxLayout(self)
+
+        # Folder selection
+        folder_group = QGroupBox("Student Submissions")
+        folder_layout = QHBoxLayout(folder_group)
+        self.folder_path = QLineEdit()
+        self.folder_path.setPlaceholderText("Select folder containing student files...")
+        self.folder_path.setReadOnly(True)
+        folder_layout.addWidget(self.folder_path)
+        self.browse_folder_btn = QPushButton("Browse...")
+        self.browse_folder_btn.clicked.connect(self._on_browse_folder)
+        folder_layout.addWidget(self.browse_folder_btn)
+        layout.addWidget(folder_group)
+
+        # Rubric selection
+        rubric_group = QGroupBox("Grading Rubric")
+        rubric_layout = QHBoxLayout(rubric_group)
+        self.rubric_path = QLineEdit()
+        self.rubric_path.setPlaceholderText("Select rubric file (.spice-rubric)...")
+        self.rubric_path.setReadOnly(True)
+        rubric_layout.addWidget(self.rubric_path)
+        self.browse_rubric_btn = QPushButton("Browse...")
+        self.browse_rubric_btn.clicked.connect(self._on_browse_rubric)
+        rubric_layout.addWidget(self.browse_rubric_btn)
+        layout.addWidget(rubric_group)
+
+        # Reference circuit info
+        if self._reference_circuit is not None:
+            ref_label = QLabel("Reference circuit: current canvas circuit")
+            ref_label.setStyleSheet("color: green;")
+            layout.addWidget(ref_label)
+
+        # Grade button
+        btn_layout = QHBoxLayout()
+        self.grade_btn = QPushButton("Grade All")
+        self.grade_btn.setEnabled(False)
+        self.grade_btn.clicked.connect(self._on_grade)
+        btn_layout.addWidget(self.grade_btn)
+
+        self.export_btn = QPushButton("Export CSV")
+        self.export_btn.setEnabled(False)
+        self.export_btn.clicked.connect(self._on_export)
+        btn_layout.addWidget(self.export_btn)
+        layout.addLayout(btn_layout)
+
+        # Progress bar
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setVisible(False)
+        layout.addWidget(self.progress_bar)
+
+        self.progress_label = QLabel("")
+        layout.addWidget(self.progress_label)
+
+        # Results summary
+        self.results_group = QGroupBox("Results")
+        results_layout = QVBoxLayout(self.results_group)
+        self.results_label = QLabel("No results yet")
+        self.results_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        results_layout.addWidget(self.results_label)
+        self.results_group.setVisible(False)
+        layout.addWidget(self.results_group)
+
+    def _on_browse_folder(self):
+        folder = QFileDialog.getExistingDirectory(self, "Select Student Submissions Folder")
+        if folder:
+            self.folder_path.setText(folder)
+            self._update_grade_button()
+
+    def _on_browse_rubric(self):
+        filename, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select Grading Rubric",
+            "",
+            "Rubric Files (*.spice-rubric);;All Files (*)",
+        )
+        if filename:
+            try:
+                from grading.rubric import load_rubric
+
+                self._rubric = load_rubric(filename)
+                self.rubric_path.setText(filename)
+                self._update_grade_button()
+            except Exception as e:
+                QMessageBox.critical(self, "Error", f"Failed to load rubric:\n{e}")
+
+    def _update_grade_button(self):
+        self.grade_btn.setEnabled(bool(self.folder_path.text()) and self._rubric is not None)
+
+    def _on_grade(self):
+        from grading.batch_grader import BatchGrader
+
+        folder = self.folder_path.text()
+        if not folder or self._rubric is None:
+            return
+
+        self.progress_bar.setVisible(True)
+        self.progress_bar.setValue(0)
+        self.grade_btn.setEnabled(False)
+
+        grader = BatchGrader()
+
+        def progress_callback(current, total, filename):
+            if total > 0:
+                self.progress_bar.setMaximum(total)
+                self.progress_bar.setValue(current)
+            self.progress_label.setText(f"Grading: {filename}")
+
+        self._batch_result = grader.grade_folder(
+            folder_path=folder,
+            rubric=self._rubric,
+            reference_circuit=self._reference_circuit,
+            progress_callback=progress_callback,
+        )
+
+        self._display_results(self._batch_result)
+        self.grade_btn.setEnabled(True)
+        self.export_btn.setEnabled(True)
+        self.progress_label.setText("Grading complete")
+
+    def _display_results(self, result: BatchGradingResult):
+        self.results_group.setVisible(True)
+
+        lines = [
+            f"Total students: {result.total_students}",
+            f"Successfully graded: {result.successful}",
+            f"Failed: {result.failed}",
+        ]
+        if result.results:
+            lines.extend(
+                [
+                    "",
+                    f"Mean score: {result.mean_score:.1f}%",
+                    f"Median score: {result.median_score:.1f}%",
+                    f"Min score: {result.min_score:.1f}%",
+                    f"Max score: {result.max_score:.1f}%",
+                ]
+            )
+        if result.errors:
+            lines.append("")
+            lines.append(f"Errors ({len(result.errors)}):")
+            for filename, error in result.errors[:5]:
+                lines.append(f"  {filename}: {error}")
+            if len(result.errors) > 5:
+                lines.append(f"  ... and {len(result.errors) - 5} more")
+
+        self.results_label.setText("\n".join(lines))
+
+    def _on_export(self):
+        if self._batch_result is None:
+            return
+
+        filename, _ = QFileDialog.getSaveFileName(
+            self,
+            "Export Gradebook CSV",
+            "",
+            "CSV Files (*.csv);;All Files (*)",
+        )
+        if not filename:
+            return
+
+        try:
+            from grading.grade_exporter import export_gradebook_csv
+
+            export_gradebook_csv(self._batch_result, filename)
+            QMessageBox.information(self, "Exported", f"Gradebook saved to {filename}")
+        except OSError as e:
+            QMessageBox.critical(self, "Error", f"Failed to export:\n{e}")
+
+    def get_result(self) -> Optional[BatchGradingResult]:
+        return self._batch_result

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -437,6 +437,11 @@ class MenuBarMixin:
             grade_action.triggered.connect(self._toggle_grading_panel)
             instructor_menu.addAction(grade_action)
 
+            batch_grade_action = QAction("&Batch Grade...", self)
+            batch_grade_action.setToolTip("Grade a folder of student submissions")
+            batch_grade_action.triggered.connect(self._on_batch_grade)
+            instructor_menu.addAction(batch_grade_action)
+
         # Settings menu
         settings_menu = menubar.addMenu("Se&ttings")
         if settings_menu:

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -86,6 +86,13 @@ class ViewOperationsMixin:
         visible = not self.grading_panel.isVisible()
         self.grading_panel.setVisible(visible)
 
+    def _on_batch_grade(self):
+        """Open the batch grading dialog."""
+        from .batch_grading_dialog import BatchGradingDialog
+
+        dialog = BatchGradingDialog(reference_circuit=self.model, parent=self)
+        dialog.exec()
+
     # Dirty flag (unsaved changes indicator)
 
     def _on_dirty_change(self, event: str, data) -> None:

--- a/app/grading/batch_grader.py
+++ b/app/grading/batch_grader.py
@@ -1,0 +1,136 @@
+"""Batch grading engine for processing folders of student submissions.
+
+Scans a folder for circuit files, grades each against a rubric, and
+produces aggregate statistics.
+
+No Qt dependencies — pure Python module.
+"""
+
+import json
+import logging
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+from controllers.file_controller import validate_circuit_data
+from grading.grader import CircuitGrader, GradingResult
+from grading.rubric import Rubric
+from models.circuit import CircuitModel
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_EXTENSIONS = {".json", ".spice-template"}
+
+
+@dataclass
+class BatchGradingResult:
+    """Aggregated results from grading a batch of student submissions."""
+
+    rubric_title: str
+    total_students: int
+    successful: int
+    failed: int
+    results: list[GradingResult] = field(default_factory=list)
+    errors: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def mean_score(self) -> float:
+        if not self.results:
+            return 0.0
+        return statistics.mean(r.percentage for r in self.results)
+
+    @property
+    def median_score(self) -> float:
+        if not self.results:
+            return 0.0
+        return statistics.median(r.percentage for r in self.results)
+
+    @property
+    def min_score(self) -> float:
+        if not self.results:
+            return 0.0
+        return min(r.percentage for r in self.results)
+
+    @property
+    def max_score(self) -> float:
+        if not self.results:
+            return 0.0
+        return max(r.percentage for r in self.results)
+
+
+class BatchGrader:
+    """Grades a folder of student submissions against a rubric."""
+
+    def __init__(self):
+        self._grader = CircuitGrader()
+
+    def grade_folder(
+        self,
+        folder_path: str,
+        rubric: Rubric,
+        reference_circuit: Optional[CircuitModel] = None,
+        progress_callback: Optional[Callable[[int, int, str], None]] = None,
+    ) -> BatchGradingResult:
+        """Grade all circuit files in a folder.
+
+        Args:
+            folder_path: Path to folder containing student .json/.spice-template files.
+            rubric: The grading rubric to apply.
+            reference_circuit: Optional reference solution circuit.
+            progress_callback: Called with (current, total, filename) for progress updates.
+
+        Returns:
+            BatchGradingResult with per-student results and aggregate stats.
+        """
+        folder = Path(folder_path)
+        files = sorted(f for f in folder.iterdir() if f.is_file() and f.suffix in SUPPORTED_EXTENSIONS)
+
+        result = BatchGradingResult(
+            rubric_title=rubric.title,
+            total_students=len(files),
+            successful=0,
+            failed=0,
+        )
+
+        for i, filepath in enumerate(files):
+            filename = filepath.name
+            if progress_callback:
+                progress_callback(i, len(files), filename)
+
+            try:
+                circuit = self._load_circuit(filepath)
+                grade_result = self._grader.grade(
+                    student_circuit=circuit,
+                    rubric=rubric,
+                    reference_circuit=reference_circuit,
+                    student_file=filename,
+                )
+                result.results.append(grade_result)
+                result.successful += 1
+            except Exception as e:
+                logger.warning("Failed to grade %s: %s", filename, e)
+                result.errors.append((filename, str(e)))
+                result.failed += 1
+
+        if progress_callback:
+            progress_callback(len(files), len(files), "Done")
+
+        return result
+
+    @staticmethod
+    def _load_circuit(filepath: Path) -> CircuitModel:
+        """Load a circuit from a .json or .spice-template file."""
+        with open(filepath, "r") as f:
+            data = json.load(f)
+
+        # Handle template files (extract starter_circuit)
+        if "template_version" in data and "starter_circuit" in data:
+            if data["starter_circuit"] is not None:
+                validate_circuit_data(data["starter_circuit"])
+                return CircuitModel.from_dict(data["starter_circuit"])
+            else:
+                return CircuitModel()
+
+        validate_circuit_data(data)
+        return CircuitModel.from_dict(data)

--- a/app/grading/grade_exporter.py
+++ b/app/grading/grade_exporter.py
@@ -1,0 +1,73 @@
+"""CSV gradebook export for batch grading results.
+
+Produces a spreadsheet-ready CSV with one row per student and columns
+for each rubric check.
+
+No Qt dependencies — pure Python module.
+"""
+
+import csv
+from pathlib import Path
+
+from grading.batch_grader import BatchGradingResult
+
+
+def export_gradebook_csv(result: BatchGradingResult, filepath: str) -> None:
+    """Export batch grading results as a CSV gradebook.
+
+    Format:
+        Student File, Total Score, Percentage, check_1 (Npts), check_2 (Npts), ...
+
+    Args:
+        result: The batch grading result to export.
+        filepath: Output CSV file path.
+    """
+    filepath = Path(filepath)
+
+    if not result.results:
+        with open(filepath, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["No results to export"])
+        return
+
+    # Build header from first result's check IDs
+    first = result.results[0]
+    check_headers = [f"{cr.check_id} ({cr.points_possible}pts)" for cr in first.check_results]
+
+    header = ["Student File", "Total Score", "Percentage"] + check_headers
+
+    with open(filepath, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+
+        for gr in result.results:
+            row = [
+                gr.student_file,
+                f"{gr.earned_points}/{gr.total_points}",
+                f"{gr.percentage:.1f}%",
+            ]
+            for cr in gr.check_results:
+                row.append(cr.points_earned)
+            writer.writerow(row)
+
+        # Summary row
+        writer.writerow([])
+        writer.writerow(["Summary"])
+        writer.writerow(["Total Students", result.total_students])
+        writer.writerow(["Successfully Graded", result.successful])
+        writer.writerow(["Failed", result.failed])
+        if result.results:
+            writer.writerow(["Mean Score", f"{result.mean_score:.1f}%"])
+            writer.writerow(["Median Score", f"{result.median_score:.1f}%"])
+            writer.writerow(["Min Score", f"{result.min_score:.1f}%"])
+            writer.writerow(["Max Score", f"{result.max_score:.1f}%"])
+
+    # Append errors if any
+    if result.errors:
+        with open(filepath, "a", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow([])
+            writer.writerow(["Errors"])
+            writer.writerow(["Filename", "Error"])
+            for filename, error in result.errors:
+                writer.writerow([filename, error])

--- a/app/tests/unit/test_batch_grading.py
+++ b/app/tests/unit/test_batch_grading.py
@@ -1,0 +1,331 @@
+"""Tests for batch grading and CSV gradebook export."""
+
+import csv
+import json
+
+import pytest
+from grading.batch_grader import BatchGrader, BatchGradingResult
+from grading.grade_exporter import export_gradebook_csv
+from grading.rubric import Rubric, RubricCheck, save_rubric
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from models.wire import WireData
+
+
+def _build_circuit(r_value="1k", c_value="100n"):
+    """Build a simple V1-R1-C1-GND circuit."""
+    model = CircuitModel()
+    model.components["V1"] = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value="5V",
+        position=(0.0, 0.0),
+    )
+    model.components["R1"] = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value=r_value,
+        position=(100.0, 0.0),
+    )
+    model.components["C1"] = ComponentData(
+        component_id="C1",
+        component_type="Capacitor",
+        value=c_value,
+        position=(200.0, 0.0),
+    )
+    model.components["GND1"] = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(0.0, 100.0),
+    )
+    model.wires = [
+        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
+        WireData(start_component_id="R1", start_terminal=1, end_component_id="C1", end_terminal=0),
+        WireData(start_component_id="C1", start_terminal=1, end_component_id="GND1", end_terminal=0),
+        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+    ]
+    model.component_counter = {"V": 1, "R": 1, "C": 1, "GND": 1}
+    model.analysis_type = "AC Sweep"
+    model.rebuild_nodes()
+    return model
+
+
+def _build_rubric():
+    return Rubric(
+        title="RC Filter Test",
+        total_points=50,
+        checks=[
+            RubricCheck(
+                check_id="r1_exists",
+                check_type="component_exists",
+                points=25,
+                params={"component_id": "R1", "component_type": "Resistor"},
+                feedback_pass="R1 present",
+                feedback_fail="R1 missing",
+            ),
+            RubricCheck(
+                check_id="r1_value",
+                check_type="component_value",
+                points=25,
+                params={"component_id": "R1", "expected_value": "1k", "tolerance_pct": 10},
+                feedback_pass="R1 value OK",
+                feedback_fail="R1 value wrong",
+            ),
+        ],
+    )
+
+
+def _save_circuit(circuit, filepath):
+    """Save a circuit to a JSON file."""
+    with open(filepath, "w") as f:
+        json.dump(circuit.to_dict(), f)
+
+
+class TestBatchGrader:
+    def test_grade_empty_folder(self, tmp_path):
+        grader = BatchGrader()
+        rubric = _build_rubric()
+        result = grader.grade_folder(str(tmp_path), rubric)
+        assert result.total_students == 0
+        assert result.successful == 0
+        assert result.failed == 0
+
+    def test_grade_single_correct_student(self, tmp_path):
+        circuit = _build_circuit()
+        _save_circuit(circuit, tmp_path / "student1.json")
+
+        grader = BatchGrader()
+        rubric = _build_rubric()
+        result = grader.grade_folder(str(tmp_path), rubric)
+
+        assert result.total_students == 1
+        assert result.successful == 1
+        assert result.failed == 0
+        assert len(result.results) == 1
+        assert result.results[0].earned_points == 50
+
+    def test_grade_multiple_students(self, tmp_path):
+        # Correct student
+        _save_circuit(_build_circuit(), tmp_path / "correct.json")
+        # Wrong value student
+        _save_circuit(_build_circuit(r_value="10k"), tmp_path / "wrong_value.json")
+
+        grader = BatchGrader()
+        rubric = _build_rubric()
+        result = grader.grade_folder(str(tmp_path), rubric)
+
+        assert result.total_students == 2
+        assert result.successful == 2
+        assert result.failed == 0
+        scores = sorted(r.earned_points for r in result.results)
+        assert scores == [25, 50]
+
+    def test_grade_with_invalid_file(self, tmp_path):
+        _save_circuit(_build_circuit(), tmp_path / "good.json")
+        # Write invalid JSON
+        (tmp_path / "bad.json").write_text("not valid json")
+
+        grader = BatchGrader()
+        rubric = _build_rubric()
+        result = grader.grade_folder(str(tmp_path), rubric)
+
+        assert result.total_students == 2
+        assert result.successful == 1
+        assert result.failed == 1
+        assert len(result.errors) == 1
+        assert result.errors[0][0] == "bad.json"
+
+    def test_grade_ignores_non_circuit_files(self, tmp_path):
+        _save_circuit(_build_circuit(), tmp_path / "student.json")
+        (tmp_path / "readme.txt").write_text("ignore me")
+        (tmp_path / "notes.md").write_text("also ignore")
+
+        grader = BatchGrader()
+        rubric = _build_rubric()
+        result = grader.grade_folder(str(tmp_path), rubric)
+
+        assert result.total_students == 1
+        assert result.successful == 1
+
+    def test_grade_with_template_files(self, tmp_path):
+        circuit = _build_circuit()
+        template_data = {
+            "template_version": "1.0",
+            "starter_circuit": circuit.to_dict(),
+        }
+        with open(tmp_path / "student.spice-template", "w") as f:
+            json.dump(template_data, f)
+
+        grader = BatchGrader()
+        rubric = _build_rubric()
+        result = grader.grade_folder(str(tmp_path), rubric)
+
+        assert result.total_students == 1
+        assert result.successful == 1
+
+    def test_progress_callback_invoked(self, tmp_path):
+        _save_circuit(_build_circuit(), tmp_path / "s1.json")
+        _save_circuit(_build_circuit(), tmp_path / "s2.json")
+
+        calls = []
+
+        def callback(current, total, filename):
+            calls.append((current, total, filename))
+
+        grader = BatchGrader()
+        rubric = _build_rubric()
+        grader.grade_folder(str(tmp_path), rubric, progress_callback=callback)
+
+        assert len(calls) == 3  # 2 files + 1 "Done"
+        assert calls[-1][2] == "Done"
+
+    def test_grade_with_reference_circuit(self, tmp_path):
+        _save_circuit(_build_circuit(), tmp_path / "student.json")
+        reference = _build_circuit()
+
+        grader = BatchGrader()
+        rubric = _build_rubric()
+        result = grader.grade_folder(str(tmp_path), rubric, reference_circuit=reference)
+
+        assert result.successful == 1
+
+
+class TestBatchGradingResultStats:
+    def test_empty_results_stats(self):
+        result = BatchGradingResult(
+            rubric_title="Test",
+            total_students=0,
+            successful=0,
+            failed=0,
+        )
+        assert result.mean_score == 0.0
+        assert result.median_score == 0.0
+        assert result.min_score == 0.0
+        assert result.max_score == 0.0
+
+    def test_stats_with_results(self, tmp_path):
+        _save_circuit(_build_circuit(), tmp_path / "perfect.json")
+        _save_circuit(_build_circuit(r_value="10k"), tmp_path / "partial.json")
+
+        grader = BatchGrader()
+        rubric = _build_rubric()
+        result = grader.grade_folder(str(tmp_path), rubric)
+
+        assert result.mean_score == pytest.approx(75.0)
+        assert result.median_score == pytest.approx(75.0)
+        assert result.min_score == pytest.approx(50.0)
+        assert result.max_score == pytest.approx(100.0)
+
+
+class TestGradeExporter:
+    def test_export_gradebook_csv(self, tmp_path):
+        submissions = tmp_path / "submissions"
+        submissions.mkdir()
+        _save_circuit(_build_circuit(), submissions / "alice.json")
+        _save_circuit(_build_circuit(r_value="10k"), submissions / "bob.json")
+
+        grader = BatchGrader()
+        rubric = _build_rubric()
+        result = grader.grade_folder(str(submissions), rubric)
+
+        csv_path = tmp_path / "gradebook.csv"
+        export_gradebook_csv(result, str(csv_path))
+
+        assert csv_path.exists()
+        content = csv_path.read_text()
+        assert "Student File" in content
+        assert "Total Score" in content
+        assert "r1_exists" in content
+        assert "r1_value" in content
+        assert "alice.json" in content
+        assert "bob.json" in content
+        assert "Mean Score" in content
+
+    def test_export_empty_results(self, tmp_path):
+        result = BatchGradingResult(
+            rubric_title="Test",
+            total_students=0,
+            successful=0,
+            failed=0,
+        )
+        csv_path = tmp_path / "empty.csv"
+        export_gradebook_csv(result, str(csv_path))
+
+        assert csv_path.exists()
+        content = csv_path.read_text()
+        assert "No results" in content
+
+    def test_export_includes_errors(self, tmp_path):
+        submissions = tmp_path / "submissions"
+        submissions.mkdir()
+        _save_circuit(_build_circuit(), submissions / "good.json")
+        (submissions / "bad.json").write_text("invalid")
+
+        grader = BatchGrader()
+        rubric = _build_rubric()
+        result = grader.grade_folder(str(submissions), rubric)
+
+        csv_path = tmp_path / "gradebook.csv"
+        export_gradebook_csv(result, str(csv_path))
+
+        content = csv_path.read_text()
+        assert "Errors" in content
+        assert "bad.json" in content
+
+    def test_csv_has_correct_columns(self, tmp_path):
+        submissions = tmp_path / "submissions"
+        submissions.mkdir()
+        _save_circuit(_build_circuit(), submissions / "student.json")
+
+        grader = BatchGrader()
+        rubric = _build_rubric()
+        result = grader.grade_folder(str(submissions), rubric)
+
+        csv_path = tmp_path / "gradebook.csv"
+        export_gradebook_csv(result, str(csv_path))
+
+        with open(csv_path) as f:
+            reader = csv.reader(f)
+            header = next(reader)
+
+        assert header[0] == "Student File"
+        assert header[1] == "Total Score"
+        assert header[2] == "Percentage"
+        assert "r1_exists (25pts)" in header
+        assert "r1_value (25pts)" in header
+
+
+class TestBatchGradingDialog:
+    def test_dialog_creates(self, qtbot):
+        from GUI.batch_grading_dialog import BatchGradingDialog
+
+        dialog = BatchGradingDialog()
+        qtbot.addWidget(dialog)
+
+        assert dialog.folder_path is not None
+        assert dialog.rubric_path is not None
+        assert dialog.grade_btn is not None
+        assert dialog.export_btn is not None
+        assert dialog.progress_bar is not None
+
+    def test_grade_button_initially_disabled(self, qtbot):
+        from GUI.batch_grading_dialog import BatchGradingDialog
+
+        dialog = BatchGradingDialog()
+        qtbot.addWidget(dialog)
+        assert not dialog.grade_btn.isEnabled()
+
+    def test_export_button_initially_disabled(self, qtbot):
+        from GUI.batch_grading_dialog import BatchGradingDialog
+
+        dialog = BatchGradingDialog()
+        qtbot.addWidget(dialog)
+        assert not dialog.export_btn.isEnabled()
+
+    def test_results_group_initially_hidden(self, qtbot):
+        from GUI.batch_grading_dialog import BatchGradingDialog
+
+        dialog = BatchGradingDialog()
+        qtbot.addWidget(dialog)
+        assert not dialog.results_group.isVisible()


### PR DESCRIPTION
## Summary

- Add `BatchGrader` class for processing folders of student `.json`/`.spice-template` files
- Add `export_gradebook_csv()` producing spreadsheet-ready CSV with per-check columns and aggregate stats
- Add `BatchGradingDialog` with folder/rubric selectors, progress bar, and results summary
- Add "Batch Grade..." to Instructor menu
- 18 tests covering batch grading, CSV export format, error handling, statistics, and dialog structure

## Test plan

- [x] All 18 batch grading tests pass
- [x] Full suite (1566 tests) passes
- [x] Lint clean
- [ ] Human testing: open Batch Grade dialog, select folder and rubric, verify progress bar and results summary

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)