### PR TITLE
persist wire waypoints across save/load (#261)

### DIFF
--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -67,7 +67,11 @@ class WireGraphicsItem(QGraphicsPathItem):
         self.setPen(QPen(self.layer_color, theme_manager.wire_thickness_px))
         self.setFlag(QGraphicsPathItem.GraphicsItemFlag.ItemIsSelectable)
         self.setZValue(1)  # Render wires above components (z=0)
-        self.update_position()
+
+        if self.model.waypoints:
+            self._restore_waypoints()
+        else:
+            self.update_position()
 
     # --- Data delegation properties ---
 
@@ -211,6 +215,16 @@ class WireGraphicsItem(QGraphicsPathItem):
             self.scene().update(self.boundingRect())
 
         self.update()  # Force item redraw
+
+    def _restore_waypoints(self):
+        """Restore wire path from persisted waypoints without running pathfinding."""
+        self.waypoints = [QPointF(x, y) for x, y in self.model.waypoints]
+        path = QPainterPath()
+        if self.waypoints:
+            path.moveTo(self.waypoints[0])
+            for waypoint in self.waypoints[1:]:
+                path.lineTo(waypoint)
+        self.setPath(path)
 
     def _notify_routing_failed(self):
         """Show status bar message when wire routing fails."""

--- a/app/models/wire.py
+++ b/app/models/wire.py
@@ -55,28 +55,34 @@ class WireData:
         Serialize wire to dictionary.
 
         Format matches the existing JSON circuit file format for compatibility.
-        Note: waypoints are NOT serialized (they are recomputed on load).
+        Waypoints are persisted so wire layouts survive save/load.
         """
-        return {
+        data = {
             "start_comp": self.start_component_id,
             "start_term": self.start_terminal,
             "end_comp": self.end_component_id,
             "end_term": self.end_terminal,
         }
+        if self.waypoints:
+            data["waypoints"] = [[x, y] for x, y in self.waypoints]
+        return data
 
     @classmethod
     def from_dict(cls, data: dict) -> "WireData":
         """
         Deserialize wire from dictionary.
 
-        Handles the existing JSON circuit file format.
+        Handles both old format (no waypoints) and new format (with waypoints).
         """
-        return cls(
+        wire = cls(
             start_component_id=data["start_comp"],
             start_terminal=data["start_term"],
             end_component_id=data["end_comp"],
             end_terminal=data["end_term"],
         )
+        if "waypoints" in data:
+            wire.waypoints = [(float(x), float(y)) for x, y in data["waypoints"]]
+        return wire
 
     def __repr__(self) -> str:
         return (


### PR DESCRIPTION
## Summary - Serialize wire waypoints in WireData.to_dict() as [[x, y], ...] lists - Deserialize waypoints in from_dict() with backward compatibility for old files - WireGraphicsItem skips pathfinding when model has persisted waypoints, using _restore_waypoints() instead - Old circuit files without waypoints continue to work (waypoints recomputed via pathfinding) - Waypoints only included in JSON when non-empty (no bloat for empty waypoints) - 5 new unit tests covering round-trip, file persistence, backward compatibility Closes #261 ## Test plan - [x] All 2497 tests pass (0 failures, 5 new) - [ ] Manual: save circuit with wires, reload — wire paths should be identical - [ ] Manual: load old circuit file (no waypoints) — wires reroute as before - [ ] Manual: move a component, wires reroute; save/load preserves new paths 🤖 Generated with [Claude Code](https://claude.com/claude-code)