### PR TITLE
add --version flag and stdin pipe support

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -22,6 +22,8 @@ from controllers.circuit_controller import CircuitController
 from controllers.file_controller import validate_circuit_data
 from controllers.simulation_controller import SimulationController
 from models.circuit import CircuitModel
+
+__version__ = "0.1.0"
 from simulation.csv_exporter import (
     export_ac_results,
     export_dc_sweep_results,
@@ -35,20 +37,41 @@ def try_load_circuit(filepath: str) -> tuple[CircuitModel | None, str]:
     """Load and validate a circuit JSON file without exiting.
 
     Args:
-        filepath: Path to the circuit JSON file.
+        filepath: Path to the circuit JSON file, or "-" to read from stdin.
 
     Returns:
         (model, "") on success, or (None, error_message) on failure.
     """
+    if filepath == "-":
+        return _load_circuit_from_text(sys.stdin.read(), "<stdin>")
+
     path = Path(filepath)
     if not path.exists():
         return None, f"file not found: {filepath}"
 
     try:
         with open(path, "r") as f:
-            data = json.load(f)
+            text = f.read()
+    except OSError as e:
+        return None, f"error reading {filepath}: {e}"
+
+    return _load_circuit_from_text(text, filepath)
+
+
+def _load_circuit_from_text(text: str, source: str) -> tuple[CircuitModel | None, str]:
+    """Parse and validate circuit JSON text.
+
+    Args:
+        text: Raw JSON text.
+        source: Source name for error messages.
+
+    Returns:
+        (model, "") on success, or (None, error_message) on failure.
+    """
+    try:
+        data = json.loads(text)
     except json.JSONDecodeError as e:
-        return None, f"invalid JSON in {filepath}: {e}"
+        return None, f"invalid JSON in {source}: {e}"
 
     try:
         validate_circuit_data(data)
@@ -299,11 +322,12 @@ def build_parser() -> argparse.ArgumentParser:
         prog="spice-gui-cli",
         description="Spice-GUI batch operations — simulate, validate, and export circuits from the command line.",
     )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # simulate
     sim_parser = subparsers.add_parser("simulate", help="Run simulation and output results")
-    sim_parser.add_argument("circuit", help="Path to circuit JSON file")
+    sim_parser.add_argument("circuit", help="Path to circuit JSON file (use '-' for stdin)")
     sim_parser.add_argument("--format", choices=["json", "csv"], default="json", help="Output format (default: json)")
     sim_parser.add_argument("--output", "-o", help="Write results to file instead of stdout")
     sim_parser.add_argument(
@@ -314,11 +338,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     # validate
     val_parser = subparsers.add_parser("validate", help="Check circuit for errors without simulating")
-    val_parser.add_argument("circuit", help="Path to circuit JSON file")
+    val_parser.add_argument("circuit", help="Path to circuit JSON file (use '-' for stdin)")
 
     # export
     exp_parser = subparsers.add_parser("export", help="Export circuit in specified format")
-    exp_parser.add_argument("circuit", help="Path to circuit JSON file")
+    exp_parser.add_argument("circuit", help="Path to circuit JSON file (use '-' for stdin)")
     exp_parser.add_argument(
         "--format", "-f", choices=["cir", "json"], default="cir", help="Export format (default: cir)"
     )

--- a/app/tests/unit/test_cli.py
+++ b/app/tests/unit/test_cli.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 
 import pytest
 from cli import (
-    __version__,
     REPL_BANNER,
+    __version__,
     build_parser,
     build_repl_namespace,
     cmd_batch,
@@ -372,6 +372,8 @@ class TestStdinPipe:
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         assert "components" in data
+
+
 class TestReplCommand:
     def test_repl_namespace_has_circuit(self):
         ns = build_repl_namespace()

--- a/app/tests/unit/test_cli.py
+++ b/app/tests/unit/test_cli.py
@@ -1,10 +1,22 @@
 """Tests for the CLI batch operations (app/cli.py)."""
 
+import io
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
-from cli import build_parser, cmd_batch, cmd_export, cmd_simulate, cmd_validate, load_circuit, main, try_load_circuit
+from cli import (
+    __version__,
+    build_parser,
+    cmd_batch,
+    cmd_export,
+    cmd_simulate,
+    cmd_validate,
+    load_circuit,
+    main,
+    try_load_circuit,
+)
 from models.circuit import CircuitModel
 
 
@@ -313,3 +325,47 @@ class TestBatchCommand:
         if code == 0:
             csv_files = list(Path(out_dir).glob("*.csv"))
             assert len(csv_files) == 3
+
+
+class TestVersion:
+    def test_version_flag(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            build_parser().parse_args(["--version"])
+        assert exc_info.value.code == 0
+
+    def test_version_string(self):
+        assert __version__
+        parts = __version__.split(".")
+        assert len(parts) == 3
+
+
+class TestStdinPipe:
+    def test_load_from_stdin(self, voltage_divider):
+        """Reading from '-' reads stdin."""
+        circuit_json = Path(voltage_divider).read_text()
+        with patch("sys.stdin", io.StringIO(circuit_json)):
+            model, error = try_load_circuit("-")
+        assert model is not None
+        assert error == ""
+        assert len(model.components) == 4
+
+    def test_load_invalid_stdin(self):
+        with patch("sys.stdin", io.StringIO("not json")):
+            model, error = try_load_circuit("-")
+        assert model is None
+        assert "invalid JSON" in error
+
+    def test_validate_from_stdin(self, voltage_divider, capsys):
+        circuit_json = Path(voltage_divider).read_text()
+        with patch("sys.stdin", io.StringIO(circuit_json)):
+            code = main(["validate", "-"])
+        assert code == 0
+
+    def test_export_from_stdin(self, voltage_divider, capsys):
+        circuit_json = Path(voltage_divider).read_text()
+        with patch("sys.stdin", io.StringIO(circuit_json)):
+            code = main(["export", "-", "--format", "json"])
+        assert code == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "components" in data


### PR DESCRIPTION
## Summary
- Adds `--version` flag printing version string (0.1.0)
- Supports `-` as circuit path to read JSON from stdin for pipe composition
- Enables: `cat circuit.json | python -m cli validate -` and similar Unix pipeline patterns
- Refactored `try_load_circuit` to share JSON parsing logic between file and stdin paths

## Test plan
- [x] 6 new tests covering: version flag, version string format, stdin loading (valid + invalid), validate from stdin, export from stdin
- [x] All 40 CLI tests pass
- [x] Lint clean

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)