### PR TITLE
add collapsible category groups in component palette (#259)

### DIFF
--- a/app/tests/unit/test_component_palette.py
+++ b/app/tests/unit/test_component_palette.py
@@ -1,14 +1,14 @@
 """
 Unit tests for ComponentPalette.
 
-Tests component listing, signal emission on double-click,
-drag support configuration, and search filtering.
+Tests component listing, categories, signal emission on double-click,
+drag support configuration, search filtering, and collapse persistence.
 """
 
 import pytest
-from GUI.component_palette import ComponentPalette
+from GUI.component_palette import COMPONENT_CATEGORIES, ComponentPalette
 from GUI.styles import COMPONENTS
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import QSettings, Qt
 
 
 @pytest.fixture
@@ -22,39 +22,116 @@ class TestComponentPaletteContents:
     """Test that palette lists all expected components."""
 
     def test_lists_all_component_types(self, palette):
-        lw = palette.list_widget
-        item_texts = [lw.item(i).text() for i in range(lw.count())]
+        names = palette.get_component_names()
         for comp_type in COMPONENTS:
-            assert comp_type in item_texts
+            assert comp_type in names
 
-    def test_item_count_matches_components(self, palette):
-        assert palette.list_widget.count() == len(COMPONENTS)
+    def test_component_count_matches(self, palette):
+        assert len(palette.get_component_names()) == len(COMPONENTS)
 
     def test_items_have_icons(self, palette):
-        lw = palette.list_widget
-        for i in range(lw.count()):
-            assert not lw.item(i).icon().isNull()
+        for cat_item in palette._category_items.values():
+            for i in range(cat_item.childCount()):
+                assert not cat_item.child(i).icon(0).isNull()
+
+
+class TestComponentPaletteCategories:
+    """Test collapsible category groups."""
+
+    def test_has_expected_categories(self, palette):
+        assert palette.get_category_names() == list(COMPONENT_CATEGORIES.keys())
+
+    def test_all_categories_expanded_by_default(self, palette):
+        for category_name in COMPONENT_CATEGORIES:
+            assert palette.is_category_expanded(category_name)
+
+    def test_passive_category_contains_expected(self, palette):
+        cat = palette._category_items["Passive"]
+        children = [cat.child(i).text(0) for i in range(cat.childCount())]
+        assert children == ["Resistor", "Capacitor", "Inductor"]
+
+    def test_sources_category_contains_expected(self, palette):
+        cat = palette._category_items["Sources"]
+        children = [cat.child(i).text(0) for i in range(cat.childCount())]
+        assert children == ["Voltage Source", "Current Source", "Waveform Source"]
+
+    def test_semiconductors_category_contains_expected(self, palette):
+        cat = palette._category_items["Semiconductors"]
+        children = [cat.child(i).text(0) for i in range(cat.childCount())]
+        assert "Diode" in children
+        assert "BJT NPN" in children
+        assert "MOSFET NMOS" in children
+
+    def test_category_headers_are_bold(self, palette):
+        for cat_item in palette._category_items.values():
+            assert cat_item.font(0).bold()
+
+    def test_category_items_not_selectable(self, palette):
+        for cat_item in palette._category_items.values():
+            assert not (cat_item.flags() & Qt.ItemFlag.ItemIsSelectable)
+
+    def test_component_items_are_selectable(self, palette):
+        cat = palette._category_items["Passive"]
+        child = cat.child(0)
+        assert child.flags() & Qt.ItemFlag.ItemIsSelectable
+
+    def test_component_items_are_draggable(self, palette):
+        cat = palette._category_items["Passive"]
+        child = cat.child(0)
+        assert child.flags() & Qt.ItemFlag.ItemIsDragEnabled
+
+
+class TestComponentPaletteCollapseState:
+    """Test that collapse state persists via QSettings."""
+
+    def test_collapse_persists(self, palette, qtbot):
+        # Collapse the Passive category
+        palette._category_items["Passive"].setExpanded(False)
+        palette._save_collapse_state()
+
+        # Create a new palette - should restore collapsed state
+        p2 = ComponentPalette()
+        qtbot.addWidget(p2)
+        assert not p2.is_category_expanded("Passive")
+
+        # Clean up: restore default
+        settings = QSettings("SDSMT", "SDM Spice")
+        settings.remove("palette/collapsed/Passive")
+
+    def test_expand_persists(self, palette, qtbot):
+        # Ensure expanded state round-trips
+        palette._category_items["Sources"].setExpanded(True)
+        palette._save_collapse_state()
+
+        p2 = ComponentPalette()
+        qtbot.addWidget(p2)
+        assert p2.is_category_expanded("Sources")
 
 
 class TestComponentPaletteSignals:
     """Test signal emission on interaction."""
 
     def test_double_click_emits_component_type(self, palette, qtbot):
-        lw = palette.list_widget
-        first_item = lw.item(0)
+        cat = palette._category_items["Passive"]
+        first_child = cat.child(0)
         with qtbot.waitSignal(palette.componentDoubleClicked, timeout=1000) as blocker:
-            lw.itemDoubleClicked.emit(first_item)
-        assert blocker.args == [first_item.text()]
+            palette.tree_widget.itemDoubleClicked.emit(first_child, 0)
+        assert blocker.args == [first_child.text(0)]
+
+    def test_double_click_on_category_does_not_emit(self, palette, qtbot):
+        cat = palette._category_items["Passive"]
+        with qtbot.assertNotEmitted(palette.componentDoubleClicked):
+            palette.tree_widget.itemDoubleClicked.emit(cat, 0)
 
 
 class TestComponentPaletteDragConfig:
     """Test drag-and-drop configuration."""
 
     def test_drag_enabled(self, palette):
-        assert palette.list_widget.dragEnabled()
+        assert palette.tree_widget.dragEnabled()
 
     def test_default_drop_action_is_copy(self, palette):
-        assert palette.list_widget.defaultDropAction() == Qt.DropAction.CopyAction
+        assert palette.tree_widget.defaultDropAction() == Qt.DropAction.CopyAction
 
 
 class TestComponentPaletteSearch:
@@ -62,36 +139,44 @@ class TestComponentPaletteSearch:
 
     def test_filter_hides_non_matching(self, palette):
         palette.search_input.setText("resistor")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = palette.get_visible_component_names()
         assert "Resistor" in visible
         assert "Capacitor" not in visible
 
     def test_filter_is_case_insensitive(self, palette):
         palette.search_input.setText("CAPACITOR")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = palette.get_visible_component_names()
         assert "Capacitor" in visible
 
     def test_empty_filter_shows_all(self, palette):
         palette.search_input.setText("xyz")
         palette.search_input.setText("")
-        lw = palette.list_widget
-        visible_count = sum(1 for i in range(lw.count()) if not lw.item(i).isHidden())
-        assert visible_count == len(COMPONENTS)
+        visible = palette.get_visible_component_names()
+        assert len(visible) == len(COMPONENTS)
 
     def test_filter_matches_tooltip(self, palette):
         # "Resists" appears in the Resistor tooltip
         palette.search_input.setText("resists")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = palette.get_visible_component_names()
         assert "Resistor" in visible
 
     def test_filter_no_matches(self, palette):
         palette.search_input.setText("xyznonexistent")
-        lw = palette.list_widget
-        visible_count = sum(1 for i in range(lw.count()) if not lw.item(i).isHidden())
-        assert visible_count == 0
+        visible = palette.get_visible_component_names()
+        assert len(visible) == 0
 
     def test_search_input_has_placeholder(self, palette):
         assert "filter" in palette.search_input.placeholderText().lower()
+
+    def test_filter_auto_expands_matching_category(self, palette):
+        # Collapse Passive, then search for "resistor" - should auto-expand
+        palette._category_items["Passive"].setExpanded(False)
+        palette.search_input.setText("resistor")
+        assert palette.is_category_expanded("Passive")
+
+    def test_filter_hides_empty_categories(self, palette):
+        palette.search_input.setText("resistor")
+        # Semiconductors should be hidden (no matches)
+        assert palette._category_items["Semiconductors"].isHidden()
+        # Passive should be visible
+        assert not palette._category_items["Passive"].isHidden()

--- a/app/tests/unit/test_qtbot_widget_interactions.py
+++ b/app/tests/unit/test_qtbot_widget_interactions.py
@@ -123,15 +123,13 @@ class TestComponentPaletteInteractions:
     def test_search_for_op_amp(self, palette):
         """Searching 'op' shows Op-Amp."""
         palette.search_input.setText("op")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = palette.get_visible_component_names()
         assert "Op-Amp" in visible
 
     def test_search_for_diode(self, palette):
         """Searching 'diode' shows Diode, LED, and Zener Diode."""
         palette.search_input.setText("diode")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = palette.get_visible_component_names()
         assert "Diode" in visible
         assert "Zener Diode" in visible
 
@@ -139,9 +137,8 @@ class TestComponentPaletteInteractions:
         """Clearing search shows all items again."""
         palette.search_input.setText("xyz_no_match")
         palette.search_input.clear()
-        lw = palette.list_widget
-        visible = sum(1 for i in range(lw.count()) if not lw.item(i).isHidden())
-        assert visible == lw.count()
+        visible = palette.get_visible_component_names()
+        assert len(visible) == len(palette.get_component_names())
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary - Replace flat  with  organized into 5 collapsible categories: Passive, Sources, Semiconductors, Controlled Sources, Other - Category expand/collapse state persists across sessions via QSettings - Search filter auto-expands matching categories and hides empty ones - Drag-and-drop and double-click placement still work as before - 26 unit tests (12 new for categories and collapse persistence) Closes #259 ## Test plan - [x] All 2506 existing tests pass (0 failures) - [x] 26 palette-specific tests pass including new category/collapse tests - [ ] Manual: verify categories expand/collapse with click - [ ] Manual: verify collapse state persists across app restart - [ ] Manual: verify search auto-expands matching categories - [ ] Manual: verify drag-and-drop from categorized palette to canvas 🤖 Generated with [Claude Code](https://claude.com/claude-code)