### PR TITLE
add circuit report generation (PDF with schematic, netlist, results)

### DIFF
--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -85,6 +85,11 @@ class MenuBarMixin:
         export_latex_action.triggered.connect(self.export_circuitikz)
         file_menu.addAction(export_latex_action)
 
+        generate_report_action = QAction("&Generate Circuit Report (PDF)...", self)
+        generate_report_action.setToolTip("Generate a comprehensive PDF report with schematic, netlist, and results")
+        generate_report_action.triggered.connect(self._on_generate_report)
+        file_menu.addAction(generate_report_action)
+
         file_menu.addSeparator()
 
         print_action = QAction("&Print...", self)

--- a/app/GUI/report_dialog.py
+++ b/app/GUI/report_dialog.py
@@ -1,0 +1,91 @@
+"""Dialog for configuring circuit report generation."""
+
+from PyQt6.QtWidgets import QCheckBox, QDialog, QDialogButtonBox, QGroupBox, QHBoxLayout, QLabel, QLineEdit, QVBoxLayout
+
+
+class ReportDialog(QDialog):
+    """Dialog for selecting which sections to include in a circuit report.
+
+    Presents checkboxes for each report section and text fields for
+    student name and circuit name.
+    """
+
+    def __init__(self, parent=None, circuit_name: str = "", has_results: bool = False):
+        super().__init__(parent)
+        self.setWindowTitle("Generate Circuit Report")
+        self.setMinimumWidth(400)
+
+        layout = QVBoxLayout(self)
+
+        # Circuit info section
+        info_group = QGroupBox("Report Info")
+        info_layout = QVBoxLayout(info_group)
+
+        name_row = QHBoxLayout()
+        name_row.addWidget(QLabel("Circuit Name:"))
+        self._circuit_name = QLineEdit(circuit_name)
+        self._circuit_name.setPlaceholderText("My Circuit")
+        name_row.addWidget(self._circuit_name)
+        info_layout.addLayout(name_row)
+
+        student_row = QHBoxLayout()
+        student_row.addWidget(QLabel("Student Name:"))
+        self._student_name = QLineEdit()
+        self._student_name.setPlaceholderText("(optional)")
+        student_row.addWidget(self._student_name)
+        info_layout.addLayout(student_row)
+
+        layout.addWidget(info_group)
+
+        # Sections checkboxes
+        sections_group = QGroupBox("Report Sections")
+        sections_layout = QVBoxLayout(sections_group)
+
+        self._cb_title = QCheckBox("Title Page")
+        self._cb_title.setChecked(True)
+        sections_layout.addWidget(self._cb_title)
+
+        self._cb_schematic = QCheckBox("Schematic Diagram")
+        self._cb_schematic.setChecked(True)
+        sections_layout.addWidget(self._cb_schematic)
+
+        self._cb_netlist = QCheckBox("SPICE Netlist")
+        self._cb_netlist.setChecked(True)
+        sections_layout.addWidget(self._cb_netlist)
+
+        self._cb_analysis = QCheckBox("Analysis Configuration")
+        self._cb_analysis.setChecked(True)
+        sections_layout.addWidget(self._cb_analysis)
+
+        self._cb_results = QCheckBox("Simulation Results")
+        self._cb_results.setChecked(has_results)
+        if not has_results:
+            self._cb_results.setEnabled(False)
+            self._cb_results.setToolTip("No simulation results available")
+        sections_layout.addWidget(self._cb_results)
+
+        layout.addWidget(sections_group)
+
+        # Buttons
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def get_config(self):
+        """Return a ReportConfig from the dialog selections.
+
+        Returns:
+            ReportConfig with the user's selections.
+        """
+        from GUI.report_generator import ReportConfig
+
+        return ReportConfig(
+            include_title=self._cb_title.isChecked(),
+            include_schematic=self._cb_schematic.isChecked(),
+            include_netlist=self._cb_netlist.isChecked(),
+            include_analysis=self._cb_analysis.isChecked(),
+            include_results=self._cb_results.isChecked(),
+            student_name=self._student_name.text().strip(),
+            circuit_name=self._circuit_name.text().strip(),
+        )

