### PR TITLE
add power dissipation and RMS metrics for transient analysis

### DIFF
--- a/app/GUI/main_window_simulation.py
+++ b/app/GUI/main_window_simulation.py
@@ -313,6 +313,13 @@ class SimulationMixin:
             table_string = ResultParser.format_results_as_table(tran_data)
             self.results_text.append(table_string)
 
+            # Power summary for resistors
+            from simulation.power_metrics import compute_transient_power_metrics, format_power_summary
+
+            power_metrics = compute_transient_power_metrics(tran_data, self.model.components)
+            if power_metrics:
+                self.results_text.append(format_power_summary(power_metrics))
+
             self.results_text.append("\n" + "-" * 40)
             self.results_text.append("Waveform plot has also been generated in a new window.")
 

--- a/app/simulation/power_metrics.py
+++ b/app/simulation/power_metrics.py
@@ -1,0 +1,154 @@
+"""
+simulation/power_metrics.py
+
+Computes RMS voltage/current and average/peak power from transient simulation data.
+"""
+
+import math
+
+from GUI.format_utils import parse_value
+
+
+def compute_rms(values):
+    """Compute the RMS (root-mean-square) of a list of numeric values.
+
+    Args:
+        values: list of float values
+
+    Returns:
+        RMS value as float, or 0.0 if empty.
+    """
+    if not values:
+        return 0.0
+    mean_sq = sum(v * v for v in values) / len(values)
+    return math.sqrt(mean_sq)
+
+
+def compute_transient_power_metrics(tran_data, components):
+    """Compute power metrics from transient simulation data.
+
+    For each resistor, computes:
+    - Vrms: RMS voltage across the component
+    - Irms: RMS current through the component
+    - Pavg: average power dissipated
+    - Ppeak: peak instantaneous power
+
+    Args:
+        tran_data: list[dict] — time-series data from parse_transient_results.
+            Each dict has keys like "time", node labels, and "v_r1" for resistor voltages.
+        components: dict mapping component_id -> ComponentData
+
+    Returns:
+        list[dict] with keys: component_id, component_type, value, vrms, irms, pavg, ppeak.
+        Only includes components for which metrics could be computed.
+    """
+    if not tran_data or not components:
+        return []
+
+    results = []
+
+    for comp_id, comp in components.items():
+        if comp.component_type == "Ground":
+            continue
+
+        # Look for voltage-across vector in the transient data
+        v_key = f"v_{comp_id.lower()}"
+        if v_key not in tran_data[0]:
+            continue
+
+        voltage_series = [row[v_key] for row in tran_data if v_key in row]
+        if not voltage_series:
+            continue
+
+        vrms = compute_rms(voltage_series)
+
+        if comp.component_type == "Resistor":
+            try:
+                resistance = parse_value(comp.value)
+                if resistance <= 0:
+                    continue
+            except (ValueError, TypeError):
+                continue
+
+            irms = vrms / resistance
+            # Instantaneous power at each time point: P(t) = V(t)^2 / R
+            power_series = [v * v / resistance for v in voltage_series]
+            pavg = sum(power_series) / len(power_series)
+            ppeak = max(abs(p) for p in power_series)
+
+            results.append(
+                {
+                    "component_id": comp_id,
+                    "component_type": comp.component_type,
+                    "value": comp.value,
+                    "vrms": vrms,
+                    "irms": irms,
+                    "pavg": pavg,
+                    "ppeak": ppeak,
+                }
+            )
+
+    return results
+
+
+def format_power_summary(metrics):
+    """Format power metrics as a text table for display.
+
+    Args:
+        metrics: list of dicts from compute_transient_power_metrics
+
+    Returns:
+        Formatted string with power summary table.
+    """
+    if not metrics:
+        return ""
+
+    lines = []
+    lines.append("")
+    lines.append("POWER SUMMARY")
+    lines.append("=" * 70)
+    lines.append(f"  {'Component':<12s} {'Value':>8s} {'Vrms':>12s} {'Irms':>12s} {'Pavg':>12s} {'Ppeak':>12s}")
+    lines.append("-" * 70)
+
+    total_pavg = 0.0
+    for m in metrics:
+        total_pavg += m["pavg"]
+        lines.append(
+            f"  {m['component_id']:<12s} {m['value']:>8s}"
+            f" {_fmt_eng(m['vrms'], 'V'):>12s}"
+            f" {_fmt_eng(m['irms'], 'A'):>12s}"
+            f" {_fmt_eng(m['pavg'], 'W'):>12s}"
+            f" {_fmt_eng(m['ppeak'], 'W'):>12s}"
+        )
+
+    lines.append("-" * 70)
+    lines.append(f"  {'Total Pavg':<12s} {'':>8s} {'':>12s} {'':>12s} {_fmt_eng(total_pavg, 'W'):>12s}")
+    lines.append("=" * 70)
+
+    return "\n".join(lines)
+
+
+def _fmt_eng(value, unit):
+    """Format a value in engineering notation with SI prefix."""
+    if value == 0:
+        return f"0 {unit}"
+
+    abs_val = abs(value)
+    prefixes = [
+        (1e12, "T"),
+        (1e9, "G"),
+        (1e6, "M"),
+        (1e3, "k"),
+        (1, ""),
+        (1e-3, "m"),
+        (1e-6, "u"),
+        (1e-9, "n"),
+        (1e-12, "p"),
+    ]
+
+    for mult, prefix in prefixes:
+        if abs_val >= mult:
+            scaled = value / mult
+            return f"{scaled:.3g} {prefix}{unit}"
+
+    return f"{value:.3e} {unit}"

