### PR TITLE
add LTspice .asc schematic file import

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -142,6 +142,29 @@ class FileOperationsMixin:
             except (OSError, ValueError) as e:
                 QMessageBox.critical(self, "Import Error", f"Failed to import netlist:\n{e}")
 
+    def _on_import_asc(self):
+        """Import an LTspice .asc schematic file"""
+        filename, _ = QFileDialog.getOpenFileName(
+            self,
+            "Import LTspice Schematic",
+            "",
+            "LTspice Schematics (*.asc);;All Files (*)",
+        )
+        if filename:
+            try:
+                warnings = self.file_ctrl.import_asc(filename)
+                self.setWindowTitle(f"Circuit Design GUI - {Path(filename).name} (imported)")
+                self._sync_analysis_menu()
+                self._set_dirty(True)
+                num_components = len(self.model.components)
+                num_wires = len(self.model.wires)
+                msg = f"Imported {num_components} components and {num_wires} wires from {Path(filename).name}."
+                if warnings:
+                    msg += "\n\nWarnings:\n" + "\n".join(f"  - {w}" for w in warnings)
+                QMessageBox.information(self, "Import Successful", msg)
+            except (OSError, ValueError) as e:
+                QMessageBox.critical(self, "Import Error", f"Failed to import LTspice schematic:\n{e}")
+
     def _load_last_session(self):
         """Load last session using FileController"""
         last_file = self.file_ctrl.load_last_session()

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -59,6 +59,11 @@ class MenuBarMixin:
         import_netlist_action.triggered.connect(self._on_import_netlist)
         file_menu.addAction(import_netlist_action)
 
+        import_asc_action = QAction("Import &LTspice Schematic...", self)
+        import_asc_action.setToolTip("Import an LTspice schematic file (.asc)")
+        import_asc_action.triggered.connect(self._on_import_asc)
+        file_menu.addAction(import_asc_action)
+
         export_netlist_action = QAction("Export &Netlist...", self)
         export_netlist_action.setShortcut(kb.get("file.export_netlist"))
         export_netlist_action.setToolTip("Export the generated SPICE netlist to a .cir file")

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -330,6 +330,50 @@ class FileController:
         if self.circuit_ctrl:
             self.circuit_ctrl._notify("model_loaded", None)
 
+    def import_asc(self, filepath) -> list[str]:
+        """Import an LTspice .asc schematic file into the current model.
+
+        Parses the .asc schematic, maps LTspice components to Spice-GUI
+        types, creates wires based on coordinate matching, and optionally
+        sets the analysis type.
+
+        Args:
+            filepath: Path or string to the .asc file.
+
+        Returns:
+            List of warning messages (unsupported components, etc.)
+
+        Raises:
+            OSError: If the file cannot be read.
+            simulation.asc_parser.AscParseError: If parsing fails.
+        """
+        from simulation.asc_parser import import_asc
+
+        filepath = Path(filepath)
+        with open(filepath, "r") as f:
+            text = f.read()
+
+        new_model, analysis, warnings = import_asc(text)
+
+        self.model.clear()
+        self.model.components = new_model.components
+        self.model.wires = new_model.wires
+        self.model.nodes = new_model.nodes
+        self.model.terminal_to_node = new_model.terminal_to_node
+        self.model.component_counter = new_model.component_counter
+
+        if analysis:
+            self.model.analysis_type = analysis["type"]
+            self.model.analysis_params = analysis["params"]
+
+        self.current_file = None
+        self.add_recent_file(filepath)
+
+        if self.circuit_ctrl:
+            self.circuit_ctrl._notify("model_loaded", None)
+
+        return warnings
+
     def clear_auto_save(self) -> None:
         """Delete the auto-save recovery file if it exists."""
         try:

