### PR TITLE
Add unified Preferences dialog (#318)

### DIFF
--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -420,9 +420,27 @@ class MenuBarMixin:
         # Settings menu
         settings_menu = menubar.addMenu("Se&ttings")
         if settings_menu:
+            preferences_action = QAction("&Preferences...", self)
+            preferences_action.triggered.connect(self._open_preferences_dialog)
+            settings_menu.addAction(preferences_action)
+
+            settings_menu.addSeparator()
+
             keybindings_action = QAction("&Keybindings...", self)
             keybindings_action.triggered.connect(self._open_keybindings_dialog)
             settings_menu.addAction(keybindings_action)
+
+    def _open_preferences_dialog(self):
+        """Open the unified preferences dialog (single-instance, non-modal)."""
+        from .preferences_dialog import PreferencesDialog
+
+        existing = getattr(self, "_preferences_dialog", None)
+        if existing is not None and existing.isVisible():
+            existing.raise_()
+            existing.activateWindow()
+            return
+        self._preferences_dialog = PreferencesDialog(self)
+        self._preferences_dialog.show()
 
     def _open_keybindings_dialog(self):
         """Open the keybindings preferences dialog."""

--- a/app/GUI/preferences_dialog.py
+++ b/app/GUI/preferences_dialog.py
@@ -1,0 +1,206 @@
+"""Unified Preferences dialog for application settings."""
+
+from PyQt6.QtCore import QSettings
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSpinBox,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .styles import theme_manager
+
+# Mapping between combo display text and internal values
+_THEME_ITEMS = [("Light", "light"), ("Dark", "dark")]
+_THEME_NAMES = {"Light Theme": 0, "Dark Theme": 1}
+
+_STYLE_ITEMS = [("IEEE / ANSI", "ieee"), ("IEC (European)", "iec")]
+_STYLE_VALUES = {"ieee": 0, "iec": 1}
+
+_COLOR_ITEMS = [("Color", "color"), ("Monochrome", "monochrome")]
+_COLOR_VALUES = {"color": 0, "monochrome": 1}
+
+_SENTINEL = object()
+
+
+class PreferencesDialog(QDialog):
+    """Tabbed preferences dialog with live preview and snapshot-revert on cancel."""
+
+    def __init__(self, main_window, parent=_SENTINEL):
+        super().__init__(main_window if parent is _SENTINEL else parent)
+        self.main_window = main_window
+        self._accepted = False
+        self.setWindowTitle("Preferences")
+        self.setMinimumWidth(400)
+
+        self._snapshot_settings()
+        self._build_ui()
+        self._load_current_values()
+        self._connect_signals()
+
+    # ---- snapshot / revert ------------------------------------------------
+
+    def _snapshot_settings(self):
+        """Capture current appearance and autosave settings for revert."""
+        self._snap_theme = theme_manager.current_theme.name  # "Light Theme" / "Dark Theme"
+        self._snap_symbol_style = theme_manager.symbol_style  # "ieee" / "iec"
+        self._snap_color_mode = theme_manager.color_mode  # "color" / "monochrome"
+        settings = QSettings("SDSMT", "SDM Spice")
+        self._snap_autosave_enabled = settings.value("autosave/enabled", True)
+        self._snap_autosave_interval = int(settings.value("autosave/interval", 60))
+
+    def _revert_settings(self):
+        """Restore appearance and autosave to snapshot values."""
+        # Revert appearance
+        theme_val = "dark" if self._snap_theme == "Dark Theme" else "light"
+        self.main_window._set_theme(theme_val)
+        self.main_window._set_symbol_style(self._snap_symbol_style)
+        self.main_window._set_color_mode(self._snap_color_mode)
+        # Revert autosave
+        settings = QSettings("SDSMT", "SDM Spice")
+        settings.setValue("autosave/enabled", self._snap_autosave_enabled)
+        settings.setValue("autosave/interval", self._snap_autosave_interval)
+        self.main_window._start_autosave_timer()
+
+    # ---- UI construction --------------------------------------------------
+
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+        self.tabs = QTabWidget()
+        layout.addWidget(self.tabs)
+
+        self.tabs.addTab(self._build_appearance_tab(), "Appearance")
+        self.tabs.addTab(self._build_grid_tab(), "Grid")
+        self.tabs.addTab(self._build_behavior_tab(), "Behavior")
+        self.tabs.addTab(self._build_keybindings_tab(), "Keybindings")
+
+        # Button row
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+        ok_btn = QPushButton("OK")
+        ok_btn.clicked.connect(self._on_ok)
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self._on_cancel)
+        btn_layout.addWidget(ok_btn)
+        btn_layout.addWidget(cancel_btn)
+        layout.addLayout(btn_layout)
+
+    def _build_appearance_tab(self):
+        widget = QWidget()
+        form = QFormLayout(widget)
+
+        self.theme_combo = QComboBox()
+        for label, _val in _THEME_ITEMS:
+            self.theme_combo.addItem(label)
+        form.addRow("Theme:", self.theme_combo)
+
+        self.style_combo = QComboBox()
+        for label, _val in _STYLE_ITEMS:
+            self.style_combo.addItem(label)
+        form.addRow("Symbol Style:", self.style_combo)
+
+        self.color_combo = QComboBox()
+        for label, _val in _COLOR_ITEMS:
+            self.color_combo.addItem(label)
+        form.addRow("Color Mode:", self.color_combo)
+
+        return widget
+
+    def _build_grid_tab(self):
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+        layout.addWidget(QLabel("Grid settings will be available in a future update."))
+        layout.addStretch()
+        return widget
+
+    def _build_behavior_tab(self):
+        widget = QWidget()
+        form = QFormLayout(widget)
+
+        self.autosave_checkbox = QCheckBox("Enable auto-save")
+        form.addRow(self.autosave_checkbox)
+
+        self.autosave_spin = QSpinBox()
+        self.autosave_spin.setRange(10, 600)
+        self.autosave_spin.setSingleStep(10)
+        self.autosave_spin.setSuffix(" seconds")
+        form.addRow("Auto-save interval:", self.autosave_spin)
+
+        return widget
+
+    def _build_keybindings_tab(self):
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+        layout.addWidget(QLabel("Keyboard shortcuts can be customized in the keybindings editor."))
+        self.keybindings_btn = QPushButton("Open Keybindings Editor...")
+        self.keybindings_btn.clicked.connect(self._open_keybindings)
+        layout.addWidget(self.keybindings_btn)
+        layout.addStretch()
+        return widget
+
+    # ---- Load current values into widgets ---------------------------------
+
+    def _load_current_values(self):
+        self.theme_combo.setCurrentIndex(_THEME_NAMES.get(self._snap_theme, 0))
+        self.style_combo.setCurrentIndex(_STYLE_VALUES.get(self._snap_symbol_style, 0))
+        self.color_combo.setCurrentIndex(_COLOR_VALUES.get(self._snap_color_mode, 0))
+
+        enabled = self._snap_autosave_enabled
+        self.autosave_checkbox.setChecked(enabled != "false" and enabled is not False)
+        self.autosave_spin.setValue(self._snap_autosave_interval)
+
+    # ---- Signal wiring (live preview) -------------------------------------
+
+    def _connect_signals(self):
+        self.theme_combo.currentIndexChanged.connect(self._on_theme_changed)
+        self.style_combo.currentIndexChanged.connect(self._on_style_changed)
+        self.color_combo.currentIndexChanged.connect(self._on_color_changed)
+
+    def _on_theme_changed(self, index):
+        self.main_window._set_theme(_THEME_ITEMS[index][1])
+
+    def _on_style_changed(self, index):
+        self.main_window._set_symbol_style(_STYLE_ITEMS[index][1])
+
+    def _on_color_changed(self, index):
+        self.main_window._set_color_mode(_COLOR_ITEMS[index][1])
+
+    # ---- Button handlers --------------------------------------------------
+
+    def _on_ok(self):
+        """Persist all settings and close."""
+        settings = QSettings("SDSMT", "SDM Spice")
+        settings.setValue("autosave/enabled", self.autosave_checkbox.isChecked())
+        settings.setValue("autosave/interval", self.autosave_spin.value())
+        self.main_window._start_autosave_timer()
+        # Appearance is already applied via live preview — settings are saved
+        # in MainWindow._save_settings() on close, but persist theme now too
+        settings.setValue("view/theme", theme_manager.current_theme.name)
+        settings.setValue("view/symbol_style", theme_manager.symbol_style)
+        settings.setValue("view/color_mode", theme_manager.color_mode)
+        self._accepted = True
+        self.close()
+
+    def _on_cancel(self):
+        """Revert to snapshot and close."""
+        self._revert_settings()
+        self.close()
+
+    def closeEvent(self, event):
+        """Treat window close (X button) as Cancel if not accepted."""
+        if not self._accepted:
+            self._revert_settings()
+        super().closeEvent(event)
+
+    # ---- Helpers ----------------------------------------------------------
+
+    def _open_keybindings(self):
+        """Open the keybindings editor dialog."""
+        self.main_window._open_keybindings_dialog()

