### PR TITLE
add LTspice .asc schematic export

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -165,6 +165,29 @@ class FileOperationsMixin:
             except (OSError, ValueError) as e:
                 QMessageBox.critical(self, "Import Error", f"Failed to import LTspice schematic:\n{e}")
 
+    def _on_export_asc(self):
+        """Export the circuit as an LTspice .asc schematic file."""
+        from simulation.asc_exporter import export_asc, write_asc
+
+        if not self.model.components:
+            QMessageBox.information(self, "Export LTspice", "Nothing to export — the canvas is empty.")
+            return
+
+        filename, _ = QFileDialog.getSaveFileName(
+            self, "Export as LTspice Schematic", "", "LTspice Schematics (*.asc);;All Files (*)"
+        )
+        if not filename:
+            return
+
+        try:
+            content = export_asc(self.model)
+            write_asc(content, filename)
+            statusBar = self.statusBar()
+            if statusBar:
+                statusBar.showMessage(f"LTspice schematic exported to {filename}", 3000)
+        except (OSError, Exception) as e:
+            QMessageBox.critical(self, "Error", f"Failed to export LTspice schematic: {e}")
+
     def _on_generate_report(self):
         """Generate a comprehensive PDF circuit report."""
         from GUI.report_dialog import ReportDialog

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -85,6 +85,11 @@ class MenuBarMixin:
         export_latex_action.triggered.connect(self.export_circuitikz)
         file_menu.addAction(export_latex_action)
 
+        export_asc_action = QAction("Export as LTspice (.&asc)...", self)
+        export_asc_action.setToolTip("Export circuit as LTspice .asc schematic file")
+        export_asc_action.triggered.connect(self._on_export_asc)
+        file_menu.addAction(export_asc_action)
+
         generate_report_action = QAction("&Generate Circuit Report (PDF)...", self)
         generate_report_action.setToolTip("Generate a comprehensive PDF report with schematic, netlist, and results")
         generate_report_action.triggered.connect(self._on_generate_report)

