### PR TITLE
Add wire rendering style preference (#320)

### DIFF
--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -321,6 +321,41 @@ class MenuBarMixin:
         self.color_mode_group.addAction(self.color_mode_action)
         self.color_mode_group.addAction(self.monochrome_mode_action)
 
+        # Wire Thickness submenu
+        wire_thickness_menu = view_menu.addMenu("&Wire Thickness")
+        self.wire_thickness_actions = {}
+
+        thin_action = QAction("&Thin (1px)", self)
+        thin_action.setCheckable(True)
+        thin_action.triggered.connect(lambda: self._set_wire_thickness("thin"))
+        wire_thickness_menu.addAction(thin_action)
+        self.wire_thickness_actions["thin"] = thin_action
+
+        normal_action = QAction("&Normal (2px)", self)
+        normal_action.setCheckable(True)
+        normal_action.setChecked(True)
+        normal_action.triggered.connect(lambda: self._set_wire_thickness("normal"))
+        wire_thickness_menu.addAction(normal_action)
+        self.wire_thickness_actions["normal"] = normal_action
+
+        thick_action = QAction("Thic&k (3px)", self)
+        thick_action.setCheckable(True)
+        thick_action.triggered.connect(lambda: self._set_wire_thickness("thick"))
+        wire_thickness_menu.addAction(thick_action)
+        self.wire_thickness_actions["thick"] = thick_action
+
+        self.wire_thickness_group = QActionGroup(self)
+        self.wire_thickness_group.addAction(thin_action)
+        self.wire_thickness_group.addAction(normal_action)
+        self.wire_thickness_group.addAction(thick_action)
+
+        # Junction dots toggle
+        self.show_junction_dots_action = QAction("Show &Junction Dots", self)
+        self.show_junction_dots_action.setCheckable(True)
+        self.show_junction_dots_action.setChecked(True)
+        self.show_junction_dots_action.triggered.connect(self._set_show_junction_dots)
+        view_menu.addAction(self.show_junction_dots_action)
+
         view_menu.addSeparator()
 
         zoom_in_action = QAction("Zoom &In", self)

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -29,6 +29,8 @@ class SettingsMixin:
         settings.setValue("view/theme", theme_manager.current_theme.name)
         settings.setValue("view/symbol_style", theme_manager.symbol_style)
         settings.setValue("view/color_mode", theme_manager.color_mode)
+        settings.setValue("view/wire_thickness", theme_manager.wire_thickness)
+        settings.setValue("view/show_junction_dots", theme_manager.show_junction_dots)
 
     def _restore_settings(self):
         """Restore user preferences from QSettings"""
@@ -97,6 +99,15 @@ class SettingsMixin:
         saved_color_mode = settings.value("view/color_mode")
         if saved_color_mode in ("color", "monochrome"):
             self._set_color_mode(saved_color_mode)
+
+        saved_wire_thickness = settings.value("view/wire_thickness")
+        if saved_wire_thickness in ("thin", "normal", "thick"):
+            self._set_wire_thickness(saved_wire_thickness)
+
+        saved_junction_dots = settings.value("view/show_junction_dots")
+        if saved_junction_dots is not None:
+            show = saved_junction_dots == "true" or saved_junction_dots is True
+            self._set_show_junction_dots(show)
 
     def closeEvent(self, event):
         """Save settings before closing"""

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -48,6 +48,21 @@ class ViewOperationsMixin:
             self.color_mode_action.setChecked(True)
         self.canvas.scene.update()
 
+    def _set_wire_thickness(self, thickness: str):
+        """Switch wire rendering thickness."""
+        theme_manager.set_wire_thickness(thickness)
+        if hasattr(self, "wire_thickness_actions"):
+            for t, action in self.wire_thickness_actions.items():
+                action.setChecked(t == thickness)
+        self.canvas.scene.update()
+
+    def _set_show_junction_dots(self, show: bool):
+        """Toggle junction dot visibility at wire intersections."""
+        theme_manager.set_show_junction_dots(show)
+        if hasattr(self, "show_junction_dots_action"):
+            self.show_junction_dots_action.setChecked(show)
+        self.canvas.scene.update()
+
     def _toggle_statistics_panel(self, checked):
         """Toggle the circuit statistics panel visibility."""
         self.statistics_panel.setVisible(checked)

--- a/app/GUI/styles/__init__.py
+++ b/app/GUI/styles/__init__.py
@@ -54,7 +54,7 @@ from .light_theme import LightTheme
 
 # Theme system
 from .theme import BaseTheme, ThemeProtocol
-from .theme_manager import COLOR_MODES, SYMBOL_STYLES, ThemeManager, theme_manager
+from .theme_manager import COLOR_MODES, SYMBOL_STYLES, WIRE_THICKNESS_PX, WIRE_THICKNESSES, ThemeManager, theme_manager
 
 __all__ = [
     # Constants
@@ -87,4 +87,6 @@ __all__ = [
     "theme_store",
     "SYMBOL_STYLES",
     "COLOR_MODES",
+    "WIRE_THICKNESSES",
+    "WIRE_THICKNESS_PX",
 ]


### PR DESCRIPTION
## Summary
- Adds wire thickness preference (thin/normal/thick -> 1/2/3px) and junction dot visibility toggle to ThemeManager, following the existing symbol_style/color_mode pattern
- Adds controls to Preferences dialog Appearance tab and View menu
- Updates wire_item.py paint method to read thickness from theme_manager and render junction dots at interior waypoints
- Settings persist via QSettings across sessions and changes apply immediately to all wires on canvas

## Changes
- **theme_manager.py**: Added wire_thickness, wire_thickness_px, show_junction_dots properties with set_wire_thickness() and set_show_junction_dots() methods
- **preferences_dialog.py**: Added wire thickness combo and junction dots checkbox to Appearance tab with live preview, snapshot/revert, and OK persistence
- **main_window_menus.py**: Added Wire Thickness submenu and Show Junction Dots toggle to View menu
- **main_window_view.py**: Added _set_wire_thickness() and _set_show_junction_dots() methods
- **main_window_settings.py**: Added save/restore for wire rendering preferences
- **wire_item.py**: Updated paint() to use dynamic pen width and draw junction dots; added boundingRect() override for dot margins
- **test_preferences_dialog.py**: Added 21 new tests covering dialog structure, live preview, cancel revert, OK persistence, and ThemeManager properties

## Test plan
- [x] All 2482 existing tests pass (0 failures)
- [x] 21 new tests for wire rendering preferences pass
- [ ] Manual: Open Preferences > Appearance, change wire thickness and verify all wires update
- [ ] Manual: Toggle junction dots checkbox and verify dots appear/disappear at wire bends
- [ ] Manual: Use View > Wire Thickness submenu to change thickness
- [ ] Manual: Use View > Show Junction Dots toggle
- [ ] Manual: Close and reopen app, verify settings persist

Closes #320