### PR TITLE
Add auto-save interval configuration UI (#322)

### DIFF
--- a/app/tests/unit/test_preferences_dialog.py
+++ b/app/tests/unit/test_preferences_dialog.py
@@ -299,13 +299,16 @@ class TestAutosaveSpinboxState:
         assert not dlg.autosave_checkbox.isChecked()
         assert not dlg.autosave_spin.isEnabled()
 
-    def test_cancel_reverts_autosave_enabled(self, dialog, mock_main_window):
+    def test_cancel_reverts_autosave_enabled(self, qtbot, mock_main_window):
         """Cancel should revert auto-save enabled to the snapshot value."""
-        dialog.autosave_checkbox.setChecked(False)
-        dialog._on_cancel()
+        # Ensure autosave is enabled before opening dialog so snapshot captures True
         settings = QSettings("SDSMT", "SDM Spice")
+        settings.setValue("autosave/enabled", True)
+        dlg = PreferencesDialog(mock_main_window, parent=None)
+        qtbot.addWidget(dlg)
+        dlg.autosave_checkbox.setChecked(False)
+        dlg._on_cancel()
         enabled = settings.value("autosave/enabled")
-        # Snapshot was True (default), so it should revert to True
         assert enabled is True or enabled == "true"
         mock_main_window._start_autosave_timer.assert_called()
 


### PR DESCRIPTION
## Summary
- Disables the auto-save interval spinbox when auto-save checkbox is unchecked (UX polish)
- Initializes spinbox enabled state to match checkbox value on dialog open
- Connects checkbox toggle signal to spinbox setEnabled for real-time state sync
- Timer restart on OK/Cancel was already implemented and verified working

## Changes
- `app/GUI/preferences_dialog.py`: Added `autosave_checkbox.toggled -> autosave_spin.setEnabled` signal connection and initial enabled state sync in `_load_current_values`
- `app/tests/unit/test_preferences_dialog.py`: Added 6 new tests in `TestAutosaveSpinboxState` class covering spinbox enabled/disabled state, toggle behavior, initial state matching, and cancel revert logic

## Test plan
- [x] Spinbox disabled when checkbox unchecked
- [x] Spinbox enabled when checkbox checked
- [x] Toggling checkbox updates spinbox enabled state
- [x] Initial spinbox state matches persisted QSettings value
- [x] Cancel reverts autosave enabled setting and restarts timer
- [x] Cancel reverts autosave interval setting
- [ ] Manual verification of auto-save timer restart in full app

Closes #322