### PR TITLE
add interactive REPL subcommand with scripting API

### DIFF
--- a/app/tests/unit/test_cli.py
+++ b/app/tests/unit/test_cli.py
@@ -4,8 +4,20 @@ import json
 from pathlib import Path
 
 import pytest
-from cli import build_parser, cmd_batch, cmd_export, cmd_simulate, cmd_validate, load_circuit, main, try_load_circuit
+from cli import (
+    REPL_BANNER,
+    build_parser,
+    build_repl_namespace,
+    cmd_batch,
+    cmd_export,
+    cmd_simulate,
+    cmd_validate,
+    load_circuit,
+    main,
+    try_load_circuit,
+)
 from models.circuit import CircuitModel
+from scripting.circuit import Circuit
 
 
 @pytest.fixture
@@ -313,3 +325,43 @@ class TestBatchCommand:
         if code == 0:
             csv_files = list(Path(out_dir).glob("*.csv"))
             assert len(csv_files) == 3
+
+
+class TestReplCommand:
+    def test_repl_namespace_has_circuit(self):
+        ns = build_repl_namespace()
+        assert "Circuit" in ns
+        assert ns["Circuit"] is Circuit
+
+    def test_repl_namespace_has_simulation_result(self):
+        ns = build_repl_namespace()
+        assert "SimulationResult" in ns
+
+    def test_repl_namespace_has_component_types(self):
+        ns = build_repl_namespace()
+        assert "COMPONENT_TYPES" in ns
+        assert "Resistor" in ns["COMPONENT_TYPES"]
+
+    def test_repl_namespace_load_circuit(self, voltage_divider):
+        ns = build_repl_namespace(voltage_divider)
+        assert "circuit" in ns
+        assert isinstance(ns["circuit"], Circuit)
+        assert len(ns["circuit"].components) == 4
+
+    def test_repl_namespace_load_nonexistent(self, capsys):
+        ns = build_repl_namespace("/nonexistent/file.json")
+        assert "circuit" not in ns
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+
+    def test_repl_banner_content(self):
+        assert "Circuit" in REPL_BANNER
+        assert "Quick start" in REPL_BANNER
+
+    def test_repl_parser(self, voltage_divider):
+        args = build_parser().parse_args(["repl", "--load", voltage_divider])
+        assert args.load == voltage_divider
+
+    def test_repl_parser_no_args(self):
+        args = build_parser().parse_args(["repl"])
+        assert args.load is None


### PR DESCRIPTION
## Summary
- Adds `repl` subcommand to the CLI that launches an interactive Python REPL
- Pre-loads the scripting API (`Circuit`, `SimulationResult`, `COMPONENT_TYPES`) into the namespace
- Supports `--load <file.json>` to pre-load a circuit as `circuit` variable
- Uses IPython if available, falls back to stdlib `code.interact()`

## Test plan
- [x] 8 new tests covering: namespace population, SimulationResult/COMPONENT_TYPES presence, circuit loading, nonexistent file warning, banner content, parser args
- [x] All 42 CLI tests pass
- [x] Lint clean

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)