--- a/app/tests/unit/test_preferences_dialog.py
+++ b/app/tests/unit/test_preferences_dialog.py
@@ -125,7 +125,8 @@ class TestOkPersist:
 
         settings = QSettings("SDSMT", "SDM Spice")
         assert settings.value("autosave/interval") == 120
-        assert settings.value("autosave/enabled") is True
+        enabled = settings.value("autosave/enabled")
+        assert enabled is True or enabled == "true"  # Windows registry stores as string
         mock_main_window._start_autosave_timer.assert_called()
 
 

--- a/app/tests/unit/test_preferences_dialog.py
+++ b/app/tests/unit/test_preferences_dialog.py
@@ -1,0 +1,140 @@
+"""Tests for the unified Preferences dialog."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from GUI.preferences_dialog import PreferencesDialog
+from PyQt6.QtCore import QSettings
+from PyQt6.QtWidgets import QCheckBox, QComboBox, QPushButton, QSpinBox, QTabWidget
+
+
+@pytest.fixture
+def mock_main_window():
+    """Create a mock MainWindow with the methods PreferencesDialog calls."""
+    mw = MagicMock()
+    mw._set_theme = MagicMock()
+    mw._set_symbol_style = MagicMock()
+    mw._set_color_mode = MagicMock()
+    mw._start_autosave_timer = MagicMock()
+    mw._open_keybindings_dialog = MagicMock()
+    return mw
+
+
+@pytest.fixture
+def dialog(qtbot, mock_main_window):
+    """Create a PreferencesDialog with default (light/ieee/color) settings."""
+    dlg = PreferencesDialog(mock_main_window, parent=None)
+    qtbot.addWidget(dlg)
+    return dlg
+
+
+class TestDialogStructure:
+    """Tests verifying the dialog has the expected widgets."""
+
+    def test_has_four_tabs(self, dialog):
+        tabs = dialog.findChild(QTabWidget)
+        assert tabs is not None
+        assert tabs.count() == 4
+        assert tabs.tabText(0) == "Appearance"
+        assert tabs.tabText(1) == "Grid"
+        assert tabs.tabText(2) == "Behavior"
+        assert tabs.tabText(3) == "Keybindings"
+
+    def test_appearance_tab_has_combos(self, dialog):
+        tab = dialog.tabs.widget(0)
+        combos = tab.findChildren(QComboBox)
+        assert len(combos) == 3
+
+    def test_grid_tab_is_placeholder(self, dialog):
+        tab = dialog.tabs.widget(1)
+        combos = tab.findChildren(QComboBox)
+        assert len(combos) == 0
+
+    def test_behavior_tab_has_autosave(self, dialog):
+        tab = dialog.tabs.widget(2)
+        checkboxes = tab.findChildren(QCheckBox)
+        spinboxes = tab.findChildren(QSpinBox)
+        assert len(checkboxes) == 1
+        assert len(spinboxes) == 1
+        assert spinboxes[0].minimum() == 10
+        assert spinboxes[0].maximum() == 600
+
+    def test_keybindings_tab_has_button(self, dialog):
+        tab = dialog.tabs.widget(3)
+        buttons = tab.findChildren(QPushButton)
+        labels = [b.text() for b in buttons]
+        assert "Open Keybindings Editor..." in labels
+
+
+class TestLivePreview:
+    """Tests verifying combo changes call MainWindow methods immediately."""
+
+    def test_theme_combo_live_preview(self, dialog, mock_main_window):
+        mock_main_window._set_theme.reset_mock()
+        dialog.theme_combo.setCurrentIndex(1)  # Dark
+        mock_main_window._set_theme.assert_called_with("dark")
+
+    def test_symbol_style_combo_live_preview(self, dialog, mock_main_window):
+        mock_main_window._set_symbol_style.reset_mock()
+        dialog.style_combo.setCurrentIndex(1)  # IEC
+        mock_main_window._set_symbol_style.assert_called_with("iec")
+
+    def test_color_mode_combo_live_preview(self, dialog, mock_main_window):
+        mock_main_window._set_color_mode.reset_mock()
+        dialog.color_combo.setCurrentIndex(1)  # Monochrome
+        mock_main_window._set_color_mode.assert_called_with("monochrome")
+
+
+class TestCancelRevert:
+    """Tests verifying Cancel reverts to snapshot values."""
+
+    def test_cancel_reverts(self, dialog, mock_main_window):
+        # Change combos (triggers live preview)
+        dialog.theme_combo.setCurrentIndex(1)
+        dialog.style_combo.setCurrentIndex(1)
+        dialog.color_combo.setCurrentIndex(1)
+        mock_main_window._set_theme.reset_mock()
+        mock_main_window._set_symbol_style.reset_mock()
+        mock_main_window._set_color_mode.reset_mock()
+
+        dialog._on_cancel()
+
+        # Should revert to snapshot (light/ieee/color)
+        mock_main_window._set_theme.assert_called_with("light")
+        mock_main_window._set_symbol_style.assert_called_with("ieee")
+        mock_main_window._set_color_mode.assert_called_with("color")
+
+    def test_close_button_reverts(self, dialog, mock_main_window):
+        """X-close should behave like Cancel (revert)."""
+        dialog.theme_combo.setCurrentIndex(1)
+        mock_main_window._set_theme.reset_mock()
+
+        dialog.close()  # triggers closeEvent with _accepted=False
+
+        mock_main_window._set_theme.assert_called_with("light")
+
+
+class TestOkPersist:
+    """Tests verifying OK persists settings."""
+
+    def test_ok_persists_autosave(self, dialog, mock_main_window):
+        dialog.autosave_checkbox.setChecked(True)
+        dialog.autosave_spin.setValue(120)
+
+        dialog._on_ok()
+
+        settings = QSettings("SDSMT", "SDM Spice")
+        assert settings.value("autosave/interval") == 120
+        assert settings.value("autosave/enabled") is True
+        mock_main_window._start_autosave_timer.assert_called()
+
+
+class TestInitialValues:
+    """Tests verifying initial widget values match snapshot."""
+
+    def test_initial_values_match_current(self, dialog):
+        # theme_manager defaults: Light Theme, ieee, color
+        assert dialog.theme_combo.currentIndex() == 0  # Light
+        assert dialog.style_combo.currentIndex() == 0  # IEEE
+        assert dialog.color_combo.currentIndex() == 0  # Color
+        assert dialog.autosave_spin.value() >= 10  # Within valid range


### PR DESCRIPTION
## Summary
- Adds a tabbed Preferences dialog (Settings > Preferences) consolidating theme, symbol style, color mode, and auto-save settings into one place
- Non-modal with live preview — changing appearance combos immediately updates the canvas
- Snapshot-and-revert: Cancel or X-close restores original settings; OK persists to QSettings
- Single-instance guard prevents multiple dialog windows
- 12 unit tests covering structure, live preview, cancel revert, OK persistence, and initial values

Closes #318

## Test plan
- [ ] `python -m pytest app/tests/unit/test_preferences_dialog.py -v` — all 12 tests pass
- [ ] `python -m pytest` — full suite (1507 tests), no regressions
- [ ] `make lint` — clean
- [ ] Manual: Settings > Preferences opens dialog; changing theme/style/color previews live; Cancel reverts; auto-save interval persists across restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)