--- a/app/simulation/asc_parser.py
+++ b/app/simulation/asc_parser.py
@@ -1,0 +1,596 @@
+"""
+simulation/asc_parser.py
+
+Parses LTspice .asc schematic files and converts them into CircuitModel
+objects for display on the canvas.
+
+LTspice .asc format is a plain-text format with lines like:
+    Version 4
+    SHEET 1 880 680
+    WIRE 192 192 80 192
+    FLAG 80 256 0
+    SYMBOL res 80 96 R0
+    SYMATTR InstName R1
+    SYMATTR Value 1k
+    TEXT -32 280 Left 2 .tran 10m
+"""
+
+import logging
+import re
+
+from models.circuit import CircuitModel
+from models.component import DEFAULT_VALUES, SPICE_SYMBOLS, ComponentData
+from models.wire import WireData
+
+logger = logging.getLogger(__name__)
+
+
+class AscParseError(ValueError):
+    """Raised when an .asc file cannot be parsed."""
+
+
+# LTspice symbol name -> Spice-GUI component type
+_SYMBOL_TO_TYPE = {
+    "res": "Resistor",
+    "res2": "Resistor",
+    "cap": "Capacitor",
+    "cap2": "Capacitor",
+    "polcap": "Capacitor",
+    "ind": "Inductor",
+    "ind2": "Inductor",
+    "voltage": "Voltage Source",
+    "current": "Current Source",
+    "diode": "Diode",
+    "schottky": "Diode",
+    "zener": "Zener Diode",
+    "LED": "LED",
+    "led": "LED",
+    "npn": "BJT NPN",
+    "npn2": "BJT NPN",
+    "pnp": "BJT PNP",
+    "pnp2": "BJT PNP",
+    "nmos": "MOSFET NMOS",
+    "nmos3": "MOSFET NMOS",
+    "pmos": "MOSFET PMOS",
+    "pmos3": "MOSFET PMOS",
+    "Opamps\\\\opamp": "Op-Amp",
+    "Opamps\\\\opamp2": "Op-Amp",
+    "opamp": "Op-Amp",
+    "e": "VCVS",
+    "e2": "VCVS",
+    "f": "CCCS",
+    "f2": "CCCS",
+    "g": "VCCS",
+    "g2": "VCCS",
+    "h": "CCVS",
+    "h2": "CCVS",
+}
+
+# Pin offsets (dx, dy) relative to SYMBOL position for each type (at R0 orientation)
+# LTspice convention: R0 = vertical, pin 1 at top
+_PIN_OFFSETS = {
+    "Resistor": [(0, 0), (0, 80)],
+    "Capacitor": [(0, 0), (0, 64)],
+    "Inductor": [(0, 0), (0, 80)],
+    "Voltage Source": [(0, 0), (0, 112)],
+    "Current Source": [(0, 0), (0, 112)],
+    "Diode": [(0, 0), (0, 64)],
+    "LED": [(0, 0), (0, 64)],
+    "Zener Diode": [(0, 0), (0, 64)],
+    "BJT NPN": [(16, 0), (-16, 32), (16, 64)],  # C, B, E
+    "BJT PNP": [(16, 64), (-16, 32), (16, 0)],  # C, B, E
+    "MOSFET NMOS": [(16, 0), (-16, 32), (16, 64)],  # D, G, S
+    "MOSFET PMOS": [(16, 64), (-16, 32), (16, 0)],  # D, G, S
+    "Op-Amp": [(-32, 32), (-32, -32), (32, 0)],  # in+, in-, out
+    "VCVS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
+    "CCVS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
+    "VCCS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
+    "CCCS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
+}
+
+# Coordinate scale factor: LTspice units -> Spice-GUI scene coordinates
+_SCALE = 1.0
+
+
+def _transform_pin(dx, dy, rotation_code):
+    """Transform a pin offset by the LTspice rotation code.
+
+    LTspice rotation codes:
+        R0: no rotation (default)
+        R90: 90 degrees CW
+        R180: 180 degrees
+        R270: 270 degrees CW (= 90 CCW)
+        M0: horizontal mirror
+        M90: mirror + 90 CW
+        M180: mirror + 180
+        M270: mirror + 270 CW
+    """
+    code = rotation_code.upper() if rotation_code else "R0"
+    mirrored = code.startswith("M")
+    angle = int(code[1:]) if len(code) > 1 else 0
+
+    if mirrored:
+        dx = -dx
+
+    if angle == 0:
+        return dx, dy
+    elif angle == 90:
+        return dy, -dx
+    elif angle == 180:
+        return -dx, -dy
+    elif angle == 270:
+        return -dy, dx
+    return dx, dy
+
+
+def _rotation_to_degrees(rotation_code):
+    """Convert LTspice rotation code to Spice-GUI rotation degrees and flip state.
+
+    Returns (rotation_degrees, flip_h).
+    """
+    code = rotation_code.upper() if rotation_code else "R0"
+    mirrored = code.startswith("M")
+    angle = int(code[1:]) if len(code) > 1 else 0
+
+    # LTspice R0 is vertical, Spice-GUI 0 is horizontal
+    # We use rotation 90 to convert from LTspice vertical to Spice-GUI horizontal
+    # for 2-terminal components. For multi-terminal, keep as-is.
+    return angle, mirrored
+
+
+def parse_asc(text):
+    """Parse LTspice .asc schematic text into a structured representation.
+
+    Args:
+        text: The full text content of a .asc file.
+
+    Returns:
+        dict with keys:
+            components: list of parsed component dicts
+            wires: list of (x1, y1, x2, y2) wire segments
+            flags: list of (x, y, label) flag entries
+            analysis: dict with type and params, or None
+            warnings: list of warning messages
+
+    Raises:
+        AscParseError: If the file is empty or has no recognizable content.
+    """
+    lines = text.strip().replace("\r\n", "\n").split("\n")
+    if not lines:
+        raise AscParseError("Empty .asc file.")
+
+    components = []
+    wires = []
+    flags = []
+    analysis = None
+    warnings = []
+
+    current_symbol = None
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        if stripped.startswith("WIRE "):
+            parts = stripped.split()
+            if len(parts) >= 5:
+                try:
+                    x1, y1, x2, y2 = int(parts[1]), int(parts[2]), int(parts[3]), int(parts[4])
+                    wires.append((x1, y1, x2, y2))
+                except ValueError:
+                    pass
+
+        elif stripped.startswith("FLAG "):
+            parts = stripped.split()
+            if len(parts) >= 4:
+                try:
+                    x, y = int(parts[1]), int(parts[2])
+                    label = parts[3]
+                    flags.append((x, y, label))
+                except ValueError:
+                    pass
+
+        elif stripped.startswith("SYMBOL "):
+            # Save any previous symbol
+            if current_symbol is not None:
+                components.append(current_symbol)
+
+            parts = stripped.split()
+            if len(parts) >= 5:
+                try:
+                    sym_name = parts[1]
+                    x, y = int(parts[2]), int(parts[3])
+                    rotation = parts[4] if len(parts) > 4 else "R0"
+                    current_symbol = {
+                        "ltspice_name": sym_name,
+                        "x": x,
+                        "y": y,
+                        "rotation": rotation,
+                        "inst_name": None,
+                        "value": None,
+                        "value2": None,
+                        "spice_model": None,
+                    }
+                except ValueError:
+                    current_symbol = None
+
+        elif stripped.startswith("SYMATTR "):
+            if current_symbol is not None:
+                # Split only into 3 parts: SYMATTR key value
+                parts = stripped.split(None, 2)
+                if len(parts) >= 3:
+                    attr_name = parts[1]
+                    attr_value = parts[2]
+                    if attr_name == "InstName":
+                        current_symbol["inst_name"] = attr_value
+                    elif attr_name == "Value":
+                        current_symbol["value"] = attr_value
+                    elif attr_name == "Value2":
+                        current_symbol["value2"] = attr_value
+                    elif attr_name == "SpiceModel":
+                        current_symbol["spice_model"] = attr_value
+
+        elif stripped.startswith("TEXT "):
+            # TEXT format: TEXT x y alignment size text_content
+            # SPICE directives are preceded by !
+            parts = stripped.split(None, 5)
+            if len(parts) >= 6:
+                text_content = parts[5]
+                if text_content.startswith("!"):
+                    directive = text_content[1:].strip()
+                    parsed_analysis = _parse_directive(directive)
+                    if parsed_analysis is not None:
+                        analysis = parsed_analysis
+
+    # Don't forget the last symbol
+    if current_symbol is not None:
+        components.append(current_symbol)
+
+    if not components and not wires and not flags:
+        raise AscParseError("No components, wires, or flags found in .asc file.")
+
+    return {
+        "components": components,
+        "wires": wires,
+        "flags": flags,
+        "analysis": analysis,
+        "warnings": warnings,
+    }
+
+
+def _parse_directive(directive):
+    """Parse a SPICE directive from a TEXT line."""
+    lower = directive.lower()
+    if lower.startswith(".tran"):
+        return _parse_tran(directive)
+    elif lower.startswith(".ac"):
+        return _parse_ac(directive)
+    elif lower.startswith(".dc"):
+        return _parse_dc(directive)
+    elif lower.startswith(".op"):
+        return {"type": "DC Operating Point", "params": {}}
+    return None
+
+
+def _parse_tran(directive):
+    tokens = directive.split()
+    params = {}
+    if len(tokens) >= 2:
+        params["duration"] = tokens[1]
+    if len(tokens) >= 3:
+        params["step"] = tokens[2]
+    elif len(tokens) >= 2:
+        params["step"] = tokens[1]
+    return {"type": "Transient", "params": params}
+
+
+def _parse_ac(directive):
+    tokens = directive.split()
+    params = {}
+    if len(tokens) >= 5:
+        params["sweep_type"] = tokens[1]
+        params["points"] = tokens[2]
+        params["fStart"] = tokens[3]
+        params["fStop"] = tokens[4]
+    return {"type": "AC Sweep", "params": params}
+
+
+def _parse_dc(directive):
+    tokens = directive.split()
+    params = {}
+    if len(tokens) >= 5:
+        params["source"] = tokens[1]
+        params["min"] = tokens[2]
+        params["max"] = tokens[3]
+        params["step"] = tokens[4]
+    return {"type": "DC Sweep", "params": params}
+
+
+def import_asc(text):
+    """Parse an LTspice .asc schematic and build a CircuitModel.
+
+    Args:
+        text: The full text content of a .asc file.
+
+    Returns:
+        tuple of (CircuitModel, analysis_dict_or_None, warnings_list)
+
+    Raises:
+        AscParseError: If the .asc file cannot be parsed.
+    """
+    parsed = parse_asc(text)
+    raw_components = parsed["components"]
+    raw_wires = parsed["wires"]
+    raw_flags = parsed["flags"]
+    analysis = parsed["analysis"]
+    warnings = list(parsed["warnings"])
+
+    model = CircuitModel()
+
+    # Phase 1: Convert parsed symbols to ComponentData
+    # Build a map of (x, y) -> [(comp_id, terminal_index)] for wire matching
+    pin_map = {}  # (x, y) -> [(comp_id, terminal_index)]
+    comp_info_list = []
+
+    for sym in raw_components:
+        lt_name = sym["ltspice_name"]
+
+        # Normalize: strip path prefixes for matching
+        lookup_name = lt_name
+        comp_type = _SYMBOL_TO_TYPE.get(lookup_name)
+
+        if comp_type is None:
+            # Try lowercase
+            comp_type = _SYMBOL_TO_TYPE.get(lookup_name.lower())
+
+        if comp_type is None:
+            # Try just the last path component
+            base_name = lt_name.rsplit("\\", 1)[-1] if "\\" in lt_name else lt_name
+            comp_type = _SYMBOL_TO_TYPE.get(base_name)
+            if comp_type is None:
+                comp_type = _SYMBOL_TO_TYPE.get(base_name.lower())
+
+        if comp_type is None:
+            warnings.append(f"Unsupported LTspice component '{lt_name}' — skipped")
+            continue
+
+        comp_id = sym["inst_name"]
+        if comp_id is None:
+            warnings.append(f"Component '{lt_name}' has no InstName — skipped")
+            continue
+
+        # Determine value
+        value = sym["value"]
+        if value is None:
+            value = DEFAULT_VALUES.get(comp_type, "1")
+
+        # Handle waveform sources
+        if comp_type == "Voltage Source" and value:
+            upper_val = value.upper()
+            for func in ("SIN", "PULSE", "EXP", "PWL"):
+                if func in upper_val:
+                    comp_type = "Waveform Source"
+                    break
+
+        # Also check Value2 for AC sources
+        if comp_type == "Voltage Source" and sym.get("value2"):
+            val2_upper = sym["value2"].upper()
+            for func in ("SIN", "PULSE", "EXP", "PWL"):
+                if func in val2_upper:
+                    comp_type = "Waveform Source"
+                    value = sym["value2"]
+                    break
+
+        # Convert position: scale LTspice coords to scene coords
+        pos_x = sym["x"] * _SCALE
+        pos_y = sym["y"] * _SCALE
+
+        # Convert rotation
+        rotation_deg, flip_h = _rotation_to_degrees(sym["rotation"])
+
+        component = ComponentData(
+            component_id=comp_id,
+            component_type=comp_type,
+            value=value,
+            position=(pos_x, pos_y),
+            rotation=rotation_deg,
+            flip_h=flip_h,
+        )
+
+        # Set up waveform params if applicable
+        if comp_type == "Waveform Source":
+            _setup_waveform_params(component, value)
+
+        model.add_component(component)
+
+        # Update component counter
+        symbol = SPICE_SYMBOLS.get(comp_type, "X")
+        num_match = re.search(r"(\d+)$", comp_id)
+        if num_match:
+            num = int(num_match.group(1))
+            current = model.component_counter.get(symbol, 0)
+            model.component_counter[symbol] = max(current, num)
+
+        # Calculate absolute pin positions for this component
+        pin_offsets = _PIN_OFFSETS.get(comp_type, [(0, 0), (0, 80)])
+        for term_idx, (dx, dy) in enumerate(pin_offsets):
+            tx, ty = _transform_pin(dx, dy, sym["rotation"])
+            abs_x = sym["x"] + tx
+            abs_y = sym["y"] + ty
+            key = (abs_x, abs_y)
+            if key not in pin_map:
+                pin_map[key] = []
+            pin_map[key].append((comp_id, term_idx))
+
+        comp_info_list.append({"id": comp_id, "type": comp_type})
+
+    # Phase 2: Build connectivity from wire segments
+    # Use union-find to group connected wire endpoints + pin positions
+    all_points = set()
+    for x1, y1, x2, y2 in raw_wires:
+        all_points.add((x1, y1))
+        all_points.add((x2, y2))
+    for key in pin_map:
+        all_points.add(key)
+
+    parent = {p: p for p in all_points}
+
+    def find(p):
+        while parent[p] != p:
+            parent[p] = parent[parent[p]]
+            p = parent[p]
+        return p
+
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    # Union wire segment endpoints
+    for x1, y1, x2, y2 in raw_wires:
+        union((x1, y1), (x2, y2))
+
+    # Phase 3: Handle FLAG entries
+    # FLAG x y 0 = ground, FLAG x y name = net label
+    ground_points = set()
+    for fx, fy, label in raw_flags:
+        flag_pt = (fx, fy)
+        if flag_pt not in parent:
+            parent[flag_pt] = flag_pt
+            all_points.add(flag_pt)
+
+        if label == "0":
+            ground_points.add(find(flag_pt))
+
+    # Phase 4: Create ground components
+    # Find all terminals connected to ground nets
+    gnd_count = 0
+    for pt in list(all_points):
+        root = find(pt)
+        if root in ground_points or find(pt) in ground_points:
+            # Check if any component terminal is at this point
+            if pt in pin_map:
+                for comp_id, term_idx in pin_map[pt]:
+                    gnd_count += 1
+                    gnd_id = f"GND{gnd_count}"
+
+                    gnd_x = pt[0] * _SCALE
+                    gnd_y = (pt[1] + 48) * _SCALE
+
+                    gnd_component = ComponentData(
+                        component_id=gnd_id,
+                        component_type="Ground",
+                        value="0V",
+                        position=(gnd_x, gnd_y),
+                    )
+                    model.add_component(gnd_component)
+                    model.component_counter["GND"] = gnd_count
+
+                    wire = WireData(
+                        start_component_id=comp_id,
+                        start_terminal=term_idx,
+                        end_component_id=gnd_id,
+                        end_terminal=0,
+                    )
+                    model.add_wire(wire)
+
+    # Also update ground_points to include all points in ground nets
+    # (for excluding from normal wire creation below)
+    ground_roots = set()
+    for pt in all_points:
+        root = find(pt)
+        if root in ground_points:
+            ground_roots.add(root)
+
+    # Phase 5: Create wires between component terminals sharing the same net
+    # Group terminals by their net (union-find root)
+    net_to_terminals = {}
+    for pt, terminal_list in pin_map.items():
+        root = find(pt)
+        if root in ground_roots:
+            continue  # Already handled by ground wires
+        if root not in net_to_terminals:
+            net_to_terminals[root] = []
+        net_to_terminals[root].extend(terminal_list)
+
+    for _net_root, terminals in net_to_terminals.items():
+        if len(terminals) < 2:
+            continue
+        # Chain terminals together
+        for j in range(len(terminals) - 1):
+            comp_a, term_a = terminals[j]
+            comp_b, term_b = terminals[j + 1]
+            # Skip if either component was skipped
+            if comp_a not in model.components or comp_b not in model.components:
+                continue
+            wire = WireData(
+                start_component_id=comp_a,
+                start_terminal=term_a,
+                end_component_id=comp_b,
+                end_terminal=term_b,
+            )
+            model.add_wire(wire)
+
+    # Phase 6: Rebuild node graph and set analysis
+    model.rebuild_nodes()
+
+    if analysis:
+        model.analysis_type = analysis["type"]
+        model.analysis_params = analysis["params"]
+
+    return model, analysis, warnings
+
+
+def _setup_waveform_params(component, value_str):
+    """Set up waveform parameters on a Waveform Source component."""
+    upper = value_str.upper().strip()
+
+    if "SIN" in upper:
+        component.waveform_type = "SIN"
+        params = _extract_paren_params(value_str)
+        if len(params) >= 2:
+            sin_params = {
+                "offset": params[0] if len(params) > 0 else "0",
+                "amplitude": params[1] if len(params) > 1 else "5",
+                "frequency": params[2] if len(params) > 2 else "1k",
+                "delay": params[3] if len(params) > 3 else "0",
+                "theta": params[4] if len(params) > 4 else "0",
+                "phase": params[5] if len(params) > 5 else "0",
+            }
+            component.waveform_params = {"SIN": sin_params}
+    elif "PULSE" in upper:
+        component.waveform_type = "PULSE"
+        params = _extract_paren_params(value_str)
+        if len(params) >= 2:
+            pulse_params = {
+                "v1": params[0] if len(params) > 0 else "0",
+                "v2": params[1] if len(params) > 1 else "5",
+                "td": params[2] if len(params) > 2 else "0",
+                "tr": params[3] if len(params) > 3 else "1n",
+                "tf": params[4] if len(params) > 4 else "1n",
+                "pw": params[5] if len(params) > 5 else "500u",
+                "per": params[6] if len(params) > 6 else "1m",
+            }
+            component.waveform_params = {"PULSE": pulse_params}
+    elif "EXP" in upper:
+        component.waveform_type = "EXP"
+        params = _extract_paren_params(value_str)
+        if len(params) >= 2:
+            exp_params = {
+                "v1": params[0] if len(params) > 0 else "0",
+                "v2": params[1] if len(params) > 1 else "5",
+                "td1": params[2] if len(params) > 2 else "0",
+                "tau1": params[3] if len(params) > 3 else "1u",
+                "td2": params[4] if len(params) > 4 else "2u",
+                "tau2": params[5] if len(params) > 5 else "2u",
+            }
+            component.waveform_params = {"EXP": exp_params}
+
+
+def _extract_paren_params(text):
+    """Extract whitespace-separated parameters from inside parentheses."""
+    match = re.search(r"\(([^)]*)\)", text)
+    if match:
+        return match.group(1).split()
+    return []

