### PR TITLE
add save plot button to export plots as PNG/SVG images

### DIFF
--- a/app/GUI/parameter_sweep_plot_dialog.py
+++ b/app/GUI/parameter_sweep_plot_dialog.py
@@ -9,7 +9,9 @@ import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
-from PyQt6.QtWidgets import QDialog, QVBoxLayout
+from PyQt6.QtWidgets import QDialog, QHBoxLayout, QPushButton, QVBoxLayout
+
+from .results_plot_dialog import save_plot
 
 matplotlib.use("QtAgg")
 
@@ -31,9 +33,19 @@ class ParameterSweepPlotDialog(QDialog):
 
         layout = QVBoxLayout(self)
 
+        toolbar = QHBoxLayout()
+        save_btn = QPushButton("Save Plot...")
+        save_btn.setToolTip("Export the plot as a PNG or SVG image file")
+        toolbar.addWidget(save_btn)
+        toolbar.addStretch()
+        layout.addLayout(toolbar)
+
         fig = Figure(figsize=(9, 6), dpi=100)
+        self._fig = fig
         self._canvas = FigureCanvas(fig)
         layout.addWidget(self._canvas)
+
+        save_btn.clicked.connect(lambda: save_plot(self._fig, self))
 
         if base_type == "DC Operating Point":
             self._plot_op_sweep(fig, sweep_data)

--- a/app/GUI/results_plot_dialog.py
+++ b/app/GUI/results_plot_dialog.py
@@ -14,7 +14,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
-from PyQt6.QtWidgets import QCheckBox, QDialog, QHBoxLayout, QPushButton, QTextEdit, QVBoxLayout
+from PyQt6.QtWidgets import QCheckBox, QDialog, QFileDialog, QHBoxLayout, QPushButton, QTextEdit, QVBoxLayout
 
 from .measurement_cursors import CursorReadoutPanel, MeasurementCursors
 from .styles import theme_manager
@@ -44,6 +44,29 @@ def _apply_mpl_theme(fig):
                 spine.set_edgecolor("#555555")
 
 
+def save_plot(fig, parent=None):
+    """Save a matplotlib figure to PNG or SVG via a file dialog.
+
+    Returns the file path saved to, or empty string if cancelled.
+    """
+    path, _ = QFileDialog.getSaveFileName(
+        parent,
+        "Save Plot",
+        "",
+        "PNG Image (*.png);;SVG Image (*.svg);;All Files (*)",
+    )
+    if not path:
+        return ""
+    fig.savefig(
+        path,
+        dpi=300,
+        facecolor="white",
+        edgecolor="none",
+        bbox_inches="tight",
+    )
+    return path
+
+
 class DCSweepPlotDialog(QDialog):
     """Plot dialog for DC Sweep results (voltage vs. sweep variable).
 
@@ -67,10 +90,14 @@ class DCSweepPlotDialog(QDialog):
         plot_layout = QVBoxLayout()
 
         toolbar = QHBoxLayout()
+        save_btn = QPushButton("Save Plot...")
+        save_btn.setToolTip("Export the plot as a PNG or SVG image file")
+        save_btn.clicked.connect(lambda: save_plot(self._fig, self))
+        toolbar.addWidget(save_btn)
+        toolbar.addStretch()
         clear_btn = QPushButton("Clear All")
         clear_btn.setToolTip("Remove all overlaid results and clear the plot")
         clear_btn.clicked.connect(self.clear_all)
-        toolbar.addStretch()
         toolbar.addWidget(clear_btn)
         plot_layout.addLayout(toolbar)
 
@@ -246,6 +273,10 @@ class ACSweepPlotDialog(QDialog):
         plot_layout = QVBoxLayout()
 
         toolbar = QHBoxLayout()
+        save_btn = QPushButton("Save Plot...")
+        save_btn.setToolTip("Export the plot as a PNG or SVG image file")
+        save_btn.clicked.connect(lambda: save_plot(self._fig, self))
+        toolbar.addWidget(save_btn)
         self._markers_cb = QCheckBox("Show Markers")
         self._markers_cb.setChecked(True)
         self._markers_cb.setToolTip("Show -3dB cutoff, bandwidth, gain/phase margin markers")


### PR DESCRIPTION
## Summary
- Adds a "Save Plot..." button to all plot dialogs (DC Sweep, AC Sweep, Parameter Sweep)
- Uses matplotlib `savefig()` to export as PNG (300 DPI) or SVG with white background
- Reusable `save_plot()` helper function in `results_plot_dialog.py`

Closes #371

## Test plan
- [x] `save_plot()` creates valid PNG files (non-empty)
- [x] `save_plot()` creates valid SVG files (contains `<svg` tag)
- [x] Cancel returns empty string, no file created
- [x] DC Sweep dialog has "Save Plot..." button
- [x] AC Sweep dialog has "Save Plot..." button
- [x] All 1520 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)