### PR TITLE
fix: restore annotations in load_auto_save() (#410)

### DIFF
--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -300,6 +300,7 @@ class FileController:
             self.model.component_counter = new_model.component_counter
             self.model.analysis_type = new_model.analysis_type
             self.model.analysis_params = new_model.analysis_params
+            self.model.annotations = new_model.annotations
 
             if source_path:
                 self.current_file = Path(source_path)


### PR DESCRIPTION
## Summary -  in  copied  and  from the recovered model but skipped , causing them to be silently lost on crash recovery - Added the missing  line to align with  and  - Added regression test verifying annotations (text, position, font, color) survive auto-save round-trip ## Test plan - [x] New test  passes (verifies 2 annotations with full field fidelity) - [x] All 22 existing auto-save tests continue to pass - [x] Full test suite (2850 tests) passes with no regressions Closes #410 🤖 Generated with [Claude Code](https://claude.com/claude-code)