### PR TITLE
ci: add coverage threshold to CI test step (#360)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,12 @@ jobs:
         working-directory: app
         env:
           QT_QPA_PLATFORM: offscreen
-        run: xvfb-run python -m pytest tests/ -v --tb=short --cov=. --cov-report=term-missing
+        run: xvfb-run python -m pytest tests/ -v --tb=short --cov=. --cov-report=term-missing --cov-fail-under=80
 
       - name: Run tests with coverage (Windows)
         if: runner.os == 'Windows'
         working-directory: app
-        run: python -m pytest tests/ -v --tb=short --cov=. --cov-report=term-missing
+        run: python -m pytest tests/ -v --tb=short --cov=. --cov-report=term-missing --cov-fail-under=80
 
   import-check:
     name: Import Check


### PR DESCRIPTION
## Summary - Add  to both Linux and Windows pytest commands in CI - Current coverage is 85%, so 80% provides a safety margin while preventing significant regressions -  is already installed in CI (part of requirements-dev.txt) ## Test plan - [x] CI workflow syntax validated (YAML is correct) - [x] Local test run with  passes at 85% coverage - [x] Threshold is intentionally permissive (80%) to avoid blocking PRs that only touch GUI code Closes #360 Generated with [Claude Code](https://claude.com/claude-code)