### PR TITLE
add custom color theme support (#319)

### DIFF
--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -25,6 +25,7 @@ class SettingsMixin:
         if settings.value("autosave/enabled") is None:
             settings.setValue("autosave/enabled", True)
         settings.setValue("view/show_statistics", self.statistics_panel.isVisible())
+        settings.setValue("view/theme_key", theme_manager.get_theme_key())
         settings.setValue("view/theme", theme_manager.current_theme.name)
         settings.setValue("view/symbol_style", theme_manager.symbol_style)
         settings.setValue("view/color_mode", theme_manager.color_mode)
@@ -77,9 +78,17 @@ class SettingsMixin:
             self.statistics_panel.setVisible(checked)
             self.show_statistics_action.setChecked(checked)
 
-        saved_theme = settings.value("view/theme")
-        if saved_theme == "Dark Theme":
-            self._set_theme("dark")
+        saved_theme_key = settings.value("view/theme_key")
+        if saved_theme_key and saved_theme_key != "light":
+            theme_manager.set_theme_by_key(saved_theme_key)
+            self._apply_theme()
+            if hasattr(self, "_refresh_theme_menu"):
+                self._refresh_theme_menu()
+        else:
+            # Legacy fallback: check old theme name
+            saved_theme = settings.value("view/theme")
+            if saved_theme == "Dark Theme":
+                self._set_theme("dark")
 
         saved_symbol_style = settings.value("view/symbol_style")
         if saved_symbol_style in ("ieee", "iec"):

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -11,7 +11,7 @@ class ViewOperationsMixin:
     """Mixin providing theme, visibility toggles, probe, zoom, and image export."""
 
     def _set_theme(self, theme_name: str):
-        """Switch the application theme."""
+        """Switch the application theme (legacy: 'light' or 'dark' only)."""
         if theme_name == "dark":
             theme_manager.set_theme(DarkTheme())
             self.dark_theme_action.setChecked(True)
@@ -19,40 +19,13 @@ class ViewOperationsMixin:
             theme_manager.set_theme(LightTheme())
             self.light_theme_action.setChecked(True)
         self._apply_theme()
+        if hasattr(self, "_refresh_theme_menu"):
+            self._refresh_theme_menu()
 
     def _apply_theme(self):
         """Apply the current theme to all visual elements."""
-        is_dark = theme_manager.current_theme.name == "Dark Theme"
-
-        # Apply global widget stylesheet for dark mode
-        if is_dark:
-            dark_stylesheet = (
-                "QMainWindow, QWidget { background-color: #1E1E1E; color: #D4D4D4; }"
-                " QMenuBar { background-color: #2D2D2D; color: #D4D4D4; }"
-                " QMenuBar::item:selected { background-color: #3D3D3D; }"
-                " QMenu { background-color: #2D2D2D; color: #D4D4D4; }"
-                " QMenu::item:selected { background-color: #3D3D3D; }"
-                " QLabel { color: #D4D4D4; }"
-                " QPushButton {"
-                "   background-color: #3D3D3D; color: #D4D4D4;"
-                "   border: 1px solid #555555; padding: 4px 12px; border-radius: 3px;"
-                " }"
-                " QPushButton:hover { background-color: #4D4D4D; }"
-                " QTextEdit, QLineEdit, QSpinBox, QDoubleSpinBox, QComboBox {"
-                "   background-color: #2D2D2D; color: #D4D4D4;"
-                "   border: 1px solid #555555;"
-                " }"
-                " QSplitter::handle { background-color: #3D3D3D; }"
-                " QScrollBar { background-color: #2D2D2D; }"
-                " QScrollBar::handle { background-color: #555555; }"
-                " QGroupBox { color: #D4D4D4; border: 1px solid #555555; }"
-                " QTableWidget { background-color: #2D2D2D; color: #D4D4D4;"
-                "   gridline-color: #555555; }"
-                " QHeaderView::section { background-color: #3D3D3D; color: #D4D4D4; }"
-            )
-            self.setStyleSheet(dark_stylesheet)
-        else:
-            self.setStyleSheet("")
+        theme = theme_manager.current_theme
+        self.setStyleSheet(theme.generate_dark_stylesheet())
 
         # Refresh canvas (grid + components)
         self.canvas.refresh_theme()

--- a/app/GUI/monte_carlo_results_dialog.py
+++ b/app/GUI/monte_carlo_results_dialog.py
@@ -17,19 +17,23 @@ matplotlib.use("QtAgg")
 
 def _apply_mpl_theme(fig):
     """Apply the current application theme colors to a matplotlib figure."""
-    is_dark = theme_manager.current_theme.name == "Dark Theme"
-    if is_dark:
-        bg = "#1E1E1E"
-        fg = "#D4D4D4"
+    theme = theme_manager.current_theme
+    if theme.is_dark:
+        bg = theme.color_hex("background_primary")
+        fg = theme.color_hex("text_primary")
+        bg2 = theme.color_hex("background_secondary")
+        from PyQt6.QtGui import QColor
+
+        border = QColor(bg2).lighter(150).name()
         fig.patch.set_facecolor(bg)
         for ax in fig.axes:
-            ax.set_facecolor("#2D2D2D")
+            ax.set_facecolor(bg2)
             ax.tick_params(colors=fg)
             ax.xaxis.label.set_color(fg)
             ax.yaxis.label.set_color(fg)
             ax.title.set_color(fg)
             for spine in ax.spines.values():
-                spine.set_edgecolor("#555555")
+                spine.set_edgecolor(border)
 
 
 class MonteCarloResultsDialog(QDialog):

--- a/app/GUI/preferences_dialog.py
+++ b/app/GUI/preferences_dialog.py
@@ -5,9 +5,11 @@ from PyQt6.QtWidgets import (
     QCheckBox,
     QComboBox,
     QDialog,
+    QFileDialog,
     QFormLayout,
     QHBoxLayout,
     QLabel,
+    QMessageBox,
     QPushButton,
     QSpinBox,
     QTabWidget,
@@ -15,11 +17,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from .styles import theme_manager
-
-# Mapping between combo display text and internal values
-_THEME_ITEMS = [("Light", "light"), ("Dark", "dark")]
-_THEME_NAMES = {"Light Theme": 0, "Dark Theme": 1}
+from .styles import CustomTheme, theme_manager, theme_store
 
 _STYLE_ITEMS = [("IEEE / ANSI", "ieee"), ("IEC (European)", "iec")]
 _STYLE_VALUES = {"ieee": 0, "iec": 1}
@@ -38,7 +36,7 @@ class PreferencesDialog(QDialog):
         self.main_window = main_window
         self._accepted = False
         self.setWindowTitle("Preferences")
-        self.setMinimumWidth(400)
+        self.setMinimumWidth(480)
 
         self._snapshot_settings()
         self._build_ui()
@@ -49,21 +47,20 @@ class PreferencesDialog(QDialog):
 
     def _snapshot_settings(self):
         """Capture current appearance and autosave settings for revert."""
-        self._snap_theme = theme_manager.current_theme.name  # "Light Theme" / "Dark Theme"
-        self._snap_symbol_style = theme_manager.symbol_style  # "ieee" / "iec"
-        self._snap_color_mode = theme_manager.color_mode  # "color" / "monochrome"
+        self._snap_theme_key = theme_manager.get_theme_key()
+        self._snap_theme_obj = theme_manager.current_theme
+        self._snap_symbol_style = theme_manager.symbol_style
+        self._snap_color_mode = theme_manager.color_mode
         settings = QSettings("SDSMT", "SDM Spice")
         self._snap_autosave_enabled = settings.value("autosave/enabled", True)
         self._snap_autosave_interval = int(settings.value("autosave/interval", 60))
 
     def _revert_settings(self):
         """Restore appearance and autosave to snapshot values."""
-        # Revert appearance
-        theme_val = "dark" if self._snap_theme == "Dark Theme" else "light"
-        self.main_window._set_theme(theme_val)
+        theme_manager.set_theme(self._snap_theme_obj)
+        self.main_window._apply_theme()
         self.main_window._set_symbol_style(self._snap_symbol_style)
         self.main_window._set_color_mode(self._snap_color_mode)
-        # Revert autosave
         settings = QSettings("SDSMT", "SDM Spice")
         settings.setValue("autosave/enabled", self._snap_autosave_enabled)
         settings.setValue("autosave/interval", self._snap_autosave_interval)
@@ -96,10 +93,34 @@ class PreferencesDialog(QDialog):
         widget = QWidget()
         form = QFormLayout(widget)
 
+        # Theme combo — dynamically populated
         self.theme_combo = QComboBox()
-        for label, _val in _THEME_ITEMS:
-            self.theme_combo.addItem(label)
+        self._populate_theme_combo()
         form.addRow("Theme:", self.theme_combo)
+
+        # Theme management buttons
+        theme_btn_layout = QHBoxLayout()
+        self.new_theme_btn = QPushButton("New...")
+        self.new_theme_btn.clicked.connect(self._on_new_theme)
+        self.edit_theme_btn = QPushButton("Edit...")
+        self.edit_theme_btn.clicked.connect(self._on_edit_theme)
+        self.delete_theme_btn = QPushButton("Delete")
+        self.delete_theme_btn.clicked.connect(self._on_delete_theme)
+        theme_btn_layout.addWidget(self.new_theme_btn)
+        theme_btn_layout.addWidget(self.edit_theme_btn)
+        theme_btn_layout.addWidget(self.delete_theme_btn)
+        form.addRow("", theme_btn_layout)
+
+        # Import/Export
+        ie_layout = QHBoxLayout()
+        import_btn = QPushButton("Import...")
+        import_btn.clicked.connect(self._on_import_theme)
+        export_btn = QPushButton("Export...")
+        export_btn.clicked.connect(self._on_export_theme)
+        ie_layout.addWidget(import_btn)
+        ie_layout.addWidget(export_btn)
+        ie_layout.addStretch()
+        form.addRow("", ie_layout)
 
         self.style_combo = QComboBox()
         for label, _val in _STYLE_ITEMS:
@@ -111,7 +132,25 @@ class PreferencesDialog(QDialog):
             self.color_combo.addItem(label)
         form.addRow("Color Mode:", self.color_combo)
 
+        self._update_theme_buttons()
         return widget
+
+    def _populate_theme_combo(self):
+        """Fill theme combo from theme_manager.get_available_themes()."""
+        self.theme_combo.blockSignals(True)
+        self.theme_combo.clear()
+        self._theme_keys = []
+        for display_name, key in theme_manager.get_available_themes():
+            self.theme_combo.addItem(display_name)
+            self._theme_keys.append(key)
+        self.theme_combo.blockSignals(False)
+
+    def _update_theme_buttons(self):
+        """Enable/disable Edit and Delete based on current selection."""
+        idx = self.theme_combo.currentIndex()
+        is_custom = idx >= 0 and idx < len(self._theme_keys) and self._theme_keys[idx].startswith("custom:")
+        self.edit_theme_btn.setEnabled(is_custom)
+        self.delete_theme_btn.setEnabled(is_custom)
 
     def _build_grid_tab(self):
         widget = QWidget()
@@ -148,7 +187,12 @@ class PreferencesDialog(QDialog):
     # ---- Load current values into widgets ---------------------------------
 
     def _load_current_values(self):
-        self.theme_combo.setCurrentIndex(_THEME_NAMES.get(self._snap_theme, 0))
+        current_key = theme_manager.get_theme_key()
+        if current_key in self._theme_keys:
+            self.theme_combo.setCurrentIndex(self._theme_keys.index(current_key))
+        else:
+            self.theme_combo.setCurrentIndex(0)
+
         self.style_combo.setCurrentIndex(_STYLE_VALUES.get(self._snap_symbol_style, 0))
         self.color_combo.setCurrentIndex(_COLOR_VALUES.get(self._snap_color_mode, 0))
 
@@ -164,13 +208,131 @@ class PreferencesDialog(QDialog):
         self.color_combo.currentIndexChanged.connect(self._on_color_changed)
 
     def _on_theme_changed(self, index):
-        self.main_window._set_theme(_THEME_ITEMS[index][1])
+        if 0 <= index < len(self._theme_keys):
+            key = self._theme_keys[index]
+            theme_manager.set_theme_by_key(key)
+            self.main_window._apply_theme()
+            self._update_theme_buttons()
+            # Sync the View > Theme menu checkmarks
+            if hasattr(self.main_window, "_refresh_theme_menu"):
+                self.main_window._refresh_theme_menu()
 
     def _on_style_changed(self, index):
         self.main_window._set_symbol_style(_STYLE_ITEMS[index][1])
 
     def _on_color_changed(self, index):
         self.main_window._set_color_mode(_COLOR_ITEMS[index][1])
+
+    # ---- Theme management -------------------------------------------------
+
+    def _on_new_theme(self):
+        from .theme_editor_dialog import ThemeEditorDialog
+
+        dialog = ThemeEditorDialog(self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            theme = dialog.get_theme()
+            if theme is not None:
+                theme_store.save_theme(theme)
+                self._populate_theme_combo()
+                key = f"custom:{theme_store._filename_safe(theme.name)}"
+                if key in self._theme_keys:
+                    self.theme_combo.setCurrentIndex(self._theme_keys.index(key))
+                self._update_theme_buttons()
+                if hasattr(self.main_window, "_refresh_theme_menu"):
+                    self.main_window._refresh_theme_menu()
+
+    def _on_edit_theme(self):
+        idx = self.theme_combo.currentIndex()
+        if idx < 0 or idx >= len(self._theme_keys):
+            return
+        key = self._theme_keys[idx]
+        if not key.startswith("custom:"):
+            return
+
+        current_theme = theme_manager.current_theme
+        if not isinstance(current_theme, CustomTheme):
+            return
+
+        from .theme_editor_dialog import ThemeEditorDialog
+
+        dialog = ThemeEditorDialog(self, edit_theme=current_theme)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            theme = dialog.get_theme()
+            if theme is not None:
+                # Delete old file if name changed
+                old_stem = key[len("custom:") :]
+                new_stem = theme_store._filename_safe(theme.name)
+                if old_stem != new_stem:
+                    theme_store.delete_theme(old_stem)
+                theme_store.save_theme(theme)
+                self._populate_theme_combo()
+                new_key = f"custom:{new_stem}"
+                if new_key in self._theme_keys:
+                    self.theme_combo.setCurrentIndex(self._theme_keys.index(new_key))
+                self._update_theme_buttons()
+                if hasattr(self.main_window, "_refresh_theme_menu"):
+                    self.main_window._refresh_theme_menu()
+
+    def _on_delete_theme(self):
+        idx = self.theme_combo.currentIndex()
+        if idx < 0 or idx >= len(self._theme_keys):
+            return
+        key = self._theme_keys[idx]
+        if not key.startswith("custom:"):
+            return
+
+        name = self.theme_combo.currentText()
+        reply = QMessageBox.question(
+            self,
+            "Delete Theme",
+            f'Delete custom theme "{name}"?',
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        stem = key[len("custom:") :]
+        theme_store.delete_theme(stem)
+        # Switch to Light theme
+        theme_manager.set_theme_by_key("light")
+        self.main_window._apply_theme()
+        self._populate_theme_combo()
+        self.theme_combo.setCurrentIndex(0)
+        self._update_theme_buttons()
+        if hasattr(self.main_window, "_refresh_theme_menu"):
+            self.main_window._refresh_theme_menu()
+
+    def _on_import_theme(self):
+        from pathlib import Path
+
+        path, _ = QFileDialog.getOpenFileName(self, "Import Theme", "", "Theme Files (*.json);;All Files (*)")
+        if not path:
+            return
+        theme = theme_store.import_theme(Path(path))
+        if theme is not None:
+            self._populate_theme_combo()
+            key = f"custom:{theme_store._filename_safe(theme.name)}"
+            if key in self._theme_keys:
+                self.theme_combo.setCurrentIndex(self._theme_keys.index(key))
+            self._update_theme_buttons()
+            if hasattr(self.main_window, "_refresh_theme_menu"):
+                self.main_window._refresh_theme_menu()
+        else:
+            QMessageBox.warning(self, "Import Failed", "Could not import the theme file.")
+
+    def _on_export_theme(self):
+        from pathlib import Path
+
+        current = theme_manager.current_theme
+        if not isinstance(current, CustomTheme):
+            QMessageBox.information(self, "Export Theme", "Only custom themes can be exported.")
+            return
+
+        default_name = theme_store._filename_safe(current.name) + ".json"
+        path, _ = QFileDialog.getSaveFileName(self, "Export Theme", default_name, "Theme Files (*.json);;All Files (*)")
+        if not path:
+            return
+        theme_store.export_theme(current, Path(path))
 
     # ---- Button handlers --------------------------------------------------
 
@@ -180,8 +342,8 @@ class PreferencesDialog(QDialog):
         settings.setValue("autosave/enabled", self.autosave_checkbox.isChecked())
         settings.setValue("autosave/interval", self.autosave_spin.value())
         self.main_window._start_autosave_timer()
-        # Appearance is already applied via live preview — settings are saved
-        # in MainWindow._save_settings() on close, but persist theme now too
+        # Persist theme key
+        settings.setValue("view/theme_key", theme_manager.get_theme_key())
         settings.setValue("view/theme", theme_manager.current_theme.name)
         settings.setValue("view/symbol_style", theme_manager.symbol_style)
         settings.setValue("view/color_mode", theme_manager.color_mode)

--- a/app/GUI/results_plot_dialog.py
+++ b/app/GUI/results_plot_dialog.py
@@ -29,19 +29,23 @@ _LINE_STYLES = ["-", "--", "-.", ":"]
 
 def _apply_mpl_theme(fig):
     """Apply the current application theme colors to a matplotlib figure."""
-    is_dark = theme_manager.current_theme.name == "Dark Theme"
-    if is_dark:
-        bg = "#1E1E1E"
-        fg = "#D4D4D4"
+    theme = theme_manager.current_theme
+    if theme.is_dark:
+        bg = theme.color_hex("background_primary")
+        fg = theme.color_hex("text_primary")
+        bg2 = theme.color_hex("background_secondary")
+        from PyQt6.QtGui import QColor
+
+        border = QColor(bg2).lighter(150).name()
         fig.patch.set_facecolor(bg)
         for ax in fig.axes:
-            ax.set_facecolor("#2D2D2D")
+            ax.set_facecolor(bg2)
             ax.tick_params(colors=fg)
             ax.xaxis.label.set_color(fg)
             ax.yaxis.label.set_color(fg)
             ax.title.set_color(fg)
             for spine in ax.spines.values():
-                spine.set_edgecolor("#555555")
+                spine.set_edgecolor(border)
 
 
 class DCSweepPlotDialog(QDialog):

--- a/app/GUI/styles/__init__.py
+++ b/app/GUI/styles/__init__.py
@@ -25,6 +25,8 @@ Usage:
     # theme_manager.set_theme(DarkTheme())
 """
 
+from . import theme_store
+
 # Core constants (always available, theme-independent)
 from .constants import (
     COMPONENTS,
@@ -46,6 +48,7 @@ from .constants import (
     ZOOM_MAX,
     ZOOM_MIN,
 )
+from .custom_theme import CustomTheme
 from .dark_theme import DarkTheme
 from .light_theme import LightTheme
 
@@ -80,6 +83,8 @@ __all__ = [
     "theme_manager",
     "LightTheme",
     "DarkTheme",
+    "CustomTheme",
+    "theme_store",
     "SYMBOL_STYLES",
     "COLOR_MODES",
 ]

--- a/app/GUI/styles/custom_theme.py
+++ b/app/GUI/styles/custom_theme.py
@@ -1,0 +1,80 @@
+"""custom_theme.py - User-created theme that overlays colors on a built-in base."""
+
+from .dark_theme import DarkTheme
+from .light_theme import LightTheme
+from .theme import BaseTheme
+
+
+class CustomTheme(BaseTheme):
+    """Theme with user-chosen color overrides on top of a Light or Dark base."""
+
+    def __init__(self, name: str, base: str, colors: dict, theme_is_dark: bool):
+        super().__init__()
+        self._custom_name = name
+        self._base_name = base
+        self._theme_is_dark = theme_is_dark
+
+        # Initialize from the base theme
+        base_theme = DarkTheme() if base == "dark" else LightTheme()
+        self._colors = dict(base_theme._colors)
+        self._pens = dict(base_theme._pens)
+        self._brushes = dict(base_theme._brushes)
+        self._fonts = dict(base_theme._fonts)
+        self._stylesheets = dict(base_theme._stylesheets)
+
+        # Apply user color overrides
+        self._color_overrides = dict(colors)
+        self._colors.update(colors)
+
+        # Regenerate stylesheets from new colors
+        self._rebuild_stylesheets()
+
+    @property
+    def name(self) -> str:
+        return self._custom_name
+
+    @property
+    def is_dark(self) -> bool:
+        return self._theme_is_dark
+
+    @property
+    def base_name(self) -> str:
+        return self._base_name
+
+    def get_color_overrides(self) -> dict:
+        """Return only the colors that differ from the base theme."""
+        return dict(self._color_overrides)
+
+    def _rebuild_stylesheets(self):
+        """Regenerate named stylesheets using the current color values."""
+        bg2 = self._colors.get("background_secondary", "#F0F0F0")
+        fg = self._colors.get("text_primary", "#000000")
+        fg2 = self._colors.get("text_secondary", "#666666")
+
+        if self._theme_is_dark:
+            self._stylesheets = {
+                "instructions_panel": f"""
+                    QLabel {{
+                        background-color: {bg2};
+                        color: {fg};
+                        padding: 10px;
+                        border-radius: 5px;
+                    }}
+                """,
+                "muted_label": f"QLabel {{ color: {fg2}; }}",
+                "title_bold": f"font-weight: bold; font-size: 12pt; color: {fg};",
+                "metrics_text": f"font-family: monospace; font-size: 9pt; color: {fg};",
+            }
+        else:
+            self._stylesheets = {
+                "instructions_panel": f"""
+                    QLabel {{
+                        background-color: {bg2};
+                        padding: 10px;
+                        border-radius: 5px;
+                    }}
+                """,
+                "muted_label": f"QLabel {{ color: {fg2}; }}",
+                "title_bold": "font-weight: bold; font-size: 12pt;",
+                "metrics_text": "font-family: monospace; font-size: 9pt;",
+            }

--- a/app/GUI/styles/dark_theme.py
+++ b/app/GUI/styles/dark_theme.py
@@ -4,9 +4,6 @@ dark_theme.py - Dark theme implementation.
 Provides a dark color scheme for reduced eye-strain during long lab sessions.
 """
 
-from PyQt6.QtGui import QBrush, QColor, QPen
-
-from .constants import COMPONENTS
 from .theme import BaseTheme
 
 
@@ -24,6 +21,10 @@ class DarkTheme(BaseTheme):
     @property
     def name(self) -> str:
         return "Dark Theme"
+
+    @property
+    def is_dark(self) -> bool:
+        return True
 
     def _define_colors(self):
         """Define all color values for dark mode."""
@@ -156,32 +157,3 @@ class DarkTheme(BaseTheme):
             "title_bold": "font-weight: bold; font-size: 12pt; color: #D4D4D4;",
             "metrics_text": "font-family: monospace; font-size: 9pt; color: #D4D4D4;",
         }
-
-    # ===== Helper methods (inherited from BaseTheme, same logic) =====
-
-    def get_component_color(self, component_type: str) -> QColor:
-        """Get the themed color for a component type."""
-        comp_info = COMPONENTS.get(component_type, {})
-        color_key = comp_info.get("color_key", "text_primary")
-        return self.color(color_key)
-
-    def get_component_color_hex(self, component_type: str) -> str:
-        """Get the hex color string for a component type."""
-        comp_info = COMPONENTS.get(component_type, {})
-        color_key = comp_info.get("color_key", "text_primary")
-        return self.color_hex(color_key)
-
-    def get_algorithm_color(self, algorithm: str) -> QColor:
-        """Get the themed color for an algorithm layer."""
-        key = f"algorithm_{algorithm}"
-        return self.color(key)
-
-    def create_component_pen(self, component_type: str, width: float = 2.0) -> QPen:
-        """Create a pen for drawing a specific component type."""
-        color = self.get_component_color(component_type)
-        return QPen(color, width)
-
-    def create_component_brush(self, component_type: str) -> QBrush:
-        """Create a brush for filling a specific component type."""
-        color = self.get_component_color(component_type)
-        return QBrush(color.lighter(150))

--- a/app/GUI/styles/light_theme.py
+++ b/app/GUI/styles/light_theme.py
@@ -5,9 +5,6 @@ All color values from the original codebase are centralized here.
 Teammates can update these values from design documents.
 """
 
-from PyQt6.QtGui import QBrush, QColor, QPen
-
-from .constants import COMPONENTS
 from .theme import BaseTheme
 
 
@@ -156,32 +153,3 @@ class LightTheme(BaseTheme):
             "title_bold": "font-weight: bold; font-size: 12pt;",
             "metrics_text": "font-family: monospace; font-size: 9pt;",
         }
-
-    # ===== Helper methods for common patterns =====
-
-    def get_component_color(self, component_type: str) -> QColor:
-        """Get the themed color for a component type."""
-        comp_info = COMPONENTS.get(component_type, {})
-        color_key = comp_info.get("color_key", "text_primary")
-        return self.color(color_key)
-
-    def get_component_color_hex(self, component_type: str) -> str:
-        """Get the hex color string for a component type."""
-        comp_info = COMPONENTS.get(component_type, {})
-        color_key = comp_info.get("color_key", "text_primary")
-        return self.color_hex(color_key)
-
-    def get_algorithm_color(self, algorithm: str) -> QColor:
-        """Get the themed color for an algorithm layer."""
-        key = f"algorithm_{algorithm}"
-        return self.color(key)
-
-    def create_component_pen(self, component_type: str, width: float = 2.0) -> QPen:
-        """Create a pen for drawing a specific component type."""
-        color = self.get_component_color(component_type)
-        return QPen(color, width)
-
-    def create_component_brush(self, component_type: str) -> QBrush:
-        """Create a brush for filling a specific component type."""
-        color = self.get_component_color(component_type)
-        return QBrush(color.lighter(150))

--- a/app/GUI/styles/theme_store.py
+++ b/app/GUI/styles/theme_store.py
@@ -1,0 +1,120 @@
+"""theme_store.py - Persistence layer for custom color themes.
+
+Stores themes as JSON files in ~/.spice-gui/themes/.
+"""
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+from .custom_theme import CustomTheme
+
+logger = logging.getLogger(__name__)
+
+_THEMES_DIR = Path.home() / ".spice-gui" / "themes"
+_SCHEMA_VERSION = 1
+
+
+def _filename_safe(name: str) -> str:
+    """Convert a theme name to a safe filename (lowercase, hyphens)."""
+    safe = re.sub(r"[^\w\s-]", "", name.lower())
+    safe = re.sub(r"[\s_]+", "-", safe).strip("-")
+    return safe or "untitled"
+
+
+def _ensure_dir():
+    _THEMES_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def list_custom_themes(themes_dir: Optional[Path] = None) -> list:
+    """Return list of (display_name, filename_stem) for all saved themes."""
+    d = themes_dir if themes_dir is not None else _THEMES_DIR
+    if not d.exists():
+        return []
+    result = []
+    for path in sorted(d.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            name = data.get("name", path.stem)
+            result.append((name, path.stem))
+        except (json.JSONDecodeError, OSError):
+            continue
+    return result
+
+
+def load_theme(name_or_stem: str, themes_dir: Optional[Path] = None) -> Optional[CustomTheme]:
+    """Load a custom theme by filename stem. Returns None on error."""
+    d = themes_dir if themes_dir is not None else _THEMES_DIR
+    path = d / f"{name_or_stem}.json"
+    if not path.exists():
+        logger.warning("Theme file not found: %s", path)
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return CustomTheme(
+            name=data["name"],
+            base=data.get("base", "light"),
+            colors=data.get("colors", {}),
+            theme_is_dark=data.get("is_dark", False),
+        )
+    except (json.JSONDecodeError, KeyError, OSError) as e:
+        logger.error("Failed to load theme %s: %s", name_or_stem, e)
+        return None
+
+
+def save_theme(theme: CustomTheme, themes_dir: Optional[Path] = None) -> str:
+    """Save a custom theme to disk. Returns the filename stem."""
+    d = themes_dir if themes_dir is not None else _THEMES_DIR
+    d.mkdir(parents=True, exist_ok=True)
+    stem = _filename_safe(theme.name)
+    data = {
+        "name": theme.name,
+        "base": theme.base_name,
+        "is_dark": theme.is_dark,
+        "version": _SCHEMA_VERSION,
+        "colors": theme.get_color_overrides(),
+    }
+    path = d / f"{stem}.json"
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return stem
+
+
+def delete_theme(name_or_stem: str, themes_dir: Optional[Path] = None) -> bool:
+    """Delete a custom theme file. Returns True if deleted."""
+    d = themes_dir if themes_dir is not None else _THEMES_DIR
+    path = d / f"{name_or_stem}.json"
+    if path.exists():
+        path.unlink()
+        return True
+    return False
+
+
+def export_theme(theme: CustomTheme, path: Path) -> None:
+    """Export a custom theme to an arbitrary file path."""
+    data = {
+        "name": theme.name,
+        "base": theme.base_name,
+        "is_dark": theme.is_dark,
+        "version": _SCHEMA_VERSION,
+        "colors": theme.get_color_overrides(),
+    }
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def import_theme(path: Path, themes_dir: Optional[Path] = None) -> Optional[CustomTheme]:
+    """Import a theme JSON file into the themes directory. Returns the theme or None."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        theme = CustomTheme(
+            name=data["name"],
+            base=data.get("base", "light"),
+            colors=data.get("colors", {}),
+            theme_is_dark=data.get("is_dark", False),
+        )
+        save_theme(theme, themes_dir=themes_dir)
+        return theme
+    except (json.JSONDecodeError, KeyError, OSError) as e:
+        logger.error("Failed to import theme from %s: %s", path, e)
+        return None

--- a/app/GUI/theme_editor_dialog.py
+++ b/app/GUI/theme_editor_dialog.py
@@ -1,0 +1,237 @@
+"""Theme editor dialog for creating and editing custom color themes."""
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import (
+    QColorDialog,
+    QComboBox,
+    QDialog,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .styles import CustomTheme, DarkTheme, LightTheme, theme_manager
+
+# Color groups exposed in the editor (subset of all theme keys)
+COLOR_GROUPS = [
+    (
+        "Canvas",
+        [
+            ("background_primary", "Background"),
+            ("background_secondary", "Secondary Background"),
+            ("text_primary", "Text"),
+        ],
+    ),
+    (
+        "Grid",
+        [
+            ("grid_minor", "Minor Grid"),
+            ("grid_major", "Major Grid"),
+        ],
+    ),
+    (
+        "Wires & Selection",
+        [
+            ("wire_default", "Wire"),
+            ("wire_selected", "Wire Selected"),
+            ("selection_highlight", "Selection"),
+        ],
+    ),
+    (
+        "Terminals",
+        [
+            ("terminal_default", "Terminal"),
+            ("terminal_highlight", "Terminal Highlight"),
+        ],
+    ),
+    (
+        "Components",
+        [
+            ("component_resistor", "Resistor"),
+            ("component_capacitor", "Capacitor"),
+            ("component_inductor", "Inductor"),
+            ("component_voltage_source", "Voltage Source"),
+            ("component_ground", "Ground"),
+        ],
+    ),
+]
+
+
+class ThemeEditorDialog(QDialog):
+    """Dialog for creating/editing a custom color theme."""
+
+    def __init__(self, parent=None, edit_theme=None):
+        super().__init__(parent)
+        self.setWindowTitle("Theme Editor")
+        self.setMinimumSize(480, 600)
+
+        self._result_theme = None
+        self._color_buttons = {}  # key -> QPushButton
+        self._hex_labels = {}  # key -> QLabel
+
+        # Snapshot current theme for revert on cancel
+        self._snap_theme = theme_manager.current_theme
+
+        # Load base colors
+        if edit_theme is not None and isinstance(edit_theme, CustomTheme):
+            self._initial_name = edit_theme.name
+            self._initial_base = edit_theme.base_name
+            self._initial_is_dark = edit_theme.is_dark
+            self._colors = dict((DarkTheme() if edit_theme.base_name == "dark" else LightTheme())._colors)
+            self._colors.update(edit_theme.get_color_overrides())
+        else:
+            self._initial_name = ""
+            self._initial_base = "light"
+            self._initial_is_dark = False
+            self._colors = dict(LightTheme()._colors)
+
+        self._build_ui()
+
+        if edit_theme is not None:
+            self.name_edit.setText(self._initial_name)
+            idx = self.base_combo.findData(self._initial_base)
+            if idx >= 0:
+                self.base_combo.setCurrentIndex(idx)
+
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+
+        # Name field
+        form = QFormLayout()
+        self.name_edit = QLineEdit()
+        self.name_edit.setPlaceholderText("My Custom Theme")
+        form.addRow("Theme Name:", self.name_edit)
+
+        self.base_combo = QComboBox()
+        self.base_combo.addItem("Light", "light")
+        self.base_combo.addItem("Dark", "dark")
+        self.base_combo.currentIndexChanged.connect(self._on_base_changed)
+        form.addRow("Base Theme:", self.base_combo)
+        layout.addLayout(form)
+
+        # Scrollable color groups
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll_content = QWidget()
+        scroll_layout = QVBoxLayout(scroll_content)
+
+        for group_name, keys in COLOR_GROUPS:
+            group = QGroupBox(group_name)
+            group_layout = QFormLayout(group)
+            for color_key, label in keys:
+                row = QHBoxLayout()
+                btn = QPushButton()
+                btn.setFixedSize(40, 24)
+                btn.setCursor(Qt.CursorShape.PointingHandCursor)
+                self._update_swatch(btn, self._colors.get(color_key, "#FF00FF"))
+                btn.clicked.connect(lambda checked, k=color_key: self._pick_color(k))
+                self._color_buttons[color_key] = btn
+
+                hex_label = QLabel(self._colors.get(color_key, "#FF00FF"))
+                hex_label.setMinimumWidth(70)
+                self._hex_labels[color_key] = hex_label
+
+                row.addWidget(btn)
+                row.addWidget(hex_label)
+                row.addStretch()
+                group_layout.addRow(f"{label}:", row)
+            scroll_layout.addWidget(group)
+
+        scroll_layout.addStretch()
+        scroll.setWidget(scroll_content)
+        layout.addWidget(scroll, 1)
+
+        # Buttons
+        btn_layout = QHBoxLayout()
+        reset_btn = QPushButton("Reset")
+        reset_btn.clicked.connect(self._on_reset)
+        btn_layout.addWidget(reset_btn)
+        btn_layout.addStretch()
+
+        ok_btn = QPushButton("OK")
+        ok_btn.clicked.connect(self._on_ok)
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self._on_cancel)
+        btn_layout.addWidget(ok_btn)
+        btn_layout.addWidget(cancel_btn)
+        layout.addLayout(btn_layout)
+
+    def _update_swatch(self, btn, hex_color):
+        btn.setStyleSheet(f"background-color: {hex_color}; border: 1px solid #888; border-radius: 3px;")
+
+    def _pick_color(self, key):
+        current = QColor(self._colors.get(key, "#FF00FF"))
+        color = QColorDialog.getColor(current, self, f"Pick color for {key}")
+        if color.isValid():
+            hex_val = color.name()
+            self._colors[key] = hex_val
+            self._update_swatch(self._color_buttons[key], hex_val)
+            self._hex_labels[key].setText(hex_val)
+            self._apply_preview()
+
+    def _on_base_changed(self, index):
+        base = self.base_combo.currentData()
+        base_theme = DarkTheme() if base == "dark" else LightTheme()
+        self._colors = dict(base_theme._colors)
+        # Refresh all swatches
+        for key, btn in self._color_buttons.items():
+            hex_val = self._colors.get(key, "#FF00FF")
+            self._update_swatch(btn, hex_val)
+            self._hex_labels[key].setText(hex_val)
+        self._apply_preview()
+
+    def _on_reset(self):
+        """Reset colors to the current base theme defaults."""
+        self._on_base_changed(self.base_combo.currentIndex())
+
+    def _apply_preview(self):
+        """Apply current editor colors as a live preview."""
+        base = self.base_combo.currentData()
+        is_dark = base == "dark"
+        name = self.name_edit.text() or "Preview"
+
+        # Compute overrides relative to base
+        base_theme = DarkTheme() if is_dark else LightTheme()
+        overrides = {k: v for k, v in self._colors.items() if v != base_theme._colors.get(k)}
+
+        preview = CustomTheme(name=name, base=base, colors=overrides, theme_is_dark=is_dark)
+        theme_manager.set_theme(preview)
+
+    def _on_ok(self):
+        name = self.name_edit.text().strip()
+        if not name:
+            QMessageBox.warning(self, "Name Required", "Please enter a name for the theme.")
+            return
+
+        base = self.base_combo.currentData()
+        is_dark = base == "dark"
+
+        # Compute overrides relative to base
+        base_theme = DarkTheme() if is_dark else LightTheme()
+        overrides = {k: v for k, v in self._colors.items() if v != base_theme._colors.get(k)}
+
+        self._result_theme = CustomTheme(name=name, base=base, colors=overrides, theme_is_dark=is_dark)
+        theme_manager.set_theme(self._result_theme)
+        self.accept()
+
+    def _on_cancel(self):
+        # Revert to snapshot
+        theme_manager.set_theme(self._snap_theme)
+        self.reject()
+
+    def closeEvent(self, event):
+        if self.result() != QDialog.DialogCode.Accepted:
+            theme_manager.set_theme(self._snap_theme)
+        super().closeEvent(event)
+
+    def get_theme(self):
+        """Return the created/edited CustomTheme, or None if cancelled."""
+        return self._result_theme

--- a/app/GUI/waveform_dialog.py
+++ b/app/GUI/waveform_dialog.py
@@ -38,19 +38,23 @@ HIGHLIGHT_COLORS = [QColor.fromRgbF(*cmap(i)) for i in range(12)]
 
 def _apply_mpl_theme(fig):
     """Apply the current application theme colors to a matplotlib figure."""
-    is_dark = theme_manager.current_theme.name == "Dark Theme"
-    if is_dark:
-        bg = "#1E1E1E"
-        fg = "#D4D4D4"
+    theme = theme_manager.current_theme
+    if theme.is_dark:
+        bg = theme.color_hex("background_primary")
+        fg = theme.color_hex("text_primary")
+        bg2 = theme.color_hex("background_secondary")
+        from PyQt6.QtGui import QColor
+
+        border = QColor(bg2).lighter(150).name()
         fig.patch.set_facecolor(bg)
         for ax in fig.axes:
-            ax.set_facecolor("#2D2D2D")
+            ax.set_facecolor(bg2)
             ax.tick_params(colors=fg)
             ax.xaxis.label.set_color(fg)
             ax.yaxis.label.set_color(fg)
             ax.title.set_color(fg)
             for spine in ax.spines.values():
-                spine.set_edgecolor("#555555")
+                spine.set_edgecolor(border)
 
 
 class MplCanvas(FigureCanvas):

--- a/app/tests/unit/test_custom_theme.py
+++ b/app/tests/unit/test_custom_theme.py
@@ -1,0 +1,88 @@
+"""Tests for CustomTheme class."""
+
+import pytest
+from GUI.styles import DarkTheme, LightTheme
+from GUI.styles.custom_theme import CustomTheme
+from PyQt6.QtGui import QColor
+
+
+class TestCustomThemeConstruction:
+    """Verify CustomTheme can be constructed from either base."""
+
+    def test_from_light_base(self):
+        theme = CustomTheme("My Light", "light", {}, theme_is_dark=False)
+        assert theme.name == "My Light"
+        assert theme.base_name == "light"
+        assert not theme.is_dark
+
+    def test_from_dark_base(self):
+        theme = CustomTheme("My Dark", "dark", {}, theme_is_dark=True)
+        assert theme.name == "My Dark"
+        assert theme.base_name == "dark"
+        assert theme.is_dark
+
+
+class TestColorOverrides:
+    """Verify color overrides are applied correctly."""
+
+    def test_override_applied(self):
+        theme = CustomTheme("Test", "light", {"background_primary": "#123456"}, theme_is_dark=False)
+        assert theme.color_hex("background_primary") == "#123456"
+
+    def test_fallback_to_base(self):
+        """Keys not in overrides should come from the base theme."""
+        theme = CustomTheme("Test", "light", {}, theme_is_dark=False)
+        light = LightTheme()
+        assert theme.color_hex("background_primary") == light.color_hex("background_primary")
+
+    def test_get_color_overrides_returns_only_changes(self):
+        overrides = {"wire_default": "#AABBCC"}
+        theme = CustomTheme("Test", "light", overrides, theme_is_dark=False)
+        result = theme.get_color_overrides()
+        assert result == overrides
+
+
+class TestIsDark:
+    """Verify is_dark property is correct."""
+
+    def test_light_custom_not_dark(self):
+        theme = CustomTheme("L", "light", {}, theme_is_dark=False)
+        assert not theme.is_dark
+
+    def test_dark_custom_is_dark(self):
+        theme = CustomTheme("D", "dark", {}, theme_is_dark=True)
+        assert theme.is_dark
+
+
+class TestInheritedHelpers:
+    """Verify helper methods inherited from BaseTheme work."""
+
+    def test_get_component_color(self):
+        theme = CustomTheme("Test", "dark", {}, theme_is_dark=True)
+        color = theme.get_component_color("Resistor")
+        assert isinstance(color, QColor)
+
+    def test_create_component_pen(self):
+        theme = CustomTheme("Test", "light", {}, theme_is_dark=False)
+        pen = theme.create_component_pen("Capacitor")
+        assert pen is not None
+
+
+class TestDarkStylesheet:
+    """Verify generate_dark_stylesheet() behavior."""
+
+    def test_dark_custom_has_stylesheet(self):
+        theme = CustomTheme("D", "dark", {}, theme_is_dark=True)
+        ss = theme.generate_dark_stylesheet()
+        assert len(ss) > 0
+        assert "background-color" in ss
+
+    def test_light_custom_empty_stylesheet(self):
+        theme = CustomTheme("L", "light", {}, theme_is_dark=False)
+        ss = theme.generate_dark_stylesheet()
+        assert ss == ""
+
+    def test_dark_stylesheet_uses_theme_colors(self):
+        theme = CustomTheme("D", "dark", {"background_primary": "#1A1A2E"}, theme_is_dark=True)
+        ss = theme.generate_dark_stylesheet()
+        assert "#1a1a2e" in ss.lower()

--- a/app/tests/unit/test_preferences_dialog.py
+++ b/app/tests/unit/test_preferences_dialog.py
@@ -4,8 +4,16 @@ from unittest.mock import MagicMock
 
 import pytest
 from GUI.preferences_dialog import PreferencesDialog
+from GUI.styles import LightTheme, theme_manager
 from PyQt6.QtCore import QSettings
 from PyQt6.QtWidgets import QCheckBox, QComboBox, QPushButton, QSpinBox, QTabWidget
+
+
+@pytest.fixture(autouse=True)
+def restore_theme():
+    """Ensure light theme is restored after each test."""
+    yield
+    theme_manager.set_theme(LightTheme())
 
 
 @pytest.fixture
@@ -13,10 +21,12 @@ def mock_main_window():
     """Create a mock MainWindow with the methods PreferencesDialog calls."""
     mw = MagicMock()
     mw._set_theme = MagicMock()
+    mw._apply_theme = MagicMock()
     mw._set_symbol_style = MagicMock()
     mw._set_color_mode = MagicMock()
     mw._start_autosave_timer = MagicMock()
     mw._open_keybindings_dialog = MagicMock()
+    mw._refresh_theme_menu = MagicMock()
     return mw
 
 
@@ -45,6 +55,16 @@ class TestDialogStructure:
         combos = tab.findChildren(QComboBox)
         assert len(combos) == 3
 
+    def test_appearance_tab_has_theme_buttons(self, dialog):
+        tab = dialog.tabs.widget(0)
+        buttons = tab.findChildren(QPushButton)
+        texts = {b.text() for b in buttons}
+        assert "New..." in texts
+        assert "Edit..." in texts
+        assert "Delete" in texts
+        assert "Import..." in texts
+        assert "Export..." in texts
+
     def test_grid_tab_is_placeholder(self, dialog):
         tab = dialog.tabs.widget(1)
         combos = tab.findChildren(QComboBox)
@@ -67,12 +87,13 @@ class TestDialogStructure:
 
 
 class TestLivePreview:
-    """Tests verifying combo changes call MainWindow methods immediately."""
+    """Tests verifying combo changes apply theme immediately."""
 
-    def test_theme_combo_live_preview(self, dialog, mock_main_window):
-        mock_main_window._set_theme.reset_mock()
+    def test_theme_combo_dark(self, dialog, mock_main_window):
+        mock_main_window._apply_theme.reset_mock()
         dialog.theme_combo.setCurrentIndex(1)  # Dark
-        mock_main_window._set_theme.assert_called_with("dark")
+        mock_main_window._apply_theme.assert_called()
+        assert theme_manager.current_theme.name == "Dark Theme"
 
     def test_symbol_style_combo_live_preview(self, dialog, mock_main_window):
         mock_main_window._set_symbol_style.reset_mock()
@@ -88,30 +109,18 @@ class TestLivePreview:
 class TestCancelRevert:
     """Tests verifying Cancel reverts to snapshot values."""
 
-    def test_cancel_reverts(self, dialog, mock_main_window):
-        # Change combos (triggers live preview)
-        dialog.theme_combo.setCurrentIndex(1)
-        dialog.style_combo.setCurrentIndex(1)
-        dialog.color_combo.setCurrentIndex(1)
-        mock_main_window._set_theme.reset_mock()
-        mock_main_window._set_symbol_style.reset_mock()
-        mock_main_window._set_color_mode.reset_mock()
-
+    def test_cancel_reverts_theme(self, dialog, mock_main_window):
+        dialog.theme_combo.setCurrentIndex(1)  # Dark
+        assert theme_manager.current_theme.name == "Dark Theme"
         dialog._on_cancel()
+        # Should revert to Light
+        assert theme_manager.current_theme.name == "Light Theme"
 
-        # Should revert to snapshot (light/ieee/color)
-        mock_main_window._set_theme.assert_called_with("light")
+    def test_cancel_reverts_symbol_style(self, dialog, mock_main_window):
+        dialog.style_combo.setCurrentIndex(1)
+        mock_main_window._set_symbol_style.reset_mock()
+        dialog._on_cancel()
         mock_main_window._set_symbol_style.assert_called_with("ieee")
-        mock_main_window._set_color_mode.assert_called_with("color")
-
-    def test_close_button_reverts(self, dialog, mock_main_window):
-        """X-close should behave like Cancel (revert)."""
-        dialog.theme_combo.setCurrentIndex(1)
-        mock_main_window._set_theme.reset_mock()
-
-        dialog.close()  # triggers closeEvent with _accepted=False
-
-        mock_main_window._set_theme.assert_called_with("light")
 
 
 class TestOkPersist:
@@ -126,16 +135,29 @@ class TestOkPersist:
         settings = QSettings("SDSMT", "SDM Spice")
         assert settings.value("autosave/interval") == 120
         enabled = settings.value("autosave/enabled")
-        assert enabled is True or enabled == "true"  # Windows registry stores as string
+        assert enabled is True or enabled == "true"
         mock_main_window._start_autosave_timer.assert_called()
+
+    def test_ok_persists_theme_key(self, dialog, mock_main_window):
+        dialog._on_ok()
+        settings = QSettings("SDSMT", "SDM Spice")
+        assert settings.value("view/theme_key") == "light"
 
 
 class TestInitialValues:
     """Tests verifying initial widget values match snapshot."""
 
     def test_initial_values_match_current(self, dialog):
-        # theme_manager defaults: Light Theme, ieee, color
         assert dialog.theme_combo.currentIndex() == 0  # Light
         assert dialog.style_combo.currentIndex() == 0  # IEEE
         assert dialog.color_combo.currentIndex() == 0  # Color
-        assert dialog.autosave_spin.value() >= 10  # Within valid range
+        assert dialog.autosave_spin.value() >= 10
+
+
+class TestThemeButtons:
+    """Tests for New/Edit/Delete button state."""
+
+    def test_edit_delete_disabled_for_builtin(self, dialog):
+        dialog.theme_combo.setCurrentIndex(0)  # Light
+        assert not dialog.edit_theme_btn.isEnabled()
+        assert not dialog.delete_theme_btn.isEnabled()

--- a/app/tests/unit/test_theme_editor_dialog.py
+++ b/app/tests/unit/test_theme_editor_dialog.py
@@ -1,0 +1,82 @@
+"""Tests for ThemeEditorDialog."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from GUI.styles import LightTheme, theme_manager
+from GUI.theme_editor_dialog import COLOR_GROUPS, ThemeEditorDialog
+from PyQt6.QtWidgets import QGroupBox, QLineEdit, QPushButton
+
+
+@pytest.fixture(autouse=True)
+def restore_theme():
+    """Ensure light theme is restored after each test."""
+    yield
+    theme_manager.set_theme(LightTheme())
+
+
+@pytest.fixture
+def editor(qtbot):
+    dlg = ThemeEditorDialog()
+    qtbot.addWidget(dlg)
+    return dlg
+
+
+class TestEditorStructure:
+    """Verify the dialog has expected widgets."""
+
+    def test_has_all_color_groups(self, editor):
+        groups = editor.findChildren(QGroupBox)
+        group_names = {g.title() for g in groups}
+        for expected_name, _ in COLOR_GROUPS:
+            assert expected_name in group_names
+
+    def test_has_name_field(self, editor):
+        name_edit = editor.findChild(QLineEdit)
+        assert name_edit is not None
+
+    def test_has_ok_cancel_reset_buttons(self, editor):
+        buttons = editor.findChildren(QPushButton)
+        texts = {b.text() for b in buttons}
+        assert "OK" in texts
+        assert "Cancel" in texts
+        assert "Reset" in texts
+
+
+class TestColorSwatches:
+    """Verify color swatch interaction."""
+
+    def test_all_15_keys_have_swatches(self, editor):
+        total_keys = sum(len(keys) for _, keys in COLOR_GROUPS)
+        assert total_keys == 15
+        assert len(editor._color_buttons) == 15
+
+    @patch("GUI.theme_editor_dialog.QColorDialog.getColor")
+    def test_pick_color_updates_swatch(self, mock_get_color, editor):
+        from PyQt6.QtGui import QColor
+
+        mock_get_color.return_value = QColor("#ABCDEF")
+        editor._pick_color("background_primary")
+        assert editor._colors["background_primary"] == "#abcdef"
+
+
+class TestNameRequired:
+    """Verify name validation."""
+
+    @patch("GUI.theme_editor_dialog.QMessageBox.warning")
+    def test_empty_name_shows_warning(self, mock_warning, editor, qtbot):
+        editor.name_edit.setText("")
+        # _on_ok should not accept with empty name
+        editor._on_ok()
+        assert editor.get_theme() is None
+        mock_warning.assert_called_once()
+
+
+class TestResetButton:
+    """Verify reset restores base colors."""
+
+    def test_reset_restores_base(self, editor):
+        editor._colors["background_primary"] = "#FF0000"
+        editor._on_reset()
+        light = LightTheme()
+        assert editor._colors["background_primary"] == light.color_hex("background_primary")

--- a/app/tests/unit/test_theme_store.py
+++ b/app/tests/unit/test_theme_store.py
@@ -1,0 +1,111 @@
+"""Tests for ThemeStore persistence layer."""
+
+import json
+
+import pytest
+from GUI.styles.custom_theme import CustomTheme
+from GUI.styles.theme_store import (
+    _filename_safe,
+    delete_theme,
+    export_theme,
+    import_theme,
+    list_custom_themes,
+    load_theme,
+    save_theme,
+)
+
+
+class TestFilenameSafe:
+    """Verify filename sanitization."""
+
+    def test_basic_name(self):
+        assert _filename_safe("My Theme") == "my-theme"
+
+    def test_special_chars(self):
+        assert _filename_safe("Foo!@#$%Bar") == "foobar"
+
+    def test_empty_string(self):
+        assert _filename_safe("") == "untitled"
+
+    def test_underscores_to_hyphens(self):
+        assert _filename_safe("foo_bar") == "foo-bar"
+
+
+class TestSaveLoadRoundTrip:
+    """Verify save + load round-trip."""
+
+    def test_round_trip(self, tmp_path):
+        theme = CustomTheme("Ocean Blue", "dark", {"background_primary": "#0A1628"}, theme_is_dark=True)
+        stem = save_theme(theme, themes_dir=tmp_path)
+        assert stem == "ocean-blue"
+        assert (tmp_path / "ocean-blue.json").exists()
+
+        loaded = load_theme(stem, themes_dir=tmp_path)
+        assert loaded is not None
+        assert loaded.name == "Ocean Blue"
+        assert loaded.base_name == "dark"
+        assert loaded.is_dark is True
+        assert loaded.color_hex("background_primary") == "#0A1628"
+
+
+class TestListThemes:
+    """Verify listing custom themes."""
+
+    def test_empty_dir(self, tmp_path):
+        assert list_custom_themes(themes_dir=tmp_path) == []
+
+    def test_lists_saved_themes(self, tmp_path):
+        t1 = CustomTheme("Alpha", "light", {}, theme_is_dark=False)
+        t2 = CustomTheme("Beta", "dark", {}, theme_is_dark=True)
+        save_theme(t1, themes_dir=tmp_path)
+        save_theme(t2, themes_dir=tmp_path)
+        result = list_custom_themes(themes_dir=tmp_path)
+        names = [name for name, _ in result]
+        assert "Alpha" in names
+        assert "Beta" in names
+
+
+class TestDeleteTheme:
+    """Verify theme deletion."""
+
+    def test_delete_existing(self, tmp_path):
+        theme = CustomTheme("ToDelete", "light", {}, theme_is_dark=False)
+        stem = save_theme(theme, themes_dir=tmp_path)
+        assert delete_theme(stem, themes_dir=tmp_path) is True
+        assert list_custom_themes(themes_dir=tmp_path) == []
+
+    def test_delete_nonexistent(self, tmp_path):
+        assert delete_theme("nope", themes_dir=tmp_path) is False
+
+
+class TestExportImport:
+    """Verify export + import round-trip."""
+
+    def test_export_import(self, tmp_path):
+        theme = CustomTheme("Portable", "light", {"grid_minor": "#AAAAAA"}, theme_is_dark=False)
+        export_path = tmp_path / "exported.json"
+        export_theme(theme, export_path)
+        assert export_path.exists()
+
+        import_dir = tmp_path / "imported"
+        import_dir.mkdir()
+        imported = import_theme(export_path, themes_dir=import_dir)
+        assert imported is not None
+        assert imported.name == "Portable"
+        assert imported.color_hex("grid_minor").lower() == "#aaaaaa"
+
+
+class TestInvalidJson:
+    """Verify graceful handling of corrupt files."""
+
+    def test_load_invalid_json(self, tmp_path):
+        bad_file = tmp_path / "broken.json"
+        bad_file.write_text("not valid json{{{", encoding="utf-8")
+        result = load_theme("broken", themes_dir=tmp_path)
+        assert result is None
+
+    def test_load_missing_name_key(self, tmp_path):
+        bad_file = tmp_path / "noname.json"
+        bad_file.write_text('{"base": "light", "colors": {}}', encoding="utf-8")
+        result = load_theme("noname", themes_dir=tmp_path)
+        assert result is None


### PR DESCRIPTION
## Summary

- Add `CustomTheme` class that overlays user-chosen colors on a Light or Dark base theme
- Add `ThemeStore` for JSON persistence at `~/.spice-gui/themes/` (save, load, delete, import, export)
- Add `ThemeEditorDialog` with 5 color groups (Canvas, Grid, Wires & Selection, Terminals, Components) exposing 15 key colors with live preview
- Refactor `BaseTheme` to consolidate 5 duplicate helper methods from Light/DarkTheme and add `is_dark` property + `generate_dark_stylesheet()` 
- Replace hardcoded `name == "Dark Theme"` checks in 4 files with `theme.is_dark`
- Update `PreferencesDialog` with dynamic theme combo and New/Edit/Delete/Import/Export buttons
- Add dynamic custom theme entries to View > Theme menu with mutual exclusion
- Persist custom theme keys in QSettings for cross-session restore

## Test plan

- [x] `make format` — passes
- [x] `make lint` — passes  
- [x] `python -m pytest` — 1416 tests pass, 0 failures
- [ ] Settings > Preferences > New Theme — editor opens, pick colors, OK — theme applied
- [ ] Restart app — custom theme restored
- [ ] Export theme JSON — import on fresh install — theme available
- [ ] Delete custom theme — removed from menu/combo

🤖 Generated with [Claude Code](https://claude.com/claude-code)