### PR TITLE
add pinned favorites in component palette (#260)

### DIFF
--- a/app/tests/unit/test_component_palette.py
+++ b/app/tests/unit/test_component_palette.py
@@ -1,8 +1,9 @@
 """
 Unit tests for ComponentPalette.
 
-Tests component listing, categories, signal emission on double-click,
-drag support configuration, search filtering, and collapse persistence.
+Tests component listing, categories, pinned favorites, signal emission
+on double-click, drag support configuration, search filtering, and
+collapse persistence.
 """
 
 import pytest
@@ -13,6 +14,8 @@ from PyQt6.QtCore import QSettings, Qt
 
 @pytest.fixture
 def palette(qtbot):
+    # Clean up any leftover favorites from prior runs
+    QSettings("SDSMT", "SDM Spice").remove("palette/favorites")
     p = ComponentPalette()
     qtbot.addWidget(p)
     return p
@@ -30,7 +33,7 @@ class TestComponentPaletteContents:
         assert len(palette.get_component_names()) == len(COMPONENTS)
 
     def test_items_have_icons(self, palette):
-        for cat_item in palette._category_items.values():
+        for cat_name, cat_item in palette._category_items.items():
             for i in range(cat_item.childCount()):
                 assert not cat_item.child(i).icon(0).isNull()
 
@@ -85,27 +88,120 @@ class TestComponentPaletteCollapseState:
     """Test that collapse state persists via QSettings."""
 
     def test_collapse_persists(self, palette, qtbot):
-        # Collapse the Passive category
         palette._category_items["Passive"].setExpanded(False)
         palette._save_collapse_state()
 
-        # Create a new palette - should restore collapsed state
         p2 = ComponentPalette()
         qtbot.addWidget(p2)
         assert not p2.is_category_expanded("Passive")
 
-        # Clean up: restore default
         settings = QSettings("SDSMT", "SDM Spice")
         settings.remove("palette/collapsed/Passive")
 
     def test_expand_persists(self, palette, qtbot):
-        # Ensure expanded state round-trips
         palette._category_items["Sources"].setExpanded(True)
         palette._save_collapse_state()
 
         p2 = ComponentPalette()
         qtbot.addWidget(p2)
         assert p2.is_category_expanded("Sources")
+
+
+class TestComponentPaletteFavorites:
+    """Test pinned favorites functionality."""
+
+    def test_no_favorites_by_default(self, palette):
+        assert palette.get_favorites() == []
+
+    def test_favorites_section_hidden_when_empty(self, palette):
+        assert palette._favorites_item.isHidden()
+
+    def test_favorites_not_in_category_names_when_empty(self, palette):
+        assert "Favorites" not in palette.get_category_names()
+
+    def test_pin_favorite(self, palette):
+        palette._pin_favorite("Resistor")
+        assert "Resistor" in palette.get_favorites()
+        assert not palette._favorites_item.isHidden()
+
+        # Clean up
+        QSettings("SDSMT", "SDM Spice").remove("palette/favorites")
+
+    def test_unpin_favorite(self, palette):
+        palette._pin_favorite("Resistor")
+        palette._unpin_favorite("Resistor")
+        assert "Resistor" not in palette.get_favorites()
+        assert palette._favorites_item.isHidden()
+
+        QSettings("SDSMT", "SDM Spice").remove("palette/favorites")
+
+    def test_favorites_appear_in_category_names(self, palette):
+        palette._pin_favorite("Capacitor")
+        assert "Favorites" in palette.get_category_names()
+
+        QSettings("SDSMT", "SDM Spice").remove("palette/favorites")
+
+    def test_favorite_has_icon(self, palette):
+        palette._pin_favorite("Resistor")
+        fav_child = palette._favorites_item.child(0)
+        assert not fav_child.icon(0).isNull()
+
+        QSettings("SDSMT", "SDM Spice").remove("palette/favorites")
+
+    def test_favorite_has_tooltip(self, palette):
+        palette._pin_favorite("Resistor")
+        fav_child = palette._favorites_item.child(0)
+        assert "Resists" in fav_child.toolTip(0)
+
+        QSettings("SDSMT", "SDM Spice").remove("palette/favorites")
+
+    def test_favorites_persist_across_instances(self, palette, qtbot):
+        palette._pin_favorite("Inductor")
+
+        p2 = ComponentPalette()
+        qtbot.addWidget(p2)
+        assert "Inductor" in p2.get_favorites()
+        assert not p2._favorites_item.isHidden()
+
+        QSettings("SDSMT", "SDM Spice").remove("palette/favorites")
+
+    def test_duplicate_pin_ignored(self, palette):
+        palette._pin_favorite("Resistor")
+        palette._pin_favorite("Resistor")
+        assert palette.get_favorites().count("Resistor") == 1
+
+        QSettings("SDSMT", "SDM Spice").remove("palette/favorites")
+
+    def test_favorites_section_is_expanded(self, palette):
+        palette._pin_favorite("Resistor")
+        assert palette.is_category_expanded("Favorites")
+
+        QSettings("SDSMT", "SDM Spice").remove("palette/favorites")
+
+    def test_component_still_in_original_category(self, palette):
+        palette._pin_favorite("Resistor")
+        # Resistor should still be in Passive
+        cat = palette._category_items["Passive"]
+        children = [cat.child(i).text(0) for i in range(cat.childCount())]
+        assert "Resistor" in children
+
+        QSettings("SDSMT", "SDM Spice").remove("palette/favorites")
+
+    def test_double_click_on_favorite_emits_signal(self, palette, qtbot):
+        palette._pin_favorite("Capacitor")
+        fav_child = palette._favorites_item.child(0)
+        with qtbot.waitSignal(palette.componentDoubleClicked, timeout=1000) as blocker:
+            palette.tree_widget.itemDoubleClicked.emit(fav_child, 0)
+        assert blocker.args == ["Capacitor"]
+
+        QSettings("SDSMT", "SDM Spice").remove("palette/favorites")
+
+    def test_favorite_items_are_draggable(self, palette):
+        palette._pin_favorite("Resistor")
+        fav_child = palette._favorites_item.child(0)
+        assert fav_child.flags() & Qt.ItemFlag.ItemIsDragEnabled
+
+        QSettings("SDSMT", "SDM Spice").remove("palette/favorites")
 
 
 class TestComponentPaletteSignals:
@@ -155,7 +251,6 @@ class TestComponentPaletteSearch:
         assert len(visible) == len(COMPONENTS)
 
     def test_filter_matches_tooltip(self, palette):
-        # "Resists" appears in the Resistor tooltip
         palette.search_input.setText("resists")
         visible = palette.get_visible_component_names()
         assert "Resistor" in visible
@@ -169,14 +264,21 @@ class TestComponentPaletteSearch:
         assert "filter" in palette.search_input.placeholderText().lower()
 
     def test_filter_auto_expands_matching_category(self, palette):
-        # Collapse Passive, then search for "resistor" - should auto-expand
         palette._category_items["Passive"].setExpanded(False)
         palette.search_input.setText("resistor")
         assert palette.is_category_expanded("Passive")
 
     def test_filter_hides_empty_categories(self, palette):
         palette.search_input.setText("resistor")
-        # Semiconductors should be hidden (no matches)
         assert palette._category_items["Semiconductors"].isHidden()
-        # Passive should be visible
         assert not palette._category_items["Passive"].isHidden()
+
+    def test_search_includes_favorites(self, palette):
+        palette._pin_favorite("Resistor")
+        palette.search_input.setText("resistor")
+        # Favorites section should be visible with matching favorite
+        assert not palette._favorites_item.isHidden()
+        fav_child = palette._favorites_item.child(0)
+        assert not fav_child.isHidden()
+
+        QSettings("SDSMT", "SDM Spice").remove("palette/favorites")


### PR DESCRIPTION
## Summary - Right-click any component to Pin/Unpin from Favorites - Favorites section appears at top of palette when non-empty, auto-hides when empty - Pinned components remain in their original categories - Favorites persist across sessions via QSettings - Search filter includes favorites section - Double-click and drag-and-drop work from favorites - 15 new unit tests for favorites functionality (41 total palette tests) Closes #260 Stacked on PR #415 (#259 collapsible categories) ## Test plan - [x] All 2521 tests pass (0 failures, 15 new) - [ ] Manual: right-click component > Pin to Favorites - [ ] Manual: verify Favorites section appears at top - [ ] Manual: right-click pinned > Unpin from Favorites - [ ] Manual: verify favorites persist after app restart - [ ] Manual: verify drag-and-drop from favorites to canvas 🤖 Generated with [Claude Code](https://claude.com/claude-code)