--- a/app/simulation/asc_exporter.py
+++ b/app/simulation/asc_exporter.py
@@ -1,0 +1,183 @@
+"""
+simulation/asc_exporter.py
+
+Export a CircuitModel to LTspice .asc schematic format.
+Inverse of asc_parser.py — maps Spice-GUI types back to LTspice symbols.
+
+No Qt dependencies.
+"""
+
+# Spice-GUI component type -> preferred LTspice symbol name
+_TYPE_TO_SYMBOL = {
+    "Resistor": "res",
+    "Capacitor": "cap",
+    "Inductor": "ind",
+    "Voltage Source": "voltage",
+    "Current Source": "current",
+    "Diode": "diode",
+    "LED": "LED",
+    "Zener Diode": "zener",
+    "BJT NPN": "npn",
+    "BJT PNP": "pnp",
+    "MOSFET NMOS": "nmos",
+    "MOSFET PMOS": "pmos",
+    "Op-Amp": "opamp",
+    "VCVS": "e",
+    "CCCS": "f",
+    "VCCS": "g",
+    "CCVS": "h",
+    "Waveform Source": "voltage",
+}
+
+# Pin offsets (same as asc_parser._PIN_OFFSETS)
+_PIN_OFFSETS = {
+    "Resistor": [(0, 0), (0, 80)],
+    "Capacitor": [(0, 0), (0, 64)],
+    "Inductor": [(0, 0), (0, 80)],
+    "Voltage Source": [(0, 0), (0, 112)],
+    "Current Source": [(0, 0), (0, 112)],
+    "Waveform Source": [(0, 0), (0, 112)],
+    "Diode": [(0, 0), (0, 64)],
+    "LED": [(0, 0), (0, 64)],
+    "Zener Diode": [(0, 0), (0, 64)],
+    "BJT NPN": [(16, 0), (-16, 32), (16, 64)],
+    "BJT PNP": [(16, 64), (-16, 32), (16, 0)],
+    "MOSFET NMOS": [(16, 0), (-16, 32), (16, 64)],
+    "MOSFET PMOS": [(16, 64), (-16, 32), (16, 0)],
+    "Op-Amp": [(-32, 32), (-32, -32), (32, 0)],
+    "VCVS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
+    "CCVS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
+    "VCCS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
+    "CCCS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
+    "Ground": [(0, 0)],
+}
+
+
+def _degrees_to_rotation_code(rotation, flip_h=False):
+    """Convert Spice-GUI rotation + flip to LTspice rotation code."""
+    prefix = "M" if flip_h else "R"
+    angle = int(rotation) % 360
+    return f"{prefix}{angle}"
+
+
+def _transform_pin(dx, dy, rotation, flip_h=False):
+    """Transform a pin offset by rotation and flip."""
+    if flip_h:
+        dx = -dx
+
+    angle = int(rotation) % 360
+    if angle == 0:
+        return dx, dy
+    elif angle == 90:
+        return dy, -dx
+    elif angle == 180:
+        return -dx, -dy
+    elif angle == 270:
+        return -dy, dx
+    return dx, dy
+
+
+def _format_analysis_directive(analysis_type, params):
+    """Convert analysis type and params to an LTspice TEXT directive."""
+    if analysis_type == "DC Operating Point":
+        return ".op"
+    elif analysis_type == "Transient":
+        duration = params.get("duration", "10m")
+        step = params.get("step", "")
+        if step:
+            return f".tran {duration} {step}"
+        return f".tran {duration}"
+    elif analysis_type == "AC Sweep":
+        sweep_type = params.get("sweep_type", "dec")
+        points = params.get("points", "100")
+        fstart = params.get("fStart", "1")
+        fstop = params.get("fStop", "1Meg")
+        return f".ac {sweep_type} {points} {fstart} {fstop}"
+    elif analysis_type == "DC Sweep":
+        source = params.get("source", "V1")
+        vmin = params.get("min", "0")
+        vmax = params.get("max", "5")
+        step = params.get("step", "0.1")
+        return f".dc {source} {vmin} {vmax} {step}"
+    return None
+
+
+def export_asc(model):
+    """Export a CircuitModel to LTspice .asc format text.
+
+    Args:
+        model: CircuitModel instance
+
+    Returns:
+        str: .asc file content
+    """
+    lines = []
+    lines.append("Version 4")
+    lines.append("SHEET 1 880 680")
+
+    # Build pin position map for wire generation
+    pin_positions = {}  # (comp_id, terminal_idx) -> (x, y)
+
+    # Export components (skip Ground — handled as FLAG)
+    for comp_id, comp in sorted(model.components.items()):
+        if comp.component_type == "Ground":
+            continue
+
+        symbol = _TYPE_TO_SYMBOL.get(comp.component_type)
+        if symbol is None:
+            continue
+
+        x = int(comp.position[0])
+        y = int(comp.position[1])
+        rot_code = _degrees_to_rotation_code(comp.rotation, comp.flip_h)
+
+        lines.append(f"SYMBOL {symbol} {x} {y} {rot_code}")
+        lines.append(f"SYMATTR InstName {comp_id}")
+        if comp.value:
+            lines.append(f"SYMATTR Value {comp.value}")
+
+        # Compute pin positions
+        offsets = _PIN_OFFSETS.get(comp.component_type, [(0, 0), (0, 80)])
+        for term_idx, (dx, dy) in enumerate(offsets):
+            tx, ty = _transform_pin(dx, dy, comp.rotation, comp.flip_h)
+            pin_positions[(comp_id, term_idx)] = (x + tx, y + ty)
+
+    # Export Ground components as FLAG entries
+    for comp_id, comp in sorted(model.components.items()):
+        if comp.component_type != "Ground":
+            continue
+        gx = int(comp.position[0])
+        gy = int(comp.position[1])
+        lines.append(f"FLAG {gx} {gy} 0")
+
+        # Ground has a single pin at its position
+        pin_positions[(comp_id, 0)] = (gx, gy)
+
+    # Export wires
+    for wire in model.wires:
+        start_key = (wire.start_component_id, wire.start_terminal)
+        end_key = (wire.end_component_id, wire.end_terminal)
+        if start_key in pin_positions and end_key in pin_positions:
+            x1, y1 = pin_positions[start_key]
+            x2, y2 = pin_positions[end_key]
+            lines.append(f"WIRE {x1} {y1} {x2} {y2}")
+
+    # Export analysis directive
+    if model.analysis_type:
+        directive = _format_analysis_directive(model.analysis_type, model.analysis_params)
+        if directive:
+            lines.append(f"TEXT -32 280 Left 2 !{directive}")
+
+    lines.append("")  # trailing newline
+    return "\n".join(lines)
+
+
+def write_asc(content, filepath):
+    """Write .asc content to a file.
+
+    Args:
+        content: str from export_asc()
+        filepath: output file path
+    """
+    with open(filepath, "w") as f:
+        f.write(content)

