### PR TITLE
Add waveform math expressions for computed plots (#236)

### DIFF
--- a/app/simulation/waveform_math.py
+++ b/app/simulation/waveform_math.py
@@ -1,0 +1,261 @@
+"""
+simulation/waveform_math.py
+
+Evaluate user-supplied math expressions over simulation result vectors.
+
+Expressions use Python-style syntax with simulation variable references:
+    v(out) - v(in)
+    abs(v(out))
+    20 * log10(abs(v(out)))
+    v(out) * i(R1)
+    (v(out) - v(in)) / v(in) * 100
+
+Pure Python — no Qt dependencies.
+"""
+
+import ast
+import logging
+import math
+import operator
+import re
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Safe math functions available in expressions
+_MATH_FUNCTIONS = {
+    "abs": abs,
+    "sqrt": math.sqrt,
+    "log": math.log,
+    "log10": math.log10,
+    "log2": math.log2,
+    "exp": math.exp,
+    "sin": math.sin,
+    "cos": math.cos,
+    "tan": math.tan,
+    "asin": math.asin,
+    "acos": math.acos,
+    "atan": math.atan,
+    "atan2": math.atan2,
+    "pow": pow,
+    "max": max,
+    "min": min,
+    "pi": math.pi,
+    "e": math.e,
+}
+
+# Safe binary operators
+_BINOPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+
+# Safe unary operators
+_UNARYOPS = {
+    ast.USub: operator.neg,
+    ast.UAdd: operator.pos,
+}
+
+# Pattern matching v(name) or i(name) references in expression text
+_VAR_REF_PATTERN = re.compile(r"\b([vi])\(([^)]+)\)")
+
+
+def _normalize_var_ref(match: re.Match) -> str:
+    """Convert v(out) -> __v_out__, i(R1) -> __i_R1__ for valid Python identifiers."""
+    prefix = match.group(1)
+    name = match.group(2)
+    safe_name = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+    return f"__{prefix}_{safe_name}__"
+
+
+def _preprocess_expression(expr: str) -> str:
+    """Convert SPICE-style variable references to Python identifiers."""
+    return _VAR_REF_PATTERN.sub(_normalize_var_ref, expr)
+
+
+def extract_variable_refs(expr: str) -> list[str]:
+    """
+    Extract all v(...) and i(...) references from an expression.
+
+    Returns a list of original reference strings, e.g. ["v(out)", "i(R1)"].
+    """
+    return [f"{m.group(1)}({m.group(2)})" for m in _VAR_REF_PATTERN.finditer(expr)]
+
+
+class _SafeEvaluator(ast.NodeVisitor):
+    """
+    Evaluate an AST safely with only whitelisted operations.
+
+    Variables are resolved from a provided namespace dict.
+    """
+
+    def __init__(self, namespace: dict[str, float]):
+        self._ns = namespace
+
+    def visit_Expression(self, node: ast.Expression) -> float:
+        return self.visit(node.body)
+
+    def visit_Constant(self, node: ast.Constant) -> float:
+        if isinstance(node.value, (int, float)):
+            return float(node.value)
+        raise ValueError(f"Unsupported constant type: {type(node.value).__name__}")
+
+    def visit_Name(self, node: ast.Name) -> float:
+        name = node.id
+        if name in self._ns:
+            return self._ns[name]
+        if name in _MATH_FUNCTIONS:
+            return _MATH_FUNCTIONS[name]
+        raise ValueError(f"Unknown variable: {name}")
+
+    def visit_BinOp(self, node: ast.BinOp) -> float:
+        op_type = type(node.op)
+        if op_type not in _BINOPS:
+            raise ValueError(f"Unsupported operator: {op_type.__name__}")
+        left = self.visit(node.left)
+        right = self.visit(node.right)
+        return _BINOPS[op_type](left, right)
+
+    def visit_UnaryOp(self, node: ast.UnaryOp) -> float:
+        op_type = type(node.op)
+        if op_type not in _UNARYOPS:
+            raise ValueError(f"Unsupported unary operator: {op_type.__name__}")
+        return _UNARYOPS[op_type](self.visit(node.operand))
+
+    def visit_Call(self, node: ast.Call) -> float:
+        func = self.visit(node.func)
+        if not callable(func):
+            raise ValueError(f"Not a callable: {node.func}")
+        args = [self.visit(arg) for arg in node.args]
+        if node.keywords:
+            raise ValueError("Keyword arguments are not supported")
+        return func(*args)
+
+    def generic_visit(self, node: ast.AST) -> float:
+        raise ValueError(f"Unsupported expression element: {type(node).__name__}")
+
+
+def evaluate_expression(
+    expr: str,
+    variables: dict[str, float],
+) -> float:
+    """
+    Evaluate a single scalar expression.
+
+    Args:
+        expr: Math expression string, e.g. ``"v(out) - v(in)"``
+        variables: Mapping of variable references to values.
+                   Keys should be the original SPICE-style refs like ``"v(out)"``.
+
+    Returns:
+        The computed float result.
+
+    Raises:
+        ValueError: If the expression is invalid or references unknown variables.
+    """
+    # Build internal namespace: convert v(out) -> __v_out__ keys
+    namespace: dict[str, float] = {}
+    for ref, value in variables.items():
+        m = _VAR_REF_PATTERN.fullmatch(ref)
+        if m:
+            internal = _normalize_var_ref(m)
+            namespace[internal] = float(value)
+        else:
+            namespace[ref] = float(value)
+
+    # Add math constants
+    namespace["pi"] = math.pi
+    namespace["e"] = math.e
+
+    preprocessed = _preprocess_expression(expr)
+
+    try:
+        tree = ast.parse(preprocessed, mode="eval")
+    except SyntaxError as e:
+        raise ValueError(f"Invalid expression syntax: {e}") from e
+
+    evaluator = _SafeEvaluator(namespace)
+    return evaluator.visit(tree)
+
+
+def evaluate_expression_over_vectors(
+    expr: str,
+    vector_data: dict[str, list[float]],
+) -> list[float]:
+    """
+    Evaluate an expression point-by-point over aligned vectors.
+
+    Args:
+        expr: Math expression string, e.g. ``"v(out) - v(in)"``
+        vector_data: Mapping of variable references to lists of float values.
+                     All lists must have the same length.
+
+    Returns:
+        List of computed float values, one per data point.
+
+    Raises:
+        ValueError: If vectors have mismatched lengths, expression is invalid, etc.
+    """
+    if not vector_data:
+        raise ValueError("No vector data provided")
+
+    lengths = {k: len(v) for k, v in vector_data.items()}
+    unique_lengths = set(lengths.values())
+    if len(unique_lengths) > 1:
+        raise ValueError(f"Vector length mismatch: {lengths}")
+
+    n = next(iter(unique_lengths))
+    results = []
+
+    for i in range(n):
+        point_vars = {k: v[i] for k, v in vector_data.items()}
+        results.append(evaluate_expression(expr, point_vars))
+
+    return results
+
+
+def validate_expression(expr: str, available_vars: Optional[list[str]] = None) -> list[str]:
+    """
+    Check an expression for errors without evaluating it.
+
+    Args:
+        expr: The expression string to validate.
+        available_vars: Optional list of variable names that are valid
+                        (e.g. ``["v(out)", "v(in)", "i(R1)"]``).
+
+    Returns:
+        List of error strings. Empty list means the expression is valid.
+    """
+    errors = []
+
+    if not expr or not expr.strip():
+        return ["Expression is empty"]
+
+    # Check for referenced variables
+    refs = extract_variable_refs(expr)
+    if available_vars is not None:
+        for ref in refs:
+            if ref not in available_vars:
+                errors.append(f"Unknown variable: {ref}")
+
+    # Check syntax
+    preprocessed = _preprocess_expression(expr)
+    try:
+        tree = ast.parse(preprocessed, mode="eval")
+    except SyntaxError as e:
+        errors.append(f"Syntax error: {e}")
+        return errors
+
+    # Walk the AST to check for unsupported constructs
+    for node in ast.walk(tree):
+        if isinstance(node, ast.BinOp) and type(node.op) not in _BINOPS:
+            errors.append(f"Unsupported operator: {type(node.op).__name__}")
+        if isinstance(node, ast.UnaryOp) and type(node.op) not in _UNARYOPS:
+            errors.append(f"Unsupported unary operator: {type(node.op).__name__}")
+
+    return errors

--- a/app/tests/unit/test_waveform_math.py
+++ b/app/tests/unit/test_waveform_math.py
@@ -1,0 +1,219 @@
+"""Tests for simulation.waveform_math — expression evaluation over sim vectors."""
+
+import importlib
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import directly to bypass simulation/__init__.py (headless matplotlib issue).
+_mod_path = Path(__file__).resolve().parent.parent.parent / "simulation" / "waveform_math.py"
+_spec = importlib.util.spec_from_file_location("simulation.waveform_math", _mod_path)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules.setdefault("simulation.waveform_math", _mod)
+_spec.loader.exec_module(_mod)
+
+evaluate_expression = _mod.evaluate_expression
+evaluate_expression_over_vectors = _mod.evaluate_expression_over_vectors
+extract_variable_refs = _mod.extract_variable_refs
+validate_expression = _mod.validate_expression
+
+
+# ---------------------------------------------------------------------------
+# extract_variable_refs
+# ---------------------------------------------------------------------------
+
+
+class TestExtractVariableRefs:
+    def test_simple_voltage(self):
+        assert extract_variable_refs("v(out)") == ["v(out)"]
+
+    def test_multiple_refs(self):
+        refs = extract_variable_refs("v(out) - v(in)")
+        assert refs == ["v(out)", "v(in)"]
+
+    def test_current_ref(self):
+        refs = extract_variable_refs("i(R1)")
+        assert refs == ["i(R1)"]
+
+    def test_mixed(self):
+        refs = extract_variable_refs("v(out) * i(R1)")
+        assert "v(out)" in refs
+        assert "i(R1)" in refs
+
+    def test_no_refs(self):
+        assert extract_variable_refs("1 + 2") == []
+
+    def test_nested_expression(self):
+        refs = extract_variable_refs("abs(v(out))")
+        assert refs == ["v(out)"]
+
+
+# ---------------------------------------------------------------------------
+# evaluate_expression — scalar
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateExpression:
+    def test_simple_subtraction(self):
+        result = evaluate_expression("v(out) - v(in)", {"v(out)": 5.0, "v(in)": 2.0})
+        assert result == pytest.approx(3.0)
+
+    def test_multiplication(self):
+        result = evaluate_expression("v(out) * i(R1)", {"v(out)": 5.0, "i(R1)": 0.01})
+        assert result == pytest.approx(0.05)
+
+    def test_abs_function(self):
+        result = evaluate_expression("abs(v(out))", {"v(out)": -3.5})
+        assert result == pytest.approx(3.5)
+
+    def test_log10(self):
+        result = evaluate_expression("log10(v(out))", {"v(out)": 1000.0})
+        assert result == pytest.approx(3.0)
+
+    def test_db_conversion(self):
+        result = evaluate_expression("20 * log10(abs(v(out)))", {"v(out)": 10.0})
+        assert result == pytest.approx(20.0)
+
+    def test_sqrt(self):
+        result = evaluate_expression("sqrt(v(out))", {"v(out)": 9.0})
+        assert result == pytest.approx(3.0)
+
+    def test_trig_sin(self):
+        result = evaluate_expression("sin(v(phase))", {"v(phase)": math.pi / 2})
+        assert result == pytest.approx(1.0)
+
+    def test_constant_pi(self):
+        result = evaluate_expression("pi", {})
+        assert result == pytest.approx(math.pi)
+
+    def test_constant_e(self):
+        result = evaluate_expression("e", {})
+        assert result == pytest.approx(math.e)
+
+    def test_parenthesized(self):
+        result = evaluate_expression("(v(a) + v(b)) / 2", {"v(a)": 10.0, "v(b)": 6.0})
+        assert result == pytest.approx(8.0)
+
+    def test_power(self):
+        result = evaluate_expression("v(x) ** 2", {"v(x)": 3.0})
+        assert result == pytest.approx(9.0)
+
+    def test_unary_neg(self):
+        result = evaluate_expression("-v(out)", {"v(out)": 5.0})
+        assert result == pytest.approx(-5.0)
+
+    def test_complex_expression(self):
+        # (v(out) - v(in)) / v(in) * 100  — percentage gain
+        result = evaluate_expression(
+            "(v(out) - v(in)) / v(in) * 100",
+            {"v(out)": 11.0, "v(in)": 10.0},
+        )
+        assert result == pytest.approx(10.0)
+
+    def test_unknown_variable_raises(self):
+        with pytest.raises(ValueError, match="Unknown variable"):
+            evaluate_expression("v(missing)", {})
+
+    def test_syntax_error_raises(self):
+        with pytest.raises(ValueError, match="Invalid expression syntax"):
+            evaluate_expression("v(out) +", {"v(out)": 1.0})
+
+    def test_bare_number(self):
+        result = evaluate_expression("42", {})
+        assert result == pytest.approx(42.0)
+
+    def test_nested_function_calls(self):
+        result = evaluate_expression("abs(sqrt(v(x)))", {"v(x)": 16.0})
+        assert result == pytest.approx(4.0)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_expression_over_vectors
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateOverVectors:
+    def test_basic_vector_subtraction(self):
+        data = {
+            "v(out)": [5.0, 6.0, 7.0],
+            "v(in)": [2.0, 2.0, 2.0],
+        }
+        result = evaluate_expression_over_vectors("v(out) - v(in)", data)
+        assert result == pytest.approx([3.0, 4.0, 5.0])
+
+    def test_power_calculation(self):
+        data = {
+            "v(out)": [10.0, 20.0],
+            "i(R1)": [0.1, 0.2],
+        }
+        result = evaluate_expression_over_vectors("v(out) * i(R1)", data)
+        assert result == pytest.approx([1.0, 4.0])
+
+    def test_empty_data_raises(self):
+        with pytest.raises(ValueError, match="No vector data"):
+            evaluate_expression_over_vectors("v(out)", {})
+
+    def test_mismatched_lengths_raises(self):
+        data = {
+            "v(out)": [1.0, 2.0, 3.0],
+            "v(in)": [1.0, 2.0],
+        }
+        with pytest.raises(ValueError, match="length mismatch"):
+            evaluate_expression_over_vectors("v(out) - v(in)", data)
+
+    def test_single_point(self):
+        data = {"v(x)": [42.0]}
+        result = evaluate_expression_over_vectors("v(x) * 2", data)
+        assert result == pytest.approx([84.0])
+
+    def test_db_conversion_vector(self):
+        data = {"v(out)": [1.0, 10.0, 100.0]}
+        result = evaluate_expression_over_vectors("20 * log10(v(out))", data)
+        assert result == pytest.approx([0.0, 20.0, 40.0])
+
+
+# ---------------------------------------------------------------------------
+# validate_expression
+# ---------------------------------------------------------------------------
+
+
+class TestValidateExpression:
+    def test_valid_simple(self):
+        errors = validate_expression("v(out) - v(in)", available_vars=["v(out)", "v(in)"])
+        assert errors == []
+
+    def test_empty_expression(self):
+        errors = validate_expression("")
+        assert len(errors) == 1
+        assert "empty" in errors[0].lower()
+
+    def test_whitespace_only(self):
+        errors = validate_expression("   ")
+        assert len(errors) == 1
+
+    def test_unknown_variable(self):
+        errors = validate_expression("v(missing)", available_vars=["v(out)"])
+        assert any("Unknown variable" in e for e in errors)
+
+    def test_syntax_error(self):
+        errors = validate_expression("v(out) +")
+        assert any("Syntax error" in e or "syntax" in e.lower() for e in errors)
+
+    def test_valid_without_available_vars(self):
+        # When available_vars is None, variable checking is skipped
+        errors = validate_expression("v(anything)")
+        assert errors == []
+
+    def test_multiple_errors(self):
+        errors = validate_expression("v(a) + v(b)", available_vars=["v(c)"])
+        assert len(errors) == 2  # both v(a) and v(b) unknown
+
+    def test_pure_math(self):
+        errors = validate_expression("1 + 2 * 3")
+        assert errors == []
+
+    def test_function_call_valid(self):
+        errors = validate_expression("abs(v(out))", available_vars=["v(out)"])
+        assert errors == []


### PR DESCRIPTION
## Summary - Adds waveform_math module with safe AST-based expression evaluator for computing derived quantities from simulation result vectors - Supports SPICE-style v()/i() variable references, standard math functions (abs, sqrt, log10, trig, etc.), and constants (pi, e) - Provides point-by-point vector evaluation and expression validation utility - 38 new tests covering variable extraction, scalar evaluation, vector evaluation, and validation ## Test plan - [x] All 38 new tests pass - [x] Existing tests unaffected - [ ] Manual: evaluate expressions like 'v(out) - v(in)' and '20*log10(abs(v(out)))' against real simulation data Closes #236