--- a/app/tests/unit/test_power_metrics.py
+++ b/app/tests/unit/test_power_metrics.py
@@ -1,0 +1,230 @@
+"""Tests for transient power metrics computation."""
+
+import math
+
+from models.component import ComponentData
+from simulation.power_metrics import _fmt_eng, compute_rms, compute_transient_power_metrics, format_power_summary
+
+# ---------------------------------------------------------------------------
+# compute_rms tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRms:
+    def test_empty_list(self):
+        assert compute_rms([]) == 0.0
+
+    def test_dc_signal(self):
+        """RMS of a constant signal equals its absolute value."""
+        assert compute_rms([5.0, 5.0, 5.0]) == 5.0
+
+    def test_negative_dc(self):
+        assert compute_rms([-3.0, -3.0, -3.0]) == 3.0
+
+    def test_sine_wave_approximation(self):
+        """RMS of a sine wave is Vpeak / sqrt(2)."""
+        import math
+
+        n = 10000
+        peak = 10.0
+        values = [peak * math.sin(2 * math.pi * i / n) for i in range(n)]
+        expected = peak / math.sqrt(2)
+        assert abs(compute_rms(values) - expected) < 0.01
+
+    def test_single_value(self):
+        assert compute_rms([7.0]) == 7.0
+
+    def test_mixed_positive_negative(self):
+        """RMS of [1, -1] = 1."""
+        assert compute_rms([1.0, -1.0]) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# compute_transient_power_metrics tests
+# ---------------------------------------------------------------------------
+
+
+def _make_component(cid, ctype, value="1k"):
+    return ComponentData(
+        component_id=cid,
+        component_type=ctype,
+        value=value,
+        position=(0, 0),
+    )
+
+
+class TestComputeTransientPowerMetrics:
+    def test_empty_data(self):
+        assert compute_transient_power_metrics([], {}) == []
+
+    def test_none_data(self):
+        assert compute_transient_power_metrics(None, {}) == []
+
+    def test_no_components(self):
+        data = [{"time": 0.0, "v_r1": 5.0}]
+        assert compute_transient_power_metrics(data, {}) == []
+
+    def test_resistor_dc_voltage(self):
+        """Constant 10V across 1k resistor: Vrms=10, Irms=10mA, Pavg=0.1W."""
+        components = {"R1": _make_component("R1", "Resistor", "1k")}
+        data = [
+            {"time": 0.0, "v_r1": 10.0},
+            {"time": 1e-3, "v_r1": 10.0},
+            {"time": 2e-3, "v_r1": 10.0},
+        ]
+        metrics = compute_transient_power_metrics(data, components)
+        assert len(metrics) == 1
+        m = metrics[0]
+        assert m["component_id"] == "R1"
+        assert m["vrms"] == 10.0
+        assert abs(m["irms"] - 0.01) < 1e-9
+        assert abs(m["pavg"] - 0.1) < 1e-9
+        assert abs(m["ppeak"] - 0.1) < 1e-9
+
+    def test_resistor_varying_voltage(self):
+        """0V and 10V alternating across 100 ohm: Vrms=sqrt(50), Pavg=0.5W."""
+        components = {"R1": _make_component("R1", "Resistor", "100")}
+        data = [
+            {"time": 0.0, "v_r1": 0.0},
+            {"time": 1e-3, "v_r1": 10.0},
+        ]
+        metrics = compute_transient_power_metrics(data, components)
+        assert len(metrics) == 1
+        m = metrics[0]
+        assert abs(m["vrms"] - math.sqrt(50)) < 1e-9
+        # Pavg = mean(0/100, 100/100) = 0.5
+        assert abs(m["pavg"] - 0.5) < 1e-9
+        # Ppeak = 100/100 = 1.0
+        assert abs(m["ppeak"] - 1.0) < 1e-9
+
+    def test_multiple_resistors(self):
+        """Two resistors should each get their own metrics."""
+        components = {
+            "R1": _make_component("R1", "Resistor", "1k"),
+            "R2": _make_component("R2", "Resistor", "2k"),
+        }
+        data = [
+            {"time": 0.0, "v_r1": 5.0, "v_r2": 10.0},
+            {"time": 1e-3, "v_r1": 5.0, "v_r2": 10.0},
+        ]
+        metrics = compute_transient_power_metrics(data, components)
+        assert len(metrics) == 2
+        ids = {m["component_id"] for m in metrics}
+        assert ids == {"R1", "R2"}
+
+    def test_ground_component_skipped(self):
+        components = {"GND": _make_component("GND", "Ground", "0")}
+        data = [{"time": 0.0}]
+        metrics = compute_transient_power_metrics(data, components)
+        assert len(metrics) == 0
+
+    def test_missing_voltage_key(self):
+        """Components without v_XX key in data are skipped."""
+        components = {"R1": _make_component("R1", "Resistor", "1k")}
+        data = [{"time": 0.0, "out": 5.0}]
+        metrics = compute_transient_power_metrics(data, components)
+        assert len(metrics) == 0
+
+    def test_non_resistor_skipped(self):
+        """Only resistors get power metrics (voltage sources lack current data)."""
+        components = {"V1": _make_component("V1", "Voltage Source", "5")}
+        data = [{"time": 0.0, "v_v1": 5.0}]
+        metrics = compute_transient_power_metrics(data, components)
+        assert len(metrics) == 0
+
+    def test_invalid_resistance_value(self):
+        """Components with unparseable values are skipped."""
+        components = {"R1": _make_component("R1", "Resistor", "abc")}
+        data = [{"time": 0.0, "v_r1": 5.0}]
+        metrics = compute_transient_power_metrics(data, components)
+        assert len(metrics) == 0
+
+    def test_si_prefix_resistance(self):
+        """Resistance with SI prefix parsed correctly (10k = 10000)."""
+        components = {"R1": _make_component("R1", "Resistor", "10k")}
+        data = [{"time": 0.0, "v_r1": 100.0}]
+        metrics = compute_transient_power_metrics(data, components)
+        assert len(metrics) == 1
+        # P = V^2/R = 10000/10000 = 1W
+        assert abs(metrics[0]["pavg"] - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# format_power_summary tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPowerSummary:
+    def test_empty_metrics(self):
+        assert format_power_summary([]) == ""
+
+    def test_single_resistor(self):
+        metrics = [
+            {
+                "component_id": "R1",
+                "component_type": "Resistor",
+                "value": "1k",
+                "vrms": 10.0,
+                "irms": 0.01,
+                "pavg": 0.1,
+                "ppeak": 0.1,
+            }
+        ]
+        result = format_power_summary(metrics)
+        assert "POWER SUMMARY" in result
+        assert "R1" in result
+        assert "1k" in result
+        assert "Total" in result
+
+    def test_total_power(self):
+        """Total Pavg should sum individual pavg values."""
+        metrics = [
+            {
+                "component_id": "R1",
+                "component_type": "Resistor",
+                "value": "1k",
+                "vrms": 10.0,
+                "irms": 0.01,
+                "pavg": 0.1,
+                "ppeak": 0.1,
+            },
+            {
+                "component_id": "R2",
+                "component_type": "Resistor",
+                "value": "2k",
+                "vrms": 10.0,
+                "irms": 0.005,
+                "pavg": 0.05,
+                "ppeak": 0.05,
+            },
+        ]
+        result = format_power_summary(metrics)
+        # Total should be 0.15W = 150mW
+        assert "150 mW" in result
+
+
+# ---------------------------------------------------------------------------
+# _fmt_eng tests
+# ---------------------------------------------------------------------------
+
+
+class TestFmtEng:
+    def test_zero(self):
+        assert _fmt_eng(0, "W") == "0 W"
+
+    def test_milliwatts(self):
+        result = _fmt_eng(0.015, "W")
+        assert "mW" in result
+
+    def test_kilohms(self):
+        result = _fmt_eng(4700, "V")
+        assert "kV" in result
+
+    def test_microamps(self):
+        result = _fmt_eng(0.000050, "A")
+        assert "uA" in result
+
+    def test_plain_unit(self):
+        result = _fmt_eng(5.0, "V")
+        assert "V" in result
+        assert "5" in result


### PR DESCRIPTION
## Summary
- Computes Vrms, Irms, average power, and peak power for each resistor after transient simulation
- Displays power summary table below transient results (component, value, Vrms, Irms, Pavg, Ppeak)
- Shows total average power dissipated across all resistors
- Uses voltage-across-resistor vectors already present in wrdata output

## Changes
- **`app/simulation/power_metrics.py`** (new): `compute_rms()`, `compute_transient_power_metrics()`, `format_power_summary()`
- **`app/GUI/main_window_simulation.py`**: Calls power metrics after transient table display
- **`app/tests/unit/test_power_metrics.py`** (new): 25 tests

## Test plan
- [x] 25 new tests pass (RMS computation, DC/varying voltage, multiple resistors, edge cases, formatting)
- [x] Full suite: 1469 passed
- [x] Lint clean

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)