### PR TITLE
Add rubric auto-generation from reference circuit (#369)

### DIFF
--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -473,6 +473,13 @@ class MenuBarMixin:
             create_rubric_action.triggered.connect(self._on_create_rubric)
             instructor_menu.addAction(create_rubric_action)
 
+            generate_rubric_action = QAction("&Generate Rubric from Circuit...", self)
+            generate_rubric_action.setToolTip(
+                "Auto-generate a rubric from the current circuit and open it in the editor"
+            )
+            generate_rubric_action.triggered.connect(self._on_generate_rubric)
+            instructor_menu.addAction(generate_rubric_action)
+
             instructor_menu.addSeparator()
 
             grade_action = QAction("&Grade Student Circuit...", self)

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -73,6 +73,24 @@ class ViewOperationsMixin:
         dialog = RubricEditorDialog(parent=self)
         dialog.exec()
 
+    def _on_generate_rubric(self):
+        """Auto-generate a rubric from the current canvas circuit."""
+        from .rubric_editor_dialog import RubricEditorDialog
+
+        if not self.model.components:
+            QMessageBox.information(
+                self,
+                "Generate Rubric",
+                "The canvas is empty. Build a reference circuit first.",
+            )
+            return
+
+        from grading.rubric_generator import generate_rubric
+
+        rubric = generate_rubric(self.model, title="Auto-Generated Rubric")
+        dialog = RubricEditorDialog(rubric=rubric, parent=self)
+        dialog.exec()
+
     # Dirty flag (unsaved changes indicator)
 
     def _on_dirty_change(self, event: str, data) -> None:

--- a/app/grading/rubric_generator.py
+++ b/app/grading/rubric_generator.py
@@ -1,0 +1,164 @@
+"""Auto-generate a rubric skeleton from a reference circuit.
+
+Analyzes a CircuitModel to produce checks for component existence,
+component values, topology connections, ground presence, and analysis type.
+
+No Qt dependencies — pure Python module.
+"""
+
+from models.circuit import CircuitModel
+from models.component import DEFAULT_VALUES
+
+from .rubric import Rubric, RubricCheck
+
+
+def generate_rubric(
+    circuit: CircuitModel,
+    title: str = "Auto-Generated Rubric",
+) -> Rubric:
+    """Generate a rubric skeleton from a reference circuit.
+
+    Creates the following checks:
+    - ``component_exists`` for each non-ground component
+    - ``component_value`` for each component whose value differs from the
+      type default (i.e. the instructor intentionally set it)
+    - ``topology`` for each wire connection between two non-ground components
+    - ``ground`` if a ground component is present
+    - ``analysis_type`` if the circuit uses a non-default analysis
+
+    Points are distributed equally across all generated checks (at least 1
+    each).  The instructor is expected to open the result in the rubric
+    editor and adjust points and feedback.
+
+    Args:
+        circuit: The reference solution circuit.
+        title: Title for the generated rubric.
+
+    Returns:
+        A Rubric populated with auto-generated checks.
+    """
+    checks: list[RubricCheck] = []
+    used_ids: set[str] = set()
+
+    def _unique_id(base: str) -> str:
+        candidate = base
+        n = 2
+        while candidate in used_ids:
+            candidate = f"{base}_{n}"
+            n += 1
+        used_ids.add(candidate)
+        return candidate
+
+    # --- component_exists checks ---
+    for comp in sorted(circuit.components.values(), key=lambda c: c.component_id):
+        if comp.component_type == "Ground":
+            continue
+        check_id = _unique_id(f"exists_{comp.component_id}")
+        checks.append(
+            RubricCheck(
+                check_id=check_id,
+                check_type="component_exists",
+                points=1,
+                params={
+                    "component_id": comp.component_id,
+                    "component_type": comp.component_type,
+                },
+                feedback_pass=f"{comp.component_id} ({comp.component_type}) found.",
+                feedback_fail=f"Missing {comp.component_id} ({comp.component_type}).",
+            )
+        )
+
+    # --- component_value checks ---
+    for comp in sorted(circuit.components.values(), key=lambda c: c.component_id):
+        if comp.component_type == "Ground":
+            continue
+        default = DEFAULT_VALUES.get(comp.component_type, "")
+        if comp.value and comp.value != default:
+            check_id = _unique_id(f"value_{comp.component_id}")
+            checks.append(
+                RubricCheck(
+                    check_id=check_id,
+                    check_type="component_value",
+                    points=1,
+                    params={
+                        "component_id": comp.component_id,
+                        "expected_value": comp.value,
+                        "tolerance_pct": 5.0,
+                    },
+                    feedback_pass=f"{comp.component_id} has correct value ({comp.value}).",
+                    feedback_fail=f"{comp.component_id} value should be {comp.value}.",
+                )
+            )
+
+    # --- topology checks (from wire connections between non-ground components) ---
+    seen_pairs: set[tuple[str, str]] = set()
+    for wire in circuit.wires:
+        a = wire.start_component_id
+        b = wire.end_component_id
+        if a == b:
+            continue
+        comp_a = circuit.components.get(a)
+        comp_b = circuit.components.get(b)
+        if comp_a is None or comp_b is None:
+            continue
+        if comp_a.component_type == "Ground" or comp_b.component_type == "Ground":
+            continue
+        pair = tuple(sorted([a, b]))
+        if pair in seen_pairs:
+            continue
+        seen_pairs.add(pair)
+        check_id = _unique_id(f"connected_{pair[0]}_{pair[1]}")
+        checks.append(
+            RubricCheck(
+                check_id=check_id,
+                check_type="topology",
+                points=1,
+                params={
+                    "component_a": pair[0],
+                    "component_b": pair[1],
+                    "shared_node": True,
+                },
+                feedback_pass=f"{pair[0]} and {pair[1]} are connected.",
+                feedback_fail=f"{pair[0]} and {pair[1]} should be connected.",
+            )
+        )
+
+    # --- ground check ---
+    has_ground = any(c.component_type == "Ground" for c in circuit.components.values())
+    if has_ground:
+        check_id = _unique_id("has_ground")
+        checks.append(
+            RubricCheck(
+                check_id=check_id,
+                check_type="ground",
+                points=1,
+                params={},
+                feedback_pass="Ground connection present.",
+                feedback_fail="Circuit must have a ground connection.",
+            )
+        )
+
+    # --- analysis_type check ---
+    if circuit.analysis_type != "DC Operating Point":
+        check_id = _unique_id("analysis_type")
+        checks.append(
+            RubricCheck(
+                check_id=check_id,
+                check_type="analysis_type",
+                points=1,
+                params={"expected_type": circuit.analysis_type},
+                feedback_pass=f"Analysis type is {circuit.analysis_type}.",
+                feedback_fail=f"Analysis type should be {circuit.analysis_type}.",
+            )
+        )
+
+    # Distribute points equally (minimum 1 per check)
+    if checks:
+        base_points = max(1, 100 // len(checks))
+        for check in checks:
+            check.points = base_points
+        total = base_points * len(checks)
+    else:
+        total = 0
+
+    return Rubric(title=title, total_points=total, checks=checks)

--- a/app/tests/unit/test_rubric_generator.py
+++ b/app/tests/unit/test_rubric_generator.py
@@ -1,0 +1,257 @@
+"""Tests for rubric auto-generation from a reference circuit."""
+
+import pytest
+from grading.rubric import VALID_CHECK_TYPES
+from grading.rubric_generator import generate_rubric
+from models.circuit import CircuitModel
+
+from ..conftest import make_component, make_wire
+
+
+def _build_model(components, wires):
+    """Build a CircuitModel from component and wire lists."""
+    model = CircuitModel()
+    for comp in components:
+        model.add_component(comp)
+    for wire in wires:
+        model.add_wire(wire)
+    return model
+
+
+class TestGenerateRubric:
+    """Tests for the generate_rubric function."""
+
+    def test_empty_circuit_returns_empty_rubric(self):
+        """An empty circuit produces a rubric with no checks."""
+        model = CircuitModel()
+        rubric = generate_rubric(model)
+        assert rubric.title == "Auto-Generated Rubric"
+        assert rubric.total_points == 0
+        assert rubric.checks == []
+
+    def test_custom_title(self):
+        """Custom title is used in the generated rubric."""
+        model = CircuitModel()
+        rubric = generate_rubric(model, title="My Assignment")
+        assert rubric.title == "My Assignment"
+
+    def test_component_exists_checks(self):
+        """Each non-ground component gets an existence check."""
+        model = _build_model(
+            [
+                make_component("Resistor", "R1", "1k"),
+                make_component("Capacitor", "C1", "1u"),
+                make_component("Ground", "GND1", "0V"),
+            ],
+            [],
+        )
+        rubric = generate_rubric(model)
+        exists_checks = [c for c in rubric.checks if c.check_type == "component_exists"]
+        assert len(exists_checks) == 2
+        ids = {c.params["component_id"] for c in exists_checks}
+        assert ids == {"R1", "C1"}
+
+    def test_ground_not_in_exists_checks(self):
+        """Ground components are excluded from existence checks."""
+        model = _build_model(
+            [make_component("Ground", "GND1", "0V")],
+            [],
+        )
+        rubric = generate_rubric(model)
+        exists_checks = [c for c in rubric.checks if c.check_type == "component_exists"]
+        assert len(exists_checks) == 0
+
+    def test_component_value_checks_for_non_default(self):
+        """Value checks are generated for components with non-default values."""
+        model = _build_model(
+            [
+                make_component("Resistor", "R1", "10k"),  # default is 1k
+                make_component("Resistor", "R2", "1k"),  # matches default
+            ],
+            [],
+        )
+        rubric = generate_rubric(model)
+        value_checks = [c for c in rubric.checks if c.check_type == "component_value"]
+        assert len(value_checks) == 1
+        assert value_checks[0].params["component_id"] == "R1"
+        assert value_checks[0].params["expected_value"] == "10k"
+        assert value_checks[0].params["tolerance_pct"] == 5.0
+
+    def test_topology_checks_for_wires(self):
+        """Topology checks are generated for wire connections between non-ground components."""
+        r1 = make_component("Resistor", "R1", "1k")
+        r2 = make_component("Resistor", "R2", "1k")
+        model = _build_model(
+            [r1, r2],
+            [make_wire("R1", 1, "R2", 0)],
+        )
+        rubric = generate_rubric(model)
+        topo_checks = [c for c in rubric.checks if c.check_type == "topology"]
+        assert len(topo_checks) == 1
+        params = topo_checks[0].params
+        assert set([params["component_a"], params["component_b"]]) == {"R1", "R2"}
+        assert params["shared_node"] is True
+
+    def test_no_duplicate_topology_checks(self):
+        """Multiple wires between the same pair of components produce only one topology check."""
+        r1 = make_component("Resistor", "R1", "1k")
+        r2 = make_component("Resistor", "R2", "1k")
+        model = _build_model(
+            [r1, r2],
+            [
+                make_wire("R1", 0, "R2", 0),
+                make_wire("R1", 1, "R2", 1),
+            ],
+        )
+        rubric = generate_rubric(model)
+        topo_checks = [c for c in rubric.checks if c.check_type == "topology"]
+        assert len(topo_checks) == 1
+
+    def test_topology_excludes_ground_wires(self):
+        """Wires to ground components don't generate topology checks."""
+        r1 = make_component("Resistor", "R1", "1k")
+        gnd = make_component("Ground", "GND1", "0V")
+        model = _build_model(
+            [r1, gnd],
+            [make_wire("R1", 1, "GND1", 0)],
+        )
+        rubric = generate_rubric(model)
+        topo_checks = [c for c in rubric.checks if c.check_type == "topology"]
+        assert len(topo_checks) == 0
+
+    def test_ground_check_present(self):
+        """A ground check is generated when the circuit has a ground component."""
+        model = _build_model(
+            [make_component("Ground", "GND1", "0V")],
+            [],
+        )
+        rubric = generate_rubric(model)
+        ground_checks = [c for c in rubric.checks if c.check_type == "ground"]
+        assert len(ground_checks) == 1
+
+    def test_no_ground_check_without_ground(self):
+        """No ground check when the circuit has no ground component."""
+        model = _build_model(
+            [make_component("Resistor", "R1", "1k")],
+            [],
+        )
+        rubric = generate_rubric(model)
+        ground_checks = [c for c in rubric.checks if c.check_type == "ground"]
+        assert len(ground_checks) == 0
+
+    def test_analysis_type_check_non_default(self):
+        """Analysis type check generated for non-default analysis."""
+        model = CircuitModel()
+        model.add_component(make_component("Resistor", "R1", "1k"))
+        model.analysis_type = "AC Sweep"
+        rubric = generate_rubric(model)
+        at_checks = [c for c in rubric.checks if c.check_type == "analysis_type"]
+        assert len(at_checks) == 1
+        assert at_checks[0].params["expected_type"] == "AC Sweep"
+
+    def test_no_analysis_type_check_for_default(self):
+        """No analysis type check when using default DC Operating Point."""
+        model = CircuitModel()
+        model.add_component(make_component("Resistor", "R1", "1k"))
+        rubric = generate_rubric(model)
+        at_checks = [c for c in rubric.checks if c.check_type == "analysis_type"]
+        assert len(at_checks) == 0
+
+    def test_equal_point_distribution(self):
+        """Points are distributed equally across all checks."""
+        model = _build_model(
+            [
+                make_component("Resistor", "R1", "10k"),
+                make_component("Resistor", "R2", "20k"),
+                make_component("Ground", "GND1", "0V"),
+            ],
+            [make_wire("R1", 1, "R2", 0)],
+        )
+        rubric = generate_rubric(model)
+        assert len(rubric.checks) > 0
+        points = [c.points for c in rubric.checks]
+        # All checks have the same points
+        assert len(set(points)) == 1
+        # Total points matches
+        assert rubric.total_points == sum(points)
+
+    def test_unique_check_ids(self):
+        """All generated check IDs are unique."""
+        model = _build_model(
+            [
+                make_component("Resistor", "R1", "10k"),
+                make_component("Resistor", "R2", "20k"),
+                make_component("Voltage Source", "V1", "12V"),
+                make_component("Ground", "GND1", "0V"),
+            ],
+            [
+                make_wire("V1", 0, "R1", 0),
+                make_wire("R1", 1, "R2", 0),
+                make_wire("R2", 1, "GND1", 0),
+                make_wire("V1", 1, "GND1", 0),
+            ],
+        )
+        rubric = generate_rubric(model)
+        ids = [c.check_id for c in rubric.checks]
+        assert len(ids) == len(set(ids))
+
+    def test_all_check_types_valid(self):
+        """All generated checks use valid check types."""
+        model = _build_model(
+            [
+                make_component("Resistor", "R1", "10k"),
+                make_component("Ground", "GND1", "0V"),
+            ],
+            [make_wire("R1", 1, "GND1", 0)],
+        )
+        model.analysis_type = "Transient"
+        rubric = generate_rubric(model)
+        for check in rubric.checks:
+            assert check.check_type in VALID_CHECK_TYPES
+
+    def test_feedback_messages_populated(self):
+        """Generated checks have non-empty feedback messages."""
+        model = _build_model(
+            [make_component("Resistor", "R1", "10k")],
+            [],
+        )
+        rubric = generate_rubric(model)
+        for check in rubric.checks:
+            assert check.feedback_pass
+            assert check.feedback_fail
+
+    def test_full_circuit_rubric(self):
+        """Integration test: voltage divider produces expected check types."""
+        model = _build_model(
+            [
+                make_component("Voltage Source", "V1", "12V"),
+                make_component("Resistor", "R1", "10k"),
+                make_component("Resistor", "R2", "20k"),
+                make_component("Ground", "GND1", "0V"),
+            ],
+            [
+                make_wire("V1", 0, "R1", 0),
+                make_wire("R1", 1, "R2", 0),
+                make_wire("R2", 1, "GND1", 0),
+                make_wire("V1", 1, "GND1", 0),
+            ],
+        )
+        rubric = generate_rubric(model, title="Voltage Divider")
+        assert rubric.title == "Voltage Divider"
+
+        check_types = {c.check_type for c in rubric.checks}
+        assert "component_exists" in check_types
+        assert "component_value" in check_types
+        assert "topology" in check_types
+        assert "ground" in check_types
+
+        # 3 exists (V1, R1, R2) + 3 values (all non-default) + 2 topology + 1 ground = 9
+        exists_count = sum(1 for c in rubric.checks if c.check_type == "component_exists")
+        value_count = sum(1 for c in rubric.checks if c.check_type == "component_value")
+        topo_count = sum(1 for c in rubric.checks if c.check_type == "topology")
+        ground_count = sum(1 for c in rubric.checks if c.check_type == "ground")
+
+        assert exists_count == 3
+        assert value_count == 3
+        assert topo_count == 2  # V1-R1, R1-R2 (ground wires excluded)
+        assert ground_count == 1


### PR DESCRIPTION
## Summary
- Adds rubric_generator.py in app/grading/ that analyzes a reference CircuitModel to auto-generate a rubric skeleton with component_exists, component_value, topology, ground, and analysis_type checks
- Adds Generate Rubric from Circuit menu item under Instructor menu that opens the generated rubric in the rubric editor for review/customization
- Points distributed equally across all generated checks; instructor adjusts in editor

## Test plan
- [x] 17 unit tests covering all check types, edge cases, and integration
- [ ] Manual: build a circuit, click Instructor > Generate Rubric from Circuit, verify checks populate the rubric editor

Generated with Claude Code