--- a/app/tests/unit/test_asc_parser.py
+++ b/app/tests/unit/test_asc_parser.py
@@ -1,0 +1,431 @@
+"""Tests for LTspice .asc file parser."""
+
+import pytest
+from simulation.asc_parser import AscParseError, _transform_pin, import_asc, parse_asc
+
+# --- Sample .asc content for tests ---
+
+SIMPLE_RC = """\
+Version 4
+SHEET 1 880 680
+WIRE 192 80 80 80
+WIRE 192 192 192 160
+WIRE 80 192 80 80
+WIRE 192 192 80 192
+FLAG 80 192 0
+SYMBOL res 176 64 R0
+SYMATTR InstName R1
+SYMATTR Value 1k
+SYMBOL cap 176 96 R0
+SYMATTR InstName C1
+SYMATTR Value 1u
+SYMBOL voltage 80 80 R0
+SYMATTR InstName V1
+SYMATTR Value 5V
+"""
+
+VOLTAGE_DIVIDER = """\
+Version 4
+SHEET 1 880 680
+WIRE 192 80 80 80
+WIRE 192 192 192 80
+WIRE 80 256 80 80
+WIRE 192 256 192 192
+WIRE 192 256 80 256
+FLAG 80 256 0
+SYMBOL res 176 64 R0
+SYMATTR InstName R1
+SYMATTR Value 10k
+SYMBOL res 176 176 R0
+SYMATTR InstName R2
+SYMATTR Value 10k
+SYMBOL voltage 80 80 R0
+SYMATTR InstName V1
+SYMATTR Value 5V
+"""
+
+WITH_ANALYSIS = """\
+Version 4
+SHEET 1 880 680
+WIRE 192 80 80 80
+FLAG 80 192 0
+SYMBOL res 176 64 R0
+SYMATTR InstName R1
+SYMATTR Value 1k
+SYMBOL voltage 80 80 R0
+SYMATTR InstName V1
+SYMATTR Value 5V
+TEXT -32 280 Left 2 !.tran 10m
+"""
+
+UNSUPPORTED_COMPONENT = """\
+Version 4
+SHEET 1 880 680
+WIRE 192 80 80 80
+FLAG 80 192 0
+SYMBOL res 176 64 R0
+SYMATTR InstName R1
+SYMATTR Value 1k
+SYMBOL voltage 80 80 R0
+SYMATTR InstName V1
+SYMATTR Value 5V
+SYMBOL some_exotic_part 300 80 R0
+SYMATTR InstName X1
+SYMATTR Value exotic
+"""
+
+OP_AMP_CIRCUIT = """\
+Version 4
+SHEET 1 880 680
+WIRE 192 80 80 80
+WIRE 400 160 368 160
+FLAG 80 192 0
+SYMBOL res 176 64 R0
+SYMATTR InstName R1
+SYMATTR Value 10k
+SYMBOL Opamps\\\\opamp 336 192 R0
+SYMATTR InstName U1
+SYMATTR Value Ideal
+SYMBOL voltage 80 80 R0
+SYMATTR InstName V1
+SYMATTR Value 1V
+"""
+
+BJT_CIRCUIT = """\
+Version 4
+SHEET 1 880 680
+WIRE 192 80 80 80
+FLAG 80 256 0
+SYMBOL npn 160 112 R0
+SYMATTR InstName Q1
+SYMATTR Value 2N3904
+SYMBOL res 176 64 R0
+SYMATTR InstName R1
+SYMATTR Value 4.7k
+SYMBOL voltage 80 80 R0
+SYMATTR InstName V1
+SYMATTR Value 12V
+"""
+
+WAVEFORM_SOURCE = """\
+Version 4
+SHEET 1 880 680
+WIRE 192 80 80 80
+FLAG 80 192 0
+SYMBOL res 176 64 R0
+SYMATTR InstName R1
+SYMATTR Value 1k
+SYMBOL voltage 80 80 R0
+SYMATTR InstName V1
+SYMATTR Value SINE(0 5 1k)
+"""
+
+AC_ANALYSIS = """\
+Version 4
+SHEET 1 880 680
+WIRE 192 80 80 80
+FLAG 80 192 0
+SYMBOL res 176 64 R0
+SYMATTR InstName R1
+SYMATTR Value 1k
+SYMBOL voltage 80 80 R0
+SYMATTR InstName V1
+SYMATTR Value 1V
+TEXT -32 280 Left 2 !.ac dec 100 1 100k
+"""
+
+DC_SWEEP = """\
+Version 4
+SHEET 1 880 680
+WIRE 192 80 80 80
+FLAG 80 192 0
+SYMBOL res 176 64 R0
+SYMATTR InstName R1
+SYMATTR Value 1k
+SYMBOL voltage 80 80 R0
+SYMATTR InstName V1
+SYMATTR Value 5V
+TEXT -32 280 Left 2 !.dc V1 0 10 0.1
+"""
+
+ROTATED_COMPONENTS = """\
+Version 4
+SHEET 1 880 680
+WIRE 192 80 80 80
+FLAG 80 192 0
+SYMBOL res 176 64 R90
+SYMATTR InstName R1
+SYMATTR Value 1k
+SYMBOL cap 300 64 M0
+SYMATTR InstName C1
+SYMATTR Value 1u
+SYMBOL voltage 80 80 R0
+SYMATTR InstName V1
+SYMATTR Value 5V
+"""
+
+MULTIPLE_GROUNDS = """\
+Version 4
+SHEET 1 880 680
+WIRE 192 80 80 80
+FLAG 80 192 0
+FLAG 300 192 0
+SYMBOL res 176 64 R0
+SYMATTR InstName R1
+SYMATTR Value 1k
+SYMBOL voltage 80 80 R0
+SYMATTR InstName V1
+SYMATTR Value 5V
+"""
+
+DIODE_AND_MOSFET = """\
+Version 4
+SHEET 1 880 680
+WIRE 192 80 80 80
+FLAG 80 256 0
+SYMBOL diode 176 80 R0
+SYMATTR InstName D1
+SYMATTR Value IS=1e-14
+SYMBOL nmos 256 128 R0
+SYMATTR InstName M1
+SYMATTR Value NMOS1
+SYMBOL voltage 80 80 R0
+SYMATTR InstName V1
+SYMATTR Value 5V
+"""
+
+
+class TestParseAsc:
+    def test_parses_simple_rc(self):
+        result = parse_asc(SIMPLE_RC)
+        assert len(result["components"]) == 3
+        assert len(result["wires"]) == 4
+        assert len(result["flags"]) == 1
+
+    def test_parses_component_names(self):
+        result = parse_asc(SIMPLE_RC)
+        names = {c["inst_name"] for c in result["components"]}
+        assert names == {"R1", "C1", "V1"}
+
+    def test_parses_component_values(self):
+        result = parse_asc(SIMPLE_RC)
+        values = {c["inst_name"]: c["value"] for c in result["components"]}
+        assert values["R1"] == "1k"
+        assert values["C1"] == "1u"
+        assert values["V1"] == "5V"
+
+    def test_parses_positions(self):
+        result = parse_asc(SIMPLE_RC)
+        positions = {c["inst_name"]: (c["x"], c["y"]) for c in result["components"]}
+        assert positions["R1"] == (176, 64)
+        assert positions["V1"] == (80, 80)
+
+    def test_parses_rotations(self):
+        result = parse_asc(ROTATED_COMPONENTS)
+        rotations = {c["inst_name"]: c["rotation"] for c in result["components"]}
+        assert rotations["R1"] == "R90"
+        assert rotations["C1"] == "M0"
+        assert rotations["V1"] == "R0"
+
+    def test_parses_wires(self):
+        result = parse_asc(SIMPLE_RC)
+        assert all(len(w) == 4 for w in result["wires"])
+        assert (192, 80, 80, 80) in result["wires"]
+
+    def test_parses_flags(self):
+        result = parse_asc(SIMPLE_RC)
+        assert (80, 192, "0") in result["flags"]
+
+    def test_parses_tran_analysis(self):
+        result = parse_asc(WITH_ANALYSIS)
+        assert result["analysis"] is not None
+        assert result["analysis"]["type"] == "Transient"
+        assert result["analysis"]["params"]["duration"] == "10m"
+
+    def test_parses_ac_analysis(self):
+        result = parse_asc(AC_ANALYSIS)
+        assert result["analysis"]["type"] == "AC Sweep"
+        assert result["analysis"]["params"]["sweep_type"] == "dec"
+        assert result["analysis"]["params"]["fStop"] == "100k"
+
+    def test_parses_dc_analysis(self):
+        result = parse_asc(DC_SWEEP)
+        assert result["analysis"]["type"] == "DC Sweep"
+        assert result["analysis"]["params"]["source"] == "V1"
+        assert result["analysis"]["params"]["step"] == "0.1"
+
+    def test_empty_file_raises(self):
+        with pytest.raises(AscParseError):
+            parse_asc("")
+
+    def test_no_content_raises(self):
+        with pytest.raises(AscParseError, match="No components"):
+            parse_asc("Version 4\nSHEET 1 880 680\n")
+
+    def test_handles_crlf(self):
+        crlf_content = SIMPLE_RC.replace("\n", "\r\n")
+        result = parse_asc(crlf_content)
+        assert len(result["components"]) == 3
+
+
+class TestImportAsc:
+    def test_creates_components(self):
+        model, _analysis, _warnings = import_asc(SIMPLE_RC)
+        assert "R1" in model.components
+        assert "C1" in model.components
+        assert "V1" in model.components
+
+    def test_component_types(self):
+        model, _analysis, _warnings = import_asc(SIMPLE_RC)
+        assert model.components["R1"].component_type == "Resistor"
+        assert model.components["C1"].component_type == "Capacitor"
+        assert model.components["V1"].component_type == "Voltage Source"
+
+    def test_component_values(self):
+        model, _analysis, _warnings = import_asc(VOLTAGE_DIVIDER)
+        assert model.components["R1"].value == "10k"
+        assert model.components["R2"].value == "10k"
+        assert model.components["V1"].value == "5V"
+
+    def test_creates_wires(self):
+        model, _analysis, _warnings = import_asc(VOLTAGE_DIVIDER)
+        assert len(model.wires) > 0
+
+    def test_creates_ground_components(self):
+        model, _analysis, _warnings = import_asc(SIMPLE_RC)
+        ground_comps = [c for c in model.components.values() if c.component_type == "Ground"]
+        assert len(ground_comps) >= 1
+
+    def test_sets_analysis_type(self):
+        model, analysis, _warnings = import_asc(WITH_ANALYSIS)
+        assert analysis is not None
+        assert model.analysis_type == "Transient"
+
+    def test_unsupported_component_warning(self):
+        _model, _analysis, warnings = import_asc(UNSUPPORTED_COMPONENT)
+        assert any("some_exotic_part" in w for w in warnings)
+
+    def test_unsupported_component_skipped(self):
+        model, _analysis, _warnings = import_asc(UNSUPPORTED_COMPONENT)
+        assert "X1" not in model.components
+        # But supported components should still be there
+        assert "R1" in model.components
+        assert "V1" in model.components
+
+    def test_counter_tracking(self):
+        model, _analysis, _warnings = import_asc(VOLTAGE_DIVIDER)
+        assert model.component_counter.get("R", 0) >= 2
+        assert model.component_counter.get("V", 0) >= 1
+
+    def test_op_amp_import(self):
+        model, _analysis, _warnings = import_asc(OP_AMP_CIRCUIT)
+        assert "U1" in model.components
+        assert model.components["U1"].component_type == "Op-Amp"
+
+    def test_bjt_import(self):
+        model, _analysis, _warnings = import_asc(BJT_CIRCUIT)
+        assert "Q1" in model.components
+        assert model.components["Q1"].component_type == "BJT NPN"
+        assert model.components["Q1"].value == "2N3904"
+
+    def test_diode_and_mosfet_import(self):
+        model, _analysis, _warnings = import_asc(DIODE_AND_MOSFET)
+        assert "D1" in model.components
+        assert model.components["D1"].component_type == "Diode"
+        assert "M1" in model.components
+        assert model.components["M1"].component_type == "MOSFET NMOS"
+
+    def test_nodes_rebuilt(self):
+        model, _analysis, _warnings = import_asc(SIMPLE_RC)
+        assert len(model.nodes) > 0
+
+    def test_rotated_components(self):
+        model, _analysis, _warnings = import_asc(ROTATED_COMPONENTS)
+        assert model.components["R1"].rotation == 90
+        assert model.components["C1"].flip_h is True
+
+    def test_multiple_grounds(self):
+        model, _analysis, _warnings = import_asc(MULTIPLE_GROUNDS)
+        ground_comps = [c for c in model.components.values() if c.component_type == "Ground"]
+        assert len(ground_comps) >= 1
+
+    def test_waveform_source_detection(self):
+        model, _analysis, _warnings = import_asc(WAVEFORM_SOURCE)
+        assert model.components["V1"].component_type == "Waveform Source"
+
+    def test_ac_analysis_import(self):
+        model, analysis, _warnings = import_asc(AC_ANALYSIS)
+        assert model.analysis_type == "AC Sweep"
+        assert analysis["params"]["fStart"] == "1"
+
+
+class TestTransformPin:
+    def test_r0_no_change(self):
+        assert _transform_pin(10, 20, "R0") == (10, 20)
+
+    def test_r90(self):
+        assert _transform_pin(10, 20, "R90") == (20, -10)
+
+    def test_r180(self):
+        assert _transform_pin(10, 20, "R180") == (-10, -20)
+
+    def test_r270(self):
+        assert _transform_pin(10, 20, "R270") == (-20, 10)
+
+    def test_m0_mirror(self):
+        assert _transform_pin(10, 20, "M0") == (-10, 20)
+
+    def test_m90_mirror(self):
+        assert _transform_pin(10, 20, "M90") == (20, 10)
+
+    def test_m180_mirror(self):
+        assert _transform_pin(10, 20, "M180") == (10, -20)
+
+    def test_m270_mirror(self):
+        assert _transform_pin(10, 20, "M270") == (-20, -10)
+
+    def test_none_defaults_to_r0(self):
+        assert _transform_pin(10, 20, None) == (10, 20)
+
+
+class TestFileControllerIntegration:
+    def test_import_asc_via_controller(self, tmp_path):
+        """Test the full import pipeline through FileController."""
+        from controllers.file_controller import FileController
+
+        asc_file = tmp_path / "test.asc"
+        asc_file.write_text(VOLTAGE_DIVIDER)
+
+        ctrl = FileController()
+        warnings = ctrl.import_asc(asc_file)
+
+        assert "R1" in ctrl.model.components
+        assert "R2" in ctrl.model.components
+        assert "V1" in ctrl.model.components
+        assert ctrl.current_file is None
+        assert isinstance(warnings, list)
+
+    def test_import_asc_with_unsupported(self, tmp_path):
+        """Unsupported components should produce warnings but not fail."""
+        from controllers.file_controller import FileController
+
+        asc_file = tmp_path / "test.asc"
+        asc_file.write_text(UNSUPPORTED_COMPONENT)
+
+        ctrl = FileController()
+        warnings = ctrl.import_asc(asc_file)
+
+        assert len(warnings) > 0
+        assert "R1" in ctrl.model.components
+
+    def test_import_asc_invalid_raises(self, tmp_path):
+        """Invalid .asc content should raise AscParseError."""
+        from controllers.file_controller import FileController
+        from simulation.asc_parser import AscParseError
+
+        asc_file = tmp_path / "bad.asc"
+        asc_file.write_text("")
+
+        ctrl = FileController()
+        with pytest.raises(AscParseError):
+            ctrl.import_asc(asc_file)


### PR DESCRIPTION
## Summary
- Add asc_parser module for LTspice .asc schematic import
- Supports 20+ component types with pin position mapping and union-find wire connectivity
- Handles rotation codes, ground flags, SPICE directives, waveform sources
- Unsupported components generate user-visible warnings
- Adds File > Import LTspice Schematic menu item

## Test plan
- [x] 42 unit tests - all passing
- [x] 1487 total tests pass, lint clean
- [ ] Manual: import .asc file, verify components and warnings

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)