### PR TITLE
Add default zoom level preference (#321)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -616,7 +616,10 @@ class CircuitCanvasView(QGraphicsView):
                 if main_window and hasattr(main_window, "statusBar"):
                     status = main_window.statusBar()
                     if status:
-                        status.showMessage("No simulation results available. Run a simulation first.", 3000)
+                        status.showMessage(
+                            "No simulation results available. Run a simulation first.",
+                            3000,
+                        )
             event.accept()
             return
 
@@ -845,6 +848,19 @@ class CircuitCanvasView(QGraphicsView):
     def zoom_out(self, center_point=None):
         """Zoom out by one step, optionally centered on a point."""
         self._apply_zoom(1.0 / ZOOM_FACTOR, center_point)
+
+    def set_default_zoom(self, percent):
+        """Set the zoom level to the given percentage (e.g. 100 = 100%).
+
+        Used to apply the user's preferred default zoom level when
+        opening a new circuit or launching the application.
+        """
+        scale_factor = percent / 100.0
+        # Clamp to allowed zoom range
+        scale_factor = max(ZOOM_MIN, min(ZOOM_MAX, scale_factor))
+        self.resetTransform()
+        self.scale(scale_factor, scale_factor)
+        self.zoomChanged.emit(self.get_zoom_level())
 
     def zoom_reset(self):
         """Reset zoom to 100%."""

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -25,6 +25,9 @@ class SettingsMixin:
         if settings.value("autosave/enabled") is None:
             settings.setValue("autosave/enabled", True)
         settings.setValue("view/show_statistics", self.statistics_panel.isVisible())
+        # Preserve default zoom if not yet set
+        if settings.value("view/default_zoom") is None:
+            settings.setValue("view/default_zoom", 100)
         settings.setValue("view/theme_key", theme_manager.get_theme_key())
         settings.setValue("view/theme", theme_manager.current_theme.name)
         settings.setValue("view/symbol_style", theme_manager.symbol_style)
@@ -79,6 +82,10 @@ class SettingsMixin:
             checked = show_stats == "true" or show_stats is True
             self.statistics_panel.setVisible(checked)
             self.show_statistics_action.setChecked(checked)
+
+        default_zoom = settings.value("view/default_zoom")
+        if default_zoom is not None:
+            self.canvas.set_default_zoom(int(default_zoom))
 
         saved_theme_key = settings.value("view/theme_key")
         if saved_theme_key and saved_theme_key != "light":


### PR DESCRIPTION
## Summary
- Add a default zoom level preference (50%, 75%, 100%, 125%, 150%) to the Preferences dialog Behavior tab
- Persist the setting via QSettings key `view/default_zoom`
- Apply default zoom when creating new circuits, loading files, opening examples, or opening templates
- Restore default zoom on app launch from saved settings

## Changes
- `app/GUI/preferences_dialog.py`: QComboBox with preset zoom levels, snapshot/revert on cancel
- `app/GUI/circuit_canvas.py`: `set_default_zoom(percent)` method with clamping to ZOOM_MIN/ZOOM_MAX
- `app/GUI/main_window_file_ops.py`: `_apply_default_zoom()` helper called after new/load/open/template
- `app/GUI/main_window_settings.py`: Save/restore default zoom setting
- `app/tests/unit/test_preferences_dialog.py`: 4 new tests covering structure, persistence, initial value, and cancel revert

## Test plan
- [x] Unit tests for zoom combo structure (5 items: 50%-150%)
- [x] Unit tests for OK persisting zoom to QSettings
- [x] Unit tests for Cancel reverting zoom to snapshot
- [x] Unit tests for initial value matching QSettings default (100%)
- [ ] Manual: Open Preferences > Behavior tab, change default zoom, click OK, create new circuit -- verify zoom level
- [ ] Manual: Reopen app -- verify zoom persists from previous session
- [ ] Manual: Use Fit to Circuit -- verify it still overrides default zoom

Closes #321