--- a/app/tests/unit/test_asc_exporter.py
+++ b/app/tests/unit/test_asc_exporter.py
@@ -1,0 +1,247 @@
+"""Tests for LTspice .asc schematic export."""
+
+import pytest
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from models.wire import WireData
+from simulation.asc_exporter import export_asc, write_asc
+
+
+def _make_rc_circuit():
+    """Build a simple RC circuit for testing."""
+    model = CircuitModel()
+    r1 = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value="1k",
+        position=(100.0, 100.0),
+        rotation=0,
+    )
+    c1 = ComponentData(
+        component_id="C1",
+        component_type="Capacitor",
+        value="1u",
+        position=(250.0, 100.0),
+        rotation=0,
+    )
+    v1 = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value="5",
+        position=(0.0, 100.0),
+        rotation=0,
+    )
+    gnd = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(0.0, 300.0),
+    )
+    model.add_component(r1)
+    model.add_component(c1)
+    model.add_component(v1)
+    model.add_component(gnd)
+    model.add_wire(
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="R1",
+            end_terminal=0,
+        )
+    )
+    model.add_wire(
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="C1",
+            end_terminal=0,
+        )
+    )
+    model.add_wire(
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        )
+    )
+    model.analysis_type = "Transient"
+    model.analysis_params = {"duration": "10m", "step": "10u"}
+    return model
+
+
+class TestExportAsc:
+    def test_header(self):
+        model = CircuitModel()
+        content = export_asc(model)
+        assert content.startswith("Version 4")
+        assert "SHEET 1" in content
+
+    def test_component_symbols(self):
+        model = _make_rc_circuit()
+        content = export_asc(model)
+        assert "SYMBOL res" in content
+        assert "SYMBOL cap" in content
+        assert "SYMBOL voltage" in content
+
+    def test_component_names(self):
+        model = _make_rc_circuit()
+        content = export_asc(model)
+        assert "SYMATTR InstName R1" in content
+        assert "SYMATTR InstName C1" in content
+        assert "SYMATTR InstName V1" in content
+
+    def test_component_values(self):
+        model = _make_rc_circuit()
+        content = export_asc(model)
+        assert "SYMATTR Value 1k" in content
+        assert "SYMATTR Value 1u" in content
+        assert "SYMATTR Value 5" in content
+
+    def test_wires(self):
+        model = _make_rc_circuit()
+        content = export_asc(model)
+        wire_lines = [l for l in content.split("\n") if l.startswith("WIRE")]
+        assert len(wire_lines) >= 3
+
+    def test_ground_as_flag(self):
+        model = _make_rc_circuit()
+        content = export_asc(model)
+        assert "FLAG" in content
+        # Ground should not appear as SYMBOL
+        lines = content.split("\n")
+        symbol_lines = [l for l in lines if l.startswith("SYMBOL")]
+        for sl in symbol_lines:
+            assert "Ground" not in sl
+
+    def test_analysis_directive(self):
+        model = _make_rc_circuit()
+        content = export_asc(model)
+        assert ".tran 10m" in content
+
+    def test_dc_op_directive(self):
+        model = CircuitModel()
+        model.analysis_type = "DC Operating Point"
+        model.analysis_params = {}
+        content = export_asc(model)
+        assert ".op" in content
+
+    def test_ac_sweep_directive(self):
+        model = CircuitModel()
+        model.analysis_type = "AC Sweep"
+        model.analysis_params = {
+            "sweep_type": "dec",
+            "points": "100",
+            "fStart": "1",
+            "fStop": "1Meg",
+        }
+        content = export_asc(model)
+        assert ".ac dec 100 1 1Meg" in content
+
+    def test_dc_sweep_directive(self):
+        model = CircuitModel()
+        model.analysis_type = "DC Sweep"
+        model.analysis_params = {
+            "source": "V1",
+            "min": "0",
+            "max": "5",
+            "step": "0.1",
+        }
+        content = export_asc(model)
+        assert ".dc V1 0 5 0.1" in content
+
+    def test_empty_model(self):
+        model = CircuitModel()
+        content = export_asc(model)
+        assert "Version 4" in content
+
+    def test_rotation_code(self):
+        model = CircuitModel()
+        r1 = ComponentData(
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(100.0, 100.0),
+            rotation=90,
+        )
+        model.add_component(r1)
+        content = export_asc(model)
+        assert "R90" in content
+
+    def test_flip_produces_mirror_code(self):
+        model = CircuitModel()
+        r1 = ComponentData(
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(100.0, 100.0),
+            rotation=0,
+            flip_h=True,
+        )
+        model.add_component(r1)
+        content = export_asc(model)
+        assert "M0" in content
+
+
+class TestWriteAsc:
+    def test_writes_file(self, tmp_path):
+        path = tmp_path / "circuit.asc"
+        write_asc("Version 4\nSHEET 1 880 680\n", str(path))
+        assert path.exists()
+        content = path.read_text()
+        assert "Version 4" in content
+
+    def test_round_trip_to_file(self, tmp_path):
+        model = _make_rc_circuit()
+        content = export_asc(model)
+        path = tmp_path / "test.asc"
+        write_asc(content, str(path))
+        assert path.stat().st_size > 0
+        text = path.read_text()
+        assert "SYMBOL res" in text
+        assert "WIRE" in text
+
+
+class TestImportExportRoundTrip:
+    def test_basic_round_trip(self):
+        """Export → re-import should preserve component names and types."""
+        from simulation.asc_parser import import_asc
+
+        model = _make_rc_circuit()
+        asc_text = export_asc(model)
+
+        reimported, _analysis, _warnings = import_asc(asc_text)
+
+        # Check component names are preserved
+        original_ids = {cid for cid in model.components if model.components[cid].component_type != "Ground"}
+        reimported_ids = {cid for cid in reimported.components if reimported.components[cid].component_type != "Ground"}
+        assert original_ids == reimported_ids
+
+    def test_values_preserved(self):
+        from simulation.asc_parser import import_asc
+
+        model = _make_rc_circuit()
+        asc_text = export_asc(model)
+        reimported, _, _ = import_asc(asc_text)
+
+        assert reimported.components["R1"].value == "1k"
+        assert reimported.components["C1"].value == "1u"
+
+    def test_analysis_preserved(self):
+        from simulation.asc_parser import import_asc
+
+        model = _make_rc_circuit()
+        asc_text = export_asc(model)
+        _, analysis, _ = import_asc(asc_text)
+
+        assert analysis is not None
+        assert analysis["type"] == "Transient"
+
+
+class TestNoQtDependencies:
+    def test_no_pyqt_imports(self):
+        import simulation.asc_exporter as mod
+
+        source = open(mod.__file__).read()
+        assert "PyQt" not in source
+        assert "QtCore" not in source


### PR DESCRIPTION
## Summary
- New `simulation/asc_exporter.py` — inverse of `asc_parser.py`, exports CircuitModel to LTspice .asc format
- Maps Spice-GUI component types back to LTspice SYMBOL names
- Exports WIRE lines from wire connectivity (using computed pin positions)
- Ground components exported as FLAG entries
- Analysis directives (Transient, AC, DC Sweep, DC OP) included as TEXT lines
- "Export as LTspice (.asc)..." menu item in File menu
- No new dependencies

Closes #383

## Test plan
- [x] Header format (Version 4, SHEET)
- [x] Component SYMBOL, InstName, Value lines
- [x] WIRE lines generated from model wires
- [x] Ground → FLAG conversion (no SYMBOL for Ground)
- [x] All 4 analysis directive formats
- [x] Rotation codes (R0, R90, M0 for flip)
- [x] Round-trip: export → re-import preserves component names, values, analysis type
- [x] File write creates non-empty .asc file
- [x] No Qt dependencies
- [x] All 1534 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)