### PR TITLE
Add .spice-assignment bundle format (template + rubric) (#376)

### DIFF
--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -485,6 +485,18 @@ class MenuBarMixin:
             batch_grade_action.triggered.connect(self._on_batch_grade)
             instructor_menu.addAction(batch_grade_action)
 
+            instructor_menu.addSeparator()
+
+            open_assignment_action = QAction("&Open Assignment...", self)
+            open_assignment_action.setToolTip("Open a .spice-assignment bundle (template + rubric)")
+            open_assignment_action.triggered.connect(self._on_open_assignment)
+            instructor_menu.addAction(open_assignment_action)
+
+            save_assignment_action = QAction("&Save as Assignment...", self)
+            save_assignment_action.setToolTip("Bundle the current circuit and a rubric into a .spice-assignment file")
+            save_assignment_action.triggered.connect(self._on_save_assignment)
+            instructor_menu.addAction(save_assignment_action)
+
         # Settings menu
         settings_menu = menubar.addMenu("Se&ttings")
         if settings_menu:

--- a/app/controllers/assignment_controller.py
+++ b/app/controllers/assignment_controller.py
@@ -1,0 +1,83 @@
+"""Controller for .spice-assignment bundle files.
+
+Handles save/load of assignment bundles that combine a template and rubric.
+No Qt dependencies.
+"""
+
+import json
+from pathlib import Path
+
+from grading.rubric import Rubric, validate_rubric
+from models.assignment import AssignmentBundle
+from models.template import TemplateData
+
+
+def validate_assignment_data(data: dict) -> None:
+    """Validate assignment bundle JSON structure.
+
+    Raises:
+        ValueError: If the data is invalid.
+    """
+    if not isinstance(data, dict):
+        raise ValueError("Assignment must be a JSON object")
+    if "template" not in data and "rubric" not in data:
+        raise ValueError("Assignment must contain at least a 'template' or 'rubric'")
+    if "rubric" in data and data["rubric"] is not None:
+        validate_rubric(data["rubric"])
+
+
+def save_assignment(bundle: AssignmentBundle, filepath) -> None:
+    """Save an assignment bundle to a .spice-assignment file.
+
+    Args:
+        bundle: The assignment bundle to save.
+        filepath: Path to write the file.
+    """
+    filepath = Path(filepath)
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(bundle.to_dict(), f, indent=2)
+
+
+def load_assignment(filepath) -> AssignmentBundle:
+    """Load an assignment bundle from a .spice-assignment file.
+
+    Args:
+        filepath: Path to the assignment file.
+
+    Returns:
+        An AssignmentBundle with template and/or rubric data.
+
+    Raises:
+        json.JSONDecodeError: If the file is not valid JSON.
+        ValueError: If the data structure is invalid.
+    """
+    filepath = Path(filepath)
+    with open(filepath, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    validate_assignment_data(data)
+    return AssignmentBundle.from_dict(data)
+
+
+def extract_template(bundle: AssignmentBundle) -> TemplateData:
+    """Extract the template from an assignment bundle.
+
+    Returns:
+        The template data, or an empty template if none is bundled.
+    """
+    if bundle.template is not None:
+        return bundle.template
+    return TemplateData()
+
+
+def extract_rubric(bundle: AssignmentBundle) -> Rubric:
+    """Extract the rubric from an assignment bundle.
+
+    Returns:
+        The rubric object.
+
+    Raises:
+        ValueError: If no rubric is present in the bundle.
+    """
+    if bundle.rubric is None:
+        raise ValueError("Assignment bundle does not contain a rubric")
+    return Rubric.from_dict(bundle.rubric)

--- a/app/models/assignment.py
+++ b/app/models/assignment.py
@@ -1,0 +1,41 @@
+"""Data model for assignment bundles (.spice-assignment files).
+
+Bundles a template and a rubric into a single distributable file.
+No Qt dependencies.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .template import TemplateData
+
+
+@dataclass
+class AssignmentBundle:
+    """A bundled assignment containing both a template and a rubric.
+
+    Serializes to a JSON file with extension ``.spice-assignment``.
+    """
+
+    assignment_version: str = "1.0"
+    template: Optional[TemplateData] = None
+    rubric: Optional[dict] = None  # Raw rubric dict (validated on load)
+
+    def to_dict(self) -> dict:
+        data: dict = {"assignment_version": self.assignment_version}
+        if self.template is not None:
+            data["template"] = self.template.to_dict()
+        if self.rubric is not None:
+            data["rubric"] = self.rubric
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "AssignmentBundle":
+        template = None
+        if "template" in data and data["template"] is not None:
+            template = TemplateData.from_dict(data["template"])
+        return cls(
+            assignment_version=data.get("assignment_version", "1.0"),
+            template=template,
+            rubric=data.get("rubric"),
+        )

--- a/app/tests/unit/test_assignment_bundle.py
+++ b/app/tests/unit/test_assignment_bundle.py
@@ -1,0 +1,205 @@
+"""Tests for the .spice-assignment bundle format."""
+
+import json
+
+import pytest
+from controllers.assignment_controller import (
+    extract_rubric,
+    extract_template,
+    load_assignment,
+    save_assignment,
+    validate_assignment_data,
+)
+from grading.rubric import Rubric, RubricCheck
+from models.assignment import AssignmentBundle
+from models.template import TemplateData, TemplateMetadata
+
+
+@pytest.fixture
+def sample_rubric_dict():
+    """Create a sample rubric dict."""
+    rubric = Rubric(
+        title="Test Rubric",
+        total_points=10,
+        checks=[
+            RubricCheck(
+                check_id="has_ground",
+                check_type="ground",
+                points=10,
+                params={},
+                feedback_pass="OK",
+                feedback_fail="Missing ground",
+            )
+        ],
+    )
+    return rubric.to_dict()
+
+
+@pytest.fixture
+def sample_template():
+    """Create a sample template."""
+    return TemplateData(
+        metadata=TemplateMetadata(title="Test Template", author="Tester"),
+        instructions="Build the circuit.",
+        starter_circuit={
+            "components": [{"component_id": "R1", "component_type": "Resistor", "value": "1k", "position": [0, 0]}],
+            "wires": [],
+        },
+    )
+
+
+@pytest.fixture
+def sample_bundle(sample_template, sample_rubric_dict):
+    """Create a sample assignment bundle."""
+    return AssignmentBundle(
+        template=sample_template,
+        rubric=sample_rubric_dict,
+    )
+
+
+class TestAssignmentBundleModel:
+    """Tests for AssignmentBundle data model."""
+
+    def test_to_dict(self, sample_bundle):
+        """Bundle serializes to dict with both template and rubric."""
+        d = sample_bundle.to_dict()
+        assert d["assignment_version"] == "1.0"
+        assert "template" in d
+        assert "rubric" in d
+
+    def test_from_dict_round_trip(self, sample_bundle):
+        """Bundle survives serialization round-trip."""
+        d = sample_bundle.to_dict()
+        restored = AssignmentBundle.from_dict(d)
+        assert restored.assignment_version == "1.0"
+        assert restored.template is not None
+        assert restored.template.metadata.title == "Test Template"
+        assert restored.rubric is not None
+        assert restored.rubric["title"] == "Test Rubric"
+
+    def test_empty_bundle(self):
+        """Empty bundle has no template or rubric."""
+        bundle = AssignmentBundle()
+        d = bundle.to_dict()
+        assert "template" not in d
+        assert "rubric" not in d
+
+    def test_template_only(self, sample_template):
+        """Bundle with only template, no rubric."""
+        bundle = AssignmentBundle(template=sample_template)
+        d = bundle.to_dict()
+        assert "template" in d
+        assert "rubric" not in d
+
+    def test_rubric_only(self, sample_rubric_dict):
+        """Bundle with only rubric, no template."""
+        bundle = AssignmentBundle(rubric=sample_rubric_dict)
+        d = bundle.to_dict()
+        assert "rubric" in d
+        assert "template" not in d
+
+
+class TestValidateAssignmentData:
+    """Tests for assignment data validation."""
+
+    def test_valid_with_both(self, sample_bundle):
+        """Valid bundle with template and rubric passes validation."""
+        validate_assignment_data(sample_bundle.to_dict())
+
+    def test_valid_rubric_only(self, sample_rubric_dict):
+        """Rubric-only bundle passes validation."""
+        validate_assignment_data({"rubric": sample_rubric_dict})
+
+    def test_valid_template_only(self, sample_template):
+        """Template-only bundle passes validation."""
+        validate_assignment_data({"template": sample_template.to_dict()})
+
+    def test_not_a_dict(self):
+        """Non-dict raises ValueError."""
+        with pytest.raises(ValueError, match="JSON object"):
+            validate_assignment_data([])
+
+    def test_empty_dict(self):
+        """Empty dict (no template or rubric) raises ValueError."""
+        with pytest.raises(ValueError, match="at least"):
+            validate_assignment_data({})
+
+    def test_invalid_rubric(self):
+        """Invalid rubric structure raises ValueError."""
+        with pytest.raises(ValueError):
+            validate_assignment_data({"rubric": {"title": "", "total_points": 0, "checks": []}})
+
+
+class TestSaveLoadAssignment:
+    """Tests for save/load of assignment files."""
+
+    def test_save_creates_file(self, sample_bundle, tmp_path):
+        """Saving creates a .spice-assignment file."""
+        filepath = tmp_path / "test.spice-assignment"
+        save_assignment(sample_bundle, filepath)
+        assert filepath.exists()
+
+    def test_save_writes_valid_json(self, sample_bundle, tmp_path):
+        """Saved file contains valid JSON."""
+        filepath = tmp_path / "test.spice-assignment"
+        save_assignment(sample_bundle, filepath)
+        data = json.loads(filepath.read_text())
+        assert "assignment_version" in data
+
+    def test_round_trip(self, sample_bundle, tmp_path):
+        """Save then load preserves all data."""
+        filepath = tmp_path / "test.spice-assignment"
+        save_assignment(sample_bundle, filepath)
+        loaded = load_assignment(filepath)
+
+        assert loaded.assignment_version == "1.0"
+        assert loaded.template is not None
+        assert loaded.template.metadata.title == "Test Template"
+        assert loaded.rubric is not None
+        assert loaded.rubric["title"] == "Test Rubric"
+
+    def test_load_invalid_json(self, tmp_path):
+        """Loading invalid JSON raises error."""
+        filepath = tmp_path / "bad.spice-assignment"
+        filepath.write_text("not json")
+        with pytest.raises(json.JSONDecodeError):
+            load_assignment(filepath)
+
+    def test_load_invalid_structure(self, tmp_path):
+        """Loading empty dict raises ValueError."""
+        filepath = tmp_path / "bad.spice-assignment"
+        filepath.write_text("{}")
+        with pytest.raises(ValueError):
+            load_assignment(filepath)
+
+    def test_load_nonexistent_file(self, tmp_path):
+        """Loading nonexistent file raises OSError."""
+        with pytest.raises(OSError):
+            load_assignment(tmp_path / "nope.spice-assignment")
+
+
+class TestExtractFunctions:
+    """Tests for extract_template and extract_rubric."""
+
+    def test_extract_template(self, sample_bundle):
+        """Extracts template from bundle."""
+        template = extract_template(sample_bundle)
+        assert template.metadata.title == "Test Template"
+
+    def test_extract_template_empty(self):
+        """Returns empty template when none present."""
+        bundle = AssignmentBundle()
+        template = extract_template(bundle)
+        assert template.metadata.title == ""
+
+    def test_extract_rubric(self, sample_bundle):
+        """Extracts rubric from bundle."""
+        rubric = extract_rubric(sample_bundle)
+        assert rubric.title == "Test Rubric"
+        assert len(rubric.checks) == 1
+
+    def test_extract_rubric_missing(self):
+        """Raises ValueError when no rubric present."""
+        bundle = AssignmentBundle()
+        with pytest.raises(ValueError, match="does not contain"):
+            extract_rubric(bundle)


### PR DESCRIPTION
## Summary
- New AssignmentBundle model in app/models/assignment.py
- AssignmentController for save/load with validation in app/controllers/
- Open Assignment menu item loads template circuit and rubric together
- Save as Assignment bundles current circuit with selected rubric
- Backward compatible with separate .spice-template and .spice-rubric files

## Test plan
- [x] 21 unit tests (model serialization, validation, save/load, extraction)
- [ ] Manual: create rubric, save assignment bundle, reopen and verify both load

Generated with Claude Code