--- a/app/GUI/report_generator.py
+++ b/app/GUI/report_generator.py
@@ -1,0 +1,347 @@
+"""PDF circuit report generator.
+
+Renders multi-page PDF reports containing schematic image, SPICE netlist,
+analysis configuration, and simulation results using QPrinter/QPainter.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from PyQt6.QtCore import QRectF, Qt
+from PyQt6.QtGui import QFont, QFontMetrics, QPainter
+from PyQt6.QtPrintSupport import QPrinter
+
+
+@dataclass
+class ReportConfig:
+    """Configuration for which sections to include in a circuit report."""
+
+    include_title: bool = True
+    include_schematic: bool = True
+    include_netlist: bool = True
+    include_analysis: bool = True
+    include_results: bool = True
+    student_name: str = ""
+    circuit_name: str = ""
+
+
+class ReportGenerator:
+    """Generates multi-page PDF circuit reports.
+
+    Uses QPrinter/QPainter to render a structured report with optional
+    sections: title page, schematic image, SPICE netlist, analysis
+    configuration, and simulation results.
+    """
+
+    # Page layout constants (in device pixels at high-res)
+    MARGIN_RATIO = 0.05  # 5% margin on each side
+    TITLE_FONT_SIZE = 24
+    HEADING_FONT_SIZE = 16
+    BODY_FONT_SIZE = 10
+    CODE_FONT_SIZE = 9
+
+    def __init__(self, config: ReportConfig):
+        self.config = config
+
+    def generate(
+        self,
+        filepath: str,
+        scene=None,
+        model=None,
+        netlist: str = "",
+        results_text: str = "",
+    ) -> None:
+        """Generate a PDF report to the given file path.
+
+        Args:
+            filepath: Output PDF file path.
+            scene: QGraphicsScene containing the circuit schematic.
+            model: CircuitModel with analysis type/params and component data.
+            netlist: SPICE netlist string.
+            results_text: Formatted simulation results text.
+        """
+        printer = QPrinter(QPrinter.PrinterMode.HighResolution)
+        printer.setOutputFormat(QPrinter.OutputFormat.PdfFormat)
+        printer.setOutputFileName(filepath)
+
+        painter = QPainter(printer)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        page_rect = QRectF(printer.pageRect(printer.Unit.DevicePixel))
+        margin = page_rect.width() * self.MARGIN_RATIO
+        content_rect = page_rect.adjusted(margin, margin, -margin, -margin)
+
+        first_page = True
+
+        if self.config.include_title:
+            self._render_title_page(painter, content_rect, model)
+            first_page = False
+
+        if self.config.include_schematic and scene is not None:
+            if not first_page:
+                printer.newPage()
+            self._render_schematic_page(painter, printer, content_rect, scene)
+            first_page = False
+
+        if self.config.include_netlist and netlist:
+            if not first_page:
+                printer.newPage()
+            self._render_text_section(painter, printer, content_rect, "SPICE Netlist", netlist, monospace=True)
+            first_page = False
+
+        if self.config.include_analysis and model is not None:
+            if not first_page:
+                printer.newPage()
+            analysis_text = self._format_analysis_config(model)
+            self._render_text_section(painter, printer, content_rect, "Analysis Configuration", analysis_text)
+            first_page = False
+
+        if self.config.include_results and results_text:
+            if not first_page:
+                printer.newPage()
+            self._render_text_section(
+                painter,
+                printer,
+                content_rect,
+                "Simulation Results",
+                results_text,
+                monospace=True,
+            )
+
+        painter.end()
+
+    def _render_title_page(self, painter: QPainter, rect: QRectF, model=None) -> None:
+        """Render the title page with circuit name, date, and student name."""
+        painter.fillRect(rect, Qt.GlobalColor.white)
+
+        title_font = QFont("Helvetica", self.TITLE_FONT_SIZE, QFont.Weight.Bold)
+        subtitle_font = QFont("Helvetica", self.HEADING_FONT_SIZE)
+        body_font = QFont("Helvetica", self.BODY_FONT_SIZE)
+
+        center_y = rect.top() + rect.height() * 0.35
+        center_x = rect.left() + rect.width() / 2
+
+        # Circuit name
+        title = self.config.circuit_name or "Circuit Report"
+        painter.setFont(title_font)
+        fm = QFontMetrics(title_font)
+        title_width = fm.horizontalAdvance(title)
+        painter.drawText(int(center_x - title_width / 2), int(center_y), title)
+
+        # Subtitle
+        painter.setFont(subtitle_font)
+        subtitle = "Circuit Analysis Report"
+        fm = QFontMetrics(subtitle_font)
+        sub_width = fm.horizontalAdvance(subtitle)
+        painter.drawText(int(center_x - sub_width / 2), int(center_y + fm.height() * 2), subtitle)
+
+        # Analysis type if available
+        if model and model.analysis_type:
+            analysis_line = f"Analysis: {model.analysis_type}"
+            fm_body = QFontMetrics(body_font)
+            painter.setFont(body_font)
+            al_width = fm_body.horizontalAdvance(analysis_line)
+            painter.drawText(
+                int(center_x - al_width / 2),
+                int(center_y + fm.height() * 4),
+                analysis_line,
+            )
+
+        # Component count
+        if model and model.components:
+            comp_line = f"Components: {len(model.components)}"
+            painter.setFont(body_font)
+            fm_body = QFontMetrics(body_font)
+            cl_width = fm_body.horizontalAdvance(comp_line)
+            painter.drawText(
+                int(center_x - cl_width / 2),
+                int(center_y + fm.height() * 5),
+                comp_line,
+            )
+
+        # Date and student name at bottom
+        bottom_y = rect.top() + rect.height() * 0.7
+        painter.setFont(body_font)
+        fm = QFontMetrics(body_font)
+        line_height = fm.height() * 1.5
+
+        date_str = datetime.now().strftime("%B %d, %Y")
+        date_width = fm.horizontalAdvance(date_str)
+        painter.drawText(int(center_x - date_width / 2), int(bottom_y), date_str)
+
+        if self.config.student_name:
+            name_width = fm.horizontalAdvance(self.config.student_name)
+            painter.drawText(
+                int(center_x - name_width / 2),
+                int(bottom_y + line_height),
+                self.config.student_name,
+            )
+
+    def _render_schematic_page(self, painter: QPainter, printer: QPrinter, rect: QRectF, scene) -> None:
+        """Render the circuit schematic on a dedicated page."""
+        # Heading
+        heading_font = QFont("Helvetica", self.HEADING_FONT_SIZE, QFont.Weight.Bold)
+        painter.setFont(heading_font)
+        fm = QFontMetrics(heading_font)
+        painter.drawText(int(rect.left()), int(rect.top() + fm.ascent()), "Schematic")
+
+        heading_height = fm.height() * 2
+
+        # Compute source rect from circuit items (excluding grid)
+        source_rect = self._get_scene_source_rect(scene)
+        if source_rect is None:
+            body_font = QFont("Helvetica", self.BODY_FONT_SIZE)
+            painter.setFont(body_font)
+            painter.drawText(
+                int(rect.left()),
+                int(rect.top() + heading_height + 50),
+                "(Empty canvas)",
+            )
+            return
+
+        # Available area below heading
+        avail = QRectF(
+            rect.left(),
+            rect.top() + heading_height,
+            rect.width(),
+            rect.height() - heading_height,
+        )
+
+        # Scale to fit while preserving aspect ratio
+        scale_x = avail.width() / source_rect.width()
+        scale_y = avail.height() / source_rect.height()
+        scale = min(scale_x, scale_y)
+
+        target_w = source_rect.width() * scale
+        target_h = source_rect.height() * scale
+        target_x = avail.left() + (avail.width() - target_w) / 2
+        target_y = avail.top() + (avail.height() - target_h) / 2
+        target_rect = QRectF(target_x, target_y, target_w, target_h)
+
+        # White background for schematic area
+        painter.fillRect(target_rect, Qt.GlobalColor.white)
+        scene.render(painter, target=target_rect, source=source_rect)
+
+    def _render_text_section(
+        self,
+        painter: QPainter,
+        printer: QPrinter,
+        rect: QRectF,
+        heading: str,
+        text: str,
+        monospace: bool = False,
+    ) -> None:
+        """Render a text section with heading, handling page breaks."""
+        heading_font = QFont("Helvetica", self.HEADING_FONT_SIZE, QFont.Weight.Bold)
+        if monospace:
+            body_font = QFont("Courier", self.CODE_FONT_SIZE)
+        else:
+            body_font = QFont("Helvetica", self.BODY_FONT_SIZE)
+
+        # Draw heading
+        painter.setFont(heading_font)
+        hfm = QFontMetrics(heading_font)
+        y = rect.top() + hfm.ascent()
+        painter.drawText(int(rect.left()), int(y), heading)
+        y += hfm.height() * 1.5
+
+        # Draw separator line
+        painter.drawLine(int(rect.left()), int(y), int(rect.left() + rect.width()), int(y))
+        y += hfm.height() * 0.5
+
+        # Draw body text
+        painter.setFont(body_font)
+        bfm = QFontMetrics(body_font)
+        line_height = bfm.height() * 1.2
+        bottom = rect.top() + rect.height()
+
+        lines = text.split("\n")
+        for line in lines:
+            if y + line_height > bottom:
+                # New page
+                printer.newPage()
+                y = rect.top() + hfm.height()
+                painter.setFont(heading_font)
+                painter.drawText(
+                    int(rect.left()),
+                    int(rect.top() + hfm.ascent()),
+                    f"{heading} (continued)",
+                )
+                y += hfm.height() * 0.5
+                painter.drawLine(
+                    int(rect.left()),
+                    int(y),
+                    int(rect.left() + rect.width()),
+                    int(y),
+                )
+                y += hfm.height() * 0.5
+                painter.setFont(body_font)
+
+            # Truncate line if it's too wide
+            elided = bfm.elidedText(line, Qt.TextElideMode.ElideRight, int(rect.width()))
+            painter.drawText(int(rect.left()), int(y), elided)
+            y += line_height
+
+    def _format_analysis_config(self, model) -> str:
+        """Format analysis type and parameters as readable text."""
+        lines = []
+        lines.append(f"Analysis Type: {model.analysis_type}")
+        lines.append("")
+
+        if model.analysis_params:
+            lines.append("Parameters:")
+            for key, value in model.analysis_params.items():
+                # Format parameter name nicely
+                display_key = key.replace("_", " ").title()
+                lines.append(f"  {display_key}: {value}")
+        else:
+            lines.append("Parameters: (default)")
+
+        lines.append("")
+        lines.append(f"Total Components: {len(model.components)}")
+        lines.append(f"Total Wires: {len(model.wires)}")
+
+        # Component breakdown by type
+        if model.components:
+            lines.append("")
+            lines.append("Component Summary:")
+            type_counts: dict[str, int] = {}
+            for comp in model.components.values():
+                ctype = comp.component_type
+                type_counts[ctype] = type_counts.get(ctype, 0) + 1
+            for ctype, count in sorted(type_counts.items()):
+                lines.append(f"  {ctype}: {count}")
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _get_scene_source_rect(scene) -> QRectF | None:
+        """Compute bounding rect of circuit items with padding.
+
+        Filters out grid/background items by checking for circuit item types.
+        Falls back to itemsBoundingRect if type checking is unavailable.
+        """
+        try:
+            from GUI.annotation_item import AnnotationItem
+            from GUI.component_item import ComponentGraphicsItem
+            from GUI.wire_item import WireGraphicsItem
+
+            circuit_items = [
+                item
+                for item in scene.items()
+                if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
+            ]
+            if not circuit_items:
+                return None
+            source_rect = circuit_items[0].sceneBoundingRect()
+            for item in circuit_items[1:]:
+                source_rect = source_rect.united(item.sceneBoundingRect())
+        except ImportError:
+            # Fallback for testing without full GUI imports
+            source_rect = scene.itemsBoundingRect()
+            if source_rect.isEmpty():
+                return None
+
+        padding = 40
+        source_rect.adjust(-padding, -padding, padding, padding)
+        return source_rect

--- a/app/tests/unit/test_report_generator.py
+++ b/app/tests/unit/test_report_generator.py
@@ -1,0 +1,568 @@
+"""Tests for PDF circuit report generation."""
+
+import os
+import tempfile
+
+import pytest
+from GUI.report_generator import ReportConfig, ReportGenerator
+from models.circuit import CircuitModel
+from models.component import ComponentData
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def simple_model():
+    """A simple circuit model with a few components."""
+    model = CircuitModel()
+    model.components = {
+        "R1": ComponentData("R1", "Resistor", "1k", (100, 100)),
+        "V1": ComponentData("V1", "Voltage Source", "5", (0, 100)),
+    }
+    model.analysis_type = "DC Operating Point"
+    model.analysis_params = {}
+    return model
+
+
+@pytest.fixture
+def configured_model():
+    """A model with analysis params and multiple component types."""
+    model = CircuitModel()
+    model.components = {
+        "R1": ComponentData("R1", "Resistor", "1k", (100, 100)),
+        "R2": ComponentData("R2", "Resistor", "2k", (200, 100)),
+        "C1": ComponentData("C1", "Capacitor", "1u", (100, 200)),
+        "V1": ComponentData("V1", "Voltage Source", "5", (0, 100)),
+    }
+    model.analysis_type = "AC Sweep"
+    model.analysis_params = {
+        "sweep_type": "dec",
+        "num_points": "100",
+        "fStart": "1",
+        "fStop": "100k",
+    }
+    return model
+
+
+@pytest.fixture
+def sample_netlist():
+    return "My Test Circuit\n* Generated netlist\n\nR1 1 2 1k\nV1 1 0 5\n.op\n.end\n"
+
+
+@pytest.fixture
+def sample_results():
+    return (
+        "======================================================================\n"
+        "SIMULATION COMPLETE - DC Operating Point\n"
+        "======================================================================\n"
+        "\n"
+        "NODE VOLTAGES:\n"
+        "----------------------------------------\n"
+        "  1               :     5.000000 V\n"
+        "  2               :     2.500000 V\n"
+        "----------------------------------------\n"
+    )
+
+
+# --- ReportConfig tests ---
+
+
+class TestReportConfig:
+    def test_default_config(self):
+        config = ReportConfig()
+        assert config.include_title is True
+        assert config.include_schematic is True
+        assert config.include_netlist is True
+        assert config.include_analysis is True
+        assert config.include_results is True
+        assert config.student_name == ""
+        assert config.circuit_name == ""
+
+    def test_custom_config(self):
+        config = ReportConfig(
+            include_schematic=False,
+            student_name="Alice",
+            circuit_name="RC Filter",
+        )
+        assert config.include_schematic is False
+        assert config.student_name == "Alice"
+        assert config.circuit_name == "RC Filter"
+
+
+# --- ReportGenerator tests ---
+
+
+class TestReportGeneratorTitleOnly:
+    """Test report generation with title page only (no Qt scene needed)."""
+
+    def test_generates_pdf_file(self, qtbot, simple_model):
+        config = ReportConfig(
+            include_title=True,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+            circuit_name="Test Circuit",
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(filepath=pdf_path, model=simple_model)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 0
+        finally:
+            os.unlink(pdf_path)
+
+    def test_title_with_student_name(self, qtbot, simple_model):
+        config = ReportConfig(
+            include_title=True,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+            circuit_name="Voltage Divider",
+            student_name="Jane Doe",
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(filepath=pdf_path, model=simple_model)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 100
+        finally:
+            os.unlink(pdf_path)
+
+    def test_title_without_model(self, qtbot):
+        config = ReportConfig(
+            include_title=True,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(filepath=pdf_path)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 0
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestReportGeneratorNetlist:
+    """Test report generation with netlist section."""
+
+    def test_netlist_section(self, qtbot, simple_model, sample_netlist):
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=False,
+            include_netlist=True,
+            include_analysis=False,
+            include_results=False,
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(filepath=pdf_path, model=simple_model, netlist=sample_netlist)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 100
+        finally:
+            os.unlink(pdf_path)
+
+    def test_empty_netlist_skipped(self, qtbot):
+        config = ReportConfig(
+            include_title=True,
+            include_schematic=False,
+            include_netlist=True,
+            include_analysis=False,
+            include_results=False,
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(filepath=pdf_path, netlist="")
+            assert os.path.exists(pdf_path)
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestReportGeneratorAnalysis:
+    """Test report generation with analysis configuration section."""
+
+    def test_analysis_section(self, qtbot, configured_model):
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=True,
+            include_results=False,
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(filepath=pdf_path, model=configured_model)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 100
+        finally:
+            os.unlink(pdf_path)
+
+    def test_analysis_with_empty_params(self, qtbot, simple_model):
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=True,
+            include_results=False,
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(filepath=pdf_path, model=simple_model)
+            assert os.path.exists(pdf_path)
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestReportGeneratorResults:
+    """Test report generation with simulation results section."""
+
+    def test_results_section(self, qtbot, sample_results):
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=True,
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(filepath=pdf_path, results_text=sample_results)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 100
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestReportGeneratorSchematic:
+    """Test report generation with schematic rendering."""
+
+    def test_schematic_with_scene_items(self, qtbot):
+        from PyQt6.QtWidgets import QGraphicsEllipseItem, QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(QGraphicsEllipseItem(0, 0, 100, 100))
+        scene.addItem(QGraphicsEllipseItem(150, 0, 100, 100))
+
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=True,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(filepath=pdf_path, scene=scene)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 100
+        finally:
+            os.unlink(pdf_path)
+
+    def test_schematic_with_empty_scene(self, qtbot):
+        from PyQt6.QtWidgets import QGraphicsScene
+
+        scene = QGraphicsScene()
+
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=True,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(filepath=pdf_path, scene=scene)
+            assert os.path.exists(pdf_path)
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestReportGeneratorFullReport:
+    """Test generation of a complete multi-section report."""
+
+    def test_full_report(self, qtbot, configured_model, sample_netlist, sample_results):
+        from PyQt6.QtWidgets import QGraphicsEllipseItem, QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(QGraphicsEllipseItem(0, 0, 100, 50))
+
+        config = ReportConfig(
+            include_title=True,
+            include_schematic=True,
+            include_netlist=True,
+            include_analysis=True,
+            include_results=True,
+            circuit_name="Full Report Test",
+            student_name="Test Student",
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(
+                filepath=pdf_path,
+                scene=scene,
+                model=configured_model,
+                netlist=sample_netlist,
+                results_text=sample_results,
+            )
+            assert os.path.exists(pdf_path)
+            # Full report should be reasonably large
+            assert os.path.getsize(pdf_path) > 500
+        finally:
+            os.unlink(pdf_path)
+
+    def test_all_sections_disabled_produces_valid_pdf(self, qtbot):
+        """Even with all sections off, should produce a valid (tiny) PDF."""
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(filepath=pdf_path)
+            assert os.path.exists(pdf_path)
+        finally:
+            os.unlink(pdf_path)
+
+    def test_schematic_only_no_simulation(self, qtbot, simple_model, sample_netlist):
+        """Common case: report with schematic and netlist but no sim results."""
+        from PyQt6.QtWidgets import QGraphicsRectItem, QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(QGraphicsRectItem(0, 0, 60, 30))
+
+        config = ReportConfig(
+            include_title=True,
+            include_schematic=True,
+            include_netlist=True,
+            include_analysis=True,
+            include_results=False,
+            circuit_name="RC Filter",
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(
+                filepath=pdf_path,
+                scene=scene,
+                model=simple_model,
+                netlist=sample_netlist,
+            )
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 200
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestFormatAnalysisConfig:
+    """Test the analysis config formatting helper."""
+
+    def test_format_op_analysis(self, simple_model):
+        gen = ReportGenerator(ReportConfig())
+        text = gen._format_analysis_config(simple_model)
+        assert "DC Operating Point" in text
+        assert "Total Components: 2" in text
+
+    def test_format_ac_analysis(self, configured_model):
+        gen = ReportGenerator(ReportConfig())
+        text = gen._format_analysis_config(configured_model)
+        assert "AC Sweep" in text
+        assert "Sweep Type" in text
+        assert "100" in text
+        assert "Total Components: 4" in text
+
+    def test_format_component_summary(self, configured_model):
+        gen = ReportGenerator(ReportConfig())
+        text = gen._format_analysis_config(configured_model)
+        assert "Resistor: 2" in text
+        assert "Capacitor: 1" in text
+        assert "Voltage Source: 1" in text
+
+    def test_format_empty_params(self, simple_model):
+        gen = ReportGenerator(ReportConfig())
+        text = gen._format_analysis_config(simple_model)
+        assert "(default)" in text
+
+
+class TestGetSceneSourceRect:
+    """Test the scene source rect computation."""
+
+    def test_returns_none_for_empty_scene(self, qtbot):
+        from PyQt6.QtWidgets import QGraphicsScene
+
+        scene = QGraphicsScene()
+        result = ReportGenerator._get_scene_source_rect(scene)
+        assert result is None
+
+    def test_returns_none_for_non_circuit_items(self, qtbot):
+        """Non-circuit items (e.g. grid) are filtered out, returning None."""
+        from PyQt6.QtWidgets import QGraphicsEllipseItem, QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(QGraphicsEllipseItem(10, 20, 100, 50))
+        result = ReportGenerator._get_scene_source_rect(scene)
+        # Should be None because QGraphicsEllipseItem is not a circuit item
+        assert result is None
+
+    def test_returns_rect_via_render_pipeline(self, qtbot):
+        """Schematic page renders without crashing even with generic items."""
+        from PyQt6.QtWidgets import QGraphicsRectItem, QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(QGraphicsRectItem(0, 0, 200, 100))
+
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=True,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            # Should not crash - empty scene path handles gracefully
+            gen.generate(filepath=pdf_path, scene=scene)
+            assert os.path.exists(pdf_path)
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestReportGeneratorLongText:
+    """Test pagination for long text sections."""
+
+    def test_long_netlist_paginates(self, qtbot):
+        """A very long netlist should not crash and should produce a multi-page PDF."""
+        long_netlist = "\n".join([f"R{i} n{i} n{i + 1} {i}k" for i in range(200)])
+
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=False,
+            include_netlist=True,
+            include_analysis=False,
+            include_results=False,
+        )
+        gen = ReportGenerator(config)
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            gen.generate(filepath=pdf_path, netlist=long_netlist)
+            assert os.path.exists(pdf_path)
+            # Multi-page PDF should be larger than single-page
+            assert os.path.getsize(pdf_path) > 1000
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestReportDialog:
+    """Test the report dialog configuration."""
+
+    def test_dialog_creates(self, qtbot):
+        from GUI.report_dialog import ReportDialog
+
+        dialog = ReportDialog(circuit_name="Test", has_results=True)
+        qtbot.addWidget(dialog)
+        assert dialog.windowTitle() == "Generate Circuit Report"
+
+    def test_dialog_default_config(self, qtbot):
+        from GUI.report_dialog import ReportDialog
+
+        dialog = ReportDialog(circuit_name="Test Circuit", has_results=True)
+        qtbot.addWidget(dialog)
+        config = dialog.get_config()
+        assert config.include_title is True
+        assert config.include_schematic is True
+        assert config.include_netlist is True
+        assert config.include_analysis is True
+        assert config.include_results is True
+        assert config.circuit_name == "Test Circuit"
+
+    def test_dialog_no_results(self, qtbot):
+        from GUI.report_dialog import ReportDialog
+
+        dialog = ReportDialog(has_results=False)
+        qtbot.addWidget(dialog)
+        config = dialog.get_config()
+        # Results checkbox should be unchecked when no results available
+        assert config.include_results is False
+
+    def test_dialog_student_name(self, qtbot):
+        from GUI.report_dialog import ReportDialog
+
+        dialog = ReportDialog()
+        qtbot.addWidget(dialog)
+        dialog._student_name.setText("Jane Doe")
+        config = dialog.get_config()
+        assert config.student_name == "Jane Doe"
+
+    def test_dialog_circuit_name_override(self, qtbot):
+        from GUI.report_dialog import ReportDialog
+
+        dialog = ReportDialog(circuit_name="Original")
+        qtbot.addWidget(dialog)
+        dialog._circuit_name.setText("Modified")
+        config = dialog.get_config()
+        assert config.circuit_name == "Modified"


### PR DESCRIPTION
## Summary
- Adds **File > Generate Circuit Report (PDF)** menu option for one-click PDF report generation
- Report includes: title page (circuit name, date, student name), schematic image, SPICE netlist, analysis configuration, and simulation results
- Section selection dialog lets users choose which sections to include
- Works even without simulation results (schematic + netlist only)
- Handles page breaks for long netlists/results

## New Files
- `app/GUI/report_generator.py` — `ReportGenerator` class using QPrinter/QPainter for multi-page PDF rendering
- `app/GUI/report_dialog.py` — `ReportDialog` for section selection and report configuration
- `app/tests/unit/test_report_generator.py` — 28 tests covering all sections, edge cases, and pagination

## Modified Files
- `app/GUI/main_window_menus.py` — added "Generate Circuit Report (PDF)..." menu action
- `app/GUI/main_window_file_ops.py` — added `_on_generate_report()` handler

## Test plan
- [x] 28 new tests all passing
- [x] 1473 total tests passing
- [x] Lint clean (ruff, black, isort)
- [ ] Human test: generate report with various circuit configurations
- [ ] Human test: verify PDF renders correctly with all sections

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)