### PR TITLE
Add locked components in assignment templates

### DIFF
--- a/app/GUI/__init__.py
+++ b/app/GUI/__init__.py
@@ -4,10 +4,11 @@ from .circuit_node import Node
 from .component_item import ComponentGraphicsItem
 from .component_palette import ComponentPalette
 from .main_window import MainWindow
-from .path_finding import IDAStarPathfinder, get_component_obstacles, get_wire_obstacles
-
+from .path_finding import (IDAStarPathfinder, get_component_obstacles,
+                           get_wire_obstacles)
 # Re-export from centralized styles module
-from .styles import COMPONENTS, DEFAULT_COMPONENT_COUNTER, GRID_SIZE, theme_manager
+from .styles import (COMPONENTS, DEFAULT_COMPONENT_COUNTER, GRID_SIZE,
+                     theme_manager)
 from .wire_item import WireGraphicsItem, WireItem
 
 __all__ = [

--- a/app/GUI/analysis_dialog.py
+++ b/app/GUI/analysis_dialog.py
@@ -1,16 +1,6 @@
-from PyQt6.QtWidgets import (
-    QComboBox,
-    QDialog,
-    QDialogButtonBox,
-    QFormLayout,
-    QHBoxLayout,
-    QInputDialog,
-    QLabel,
-    QLineEdit,
-    QMessageBox,
-    QPushButton,
-    QVBoxLayout,
-)
+from PyQt6.QtWidgets import (QComboBox, QDialog, QDialogButtonBox, QFormLayout,
+                             QHBoxLayout, QInputDialog, QLabel, QLineEdit,
+                             QMessageBox, QPushButton, QVBoxLayout)
 
 from .format_utils import parse_value
 from .meas_dialog import ANALYSIS_DOMAIN_MAP, MeasurementDialog
@@ -97,7 +87,9 @@ class AnalysisDialog(QDialog):
                 ("Points per Decade", "points", "int", "100"),
                 ("Sweep Type", "sweepType", "combo", ["dec", "oct", "lin"], "dec"),
             ],
-            "description": ("Noise spectral density analysis — computes output and input-referred noise vs. frequency"),
+            "description": (
+                "Noise spectral density analysis — computes output and input-referred noise vs. frequency"
+            ),
             "tooltips": {
                 "output_node": "Node name (or number) where output noise is measured, e.g. 'out' or '2'",
                 "source": "Name of the input source used as noise reference (e.g. V1)",
@@ -220,7 +212,9 @@ class AnalysisDialog(QDialog):
         # Measurements button (shown only for supported analysis types)
         meas_layout = QHBoxLayout()
         self.meas_btn = QPushButton("Measurements...")
-        self.meas_btn.setToolTip("Configure automated .meas directives for this analysis")
+        self.meas_btn.setToolTip(
+            "Configure automated .meas directives for this analysis"
+        )
         self.meas_btn.clicked.connect(self._open_meas_dialog)
         meas_layout.addWidget(self.meas_btn)
         self.meas_label = QLabel("No measurements configured")
@@ -229,7 +223,9 @@ class AnalysisDialog(QDialog):
         layout.addLayout(meas_layout)
 
         # Buttons
-        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
         button_box.accepted.connect(self.accept)
         button_box.rejected.connect(self.reject)
         layout.addWidget(button_box)
@@ -305,7 +301,9 @@ class AnalysisDialog(QDialog):
 
             # Include measurement directives if any are configured
             if self._measurements:
-                params["measurements"] = [e["directive"] for e in self._measurements if e.get("directive")]
+                params["measurements"] = [
+                    e["directive"] for e in self._measurements if e.get("directive")
+                ]
 
             return params
 
@@ -430,7 +428,9 @@ class AnalysisDialog(QDialog):
         if preset_name is None:
             return
 
-        preset = self._preset_manager.get_preset_by_name(preset_name, self.analysis_type)
+        preset = self._preset_manager.get_preset_by_name(
+            preset_name, self.analysis_type
+        )
         if preset is None:
             return
 
@@ -452,7 +452,11 @@ class AnalysisDialog(QDialog):
         """Save current parameters as a named preset."""
         params = self.get_parameters()
         if params is None:
-            QMessageBox.warning(self, "Invalid Parameters", "Please enter valid parameters before saving a preset.")
+            QMessageBox.warning(
+                self,
+                "Invalid Parameters",
+                "Please enter valid parameters before saving a preset.",
+            )
             return
 
         # Remove analysis_type key from params (stored separately)
@@ -484,9 +488,13 @@ class AnalysisDialog(QDialog):
         if preset_name is None:
             return
 
-        preset = self._preset_manager.get_preset_by_name(preset_name, self.analysis_type)
+        preset = self._preset_manager.get_preset_by_name(
+            preset_name, self.analysis_type
+        )
         if preset and preset.get("builtin"):
-            QMessageBox.information(self, "Built-in Preset", "Built-in presets cannot be deleted.")
+            QMessageBox.information(
+                self, "Built-in Preset", "Built-in presets cannot be deleted."
+            )
             return
 
         reply = QMessageBox.question(
@@ -507,5 +515,9 @@ class AnalysisDialog(QDialog):
             return
 
         preset_name = self.preset_combo.itemData(index)
-        preset = self._preset_manager.get_preset_by_name(preset_name, self.analysis_type)
-        self.delete_preset_btn.setEnabled(preset is not None and not preset.get("builtin", False))
+        preset = self._preset_manager.get_preset_by_name(
+            preset_name, self.analysis_type
+        )
+        self.delete_preset_btn.setEnabled(
+            preset is not None and not preset.get("builtin", False)
+        )

--- a/app/GUI/annotation_item.py
+++ b/app/GUI/annotation_item.py
@@ -11,7 +11,9 @@ class AnnotationItem(QGraphicsTextItem):
     and serialization for save/load.
     """
 
-    def __init__(self, text="Annotation", x=0.0, y=0.0, font_size=10, bold=False, color="#FFFFFF"):
+    def __init__(
+        self, text="Annotation", x=0.0, y=0.0, font_size=10, bold=False, color="#FFFFFF"
+    ):
         super().__init__(text)
         self.setPos(x, y)
         self.setDefaultTextColor(QColor(color))
@@ -39,7 +41,9 @@ class AnnotationItem(QGraphicsTextItem):
                 canvas._edit_annotation(self)
                 return
         # Fallback: direct edit without undo
-        text, ok = QInputDialog.getText(None, "Edit Annotation", "Text:", text=self.toPlainText())
+        text, ok = QInputDialog.getText(
+            None, "Edit Annotation", "Text:", text=self.toPlainText()
+        )
         if ok and text:
             self.setPlainText(text)
 

--- a/app/GUI/batch_grading_dialog.py
+++ b/app/GUI/batch_grading_dialog.py
@@ -6,18 +6,9 @@ import logging
 from typing import TYPE_CHECKING, Optional
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import (
-    QDialog,
-    QFileDialog,
-    QGroupBox,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QMessageBox,
-    QProgressBar,
-    QPushButton,
-    QVBoxLayout,
-)
+from PyQt6.QtWidgets import (QDialog, QFileDialog, QGroupBox, QHBoxLayout,
+                             QLabel, QLineEdit, QMessageBox, QProgressBar,
+                             QPushButton, QVBoxLayout)
 
 if TYPE_CHECKING:
     from grading.batch_grader import BatchGradingResult
@@ -101,7 +92,9 @@ class BatchGradingDialog(QDialog):
         layout.addWidget(self.results_group)
 
     def _on_browse_folder(self):
-        folder = QFileDialog.getExistingDirectory(self, "Select Student Submissions Folder")
+        folder = QFileDialog.getExistingDirectory(
+            self, "Select Student Submissions Folder"
+        )
         if folder:
             self.folder_path.setText(folder)
             self._update_grade_button()
@@ -124,7 +117,9 @@ class BatchGradingDialog(QDialog):
                 QMessageBox.critical(self, "Error", f"Failed to load rubric:\n{e}")
 
     def _update_grade_button(self):
-        self.grade_btn.setEnabled(bool(self.folder_path.text()) and self._rubric is not None)
+        self.grade_btn.setEnabled(
+            bool(self.folder_path.text()) and self._rubric is not None
+        )
 
     def _on_grade(self):
         from grading.batch_grader import BatchGrader

--- a/app/GUI/circuit_statistics_panel.py
+++ b/app/GUI/circuit_statistics_panel.py
@@ -4,7 +4,8 @@ import logging
 from collections import Counter
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QFormLayout, QGroupBox, QLabel, QScrollArea, QTextEdit, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import (QFormLayout, QGroupBox, QLabel, QScrollArea,
+                             QTextEdit, QVBoxLayout, QWidget)
 
 from .styles import theme_manager
 
@@ -152,7 +153,9 @@ class CircuitStatisticsPanel(QWidget):
             return
 
         type_counts = Counter(c.component_type for c in self.model.components.values())
-        for comp_type, count in sorted(type_counts.items(), key=lambda x: (-x[1], x[0])):
+        for comp_type, count in sorted(
+            type_counts.items(), key=lambda x: (-x[1], x[0])
+        ):
             label = QLabel(str(count))
             self._components_form.addRow(f"{comp_type}:", label)
 
@@ -192,4 +195,6 @@ class CircuitStatisticsPanel(QWidget):
             netlist = self.simulation_ctrl.generate_netlist()
             self._netlist_text.setPlainText(netlist)
         except Exception:
-            self._netlist_text.setPlainText("(netlist generation requires valid circuit)")
+            self._netlist_text.setPlainText(
+                "(netlist generation requires valid circuit)"
+            )

--- a/app/GUI/circuitikz_options_dialog.py
+++ b/app/GUI/circuitikz_options_dialog.py
@@ -1,16 +1,9 @@
 """Dialog for configuring CircuiTikZ export options."""
 
 from PyQt6.QtCore import QSettings
-from PyQt6.QtWidgets import (
-    QCheckBox,
-    QComboBox,
-    QDialog,
-    QDialogButtonBox,
-    QDoubleSpinBox,
-    QFormLayout,
-    QGroupBox,
-    QVBoxLayout,
-)
+from PyQt6.QtWidgets import (QCheckBox, QComboBox, QDialog, QDialogButtonBox,
+                             QDoubleSpinBox, QFormLayout, QGroupBox,
+                             QVBoxLayout)
 
 SETTINGS_PREFIX = "circuitikz/"
 
@@ -92,7 +85,9 @@ class CircuiTikZOptionsDialog(QDialog):
         layout.addWidget(output_group)
 
         # --- Buttons ---
-        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
         buttons.accepted.connect(self._on_accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
@@ -119,7 +114,9 @@ class CircuiTikZOptionsDialog(QDialog):
         settings.setValue(f"{SETTINGS_PREFIX}scale", opts["scale"])
         settings.setValue(f"{SETTINGS_PREFIX}include_ids", opts["include_ids"])
         settings.setValue(f"{SETTINGS_PREFIX}include_values", opts["include_values"])
-        settings.setValue(f"{SETTINGS_PREFIX}include_net_labels", opts["include_net_labels"])
+        settings.setValue(
+            f"{SETTINGS_PREFIX}include_net_labels", opts["include_net_labels"]
+        )
         settings.setValue(f"{SETTINGS_PREFIX}standalone", opts["standalone"])
 
     def _restore_settings(self):
@@ -138,11 +135,15 @@ class CircuiTikZOptionsDialog(QDialog):
 
         include_values = settings.value(f"{SETTINGS_PREFIX}include_values")
         if include_values is not None:
-            self.include_values_cb.setChecked(include_values == "true" or include_values is True)
+            self.include_values_cb.setChecked(
+                include_values == "true" or include_values is True
+            )
 
         include_net_labels = settings.value(f"{SETTINGS_PREFIX}include_net_labels")
         if include_net_labels is not None:
-            self.include_net_labels_cb.setChecked(include_net_labels == "true" or include_net_labels is True)
+            self.include_net_labels_cb.setChecked(
+                include_net_labels == "true" or include_net_labels is True
+            )
 
         standalone = settings.value(f"{SETTINGS_PREFIX}standalone")
         if standalone is not None:

--- a/app/GUI/component_palette.py
+++ b/app/GUI/component_palette.py
@@ -1,6 +1,7 @@
 from PyQt6.QtCore import QMimeData, QSize, Qt, pyqtSignal
 from PyQt6.QtGui import QBrush, QDrag, QIcon, QPainter, QPen, QPixmap
-from PyQt6.QtWidgets import QLineEdit, QListWidget, QListWidgetItem, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import (QLineEdit, QListWidget, QListWidgetItem,
+                             QVBoxLayout, QWidget)
 
 from .component_item import COMPONENT_CLASSES
 from .styles import COMPONENTS, theme_manager

--- a/app/GUI/grading_panel.py
+++ b/app/GUI/grading_panel.py
@@ -11,18 +11,9 @@ from typing import TYPE_CHECKING, Optional
 from models.circuit import CircuitModel
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor
-from PyQt6.QtWidgets import (
-    QFileDialog,
-    QGroupBox,
-    QHBoxLayout,
-    QLabel,
-    QListWidget,
-    QListWidgetItem,
-    QMessageBox,
-    QPushButton,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt6.QtWidgets import (QFileDialog, QGroupBox, QHBoxLayout, QLabel,
+                             QListWidget, QListWidgetItem, QMessageBox,
+                             QPushButton, QVBoxLayout, QWidget)
 
 if TYPE_CHECKING:
     from grading.grader import GradingResult
@@ -147,7 +138,9 @@ class GradingPanel(QWidget):
             if "template_version" in data and "starter_circuit" in data:
                 if data["starter_circuit"] is not None:
                     validate_circuit_data(data["starter_circuit"])
-                    self._student_circuit = CircuitModel.from_dict(data["starter_circuit"])
+                    self._student_circuit = CircuitModel.from_dict(
+                        data["starter_circuit"]
+                    )
                 else:
                     self._student_circuit = CircuitModel()
             else:
@@ -182,7 +175,9 @@ class GradingPanel(QWidget):
 
     def _update_grade_button(self):
         """Enable grade button when both student and rubric are loaded."""
-        self.grade_btn.setEnabled(self._student_circuit is not None and self._rubric is not None)
+        self.grade_btn.setEnabled(
+            self._student_circuit is not None and self._rubric is not None
+        )
 
     # --- Grading ---
 
@@ -213,13 +208,21 @@ class GradingPanel(QWidget):
 
         # Score header
         pct = result.percentage
-        self.score_label.setText(f"{result.earned_points}/{result.total_points} — {pct:.0f}%")
+        self.score_label.setText(
+            f"{result.earned_points}/{result.total_points} — {pct:.0f}%"
+        )
         if pct >= 90:
-            self.score_label.setStyleSheet("font-size: 16px; font-weight: bold; color: green;")
+            self.score_label.setStyleSheet(
+                "font-size: 16px; font-weight: bold; color: green;"
+            )
         elif pct >= 70:
-            self.score_label.setStyleSheet("font-size: 16px; font-weight: bold; color: #CC8800;")
+            self.score_label.setStyleSheet(
+                "font-size: 16px; font-weight: bold; color: #CC8800;"
+            )
         else:
-            self.score_label.setStyleSheet("font-size: 16px; font-weight: bold; color: red;")
+            self.score_label.setStyleSheet(
+                "font-size: 16px; font-weight: bold; color: red;"
+            )
 
         # Check results
         for cr in result.check_results:
@@ -291,7 +294,9 @@ class GradingPanel(QWidget):
                 ]
             )
             writer.writerow([])
-            writer.writerow(["Check ID", "Passed", "Points Earned", "Points Possible", "Feedback"])
+            writer.writerow(
+                ["Check ID", "Passed", "Points Earned", "Points Possible", "Feedback"]
+            )
             for cr in result.check_results:
                 writer.writerow(
                     [

--- a/app/GUI/keybindings.py
+++ b/app/GUI/keybindings.py
@@ -115,7 +115,11 @@ class KeybindingsRegistry:
             if key not in shortcut_to_actions:
                 shortcut_to_actions[key] = []
             shortcut_to_actions[key].append(action)
-        return [(s, actions) for s, actions in shortcut_to_actions.items() if len(actions) > 1]
+        return [
+            (s, actions)
+            for s, actions in shortcut_to_actions.items()
+            if len(actions) > 1
+        ]
 
     def reset_defaults(self):
         """Reset all bindings to defaults."""

--- a/app/GUI/keybindings_dialog.py
+++ b/app/GUI/keybindings_dialog.py
@@ -4,18 +4,10 @@ keybindings_dialog.py — Preferences dialog for configuring keyboard shortcuts.
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QKeySequence
-from PyQt6.QtWidgets import (
-    QDialog,
-    QHBoxLayout,
-    QHeaderView,
-    QKeySequenceEdit,
-    QLabel,
-    QMessageBox,
-    QPushButton,
-    QTableWidget,
-    QTableWidgetItem,
-    QVBoxLayout,
-)
+from PyQt6.QtWidgets import (QDialog, QHBoxLayout, QHeaderView,
+                             QKeySequenceEdit, QLabel, QMessageBox,
+                             QPushButton, QTableWidget, QTableWidgetItem,
+                             QVBoxLayout)
 
 from .keybindings import ACTION_LABELS
 
@@ -33,7 +25,9 @@ class KeybindingsDialog(QDialog):
 
         layout = QVBoxLayout(self)
 
-        layout.addWidget(QLabel("Double-click a shortcut to change it. Press Escape to clear."))
+        layout.addWidget(
+            QLabel("Double-click a shortcut to change it. Press Escape to clear.")
+        )
 
         # Table
         self._table = QTableWidget()

--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -17,19 +17,9 @@ from controllers.file_controller import FileController
 from controllers.simulation_controller import SimulationController
 from models.circuit import CircuitModel
 from PyQt6.QtCore import Qt, QTimer
-from PyQt6.QtWidgets import (
-    QHBoxLayout,
-    QLabel,
-    QMainWindow,
-    QMessageBox,
-    QPushButton,
-    QSplitter,
-    QStackedWidget,
-    QTabWidget,
-    QTextEdit,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt6.QtWidgets import (QHBoxLayout, QLabel, QMainWindow, QMessageBox,
+                             QPushButton, QSplitter, QStackedWidget,
+                             QTabWidget, QTextEdit, QVBoxLayout, QWidget)
 
 from .circuit_canvas import CircuitCanvasView
 from .circuit_statistics_panel import CircuitStatisticsPanel
@@ -223,7 +213,9 @@ class MainWindow(
         right_panel_layout.addWidget(self.properties_stack)
 
         # Circuit statistics panel
-        self.statistics_panel = CircuitStatisticsPanel(self.model, self.circuit_ctrl, self.simulation_ctrl)
+        self.statistics_panel = CircuitStatisticsPanel(
+            self.model, self.circuit_ctrl, self.simulation_ctrl
+        )
         self.statistics_panel.setVisible(False)
         right_panel_layout.addWidget(self.statistics_panel)
 
@@ -272,7 +264,9 @@ class MainWindow(
         # Tab order: Palette -> Canvas -> Properties -> Action buttons
         self.setTabOrder(self.palette, self.canvas)
         self.setTabOrder(self.canvas, self.properties_panel.value_input)
-        self.setTabOrder(self.properties_panel.value_input, self.properties_panel.apply_button)
+        self.setTabOrder(
+            self.properties_panel.value_input, self.properties_panel.apply_button
+        )
         self.setTabOrder(self.properties_panel.apply_button, self.btn_save)
         self.setTabOrder(self.btn_save, self.btn_load)
         self.setTabOrder(self.btn_load, self.btn_clear)
@@ -331,7 +325,9 @@ class MainWindow(
             component.update()
             statusBar = self.statusBar()
             if statusBar:
-                statusBar.showMessage(f"Updated {component_id} value to {new_value}", 2000)
+                statusBar.showMessage(
+                    f"Updated {component_id} value to {new_value}", 2000
+                )
 
         elif property_name == "rotation":
             component.rotation_angle = new_value
@@ -347,14 +343,18 @@ class MainWindow(
             component.update()
             statusBar = self.statusBar()
             if statusBar:
-                statusBar.showMessage(f"Updated {component_id} waveform configuration", 2000)
+                statusBar.showMessage(
+                    f"Updated {component_id} waveform configuration", 2000
+                )
 
         elif property_name == "initial_condition":
             component.initial_condition = new_value
             ic_display = new_value if new_value else "none"
             statusBar = self.statusBar()
             if statusBar:
-                statusBar.showMessage(f"Updated {component_id} initial condition to {ic_display}", 2000)
+                statusBar.showMessage(
+                    f"Updated {component_id} initial condition to {ic_display}", 2000
+                )
 
     def _refresh_netlist_preview(self):
         """Regenerate and display the netlist in the preview panel."""

--- a/app/GUI/main_window_analysis.py
+++ b/app/GUI/main_window_analysis.py
@@ -31,7 +31,9 @@ class AnalysisSettingsMixin:
                         3000,
                     )
             else:
-                QMessageBox.warning(self, "Invalid Parameters", "Please enter valid numeric values.")
+                QMessageBox.warning(
+                    self, "Invalid Parameters", "Please enter valid numeric values."
+                )
                 self.op_action.setChecked(True)
         else:
             self.op_action.setChecked(True)
@@ -50,7 +52,9 @@ class AnalysisSettingsMixin:
                         3000,
                     )
             else:
-                QMessageBox.warning(self, "Invalid Parameters", "Please enter valid numeric values.")
+                QMessageBox.warning(
+                    self, "Invalid Parameters", "Please enter valid numeric values."
+                )
                 self.op_action.setChecked(True)
         else:
             self.op_action.setChecked(True)
@@ -69,7 +73,9 @@ class AnalysisSettingsMixin:
                         3000,
                     )
             else:
-                QMessageBox.warning(self, "Invalid Parameters", "Please enter valid numeric values.")
+                QMessageBox.warning(
+                    self, "Invalid Parameters", "Please enter valid numeric values."
+                )
                 self.op_action.setChecked(True)
         else:
             self.op_action.setChecked(True)
@@ -91,7 +97,9 @@ class AnalysisSettingsMixin:
                         3000,
                     )
             else:
-                QMessageBox.warning(self, "Invalid Parameters", "Please enter valid numeric values.")
+                QMessageBox.warning(
+                    self, "Invalid Parameters", "Please enter valid numeric values."
+                )
                 self.op_action.setChecked(True)
         else:
             self.op_action.setChecked(True)
@@ -110,7 +118,9 @@ class AnalysisSettingsMixin:
                         3000,
                     )
             else:
-                QMessageBox.warning(self, "Invalid Parameters", "Please enter valid numeric values.")
+                QMessageBox.warning(
+                    self, "Invalid Parameters", "Please enter valid numeric values."
+                )
                 self.op_action.setChecked(True)
         else:
             self.op_action.setChecked(True)

--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -79,7 +79,11 @@ class FileOperationsMixin:
             data = json.loads(json_str)
             validate_circuit_data(data)
         except (json.JSONDecodeError, ValueError) as e:
-            QMessageBox.critical(self, "Invalid Circuit Data", f"Clipboard does not contain valid circuit JSON:\n{e}")
+            QMessageBox.critical(
+                self,
+                "Invalid Circuit Data",
+                f"Clipboard does not contain valid circuit JSON:\n{e}",
+            )
             return
 
         if self.model.components:
@@ -141,7 +145,9 @@ class FileOperationsMixin:
                 self._set_dirty(False)
                 statusBar = self.statusBar()
                 if statusBar:
-                    statusBar.showMessage(f"Saved to {self.file_ctrl.current_file}", 3000)
+                    statusBar.showMessage(
+                        f"Saved to {self.file_ctrl.current_file}", 3000
+                    )
             except (OSError, TypeError) as e:
                 QMessageBox.critical(self, "Error", f"Failed to save: {e}")
         else:
@@ -149,7 +155,9 @@ class FileOperationsMixin:
 
     def _on_save_as(self):
         """Save circuit to a new file"""
-        filename, _ = QFileDialog.getSaveFileName(self, "Save Circuit", "", "JSON Files (*.json);;All Files (*)")
+        filename, _ = QFileDialog.getSaveFileName(
+            self, "Save Circuit", "", "JSON Files (*.json);;All Files (*)"
+        )
         if filename:
             try:
                 # Phase 5: No sync needed - model always up to date
@@ -162,7 +170,9 @@ class FileOperationsMixin:
 
     def _on_load(self):
         """Load circuit from file"""
-        filename, _ = QFileDialog.getOpenFileName(self, "Load Circuit", "", "JSON Files (*.json);;All Files (*)")
+        filename, _ = QFileDialog.getOpenFileName(
+            self, "Load Circuit", "", "JSON Files (*.json);;All Files (*)"
+        )
         if filename:
             try:
                 self.file_ctrl.load_circuit(filename)
@@ -283,7 +293,9 @@ class FileOperationsMixin:
         if filename:
             try:
                 self.file_ctrl.import_netlist(filename)
-                self.setWindowTitle(f"Circuit Design GUI - {Path(filename).name} (imported)")
+                self.setWindowTitle(
+                    f"Circuit Design GUI - {Path(filename).name} (imported)"
+                )
                 self._sync_analysis_menu()
                 self._set_dirty(True)
                 num_components = len(self.model.components)
@@ -294,7 +306,9 @@ class FileOperationsMixin:
                     f"Imported {num_components} components and {num_wires} wires from {Path(filename).name}.",
                 )
             except (OSError, ValueError) as e:
-                QMessageBox.critical(self, "Import Error", f"Failed to import netlist:\n{e}")
+                QMessageBox.critical(
+                    self, "Import Error", f"Failed to import netlist:\n{e}"
+                )
 
     def _on_import_asc(self):
         """Import an LTspice .asc schematic file"""
@@ -307,7 +321,9 @@ class FileOperationsMixin:
         if filename:
             try:
                 warnings = self.file_ctrl.import_asc(filename)
-                self.setWindowTitle(f"Circuit Design GUI - {Path(filename).name} (imported)")
+                self.setWindowTitle(
+                    f"Circuit Design GUI - {Path(filename).name} (imported)"
+                )
                 self._sync_analysis_menu()
                 self._set_dirty(True)
                 num_components = len(self.model.components)
@@ -317,18 +333,25 @@ class FileOperationsMixin:
                     msg += "\n\nWarnings:\n" + "\n".join(f"  - {w}" for w in warnings)
                 QMessageBox.information(self, "Import Successful", msg)
             except (OSError, ValueError) as e:
-                QMessageBox.critical(self, "Import Error", f"Failed to import LTspice schematic:\n{e}")
+                QMessageBox.critical(
+                    self, "Import Error", f"Failed to import LTspice schematic:\n{e}"
+                )
 
     def _on_export_asc(self):
         """Export the circuit as an LTspice .asc schematic file."""
         from simulation.asc_exporter import export_asc, write_asc
 
         if not self.model.components:
-            QMessageBox.information(self, "Export LTspice", "Nothing to export — the canvas is empty.")
+            QMessageBox.information(
+                self, "Export LTspice", "Nothing to export — the canvas is empty."
+            )
             return
 
         filename, _ = QFileDialog.getSaveFileName(
-            self, "Export as LTspice Schematic", "", "LTspice Schematics (*.asc);;All Files (*)"
+            self,
+            "Export as LTspice Schematic",
+            "",
+            "LTspice Schematics (*.asc);;All Files (*)",
         )
         if not filename:
             return
@@ -340,7 +363,9 @@ class FileOperationsMixin:
             if statusBar:
                 statusBar.showMessage(f"LTspice schematic exported to {filename}", 3000)
         except (OSError, Exception) as e:
-            QMessageBox.critical(self, "Error", f"Failed to export LTspice schematic: {e}")
+            QMessageBox.critical(
+                self, "Error", f"Failed to export LTspice schematic: {e}"
+            )
 
     def _on_generate_report(self):
         """Generate a comprehensive PDF circuit report."""
@@ -360,7 +385,9 @@ class FileOperationsMixin:
 
         config = dialog.get_config()
 
-        filename, _ = QFileDialog.getSaveFileName(self, "Save Circuit Report", "", "PDF Files (*.pdf)")
+        filename, _ = QFileDialog.getSaveFileName(
+            self, "Save Circuit Report", "", "PDF Files (*.pdf)"
+        )
         if not filename:
             return
         if not filename.lower().endswith(".pdf"):
@@ -393,7 +420,9 @@ class FileOperationsMixin:
                 f"Circuit report saved to:\n{filename}",
             )
         except (OSError, Exception) as e:
-            QMessageBox.critical(self, "Report Error", f"Failed to generate report:\n{e}")
+            QMessageBox.critical(
+                self, "Report Error", f"Failed to generate report:\n{e}"
+            )
 
     def _load_last_session(self):
         """Load last session using FileController"""
@@ -448,7 +477,9 @@ class FileOperationsMixin:
             return
 
         # Sort categories: Basic first, then alphabetically
-        category_order = sorted(examples_by_category.keys(), key=lambda c: (c != "Basic", c))
+        category_order = sorted(
+            examples_by_category.keys(), key=lambda c: (c != "Basic", c)
+        )
 
         for i, category in enumerate(category_order):
             if i > 0:
@@ -463,7 +494,9 @@ class FileOperationsMixin:
             for example in examples_by_category[category]:
                 action = QAction(example["name"], self)
                 action.setToolTip(example["description"])
-                action.triggered.connect(lambda checked, path=example["filepath"]: self._open_example(path))
+                action.triggered.connect(
+                    lambda checked, path=example["filepath"]: self._open_example(path)
+                )
                 self.examples_menu.addAction(action)
 
     def _populate_templates_menu(self):
@@ -502,7 +535,9 @@ class FileOperationsMixin:
                     label += " (user)"
                 action = QAction(label, self)
                 action.setToolTip(template.description)
-                action.triggered.connect(lambda checked, fp=template.filepath: self._open_template(fp))
+                action.triggered.connect(
+                    lambda checked, fp=template.filepath: self._open_template(fp)
+                )
                 self.templates_menu.addAction(action)
 
         # Add separator and "Browse All..." option
@@ -572,7 +607,9 @@ class FileOperationsMixin:
         from GUI.template_dialog import SaveAsTemplateDialog
 
         if not self.model.components:
-            QMessageBox.information(self, "Save as Template", "Cannot save an empty circuit as a template.")
+            QMessageBox.information(
+                self, "Save as Template", "Cannot save an empty circuit as a template."
+            )
             return
 
         if not hasattr(self, "_template_manager"):
@@ -582,7 +619,9 @@ class FileOperationsMixin:
         if dialog.exec() == SaveAsTemplateDialog.DialogCode.Accepted:
             name, description, category = dialog.get_values()
             try:
-                self._template_manager.save_template(self.model, name, description, category)
+                self._template_manager.save_template(
+                    self.model, name, description, category
+                )
                 # Refresh the templates submenu
                 self._populate_templates_menu()
                 statusBar = self.statusBar()

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -55,12 +55,16 @@ class MenuBarMixin:
         file_menu.addSeparator()
 
         new_from_template_action = QAction("New from &Template...", self)
-        new_from_template_action.setToolTip("Create a new circuit from an assignment template")
+        new_from_template_action.setToolTip(
+            "Create a new circuit from an assignment template"
+        )
         new_from_template_action.triggered.connect(self._on_new_from_template)
         file_menu.addAction(new_from_template_action)
 
         save_as_template_action = QAction("Save as Temp&late...", self)
-        save_as_template_action.setToolTip("Save current circuit as an assignment template with metadata")
+        save_as_template_action.setToolTip(
+            "Save current circuit as an assignment template with metadata"
+        )
         save_as_template_action.triggered.connect(self._on_save_as_template)
         file_menu.addAction(save_as_template_action)
 
@@ -78,7 +82,9 @@ class MenuBarMixin:
 
         export_netlist_action = QAction("Export &Netlist...", self)
         export_netlist_action.setShortcut(kb.get("file.export_netlist"))
-        export_netlist_action.setToolTip("Export the generated SPICE netlist to a .cir file")
+        export_netlist_action.setToolTip(
+            "Export the generated SPICE netlist to a .cir file"
+        )
         export_netlist_action.triggered.connect(self.export_netlist)
         file_menu.addAction(export_netlist_action)
 
@@ -93,7 +99,9 @@ class MenuBarMixin:
         file_menu.addAction(export_pdf_action)
 
         export_latex_action = QAction("Export as &LaTeX...", self)
-        export_latex_action.setToolTip("Export circuit as CircuiTikZ LaTeX code (.tex file)")
+        export_latex_action.setToolTip(
+            "Export circuit as CircuiTikZ LaTeX code (.tex file)"
+        )
         export_latex_action.triggered.connect(self.export_circuitikz)
         file_menu.addAction(export_latex_action)
 
@@ -103,7 +111,9 @@ class MenuBarMixin:
         file_menu.addAction(export_asc_action)
 
         generate_report_action = QAction("&Generate Circuit Report (PDF)...", self)
-        generate_report_action.setToolTip("Generate a comprehensive PDF report with schematic, netlist, and results")
+        generate_report_action.setToolTip(
+            "Generate a comprehensive PDF report with schematic, netlist, and results"
+        )
         generate_report_action.triggered.connect(self._on_generate_report)
         file_menu.addAction(generate_report_action)
 
@@ -176,7 +186,9 @@ class MenuBarMixin:
         edit_menu.addSeparator()
 
         copy_latex_action = QAction("Copy as La&TeX", self)
-        copy_latex_action.setToolTip("Copy the CircuiTikZ environment block to the clipboard")
+        copy_latex_action.setToolTip(
+            "Copy the CircuiTikZ environment block to the clipboard"
+        )
         copy_latex_action.triggered.connect(self.copy_circuitikz)
         edit_menu.addAction(copy_latex_action)
 
@@ -253,7 +265,9 @@ class MenuBarMixin:
         self.probe_action = QAction("&Probe Tool", self)
         self.probe_action.setCheckable(True)
         self.probe_action.setShortcut(kb.get("tools.probe"))
-        self.probe_action.setToolTip("Click nodes or components to see voltage/current values")
+        self.probe_action.setToolTip(
+            "Click nodes or components to see voltage/current values"
+        )
         self.probe_action.triggered.connect(self._toggle_probe_mode)
         view_menu.addAction(self.probe_action)
 
@@ -274,7 +288,9 @@ class MenuBarMixin:
         self.light_theme_action = QAction("&Light", self)
         self.light_theme_action.setCheckable(True)
         self.light_theme_action.setChecked(True)
-        self.light_theme_action.triggered.connect(lambda: self._set_theme_by_key("light"))
+        self.light_theme_action.triggered.connect(
+            lambda: self._set_theme_by_key("light")
+        )
         self.theme_menu.addAction(self.light_theme_action)
         self.theme_group.addAction(self.light_theme_action)
 
@@ -314,7 +330,9 @@ class MenuBarMixin:
 
         self.monochrome_mode_action = QAction("&Monochrome", self)
         self.monochrome_mode_action.setCheckable(True)
-        self.monochrome_mode_action.triggered.connect(lambda: self._set_color_mode("monochrome"))
+        self.monochrome_mode_action.triggered.connect(
+            lambda: self._set_color_mode("monochrome")
+        )
         color_mode_menu.addAction(self.monochrome_mode_action)
 
         self.color_mode_group = QActionGroup(self)
@@ -409,7 +427,9 @@ class MenuBarMixin:
 
         mc_action = QAction("&Monte Carlo...", self)
         mc_action.setCheckable(True)
-        mc_action.setToolTip("Run Monte Carlo tolerance analysis with randomized component values")
+        mc_action.setToolTip(
+            "Run Monte Carlo tolerance analysis with randomized component values"
+        )
         mc_action.triggered.connect(self.set_analysis_monte_carlo)
         analysis_menu.addAction(mc_action)
 
@@ -469,14 +489,18 @@ class MenuBarMixin:
         instructor_menu = menubar.addMenu("&Instructor")
         if instructor_menu:
             create_rubric_action = QAction("&Create Rubric...", self)
-            create_rubric_action.setToolTip("Open the rubric editor to create or edit a grading rubric")
+            create_rubric_action.setToolTip(
+                "Open the rubric editor to create or edit a grading rubric"
+            )
             create_rubric_action.triggered.connect(self._on_create_rubric)
             instructor_menu.addAction(create_rubric_action)
 
             instructor_menu.addSeparator()
 
             grade_action = QAction("&Grade Student Circuit...", self)
-            grade_action.setToolTip("Open the grading panel to grade a student submission")
+            grade_action.setToolTip(
+                "Open the grading panel to grade a student submission"
+            )
             grade_action.triggered.connect(self._toggle_grading_panel)
             instructor_menu.addAction(grade_action)
 
@@ -537,14 +561,18 @@ class MenuBarMixin:
 
         # Add custom themes after a separator
         available = theme_manager.get_available_themes()
-        custom_themes = [(name, key) for name, key in available if key.startswith("custom:")]
+        custom_themes = [
+            (name, key) for name, key in available if key.startswith("custom:")
+        ]
         if custom_themes:
             sep = self.theme_menu.addSeparator()
             self._custom_theme_actions.append(sep)
             for display_name, key in custom_themes:
                 action = QAction(display_name, self)
                 action.setCheckable(True)
-                action.triggered.connect(lambda checked, k=key: self._set_theme_by_key(k))
+                action.triggered.connect(
+                    lambda checked, k=key: self._set_theme_by_key(k)
+                )
                 self.theme_menu.addAction(action)
                 self.theme_group.addAction(action)
                 self._custom_theme_actions.append(action)

--- a/app/GUI/main_window_print.py
+++ b/app/GUI/main_window_print.py
@@ -19,7 +19,9 @@ class PrintExportMixin:
         circuit_items = [
             item
             for item in scene.items()
-            if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
+            if isinstance(
+                item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem)
+            )
         ]
         if not circuit_items:
             return None
@@ -72,7 +74,9 @@ class PrintExportMixin:
 
         source_rect = self._get_circuit_source_rect()
         if source_rect is None:
-            QMessageBox.information(self, "Print", "Nothing to print — the canvas is empty.")
+            QMessageBox.information(
+                self, "Print", "Nothing to print — the canvas is empty."
+            )
             return
 
         printer = QPrinter(QPrinter.PrinterMode.HighResolution)
@@ -87,7 +91,9 @@ class PrintExportMixin:
 
         source_rect = self._get_circuit_source_rect()
         if source_rect is None:
-            QMessageBox.information(self, "Print Preview", "Nothing to preview — the canvas is empty.")
+            QMessageBox.information(
+                self, "Print Preview", "Nothing to preview — the canvas is empty."
+            )
             return
 
         printer = QPrinter(QPrinter.PrinterMode.HighResolution)
@@ -102,10 +108,14 @@ class PrintExportMixin:
 
         source_rect = self._get_circuit_source_rect()
         if source_rect is None:
-            QMessageBox.information(self, "Export PDF", "Nothing to export — the canvas is empty.")
+            QMessageBox.information(
+                self, "Export PDF", "Nothing to export — the canvas is empty."
+            )
             return
 
-        filename, _ = QFileDialog.getSaveFileName(self, "Export as PDF", "", "PDF Files (*.pdf)")
+        filename, _ = QFileDialog.getSaveFileName(
+            self, "Export as PDF", "", "PDF Files (*.pdf)"
+        )
         if not filename:
             return
         if not filename.lower().endswith(".pdf"):

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -136,7 +136,11 @@ class SettingsMixin:
         if reply == QMessageBox.StandardButton.Yes:
             source = self.file_ctrl.load_auto_save()
             if source is not None:
-                title = f"Circuit Design GUI - {source}" if source else "Circuit Design GUI - (Recovered)"
+                title = (
+                    f"Circuit Design GUI - {source}"
+                    if source
+                    else "Circuit Design GUI - (Recovered)"
+                )
                 self.setWindowTitle(title)
                 self._sync_analysis_menu()
                 statusBar = self.statusBar()

--- a/app/GUI/main_window_simulation.py
+++ b/app/GUI/main_window_simulation.py
@@ -4,7 +4,8 @@ import logging
 import os
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QApplication, QFileDialog, QMessageBox, QProgressDialog
+from PyQt6.QtWidgets import (QApplication, QFileDialog, QMessageBox,
+                             QProgressDialog)
 
 from .monte_carlo_results_dialog import MonteCarloResultsDialog
 from .parameter_sweep_plot_dialog import ParameterSweepPlotDialog
@@ -39,7 +40,9 @@ class SimulationMixin:
 
         default_name = ""
         if hasattr(self, "file_ctrl") and self.file_ctrl.current_file:
-            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[0]
+            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[
+                0
+            ]
             default_name = base + ".cir"
 
         filename, _ = QFileDialog.getSaveFileName(
@@ -112,7 +115,9 @@ class SimulationMixin:
         if result.data:
             from .format_utils import format_value
 
-            result.data["sweep_labels"] = [format_value(v).strip() for v in result.data.get("sweep_values", [])]
+            result.data["sweep_labels"] = [
+                format_value(v).strip() for v in result.data.get("sweep_values", [])
+            ]
 
         return result
 
@@ -302,7 +307,9 @@ class SimulationMixin:
             self.results_text.append(f"  Frequency points: {len(freqs)}")
             self.results_text.append(f"  Signals: {', '.join(sorted(mag.keys()))}")
             if freqs:
-                self.results_text.append(f"  Range: {freqs[0]:.4g} Hz — {freqs[-1]:.4g} Hz")
+                self.results_text.append(
+                    f"  Range: {freqs[0]:.4g} Hz — {freqs[-1]:.4g} Hz"
+                )
             self.results_text.append("\nBode plot opened in a new window.")
             self._show_or_overlay_plot("AC Sweep", ac_data, ACSweepPlotDialog)
         else:
@@ -324,14 +331,19 @@ class SimulationMixin:
             self.results_text.append(table_string)
 
             # Power summary for resistors
-            from simulation.power_metrics import compute_transient_power_metrics, format_power_summary
+            from simulation.power_metrics import (
+                compute_transient_power_metrics, format_power_summary)
 
-            power_metrics = compute_transient_power_metrics(tran_data, self.model.components)
+            power_metrics = compute_transient_power_metrics(
+                tran_data, self.model.components
+            )
             if power_metrics:
                 self.results_text.append(format_power_summary(power_metrics))
 
             self.results_text.append("\n" + "-" * 40)
-            self.results_text.append("Waveform plot has also been generated in a new window.")
+            self.results_text.append(
+                "Waveform plot has also been generated in a new window."
+            )
 
             # Check for overlay on existing waveform dialog
             if self._waveform_dialog is not None and self._waveform_dialog.isVisible():
@@ -377,16 +389,24 @@ class SimulationMixin:
             self.results_text.append("-" * 40)
             self.results_text.append(f"  Frequency points: {len(freqs)}")
             if freqs:
-                self.results_text.append(f"  Range: {freqs[0]:.4g} Hz \u2014 {freqs[-1]:.4g} Hz")
+                self.results_text.append(
+                    f"  Range: {freqs[0]:.4g} Hz \u2014 {freqs[-1]:.4g} Hz"
+                )
             if onoise:
-                self.results_text.append(f"  Output noise (last): {onoise[-1]:.4e} V/sqrt(Hz)")
+                self.results_text.append(
+                    f"  Output noise (last): {onoise[-1]:.4e} V/sqrt(Hz)"
+                )
             if inoise:
-                self.results_text.append(f"  Input noise (last):  {inoise[-1]:.4e} V/sqrt(Hz)")
+                self.results_text.append(
+                    f"  Input noise (last):  {inoise[-1]:.4e} V/sqrt(Hz)"
+                )
             self.results_text.append("-" * 40)
 
             # Show tabular preview (first 20 rows)
             if freqs:
-                self.results_text.append(f"  {'Freq (Hz)':>12s}  {'onoise V/rtHz':>14s}  {'inoise V/rtHz':>14s}")
+                self.results_text.append(
+                    f"  {'Freq (Hz)':>12s}  {'onoise V/rtHz':>14s}  {'inoise V/rtHz':>14s}"
+                )
                 for i, f in enumerate(freqs[:20]):
                     o_val = f"{onoise[i]:.4e}" if i < len(onoise) else "N/A"
                     i_val = f"{inoise[i]:.4e}" if i < len(inoise) else "N/A"
@@ -405,11 +425,15 @@ class SimulationMixin:
             self._last_results = sens_data
             self.results_text.append("\nDC SENSITIVITY ANALYSIS:")
             self.results_text.append("-" * 70)
-            self.results_text.append(f"  {'Element':20s} {'Value':>14s} {'Sensitivity':>14s} {'Normalized':>14s}")
+            self.results_text.append(
+                f"  {'Element':20s} {'Value':>14s} {'Sensitivity':>14s} {'Normalized':>14s}"
+            )
             self.results_text.append("-" * 70)
 
             # Sort by absolute normalized sensitivity (most impactful first)
-            sorted_data = sorted(sens_data, key=lambda r: abs(r["normalized_sensitivity"]), reverse=True)
+            sorted_data = sorted(
+                sens_data, key=lambda r: abs(r["normalized_sensitivity"]), reverse=True
+            )
             for row in sorted_data:
                 self.results_text.append(
                     f"  {row['element']:20s} {row['value']:14.4e} "
@@ -442,9 +466,13 @@ class SimulationMixin:
             if gain is not None:
                 self.results_text.append(f"  {'Transfer function':20s} : {gain:.6g}")
             if z_in is not None:
-                self.results_text.append(f"  {'Input impedance':20s} : {format_si(z_in, 'Ω')}")
+                self.results_text.append(
+                    f"  {'Input impedance':20s} : {format_si(z_in, 'Ω')}"
+                )
             if z_out is not None:
-                self.results_text.append(f"  {'Output impedance':20s} : {format_si(z_out, 'Ω')}")
+                self.results_text.append(
+                    f"  {'Output impedance':20s} : {format_si(z_out, 'Ω')}"
+                )
 
             self.results_text.append("-" * 40)
         else:
@@ -479,7 +507,9 @@ class SimulationMixin:
 
             if zeros:
                 self.results_text.append(f"\n  ZEROS ({len(zeros)}):")
-                self.results_text.append(f"  {'#':>3s}  {'Real':>14s}  {'Imaginary':>14s}  {'Freq (Hz)':>12s}")
+                self.results_text.append(
+                    f"  {'#':>3s}  {'Real':>14s}  {'Imaginary':>14s}  {'Freq (Hz)':>12s}"
+                )
                 for i, z in enumerate(zeros, 1):
                     self.results_text.append(
                         f"  {i:3d}  {z['real']:14.4e}  {z['imag']:14.4e}  {format_si(z['frequency_hz'], 'Hz'):>12s}"
@@ -519,7 +549,9 @@ class SimulationMixin:
             for node, voltage in sorted(node_voltages.items()):
                 self.results_text.append(f"  {node:15s} : {voltage:12.6f} V")
             self.results_text.append("-" * 40)
-            self.results_text.append("Note: values shown are from the final temperature step.")
+            self.results_text.append(
+                "Note: values shown are from the final temperature step."
+            )
         else:
             self.results_text.append("\nNo results found. Check raw output below.")
         self.canvas.clear_op_results()
@@ -540,9 +572,13 @@ class SimulationMixin:
             self.results_text.append("-" * 40)
             self.results_text.append(f"  Component:      {comp_id}")
             self.results_text.append(f"  Base analysis:  {base_type}")
-            self.results_text.append(f"  Steps:          {ok_count}/{len(step_results)} succeeded")
+            self.results_text.append(
+                f"  Steps:          {ok_count}/{len(step_results)} succeeded"
+            )
             if labels:
-                self.results_text.append(f"  Range:          {labels[0]} to {labels[-1]}")
+                self.results_text.append(
+                    f"  Range:          {labels[0]} to {labels[-1]}"
+                )
             if sweep_data.get("cancelled"):
                 self.results_text.append("  (sweep was cancelled)")
             self.results_text.append("-" * 40)
@@ -572,7 +608,9 @@ class SimulationMixin:
             self.results_text.append("\nMONTE CARLO RESULTS:")
             self.results_text.append("-" * 40)
             self.results_text.append(f"  Base analysis:  {base_type}")
-            self.results_text.append(f"  Runs:           {ok_count}/{len(step_results)} succeeded")
+            self.results_text.append(
+                f"  Runs:           {ok_count}/{len(step_results)} succeeded"
+            )
             tolerances = mc_data.get("tolerances", {})
             for cid, tol in sorted(tolerances.items()):
                 self.results_text.append(
@@ -629,9 +667,13 @@ class SimulationMixin:
             self.results_text.append("-" * 40)
             for cid, p in sorted(power_data.items()):
                 sign = "dissipating" if p >= 0 else "supplying"
-                self.results_text.append(f"  {cid:15s} : {format_value(abs(p), 'W'):>12s} ({sign})")
+                self.results_text.append(
+                    f"  {cid:15s} : {format_value(abs(p), 'W'):>12s} ({sign})"
+                )
             self.results_text.append("-" * 40)
-            self.results_text.append(f"  {'Total':15s} : {format_value(abs(tp), 'W'):>12s}")
+            self.results_text.append(
+                f"  {'Total':15s} : {format_value(abs(tp), 'W'):>12s}"
+            )
         else:
             self.properties_panel.clear_simulation_results()
 
@@ -675,16 +717,18 @@ class SimulationMixin:
         if self._last_results is None:
             return
 
-        from simulation.csv_exporter import (
-            export_ac_results,
-            export_dc_sweep_results,
-            export_noise_results,
-            export_op_results,
-            export_transient_results,
-            write_csv,
-        )
+        from simulation.csv_exporter import (export_ac_results,
+                                             export_dc_sweep_results,
+                                             export_noise_results,
+                                             export_op_results,
+                                             export_transient_results,
+                                             write_csv)
 
-        circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+        circuit_name = (
+            os.path.basename(str(self.file_ctrl.current_file))
+            if self.file_ctrl.current_file
+            else ""
+        )
 
         if self._last_results_type == "DC Operating Point":
             csv_content = export_op_results(self._last_results, circuit_name)
@@ -699,7 +743,9 @@ class SimulationMixin:
         else:
             return
 
-        filename, _ = QFileDialog.getSaveFileName(self, "Export Results to CSV", "", "CSV Files (*.csv);;All Files (*)")
+        filename, _ = QFileDialog.getSaveFileName(
+            self, "Export Results to CSV", "", "CSV Files (*.csv);;All Files (*)"
+        )
         if filename:
             try:
                 write_csv(csv_content, filename)
@@ -716,14 +762,20 @@ class SimulationMixin:
 
         from simulation.excel_exporter import export_to_excel
 
-        circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+        circuit_name = (
+            os.path.basename(str(self.file_ctrl.current_file))
+            if self.file_ctrl.current_file
+            else ""
+        )
 
         filename, _ = QFileDialog.getSaveFileName(
             self, "Export Results to Excel", "", "Excel Files (*.xlsx);;All Files (*)"
         )
         if filename:
             try:
-                export_to_excel(self._last_results, self._last_results_type, filename, circuit_name)
+                export_to_excel(
+                    self._last_results, self._last_results_type, filename, circuit_name
+                )
                 statusBar = self.statusBar()
                 if statusBar:
                     statusBar.showMessage(f"Results exported to {filename}", 3000)

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -135,7 +135,9 @@ class ViewOperationsMixin:
         self.canvas.set_probe_mode(checked)
         if checked:
             if not self.canvas.node_voltages and self._last_results is None:
-                self.statusBar().showMessage("Probe mode active. Run a simulation first to see values.", 3000)
+                self.statusBar().showMessage(
+                    "Probe mode active. Run a simulation first to see values.", 3000
+                )
             else:
                 self.statusBar().showMessage(
                     "Probe mode active. Click nodes or components to see values. Press Escape to exit.",
@@ -148,7 +150,9 @@ class ViewOperationsMixin:
     def _on_probe_requested(self, signal_name, probe_type):
         """Handle probe click for sweep/transient analyses (no OP data on canvas)."""
         if self._last_results is None:
-            self.statusBar().showMessage("No simulation results available. Run a simulation first.", 3000)
+            self.statusBar().showMessage(
+                "No simulation results available. Run a simulation first.", 3000
+            )
             return
 
         analysis_type = self._last_results_type
@@ -159,7 +163,9 @@ class ViewOperationsMixin:
         elif analysis_type == "AC Sweep":
             self._probe_open_ac_sweep(signal_name, probe_type)
         else:
-            self.statusBar().showMessage(f"Probe not supported for {analysis_type} analysis.", 3000)
+            self.statusBar().showMessage(
+                f"Probe not supported for {analysis_type} analysis.", 3000
+            )
 
     def _probe_open_waveform(self, signal_name, probe_type):
         """Open waveform dialog focused on the probed signal."""
@@ -218,10 +224,14 @@ class ViewOperationsMixin:
         circuit_items = [
             item
             for item in scene.items()
-            if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
+            if isinstance(
+                item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem)
+            )
         ]
         if not circuit_items:
-            QMessageBox.information(self, "Export Image", "Nothing to export — the canvas is empty.")
+            QMessageBox.information(
+                self, "Export Image", "Nothing to export — the canvas is empty."
+            )
             return
 
         source_rect = circuit_items[0].sceneBoundingRect()
@@ -238,7 +248,9 @@ class ViewOperationsMixin:
 
             generator = QSvgGenerator()
             generator.setFileName(filename)
-            generator.setSize(QSize(int(source_rect.width()), int(source_rect.height())))
+            generator.setSize(
+                QSize(int(source_rect.width()), int(source_rect.height()))
+            )
             generator.setViewBox(source_rect)
             generator.setTitle("SDM Spice Circuit")
 
@@ -265,7 +277,9 @@ class ViewOperationsMixin:
             painter.end()
             image.save(filename)
 
-        QMessageBox.information(self, "Export Image", f"Circuit exported to:\n{filename}")
+        QMessageBox.information(
+            self, "Export Image", f"Circuit exported to:\n{filename}"
+        )
 
     def export_circuitikz(self):
         """Export the circuit as a CircuiTikZ LaTeX file."""
@@ -277,7 +291,9 @@ class ViewOperationsMixin:
 
         model = self.circuit_ctrl.model
         if not model.components:
-            QMessageBox.information(self, "Export LaTeX", "Nothing to export — the canvas is empty.")
+            QMessageBox.information(
+                self, "Export LaTeX", "Nothing to export — the canvas is empty."
+            )
             return
 
         # Show options dialog
@@ -295,7 +311,11 @@ class ViewOperationsMixin:
                 nodes=model.nodes,
                 terminal_to_node=model.terminal_to_node,
                 standalone=opts["standalone"],
-                circuit_name=(os.path.basename(self.file_ctrl.current_file) if self.file_ctrl.current_file else ""),
+                circuit_name=(
+                    os.path.basename(self.file_ctrl.current_file)
+                    if self.file_ctrl.current_file
+                    else ""
+                ),
                 scale=opts["scale"],
                 include_ids=opts["include_ids"],
                 include_values=opts["include_values"],
@@ -308,7 +328,9 @@ class ViewOperationsMixin:
 
         default_name = ""
         if hasattr(self, "file_ctrl") and self.file_ctrl.current_file:
-            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[0]
+            base = os.path.splitext(os.path.basename(str(self.file_ctrl.current_file)))[
+                0
+            ]
             default_name = base + ".tex"
 
         filename, _ = QFileDialog.getSaveFileName(

--- a/app/GUI/meas_dialog.py
+++ b/app/GUI/meas_dialog.py
@@ -8,21 +8,10 @@ FIND...WHEN), and timing measurements (TRIG...TARG).
 """
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import (
-    QComboBox,
-    QDialog,
-    QDialogButtonBox,
-    QFormLayout,
-    QGroupBox,
-    QHBoxLayout,
-    QHeaderView,
-    QLabel,
-    QLineEdit,
-    QPushButton,
-    QTableWidget,
-    QTableWidgetItem,
-    QVBoxLayout,
-)
+from PyQt6.QtWidgets import (QComboBox, QDialog, QDialogButtonBox, QFormLayout,
+                             QGroupBox, QHBoxLayout, QHeaderView, QLabel,
+                             QLineEdit, QPushButton, QTableWidget,
+                             QTableWidgetItem, QVBoxLayout)
 
 # Maps the GUI analysis type name to the .meas domain keyword
 ANALYSIS_DOMAIN_MAP = {
@@ -151,7 +140,9 @@ class MeasurementEntryDialog(QDialog):
         layout.addWidget(self.preview_label)
 
         # Buttons
-        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
@@ -179,21 +170,27 @@ class MeasurementEntryDialog(QDialog):
         if meas_type in ("AVG", "RMS", "MIN", "MAX", "PP", "INTEG"):
             self.from_edit = QLineEdit()
             self.from_edit.setPlaceholderText("optional, e.g., 0 or 1m")
-            self.from_edit.setToolTip("Start of measurement range (leave empty for full range)")
+            self.from_edit.setToolTip(
+                "Start of measurement range (leave empty for full range)"
+            )
             self.from_edit.textChanged.connect(self._update_preview)
             self._dynamic_layout.addRow("From:", self.from_edit)
             self._dynamic_widgets.append(self.from_edit)
 
             self.to_edit = QLineEdit()
             self.to_edit.setPlaceholderText("optional, e.g., 10m")
-            self.to_edit.setToolTip("End of measurement range (leave empty for full range)")
+            self.to_edit.setToolTip(
+                "End of measurement range (leave empty for full range)"
+            )
             self.to_edit.textChanged.connect(self._update_preview)
             self._dynamic_layout.addRow("To:", self.to_edit)
             self._dynamic_widgets.append(self.to_edit)
 
         elif meas_type == "FIND_AT":
             self.at_edit = QLineEdit("1m")
-            self.at_edit.setToolTip("The exact point (time/frequency/voltage) at which to sample the variable")
+            self.at_edit.setToolTip(
+                "The exact point (time/frequency/voltage) at which to sample the variable"
+            )
             self.at_edit.textChanged.connect(self._update_preview)
             self._dynamic_layout.addRow("At value:", self.at_edit)
             self._dynamic_widgets.append(self.at_edit)
@@ -206,14 +203,20 @@ class MeasurementEntryDialog(QDialog):
             self._dynamic_widgets.append(self.when_var_edit)
 
             self.when_val_edit = QLineEdit("0.5")
-            self.when_val_edit.setToolTip("Value that the condition variable must equal")
+            self.when_val_edit.setToolTip(
+                "Value that the condition variable must equal"
+            )
             self.when_val_edit.textChanged.connect(self._update_preview)
             self._dynamic_layout.addRow("Equals:", self.when_val_edit)
             self._dynamic_widgets.append(self.when_val_edit)
 
             self.cross_combo = QComboBox()
-            self.cross_combo.addItems(["", "RISE=1", "FALL=1", "CROSS=1", "RISE=2", "FALL=2"])
-            self.cross_combo.setToolTip("Which crossing to use (empty = first crossing)")
+            self.cross_combo.addItems(
+                ["", "RISE=1", "FALL=1", "CROSS=1", "RISE=2", "FALL=2"]
+            )
+            self.cross_combo.setToolTip(
+                "Which crossing to use (empty = first crossing)"
+            )
             self.cross_combo.currentIndexChanged.connect(self._update_preview)
             self._dynamic_layout.addRow("Crossing:", self.cross_combo)
             self._dynamic_widgets.append(self.cross_combo)
@@ -233,7 +236,9 @@ class MeasurementEntryDialog(QDialog):
 
             self.trig_edge_combo = QComboBox()
             self.trig_edge_combo.addItems(["RISE=1", "FALL=1", "CROSS=1"])
-            self.trig_edge_combo.setToolTip("Trigger edge: rising, falling, or any crossing")
+            self.trig_edge_combo.setToolTip(
+                "Trigger edge: rising, falling, or any crossing"
+            )
             self.trig_edge_combo.currentIndexChanged.connect(self._update_preview)
             self._dynamic_layout.addRow("Trigger edge:", self.trig_edge_combo)
             self._dynamic_widgets.append(self.trig_edge_combo)
@@ -252,7 +257,9 @@ class MeasurementEntryDialog(QDialog):
 
             self.targ_edge_combo = QComboBox()
             self.targ_edge_combo.addItems(["RISE=1", "FALL=1", "CROSS=1"])
-            self.targ_edge_combo.setToolTip("Target edge: rising, falling, or any crossing")
+            self.targ_edge_combo.setToolTip(
+                "Target edge: rising, falling, or any crossing"
+            )
             self.targ_edge_combo.currentIndexChanged.connect(self._update_preview)
             self._dynamic_layout.addRow("Target edge:", self.targ_edge_combo)
             self._dynamic_widgets.append(self.targ_edge_combo)
@@ -263,7 +270,9 @@ class MeasurementEntryDialog(QDialog):
         """Update the directive preview text."""
         data = self.get_data()
         if data:
-            directive = build_directive(self._domain, data["name"], data["meas_type"], data["params"])
+            directive = build_directive(
+                self._domain, data["name"], data["meas_type"], data["params"]
+            )
             self.preview_label.setText(directive)
         else:
             self.preview_label.setText("")
@@ -317,7 +326,12 @@ class MeasurementEntryDialog(QDialog):
                 params["targ_edge"] = self.targ_edge_combo.currentText()
 
         directive = build_directive(self._domain, name, meas_type, params)
-        return {"name": name, "meas_type": meas_type, "params": params, "directive": directive}
+        return {
+            "name": name,
+            "meas_type": meas_type,
+            "params": params,
+            "directive": directive,
+        }
 
     def _load_initial(self, data):
         """Pre-populate form from a data dict."""
@@ -437,7 +451,9 @@ class MeasurementDialog(QDialog):
         layout.addLayout(btn_layout)
 
         # OK / Cancel
-        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
@@ -457,7 +473,9 @@ class MeasurementDialog(QDialog):
             self.table.setItem(row, 1, type_item)
 
             directive_item = QTableWidgetItem(entry.get("directive", ""))
-            directive_item.setFlags(directive_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+            directive_item.setFlags(
+                directive_item.flags() & ~Qt.ItemFlag.ItemIsEditable
+            )
             self.table.setItem(row, 2, directive_item)
 
         self._update_buttons()

--- a/app/GUI/measurement_cursors.py
+++ b/app/GUI/measurement_cursors.py
@@ -7,7 +7,8 @@ a readout panel showing X/Y values and deltas, and real-time updates.
 
 import numpy as np
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QGroupBox, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import (QGroupBox, QHBoxLayout, QLabel, QPushButton,
+                             QVBoxLayout, QWidget)
 
 
 class MeasurementCursors:

--- a/app/GUI/monte_carlo_dialog.py
+++ b/app/GUI/monte_carlo_dialog.py
@@ -6,21 +6,10 @@ distribution, and select the base analysis type.
 """
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import (
-    QComboBox,
-    QDialog,
-    QDialogButtonBox,
-    QDoubleSpinBox,
-    QFormLayout,
-    QGroupBox,
-    QHeaderView,
-    QLabel,
-    QLineEdit,
-    QSpinBox,
-    QTableWidget,
-    QTableWidgetItem,
-    QVBoxLayout,
-)
+from PyQt6.QtWidgets import (QComboBox, QDialog, QDialogButtonBox,
+                             QDoubleSpinBox, QFormLayout, QGroupBox,
+                             QHeaderView, QLabel, QLineEdit, QSpinBox,
+                             QTableWidget, QTableWidgetItem, QVBoxLayout)
 
 # Base analysis types available for Monte Carlo
 MC_BASE_ANALYSIS_TYPES = [
@@ -43,7 +32,11 @@ class MonteCarloDialog(QDialog):
         from simulation.monte_carlo import MC_ELIGIBLE_TYPES
 
         self._components = components
-        self._eligible = {cid: comp for cid, comp in components.items() if comp.component_type in MC_ELIGIBLE_TYPES}
+        self._eligible = {
+            cid: comp
+            for cid, comp in components.items()
+            if comp.component_type in MC_ELIGIBLE_TYPES
+        }
         self._base_field_widgets = {}
         self._init_ui()
 
@@ -89,10 +82,16 @@ class MonteCarloDialog(QDialog):
             self.tol_table = None
         else:
             self.tol_table = QTableWidget()
-            self.tol_table.setToolTip("Set tolerance and distribution for each component")
+            self.tol_table.setToolTip(
+                "Set tolerance and distribution for each component"
+            )
             self.tol_table.setColumnCount(4)
-            self.tol_table.setHorizontalHeaderLabels(["Component", "Type", "Tolerance (%)", "Distribution"])
-            self.tol_table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+            self.tol_table.setHorizontalHeaderLabels(
+                ["Component", "Type", "Tolerance (%)", "Distribution"]
+            )
+            self.tol_table.horizontalHeader().setSectionResizeMode(
+                QHeaderView.ResizeMode.Stretch
+            )
             self.tol_table.setRowCount(len(self._eligible))
 
             for row, (cid, comp) in enumerate(sorted(self._eligible.items())):
@@ -121,7 +120,9 @@ class MonteCarloDialog(QDialog):
                 # Distribution combo
                 dist_combo = QComboBox()
                 dist_combo.addItems(["Gaussian", "Uniform"])
-                dist_combo.setToolTip("Gaussian: normal distribution; Uniform: equal probability across range")
+                dist_combo.setToolTip(
+                    "Gaussian: normal distribution; Uniform: equal probability across range"
+                )
                 self.tol_table.setCellWidget(row, 3, dist_combo)
 
             tol_layout.addWidget(self.tol_table)
@@ -129,7 +130,9 @@ class MonteCarloDialog(QDialog):
         layout.addWidget(tol_group)
 
         # --- Buttons ---
-        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)

--- a/app/GUI/monte_carlo_results_dialog.py
+++ b/app/GUI/monte_carlo_results_dialog.py
@@ -7,7 +7,8 @@ import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
-from PyQt6.QtWidgets import QComboBox, QDialog, QHBoxLayout, QLabel, QTextEdit, QVBoxLayout
+from PyQt6.QtWidgets import (QComboBox, QDialog, QHBoxLayout, QLabel,
+                             QTextEdit, QVBoxLayout)
 from simulation.monte_carlo import compute_mc_statistics
 
 from .styles import theme_manager
@@ -107,7 +108,9 @@ class MonteCarloResultsDialog(QDialog):
                 continue
 
             if self._base_type == "DC Operating Point":
-                voltages = data.get("node_voltages", {}) if isinstance(data, dict) else data
+                voltages = (
+                    data.get("node_voltages", {}) if isinstance(data, dict) else data
+                )
                 if isinstance(voltages, dict):
                     for node, val in voltages.items():
                         key = f"V({node})"
@@ -194,10 +197,14 @@ class MonteCarloResultsDialog(QDialog):
                 if not isinstance(data, list) or not data:
                     continue
                 time_vals = [row.get("time", 0) for row in data]
-                signal_keys = sorted(k for k in data[0].keys() if k.lower() not in ("time", "index"))
+                signal_keys = sorted(
+                    k for k in data[0].keys() if k.lower() not in ("time", "index")
+                )
                 for j, key in enumerate(signal_keys):
                     vals = [row.get(key, 0) for row in data]
-                    ax.plot(time_vals, vals, alpha=0.2, color=cmap(j % 10), linewidth=0.5)
+                    ax.plot(
+                        time_vals, vals, alpha=0.2, color=cmap(j % 10), linewidth=0.5
+                    )
             ax.set_xlabel("Time (s)")
             ax.set_ylabel("Voltage (V)")
             ax.set_title("Transient — All Runs")
@@ -234,7 +241,9 @@ class MonteCarloResultsDialog(QDialog):
                 freqs = data.get("frequencies", [])
                 mag = data.get("magnitude", {})
                 for j, (node, vals) in enumerate(sorted(mag.items())):
-                    ax.semilogx(freqs, vals, alpha=0.2, color=cmap(j % 10), linewidth=0.5)
+                    ax.semilogx(
+                        freqs, vals, alpha=0.2, color=cmap(j % 10), linewidth=0.5
+                    )
             ax.set_xlabel("Frequency (Hz)")
             ax.set_ylabel("Magnitude")
             ax.set_title("AC Sweep — All Runs")
@@ -253,10 +262,17 @@ class MonteCarloResultsDialog(QDialog):
         values = self._metrics.get(metric, [])
 
         if not values:
-            ax.text(0.5, 0.5, "No data", ha="center", va="center", transform=ax.transAxes)
+            ax.text(
+                0.5, 0.5, "No data", ha="center", va="center", transform=ax.transAxes
+            )
             self._summary.setPlainText("No metric data available.")
         else:
-            ax.hist(values, bins=min(30, max(5, len(values) // 3)), edgecolor="black", alpha=0.7)
+            ax.hist(
+                values,
+                bins=min(30, max(5, len(values) // 3)),
+                edgecolor="black",
+                alpha=0.7,
+            )
             ax.set_xlabel(metric)
             ax.set_ylabel("Count")
             ax.set_title(f"Distribution — {metric}")

--- a/app/GUI/netlist_preview.py
+++ b/app/GUI/netlist_preview.py
@@ -6,7 +6,8 @@ with basic syntax highlighting.
 import re
 
 from PyQt6.QtGui import QColor, QFont, QSyntaxHighlighter, QTextCharFormat
-from PyQt6.QtWidgets import QHBoxLayout, QLabel, QPushButton, QTextEdit, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import (QHBoxLayout, QLabel, QPushButton, QTextEdit,
+                             QVBoxLayout, QWidget)
 
 
 class SpiceHighlighter(QSyntaxHighlighter):
@@ -31,7 +32,14 @@ class SpiceHighlighter(QSyntaxHighlighter):
         control_fmt = QTextCharFormat()
         control_fmt.setForeground(QColor("#9C27B0"))
         control_fmt.setFontWeight(QFont.Weight.Bold)
-        self._rules.append((re.compile(r"^(run|quit|print|set|let|wrdata|setplot)\b.*$", re.IGNORECASE), control_fmt))
+        self._rules.append(
+            (
+                re.compile(
+                    r"^(run|quit|print|set|let|wrdata|setplot)\b.*$", re.IGNORECASE
+                ),
+                control_fmt,
+            )
+        )
 
     def highlightBlock(self, text):
         """Apply syntax highlighting rules to a single line of text."""
@@ -73,7 +81,9 @@ class NetlistPreviewWidget(QWidget):
         self.text_edit = QTextEdit()
         self.text_edit.setReadOnly(True)
         self.text_edit.setFont(QFont("Monospace", 9))
-        self.text_edit.setPlaceholderText("No netlist generated yet. Add components and click Refresh.")
+        self.text_edit.setPlaceholderText(
+            "No netlist generated yet. Add components and click Refresh."
+        )
         layout.addWidget(self.text_edit)
 
         # Attach syntax highlighter

--- a/app/GUI/parameter_sweep_dialog.py
+++ b/app/GUI/parameter_sweep_dialog.py
@@ -3,17 +3,9 @@ Parameter Sweep Dialog — Configure sweeping a component parameter across a ran
 of values with a selectable base analysis type.
 """
 
-from PyQt6.QtWidgets import (
-    QComboBox,
-    QDialog,
-    QDialogButtonBox,
-    QFormLayout,
-    QGroupBox,
-    QLabel,
-    QLineEdit,
-    QSpinBox,
-    QVBoxLayout,
-)
+from PyQt6.QtWidgets import (QComboBox, QDialog, QDialogButtonBox, QFormLayout,
+                             QGroupBox, QLabel, QLineEdit, QSpinBox,
+                             QVBoxLayout)
 
 from .format_utils import format_value, parse_value
 
@@ -53,7 +45,11 @@ class ParameterSweepDialog(QDialog):
         self.setMinimumWidth(420)
 
         # Filter to sweepable components
-        self._sweepable = {cid: comp for cid, comp in components.items() if comp.component_type in SWEEPABLE_TYPES}
+        self._sweepable = {
+            cid: comp
+            for cid, comp in components.items()
+            if comp.component_type in SWEEPABLE_TYPES
+        }
 
         self._base_field_widgets = {}
         self._init_ui()
@@ -77,7 +73,9 @@ class ParameterSweepDialog(QDialog):
         self.component_combo.setToolTip("Select a component whose value will be swept")
         if self._sweepable:
             for cid, comp in sorted(self._sweepable.items()):
-                self.component_combo.addItem(f"{cid} ({comp.component_type}: {comp.value})", cid)
+                self.component_combo.addItem(
+                    f"{cid} ({comp.component_type}: {comp.value})", cid
+                )
         else:
             self.component_combo.addItem("(no sweepable components)")
             self.component_combo.setEnabled(False)
@@ -119,14 +117,18 @@ class ParameterSweepDialog(QDialog):
         self._build_base_form()
 
         # --- Buttons ---
-        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
 
         # Set defaults from first component
         self._update_defaults_from_component()
-        self.component_combo.currentIndexChanged.connect(lambda _: self._update_defaults_from_component())
+        self.component_combo.currentIndexChanged.connect(
+            lambda _: self._update_defaults_from_component()
+        )
 
     def _update_defaults_from_component(self):
         """Update start/stop defaults based on selected component's current value."""

--- a/app/GUI/parameter_sweep_plot_dialog.py
+++ b/app/GUI/parameter_sweep_plot_dialog.py
@@ -85,7 +85,14 @@ class ParameterSweepPlotDialog(QDialog):
                 all_nodes.update(r.data.keys())
 
         if not all_nodes:
-            ax.text(0.5, 0.5, "No data available", ha="center", va="center", transform=ax.transAxes)
+            ax.text(
+                0.5,
+                0.5,
+                "No data available",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+            )
             return
 
         cmap = plt.get_cmap("tab10")
@@ -98,7 +105,9 @@ class ParameterSweepPlotDialog(QDialog):
                     vals.append(sv)
                     voltages.append(r.data[node])
             if vals:
-                ax.plot(vals, voltages, "o-", label=node, color=cmap(idx % 10), markersize=4)
+                ax.plot(
+                    vals, voltages, "o-", label=node, color=cmap(idx % 10), markersize=4
+                )
 
         ax.set_xlabel(f"{component_id} Value")
         ax.set_ylabel("Voltage (V)")
@@ -131,7 +140,14 @@ class ParameterSweepPlotDialog(QDialog):
 
             for node in nodes:
                 values = [pt[node] for pt in r.data]
-                ax.plot(times, values, color=color, label=f"{node} ({component_id}={label})", alpha=0.8, linewidth=1)
+                ax.plot(
+                    times,
+                    values,
+                    color=color,
+                    label=f"{node} ({component_id}={label})",
+                    alpha=0.8,
+                    linewidth=1,
+                )
 
         ax.set_xlabel("Time (s)")
         ax.set_ylabel("Voltage (V)")
@@ -165,10 +181,20 @@ class ParameterSweepPlotDialog(QDialog):
             color = cmap(i / max(n - 1, 1))
 
             for node, mag_vals in sorted(magnitude.items()):
-                ax_mag.semilogx(freqs, mag_vals, color=color, label=f"{node} ({component_id}={label})", alpha=0.8)
+                ax_mag.semilogx(
+                    freqs,
+                    mag_vals,
+                    color=color,
+                    label=f"{node} ({component_id}={label})",
+                    alpha=0.8,
+                )
                 if node in phase:
                     ax_phase.semilogx(
-                        freqs, phase[node], color=color, label=f"{node} ({component_id}={label})", alpha=0.8
+                        freqs,
+                        phase[node],
+                        color=color,
+                        label=f"{node} ({component_id}={label})",
+                        alpha=0.8,
                     )
 
         ax_mag.set_ylabel("Magnitude")
@@ -213,7 +239,13 @@ class ParameterSweepPlotDialog(QDialog):
             for col_idx in range(2, len(headers)):
                 col_label = headers[col_idx]
                 values = [row[col_idx] for row in rows]
-                ax.plot(sweep_vals, values, color=color, label=f"{col_label} ({component_id}={label})", alpha=0.8)
+                ax.plot(
+                    sweep_vals,
+                    values,
+                    color=color,
+                    label=f"{col_label} ({component_id}={label})",
+                    alpha=0.8,
+                )
 
         ax.set_xlabel(x_label)
         ax.set_ylabel("Voltage (V)")

--- a/app/GUI/path_finding.py
+++ b/app/GUI/path_finding.py
@@ -33,7 +33,9 @@ class WeightedPathfinder(ABC):
         self.crossing_penalty = 20  # Penalty for crossing different nets
         self.same_net_cost = 0.1  # Low cost for same-net bundling
         self.body_crossing_penalty = float("inf")  # Component body crossing (blocked)
-        self.non_net_crossing_penalty = float("inf")  # Non-net terminal crossing (blocked)
+        self.non_net_crossing_penalty = float(
+            "inf"
+        )  # Non-net terminal crossing (blocked)
 
         # Performance tracking
         self.last_runtime = 0
@@ -352,7 +354,10 @@ class IDAStarPathfinder(WeightedPathfinder):
             new_direction = (dx, dy)
 
             neighbor_pos = self._grid_to_pos(neighbor)
-            if not (min_x <= neighbor_pos.x() <= max_x and min_y <= neighbor_pos.y() <= max_y):
+            if not (
+                min_x <= neighbor_pos.x() <= max_x
+                and min_y <= neighbor_pos.y() <= max_y
+            ):
                 continue
 
             if neighbor in obstacles:
@@ -487,7 +492,9 @@ def polygon_to_grid_filled(
             if y_min <= scan_y_world < y_max:
                 # Calculate x coordinate of intersection in WORLD space
                 # Linear interpolation: x = x1 + (scan_y - y1) * (x2 - x1) / (y2 - y1)
-                x_intersect_world = p1[0] + (scan_y_world - p1[1]) * (p2[0] - p1[0]) / (p2[1] - p1[1])
+                x_intersect_world = p1[0] + (scan_y_world - p1[1]) * (p2[0] - p1[0]) / (
+                    p2[1] - p1[1]
+                )
                 intersections.append(x_intersect_world)
 
         if debug_first and len(obstacles) < 20:
@@ -511,7 +518,9 @@ def polygon_to_grid_filled(
                 # Fill by converting each world X position using round() to match _pos_to_grid()
                 # This ensures obstacle coordinates exactly match the pathfinding grid system
                 # Sample at small intervals to catch all grid cells that overlap the filled region
-                step = grid_size / 4.0  # Sample 4 times per grid cell to ensure coverage
+                step = (
+                    grid_size / 4.0
+                )  # Sample 4 times per grid cell to ensure coverage
                 x_current = x_start_world
                 while x_current <= x_end_world:
                     grid_x = round(x_current / grid_size)
@@ -740,7 +749,9 @@ def get_component_obstacles(
             )
             terminal_key = (comp.component_id, i)
             is_active = terminal_key in active_terminals_set
-            terminal_info.append({"grid": term_grid, "pos": term_pos, "is_active": is_active})
+            terminal_info.append(
+                {"grid": term_grid, "pos": term_pos, "is_active": is_active}
+            )
 
         # Get active terminal positions for exclusion from body obstacles
         active_terminal_positions = {t["grid"] for t in terminal_info if t["is_active"]}

--- a/app/GUI/preferences_dialog.py
+++ b/app/GUI/preferences_dialog.py
@@ -1,21 +1,10 @@
 """Unified Preferences dialog for application settings."""
 
 from PyQt6.QtCore import QSettings
-from PyQt6.QtWidgets import (
-    QCheckBox,
-    QComboBox,
-    QDialog,
-    QFileDialog,
-    QFormLayout,
-    QHBoxLayout,
-    QLabel,
-    QMessageBox,
-    QPushButton,
-    QSpinBox,
-    QTabWidget,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt6.QtWidgets import (QCheckBox, QComboBox, QDialog, QFileDialog,
+                             QFormLayout, QHBoxLayout, QLabel, QMessageBox,
+                             QPushButton, QSpinBox, QTabWidget, QVBoxLayout,
+                             QWidget)
 
 from .styles import CustomTheme, theme_manager, theme_store
 
@@ -148,7 +137,11 @@ class PreferencesDialog(QDialog):
     def _update_theme_buttons(self):
         """Enable/disable Edit and Delete based on current selection."""
         idx = self.theme_combo.currentIndex()
-        is_custom = idx >= 0 and idx < len(self._theme_keys) and self._theme_keys[idx].startswith("custom:")
+        is_custom = (
+            idx >= 0
+            and idx < len(self._theme_keys)
+            and self._theme_keys[idx].startswith("custom:")
+        )
         self.edit_theme_btn.setEnabled(is_custom)
         self.delete_theme_btn.setEnabled(is_custom)
 
@@ -177,7 +170,9 @@ class PreferencesDialog(QDialog):
     def _build_keybindings_tab(self):
         widget = QWidget()
         layout = QVBoxLayout(widget)
-        layout.addWidget(QLabel("Keyboard shortcuts can be customized in the keybindings editor."))
+        layout.addWidget(
+            QLabel("Keyboard shortcuts can be customized in the keybindings editor.")
+        )
         self.keybindings_btn = QPushButton("Open Keybindings Editor...")
         self.keybindings_btn.clicked.connect(self._open_keybindings)
         layout.addWidget(self.keybindings_btn)
@@ -305,7 +300,9 @@ class PreferencesDialog(QDialog):
     def _on_import_theme(self):
         from pathlib import Path
 
-        path, _ = QFileDialog.getOpenFileName(self, "Import Theme", "", "Theme Files (*.json);;All Files (*)")
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Import Theme", "", "Theme Files (*.json);;All Files (*)"
+        )
         if not path:
             return
         theme = theme_store.import_theme(Path(path))
@@ -318,18 +315,24 @@ class PreferencesDialog(QDialog):
             if hasattr(self.main_window, "_refresh_theme_menu"):
                 self.main_window._refresh_theme_menu()
         else:
-            QMessageBox.warning(self, "Import Failed", "Could not import the theme file.")
+            QMessageBox.warning(
+                self, "Import Failed", "Could not import the theme file."
+            )
 
     def _on_export_theme(self):
         from pathlib import Path
 
         current = theme_manager.current_theme
         if not isinstance(current, CustomTheme):
-            QMessageBox.information(self, "Export Theme", "Only custom themes can be exported.")
+            QMessageBox.information(
+                self, "Export Theme", "Only custom themes can be exported."
+            )
             return
 
         default_name = theme_store._filename_safe(current.name) + ".json"
-        path, _ = QFileDialog.getSaveFileName(self, "Export Theme", default_name, "Theme Files (*.json);;All Files (*)")
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Export Theme", default_name, "Theme Files (*.json);;All Files (*)"
+        )
         if not path:
             return
         theme_store.export_theme(current, Path(path))

--- a/app/GUI/properties_panel.py
+++ b/app/GUI/properties_panel.py
@@ -1,7 +1,8 @@
 # waveform_dialog imported lazily in configure_waveform() for faster startup
 from models.component import DEFAULT_VALUES, OPAMP_MODELS
 from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtWidgets import QComboBox, QFormLayout, QGroupBox, QLabel, QLineEdit, QPushButton, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import (QComboBox, QFormLayout, QGroupBox, QLabel,
+                             QLineEdit, QPushButton, QVBoxLayout, QWidget)
 
 from .format_utils import format_value, validate_component_value
 from .styles import theme_manager
@@ -11,7 +12,9 @@ class PropertiesPanel(QWidget):
     """Panel for editing component properties"""
 
     # Signal emitted when a property is changed
-    property_changed = pyqtSignal(str, str, object)  # component_id, property_name, new_value
+    property_changed = pyqtSignal(
+        str, str, object
+    )  # component_id, property_name, new_value
 
     def __init__(self):
         super().__init__()
@@ -36,7 +39,9 @@ class PropertiesPanel(QWidget):
         # Component ID field (read-only)
         self.id_label = QLabel("-")
         self.id_label.setStyleSheet(theme_manager.stylesheet("muted_label"))
-        self.id_label.setToolTip("Unique identifier for this component (auto-generated)")
+        self.id_label.setToolTip(
+            "Unique identifier for this component (auto-generated)"
+        )
         self.form_layout.addRow("ID:", self.id_label)
 
         # Component Type field (read-only)
@@ -48,14 +53,18 @@ class PropertiesPanel(QWidget):
         # Value field (editable)
         self.value_input = QLineEdit()
         self.value_input.setPlaceholderText("e.g., 10k, 100u, 5V")
-        self.value_input.setToolTip("Component value with optional SI suffix (e.g., 10k, 100n, 4.7M)")
+        self.value_input.setToolTip(
+            "Component value with optional SI suffix (e.g., 10k, 100n, 4.7M)"
+        )
         self.value_input.textChanged.connect(self.on_value_changed)
         self.form_layout.addRow("Value:", self.value_input)
 
         # Op-amp model selector (shown only for Op-Amp components)
         self.opamp_model_combo = QComboBox()
         self.opamp_model_combo.addItems(OPAMP_MODELS)
-        self.opamp_model_combo.setToolTip("Select the op-amp model (Ideal or a real device)")
+        self.opamp_model_combo.setToolTip(
+            "Select the op-amp model (Ideal or a real device)"
+        )
         self.opamp_model_combo.currentTextChanged.connect(self._on_opamp_model_changed)
         self.opamp_model_combo.setVisible(False)
         self.form_layout.addRow("Model:", self.opamp_model_combo)
@@ -85,7 +94,9 @@ class PropertiesPanel(QWidget):
 
         # Apply button
         self.apply_button = QPushButton("Apply Changes")
-        self.apply_button.setToolTip("Apply the changed value to the selected component")
+        self.apply_button.setToolTip(
+            "Apply the changed value to the selected component"
+        )
         self.apply_button.clicked.connect(self.apply_changes)
         self.apply_button.setEnabled(False)
         layout.addWidget(self.apply_button)
@@ -103,7 +114,9 @@ class PropertiesPanel(QWidget):
         self.results_layout.setLabelAlignment(Qt.AlignmentFlag.AlignRight)
 
         self.power_label = QLabel("-")
-        self.power_label.setToolTip("Power dissipated by this component (P = V\u00b2/R or P = VI)")
+        self.power_label.setToolTip(
+            "Power dissipated by this component (P = V\u00b2/R or P = VI)"
+        )
         self.results_layout.addRow("Power:", self.power_label)
 
         self.voltage_label = QLabel("-")
@@ -111,7 +124,9 @@ class PropertiesPanel(QWidget):
         self.results_layout.addRow("V across:", self.voltage_label)
 
         self.total_power_label = QLabel("-")
-        self.total_power_label.setToolTip("Total power dissipated by all components in the circuit")
+        self.total_power_label.setToolTip(
+            "Total power dissipated by all components in the circuit"
+        )
         self.results_layout.addRow("Total P:", self.total_power_label)
 
         self.results_group.setVisible(False)
@@ -198,7 +213,9 @@ class PropertiesPanel(QWidget):
         else:
             self.value_input.setReadOnly(False)
             self.value_input.setVisible(True)
-            self.value_input.setPlaceholderText(f"Default: {DEFAULT_VALUES.get(component.component_type, '')}")
+            self.value_input.setPlaceholderText(
+                f"Default: {DEFAULT_VALUES.get(component.component_type, '')}"
+            )
             self.waveform_button.setVisible(False)
             self.opamp_model_combo.setVisible(False)
 
@@ -231,7 +248,9 @@ class PropertiesPanel(QWidget):
         if self.current_component.component_type != "Op-Amp":
             return
         if model_name != self.current_component.value:
-            self.property_changed.emit(self.current_component.component_id, "value", model_name)
+            self.property_changed.emit(
+                self.current_component.component_id, "value", model_name
+            )
 
     def on_value_changed(self):
         """Handle value input changes"""
@@ -247,7 +266,9 @@ class PropertiesPanel(QWidget):
         new_value = self.value_input.text().strip()
 
         # Validate value format
-        is_valid, error_msg = validate_component_value(new_value, self.current_component.component_type)
+        is_valid, error_msg = validate_component_value(
+            new_value, self.current_component.component_type
+        )
         if not is_valid:
             self.error_label.setText(error_msg)
             self.error_label.setVisible(True)
@@ -257,14 +278,18 @@ class PropertiesPanel(QWidget):
 
         # Emit signal if value changed
         if new_value != self.current_component.value:
-            self.property_changed.emit(self.current_component.component_id, "value", new_value)
+            self.property_changed.emit(
+                self.current_component.component_id, "value", new_value
+            )
 
         # Apply initial condition if applicable
         if self.current_component.component_type in ("Capacitor", "Inductor"):
             ic_value = self.ic_input.text().strip() or None
             old_ic = getattr(self.current_component, "initial_condition", None)
             if ic_value != old_ic:
-                self.property_changed.emit(self.current_component.component_id, "initial_condition", ic_value)
+                self.property_changed.emit(
+                    self.current_component.component_id, "initial_condition", ic_value
+                )
 
         self.apply_button.setEnabled(False)
 
@@ -294,7 +319,9 @@ class PropertiesPanel(QWidget):
                 self.current_component.value = spice_value
 
             # Emit property changed signal
-            self.property_changed.emit(self.current_component.component_id, "waveform", (waveform_type, params))
+            self.property_changed.emit(
+                self.current_component.component_id, "waveform", (waveform_type, params)
+            )
 
     def set_simulation_results(self, power_data, voltage_data=None, total_power=0.0):
         """Store simulation results for display when a component is selected.

--- a/app/GUI/renderers.py
+++ b/app/GUI/renderers.py
@@ -143,7 +143,9 @@ class IEEEWaveformVoltageSource(ComponentRenderer):
         # Draw sine wave symbol
         from models.component import COMPONENT_COLORS
 
-        painter.setPen(QPen(QColor(COMPONENT_COLORS.get(component.component_type, "#E91E63")), 2))
+        painter.setPen(
+            QPen(QColor(COMPONENT_COLORS.get(component.component_type, "#E91E63")), 2)
+        )
         from PyQt6.QtGui import QPainterPath
 
         path = QPainterPath()

--- a/app/GUI/report_dialog.py
+++ b/app/GUI/report_dialog.py
@@ -1,6 +1,7 @@
 """Dialog for configuring circuit report generation."""
 
-from PyQt6.QtWidgets import QCheckBox, QDialog, QDialogButtonBox, QGroupBox, QHBoxLayout, QLabel, QLineEdit, QVBoxLayout
+from PyQt6.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox, QGroupBox,
+                             QHBoxLayout, QLabel, QLineEdit, QVBoxLayout)
 
 
 class ReportDialog(QDialog):
@@ -67,7 +68,9 @@ class ReportDialog(QDialog):
         layout.addWidget(sections_group)
 
         # Buttons
-        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)

--- a/app/GUI/report_generator.py
+++ b/app/GUI/report_generator.py
@@ -86,14 +86,18 @@ class ReportGenerator:
         if self.config.include_netlist and netlist:
             if not first_page:
                 printer.newPage()
-            self._render_text_section(painter, printer, content_rect, "SPICE Netlist", netlist, monospace=True)
+            self._render_text_section(
+                painter, printer, content_rect, "SPICE Netlist", netlist, monospace=True
+            )
             first_page = False
 
         if self.config.include_analysis and model is not None:
             if not first_page:
                 printer.newPage()
             analysis_text = self._format_analysis_config(model)
-            self._render_text_section(painter, printer, content_rect, "Analysis Configuration", analysis_text)
+            self._render_text_section(
+                painter, printer, content_rect, "Analysis Configuration", analysis_text
+            )
             first_page = False
 
         if self.config.include_results and results_text:
@@ -133,7 +137,9 @@ class ReportGenerator:
         subtitle = "Circuit Analysis Report"
         fm = QFontMetrics(subtitle_font)
         sub_width = fm.horizontalAdvance(subtitle)
-        painter.drawText(int(center_x - sub_width / 2), int(center_y + fm.height() * 2), subtitle)
+        painter.drawText(
+            int(center_x - sub_width / 2), int(center_y + fm.height() * 2), subtitle
+        )
 
         # Analysis type if available
         if model and model.analysis_type:
@@ -177,7 +183,9 @@ class ReportGenerator:
                 self.config.student_name,
             )
 
-    def _render_schematic_page(self, painter: QPainter, printer: QPrinter, rect: QRectF, scene) -> None:
+    def _render_schematic_page(
+        self, painter: QPainter, printer: QPrinter, rect: QRectF, scene
+    ) -> None:
         """Render the circuit schematic on a dedicated page."""
         # Heading
         heading_font = QFont("Helvetica", self.HEADING_FONT_SIZE, QFont.Weight.Bold)
@@ -246,7 +254,9 @@ class ReportGenerator:
         y += hfm.height() * 1.5
 
         # Draw separator line
-        painter.drawLine(int(rect.left()), int(y), int(rect.left() + rect.width()), int(y))
+        painter.drawLine(
+            int(rect.left()), int(y), int(rect.left() + rect.width()), int(y)
+        )
         y += hfm.height() * 0.5
 
         # Draw body text
@@ -278,7 +288,9 @@ class ReportGenerator:
                 painter.setFont(body_font)
 
             # Truncate line if it's too wide
-            elided = bfm.elidedText(line, Qt.TextElideMode.ElideRight, int(rect.width()))
+            elided = bfm.elidedText(
+                line, Qt.TextElideMode.ElideRight, int(rect.width())
+            )
             painter.drawText(int(rect.left()), int(y), elided)
             y += line_height
 
@@ -329,7 +341,9 @@ class ReportGenerator:
             circuit_items = [
                 item
                 for item in scene.items()
-                if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
+                if isinstance(
+                    item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem)
+                )
             ]
             if not circuit_items:
                 return None

--- a/app/GUI/results_plot_dialog.py
+++ b/app/GUI/results_plot_dialog.py
@@ -14,7 +14,8 @@ import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
-from PyQt6.QtWidgets import QCheckBox, QDialog, QFileDialog, QHBoxLayout, QPushButton, QTextEdit, QVBoxLayout
+from PyQt6.QtWidgets import (QCheckBox, QDialog, QFileDialog, QHBoxLayout,
+                             QPushButton, QTextEdit, QVBoxLayout)
 
 from .measurement_cursors import CursorReadoutPanel, MeasurementCursors
 from .styles import theme_manager
@@ -191,7 +192,9 @@ class DCSweepPlotDialog(QDialog):
         # Update cursors
         if self._cursors is not None:
             self._cursors.remove()
-        self._cursors = MeasurementCursors(self._ax, self._canvas, on_cursor_moved=self._on_cursor_moved)
+        self._cursors = MeasurementCursors(
+            self._ax, self._canvas, on_cursor_moved=self._on_cursor_moved
+        )
         self._readout.set_cursors(self._cursors)
         if sweep_vals_first:
             self._cursors.set_data(sweep_vals_first)
@@ -283,7 +286,9 @@ class ACSweepPlotDialog(QDialog):
         toolbar.addWidget(save_btn)
         self._markers_cb = QCheckBox("Show Markers")
         self._markers_cb.setChecked(True)
-        self._markers_cb.setToolTip("Show -3dB cutoff, bandwidth, gain/phase margin markers")
+        self._markers_cb.setToolTip(
+            "Show -3dB cutoff, bandwidth, gain/phase margin markers"
+        )
         self._markers_cb.toggled.connect(self._toggle_markers)
         toolbar.addWidget(self._markers_cb)
         toolbar.addStretch()
@@ -306,7 +311,9 @@ class ACSweepPlotDialog(QDialog):
         self._marker_summary = QTextEdit()
         self._marker_summary.setReadOnly(True)
         self._marker_summary.setMaximumHeight(200)
-        self._marker_summary.setPlaceholderText("Frequency response markers will appear here after simulation.")
+        self._marker_summary.setPlaceholderText(
+            "Frequency response markers will appear here after simulation."
+        )
         right_layout.addWidget(self._marker_summary)
 
         right_widget = QDialog()
@@ -423,7 +430,9 @@ class ACSweepPlotDialog(QDialog):
         # Update cursors on magnitude axes (shared x with phase)
         if self._cursors is not None:
             self._cursors.remove()
-        self._cursors = MeasurementCursors(self._ax_mag, self._canvas, on_cursor_moved=self._on_cursor_moved)
+        self._cursors = MeasurementCursors(
+            self._ax_mag, self._canvas, on_cursor_moved=self._on_cursor_moved
+        )
         self._readout.set_cursors(self._cursors)
         if frequencies_first:
             self._cursors.set_data(frequencies_first)
@@ -460,20 +469,29 @@ class ACSweepPlotDialog(QDialog):
         markers = compute_markers(frequencies, mag_vals, phase_vals)
 
         if markers["peak_gain_db"] is None:
-            self._marker_summary.setPlainText("No markers computed (insufficient data).")
+            self._marker_summary.setPlainText(
+                "No markers computed (insufficient data)."
+            )
             return
 
         # Draw -3dB reference line
         ref_level = markers["ref_level_db"]
         if ref_level is not None:
             artist = self._ax_mag.axhline(
-                y=ref_level, color="#CC0066", linestyle="--", linewidth=1, alpha=0.7, label="-3dB level"
+                y=ref_level,
+                color="#CC0066",
+                linestyle="--",
+                linewidth=1,
+                alpha=0.7,
+                label="-3dB level",
             )
             self._marker_artists.append(artist)
 
         # Draw -3dB cutoff frequency markers
         for fc in markers["cutoff_3db"]:
-            artist = self._ax_mag.axvline(x=fc, color="#CC0066", linestyle=":", linewidth=1, alpha=0.7)
+            artist = self._ax_mag.axvline(
+                x=fc, color="#CC0066", linestyle=":", linewidth=1, alpha=0.7
+            )
             self._marker_artists.append(artist)
             artist = self._ax_mag.annotate(
                 f"fc={format_frequency(fc)}",
@@ -489,7 +507,9 @@ class ACSweepPlotDialog(QDialog):
         # Draw unity gain frequency marker
         if markers["unity_gain_freq"] is not None:
             ugf = markers["unity_gain_freq"]
-            artist = self._ax_mag.axvline(x=ugf, color="#006633", linestyle=":", linewidth=1, alpha=0.7)
+            artist = self._ax_mag.axvline(
+                x=ugf, color="#006633", linestyle=":", linewidth=1, alpha=0.7
+            )
             self._marker_artists.append(artist)
             artist = self._ax_mag.annotate(
                 f"0dB @ {format_frequency(ugf)}",
@@ -504,7 +524,9 @@ class ACSweepPlotDialog(QDialog):
 
         # Build summary text
         summary_lines = [f"Signal: {first_signal}", ""]
-        summary_lines.append(f"Peak gain: {markers['peak_gain_db']:.1f} dB @ {format_frequency(markers['peak_freq'])}")
+        summary_lines.append(
+            f"Peak gain: {markers['peak_gain_db']:.1f} dB @ {format_frequency(markers['peak_freq'])}"
+        )
 
         if markers["cutoff_3db"]:
             for i, fc in enumerate(markers["cutoff_3db"]):
@@ -516,13 +538,17 @@ class ACSweepPlotDialog(QDialog):
             summary_lines.append(f"Bandwidth: {format_frequency(markers['bandwidth'])}")
 
         if markers["unity_gain_freq"] is not None:
-            summary_lines.append(f"Unity-gain freq: {format_frequency(markers['unity_gain_freq'])}")
+            summary_lines.append(
+                f"Unity-gain freq: {format_frequency(markers['unity_gain_freq'])}"
+            )
 
         if markers["gain_margin_db"] is not None:
             summary_lines.append(f"Gain margin: {markers['gain_margin_db']:.1f} dB")
 
         if markers["phase_margin_deg"] is not None:
-            summary_lines.append(f"Phase margin: {markers['phase_margin_deg']:.1f}\u00b0")
+            summary_lines.append(
+                f"Phase margin: {markers['phase_margin_deg']:.1f}\u00b0"
+            )
 
         self._marker_summary.setPlainText("\n".join(summary_lines))
 

--- a/app/GUI/rubric_editor_dialog.py
+++ b/app/GUI/rubric_editor_dialog.py
@@ -6,27 +6,12 @@ import logging
 from typing import TYPE_CHECKING, Optional
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import (
-    QCheckBox,
-    QComboBox,
-    QDialog,
-    QDialogButtonBox,
-    QDoubleSpinBox,
-    QFileDialog,
-    QFormLayout,
-    QGroupBox,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QListWidget,
-    QListWidgetItem,
-    QMessageBox,
-    QPushButton,
-    QSpinBox,
-    QSplitter,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt6.QtWidgets import (QCheckBox, QComboBox, QDialog, QDialogButtonBox,
+                             QDoubleSpinBox, QFileDialog, QFormLayout,
+                             QGroupBox, QHBoxLayout, QLabel, QLineEdit,
+                             QListWidget, QListWidgetItem, QMessageBox,
+                             QPushButton, QSpinBox, QSplitter, QVBoxLayout,
+                             QWidget)
 
 if TYPE_CHECKING:
     from grading.rubric import Rubric
@@ -204,7 +189,9 @@ class RubricEditorDialog(QDialog):
 
         bottom_layout.addStretch()
 
-        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
         button_box.accepted.connect(self._on_accept)
         button_box.rejected.connect(self.reject)
         bottom_layout.addWidget(button_box)
@@ -265,7 +252,9 @@ class RubricEditorDialog(QDialog):
         has_selection = row >= 0
         self.remove_btn.setEnabled(has_selection)
         self.move_up_btn.setEnabled(has_selection and row > 0)
-        self.move_down_btn.setEnabled(has_selection and row < self.checks_list.count() - 1)
+        self.move_down_btn.setEnabled(
+            has_selection and row < self.checks_list.count() - 1
+        )
         self.detail_widget.setEnabled(has_selection)
 
         if not has_selection:
@@ -282,7 +271,9 @@ class RubricEditorDialog(QDialog):
         self._updating_ui = True
         try:
             self.check_id_edit.setText(data.get("check_id", ""))
-            self.check_type_combo.setCurrentText(data.get("check_type", "component_exists"))
+            self.check_type_combo.setCurrentText(
+                data.get("check_type", "component_exists")
+            )
             self.points_spin.setValue(data.get("points", 1))
             self.feedback_pass_edit.setText(data.get("feedback_pass", ""))
             self.feedback_fail_edit.setText(data.get("feedback_fail", ""))
@@ -482,7 +473,11 @@ class RubricEditorDialog(QDialog):
         """Save the rubric to a .spice-rubric file."""
         errors = self._validate()
         if errors:
-            QMessageBox.warning(self, "Validation Errors", "Please fix errors before saving:\n\n" + "\n".join(errors))
+            QMessageBox.warning(
+                self,
+                "Validation Errors",
+                "Please fix errors before saving:\n\n" + "\n".join(errors),
+            )
             return
 
         filename, _ = QFileDialog.getSaveFileName(
@@ -531,7 +526,9 @@ class RubricEditorDialog(QDialog):
 
             for check in rubric.checks:
                 data = check.to_dict()
-                item = QListWidgetItem(f"{data['check_id']} ({data['check_type']}, {data['points']}pt)")
+                item = QListWidgetItem(
+                    f"{data['check_id']} ({data['check_type']}, {data['points']}pt)"
+                )
                 item.setData(Qt.ItemDataRole.UserRole, data)
                 self.checks_list.addItem(item)
 
@@ -570,7 +567,9 @@ class RubricEditorDialog(QDialog):
         errors = self._validate()
         if errors:
             QMessageBox.warning(
-                self, "Validation Errors", "Please fix errors before proceeding:\n\n" + "\n".join(errors)
+                self,
+                "Validation Errors",
+                "Please fix errors before proceeding:\n\n" + "\n".join(errors),
             )
             return
 

--- a/app/GUI/styles/__init__.py
+++ b/app/GUI/styles/__init__.py
@@ -26,35 +26,22 @@ Usage:
 """
 
 from . import theme_store
-
 # Core constants (always available, theme-independent)
-from .constants import (
-    COMPONENTS,
-    DEFAULT_COMPONENT_COUNTER,
-    DEFAULT_SPLITTER_SIZES,
-    DEFAULT_WINDOW_SIZE,
-    GRID_EXTENT,
-    GRID_SIZE,
-    INITIAL_LOAD_COUNT,
-    MAJOR_GRID_INTERVAL,
-    SCROLL_LOAD_COUNT,
-    SIMULATION_TIMEOUT,
-    TERMINAL_CLICK_RADIUS,
-    TERMINAL_HOVER_RADIUS,
-    WIRE_CLICK_WIDTH,
-    WIRE_UPDATE_DELAY_MS,
-    ZOOM_FACTOR,
-    ZOOM_FIT_PADDING,
-    ZOOM_MAX,
-    ZOOM_MIN,
-)
+from .constants import (COMPONENTS, DEFAULT_COMPONENT_COUNTER,
+                        DEFAULT_SPLITTER_SIZES, DEFAULT_WINDOW_SIZE,
+                        GRID_EXTENT, GRID_SIZE, INITIAL_LOAD_COUNT,
+                        MAJOR_GRID_INTERVAL, SCROLL_LOAD_COUNT,
+                        SIMULATION_TIMEOUT, TERMINAL_CLICK_RADIUS,
+                        TERMINAL_HOVER_RADIUS, WIRE_CLICK_WIDTH,
+                        WIRE_UPDATE_DELAY_MS, ZOOM_FACTOR, ZOOM_FIT_PADDING,
+                        ZOOM_MAX, ZOOM_MIN)
 from .custom_theme import CustomTheme
 from .dark_theme import DarkTheme
 from .light_theme import LightTheme
-
 # Theme system
 from .theme import BaseTheme, ThemeProtocol
-from .theme_manager import COLOR_MODES, SYMBOL_STYLES, ThemeManager, theme_manager
+from .theme_manager import (COLOR_MODES, SYMBOL_STYLES, ThemeManager,
+                            theme_manager)
 
 __all__ = [
     # Constants

--- a/app/GUI/styles/dark_theme.py
+++ b/app/GUI/styles/dark_theme.py
@@ -117,7 +117,11 @@ class DarkTheme(BaseTheme):
             # Probe pens
             "probe_voltage": {"color": "probe_voltage", "width": 1.5},
             "probe_current": {"color": "probe_current", "width": 1.5},
-            "probe_highlight": {"color": "probe_highlight", "width": 2.0, "style": "dash"},
+            "probe_highlight": {
+                "color": "probe_highlight",
+                "width": 2.0,
+                "style": "dash",
+            },
         }
 
     def _define_brushes(self):

--- a/app/GUI/styles/light_theme.py
+++ b/app/GUI/styles/light_theme.py
@@ -114,7 +114,11 @@ class LightTheme(BaseTheme):
             # Probe pens
             "probe_voltage": {"color": "probe_voltage", "width": 1.5},
             "probe_current": {"color": "probe_current", "width": 1.5},
-            "probe_highlight": {"color": "probe_highlight", "width": 2.0, "style": "dash"},
+            "probe_highlight": {
+                "color": "probe_highlight",
+                "width": 2.0,
+                "style": "dash",
+            },
         }
 
     def _define_brushes(self):

--- a/app/GUI/styles/theme_store.py
+++ b/app/GUI/styles/theme_store.py
@@ -44,7 +44,9 @@ def list_custom_themes(themes_dir: Optional[Path] = None) -> list:
     return result
 
 
-def load_theme(name_or_stem: str, themes_dir: Optional[Path] = None) -> Optional[CustomTheme]:
+def load_theme(
+    name_or_stem: str, themes_dir: Optional[Path] = None
+) -> Optional[CustomTheme]:
     """Load a custom theme by filename stem. Returns None on error."""
     d = themes_dir if themes_dir is not None else _THEMES_DIR
     path = d / f"{name_or_stem}.json"
@@ -103,7 +105,9 @@ def export_theme(theme: CustomTheme, path: Path) -> None:
     path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
-def import_theme(path: Path, themes_dir: Optional[Path] = None) -> Optional[CustomTheme]:
+def import_theme(
+    path: Path, themes_dir: Optional[Path] = None
+) -> Optional[CustomTheme]:
     """Import a theme JSON file into the themes directory. Returns the theme or None."""
     try:
         data = json.loads(path.read_text(encoding="utf-8"))

--- a/app/GUI/template_dialog.py
+++ b/app/GUI/template_dialog.py
@@ -4,20 +4,10 @@ from typing import Optional
 
 from controllers.template_manager import TemplateInfo, TemplateManager
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import (
-    QDialog,
-    QDialogButtonBox,
-    QFormLayout,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QListWidget,
-    QListWidgetItem,
-    QMessageBox,
-    QPushButton,
-    QTextEdit,
-    QVBoxLayout,
-)
+from PyQt6.QtWidgets import (QDialog, QDialogButtonBox, QFormLayout,
+                             QHBoxLayout, QLabel, QLineEdit, QListWidget,
+                             QListWidgetItem, QMessageBox, QPushButton,
+                             QTextEdit, QVBoxLayout)
 
 
 class NewFromTemplateDialog(QDialog):
@@ -72,7 +62,9 @@ class NewFromTemplateDialog(QDialog):
         right.addStretch()
 
         # OK / Cancel
-        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
         self.ok_button = buttons.button(QDialogButtonBox.StandardButton.Ok)
         self.ok_button.setEnabled(False)
         buttons.accepted.connect(self.accept)
@@ -170,22 +162,30 @@ class SaveAsTemplateDialog(QDialog):
         layout.addRow("Name:", self.name_edit)
 
         self.description_edit = QTextEdit()
-        self.description_edit.setPlaceholderText("Optional description of the circuit template...")
+        self.description_edit.setPlaceholderText(
+            "Optional description of the circuit template..."
+        )
         self.description_edit.setMaximumHeight(80)
         layout.addRow("Description:", self.description_edit)
 
         self.category_edit = QLineEdit()
-        self.category_edit.setPlaceholderText("e.g. Filters, Amplifiers, Power (default: User)")
+        self.category_edit.setPlaceholderText(
+            "e.g. Filters, Amplifiers, Power (default: User)"
+        )
         layout.addRow("Category:", self.category_edit)
 
-        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
         self.ok_button = buttons.button(QDialogButtonBox.StandardButton.Ok)
         self.ok_button.setEnabled(False)
         buttons.accepted.connect(self._validate_and_accept)
         buttons.rejected.connect(self.reject)
         layout.addRow(buttons)
 
-        self.name_edit.textChanged.connect(lambda text: self.ok_button.setEnabled(bool(text.strip())))
+        self.name_edit.textChanged.connect(
+            lambda text: self.ok_button.setEnabled(bool(text.strip()))
+        )
 
     def _validate_and_accept(self):
         if not self.name_edit.text().strip():

--- a/app/GUI/template_metadata_dialog.py
+++ b/app/GUI/template_metadata_dialog.py
@@ -1,7 +1,8 @@
 """Dialog for entering template metadata when saving as assignment template."""
 
 from models.template import TemplateMetadata
-from PyQt6.QtWidgets import QDialog, QDialogButtonBox, QFormLayout, QLineEdit, QPlainTextEdit, QVBoxLayout
+from PyQt6.QtWidgets import (QDialog, QDialogButtonBox, QFormLayout, QLineEdit,
+                             QPlainTextEdit, QVBoxLayout)
 
 
 class TemplateMetadataDialog(QDialog):
@@ -35,17 +36,23 @@ class TemplateMetadataDialog(QDialog):
         form.addRow("Description:", self.description_edit)
 
         self.tags_edit = QLineEdit()
-        self.tags_edit.setPlaceholderText("Comma-separated tags, e.g., filters, AC, lab-3")
+        self.tags_edit.setPlaceholderText(
+            "Comma-separated tags, e.g., filters, AC, lab-3"
+        )
         form.addRow("Tags:", self.tags_edit)
 
         layout.addLayout(form)
 
         self.instructions_edit = QPlainTextEdit()
-        self.instructions_edit.setPlaceholderText("Assignment instructions for students...")
+        self.instructions_edit.setPlaceholderText(
+            "Assignment instructions for students..."
+        )
         self.instructions_edit.setMaximumHeight(120)
         layout.addWidget(self.instructions_edit)
 
-        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
         buttons.accepted.connect(self._on_accept)
         buttons.rejected.connect(self.reject)
         layout.addWidget(buttons)
@@ -62,7 +69,9 @@ class TemplateMetadataDialog(QDialog):
         from datetime import date
 
         tags_text = self.tags_edit.text().strip()
-        tags = [t.strip() for t in tags_text.split(",") if t.strip()] if tags_text else []
+        tags = (
+            [t.strip() for t in tags_text.split(",") if t.strip()] if tags_text else []
+        )
 
         return TemplateMetadata(
             title=self.title_edit.text().strip(),

--- a/app/GUI/theme_editor_dialog.py
+++ b/app/GUI/theme_editor_dialog.py
@@ -2,21 +2,10 @@
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor
-from PyQt6.QtWidgets import (
-    QColorDialog,
-    QComboBox,
-    QDialog,
-    QFormLayout,
-    QGroupBox,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QMessageBox,
-    QPushButton,
-    QScrollArea,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt6.QtWidgets import (QColorDialog, QComboBox, QDialog, QFormLayout,
+                             QGroupBox, QHBoxLayout, QLabel, QLineEdit,
+                             QMessageBox, QPushButton, QScrollArea,
+                             QVBoxLayout, QWidget)
 
 from .styles import CustomTheme, DarkTheme, LightTheme, theme_manager
 
@@ -85,7 +74,11 @@ class ThemeEditorDialog(QDialog):
             self._initial_name = edit_theme.name
             self._initial_base = edit_theme.base_name
             self._initial_is_dark = edit_theme.is_dark
-            self._colors = dict((DarkTheme() if edit_theme.base_name == "dark" else LightTheme())._colors)
+            self._colors = dict(
+                (
+                    DarkTheme() if edit_theme.base_name == "dark" else LightTheme()
+                )._colors
+            )
             self._colors.update(edit_theme.get_color_overrides())
         else:
             self._initial_name = ""
@@ -165,7 +158,9 @@ class ThemeEditorDialog(QDialog):
         layout.addLayout(btn_layout)
 
     def _update_swatch(self, btn, hex_color):
-        btn.setStyleSheet(f"background-color: {hex_color}; border: 1px solid #888; border-radius: 3px;")
+        btn.setStyleSheet(
+            f"background-color: {hex_color}; border: 1px solid #888; border-radius: 3px;"
+        )
 
     def _pick_color(self, key):
         current = QColor(self._colors.get(key, "#FF00FF"))
@@ -200,15 +195,21 @@ class ThemeEditorDialog(QDialog):
 
         # Compute overrides relative to base
         base_theme = DarkTheme() if is_dark else LightTheme()
-        overrides = {k: v for k, v in self._colors.items() if v != base_theme._colors.get(k)}
+        overrides = {
+            k: v for k, v in self._colors.items() if v != base_theme._colors.get(k)
+        }
 
-        preview = CustomTheme(name=name, base=base, colors=overrides, theme_is_dark=is_dark)
+        preview = CustomTheme(
+            name=name, base=base, colors=overrides, theme_is_dark=is_dark
+        )
         theme_manager.set_theme(preview)
 
     def _on_ok(self):
         name = self.name_edit.text().strip()
         if not name:
-            QMessageBox.warning(self, "Name Required", "Please enter a name for the theme.")
+            QMessageBox.warning(
+                self, "Name Required", "Please enter a name for the theme."
+            )
             return
 
         base = self.base_combo.currentData()
@@ -216,9 +217,13 @@ class ThemeEditorDialog(QDialog):
 
         # Compute overrides relative to base
         base_theme = DarkTheme() if is_dark else LightTheme()
-        overrides = {k: v for k, v in self._colors.items() if v != base_theme._colors.get(k)}
+        overrides = {
+            k: v for k, v in self._colors.items() if v != base_theme._colors.get(k)
+        }
 
-        self._result_theme = CustomTheme(name=name, base=base, colors=overrides, theme_is_dark=is_dark)
+        self._result_theme = CustomTheme(
+            name=name, base=base, colors=overrides, theme_is_dark=is_dark
+        )
         theme_manager.set_theme(self._result_theme)
         self.accept()
 

--- a/app/GUI/waveform_config_dialog.py
+++ b/app/GUI/waveform_config_dialog.py
@@ -1,14 +1,6 @@
-from PyQt6.QtWidgets import (
-    QComboBox,
-    QDialog,
-    QDialogButtonBox,
-    QFormLayout,
-    QGroupBox,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QVBoxLayout,
-)
+from PyQt6.QtWidgets import (QComboBox, QDialog, QDialogButtonBox, QFormLayout,
+                             QGroupBox, QHBoxLayout, QLabel, QLineEdit,
+                             QVBoxLayout)
 
 
 class WaveformConfigDialog(QDialog):
@@ -63,7 +55,9 @@ class WaveformConfigDialog(QDialog):
         self.on_type_changed(self.component.waveform_type)
 
         # Dialog buttons
-        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
         button_box.accepted.connect(self.accept)
         button_box.rejected.connect(self.reject)
         layout.addWidget(button_box)
@@ -110,27 +104,51 @@ class WaveformConfigDialog(QDialog):
         # Add fields for selected waveform type
         if waveform_type == "SIN":
             self.params_layout.addRow("Offset (V):", self.param_inputs["SIN"]["offset"])
-            self.params_layout.addRow("Amplitude (V):", self.param_inputs["SIN"]["amplitude"])
-            self.params_layout.addRow("Frequency (Hz):", self.param_inputs["SIN"]["frequency"])
+            self.params_layout.addRow(
+                "Amplitude (V):", self.param_inputs["SIN"]["amplitude"]
+            )
+            self.params_layout.addRow(
+                "Frequency (Hz):", self.param_inputs["SIN"]["frequency"]
+            )
             self.params_layout.addRow("Delay (s):", self.param_inputs["SIN"]["delay"])
             self.params_layout.addRow("Theta (1/s):", self.param_inputs["SIN"]["theta"])
             self.params_layout.addRow("Phase (deg):", self.param_inputs["SIN"]["phase"])
 
         elif waveform_type == "PULSE":
-            self.params_layout.addRow("Initial Value (V):", self.param_inputs["PULSE"]["v1"])
-            self.params_layout.addRow("Pulsed Value (V):", self.param_inputs["PULSE"]["v2"])
-            self.params_layout.addRow("Delay Time (s):", self.param_inputs["PULSE"]["td"])
-            self.params_layout.addRow("Rise Time (s):", self.param_inputs["PULSE"]["tr"])
-            self.params_layout.addRow("Fall Time (s):", self.param_inputs["PULSE"]["tf"])
-            self.params_layout.addRow("Pulse Width (s):", self.param_inputs["PULSE"]["pw"])
+            self.params_layout.addRow(
+                "Initial Value (V):", self.param_inputs["PULSE"]["v1"]
+            )
+            self.params_layout.addRow(
+                "Pulsed Value (V):", self.param_inputs["PULSE"]["v2"]
+            )
+            self.params_layout.addRow(
+                "Delay Time (s):", self.param_inputs["PULSE"]["td"]
+            )
+            self.params_layout.addRow(
+                "Rise Time (s):", self.param_inputs["PULSE"]["tr"]
+            )
+            self.params_layout.addRow(
+                "Fall Time (s):", self.param_inputs["PULSE"]["tf"]
+            )
+            self.params_layout.addRow(
+                "Pulse Width (s):", self.param_inputs["PULSE"]["pw"]
+            )
             self.params_layout.addRow("Period (s):", self.param_inputs["PULSE"]["per"])
 
         elif waveform_type == "EXP":
-            self.params_layout.addRow("Initial Value (V):", self.param_inputs["EXP"]["v1"])
-            self.params_layout.addRow("Pulsed Value (V):", self.param_inputs["EXP"]["v2"])
-            self.params_layout.addRow("Rise Delay (s):", self.param_inputs["EXP"]["td1"])
+            self.params_layout.addRow(
+                "Initial Value (V):", self.param_inputs["EXP"]["v1"]
+            )
+            self.params_layout.addRow(
+                "Pulsed Value (V):", self.param_inputs["EXP"]["v2"]
+            )
+            self.params_layout.addRow(
+                "Rise Delay (s):", self.param_inputs["EXP"]["td1"]
+            )
             self.params_layout.addRow("Rise Tau (s):", self.param_inputs["EXP"]["tau1"])
-            self.params_layout.addRow("Fall Delay (s):", self.param_inputs["EXP"]["td2"])
+            self.params_layout.addRow(
+                "Fall Delay (s):", self.param_inputs["EXP"]["td2"]
+            )
             self.params_layout.addRow("Fall Tau (s):", self.param_inputs["EXP"]["tau2"])
 
         self.update_help_text()

--- a/app/GUI/waveform_dialog.py
+++ b/app/GUI/waveform_dialog.py
@@ -4,25 +4,11 @@ import numpy as np
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from PyQt6.QtGui import QColor
-from PyQt6.QtWidgets import (
-    QCheckBox,
-    QComboBox,
-    QDialog,
-    QFileDialog,
-    QFormLayout,
-    QGroupBox,
-    QHBoxLayout,
-    QHeaderView,
-    QLabel,
-    QLineEdit,
-    QMessageBox,
-    QPushButton,
-    QScrollArea,
-    QTableWidget,
-    QTableWidgetItem,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt6.QtWidgets import (QCheckBox, QComboBox, QDialog, QFileDialog,
+                             QFormLayout, QGroupBox, QHBoxLayout, QHeaderView,
+                             QLabel, QLineEdit, QMessageBox, QPushButton,
+                             QScrollArea, QTableWidget, QTableWidgetItem,
+                             QVBoxLayout, QWidget)
 from simulation.fft_analysis import analyze_signal_spectrum
 
 from .format_utils import format_value, parse_value
@@ -84,7 +70,9 @@ class WaveformDialog(QDialog):
         self._overlay_datasets = []
 
         # Visibility state for columns
-        self.voltage_keys = sorted([k for k in data[0].keys() if k.lower() not in ["time", "index"]])
+        self.voltage_keys = sorted(
+            [k for k in data[0].keys() if k.lower() not in ["time", "index"]]
+        )
         self.column_visibility = {key: True for key in self.voltage_keys}
 
         # Visibility for overlay traces (keyed by "label — signal")
@@ -127,7 +115,9 @@ class WaveformDialog(QDialog):
         for key in self.voltage_keys:
             checkbox = QCheckBox(key)
             checkbox.setChecked(True)
-            checkbox.toggled.connect(lambda state, k=key: self._on_visibility_changed(k, state))
+            checkbox.toggled.connect(
+                lambda state, k=key: self._on_visibility_changed(k, state)
+            )
             scroll_layout.addWidget(checkbox)
 
         scroll_area.setWidget(self._toggle_scroll_content)
@@ -214,7 +204,9 @@ class WaveformDialog(QDialog):
         self._overlay_datasets.append((label, data))
 
         # Add toggle checkboxes for overlay signals
-        overlay_keys = sorted([k for k in data[0].keys() if k.lower() not in ["time", "index"]])
+        overlay_keys = sorted(
+            [k for k in data[0].keys() if k.lower() not in ["time", "index"]]
+        )
         scroll_layout = self._toggle_scroll_content.layout()
 
         separator = QLabel(f"── {label} ──")
@@ -226,7 +218,11 @@ class WaveformDialog(QDialog):
             self._overlay_visibility[overlay_key] = True
             checkbox = QCheckBox(f"{label} — {key}")
             checkbox.setChecked(True)
-            checkbox.toggled.connect(lambda state, k=overlay_key: self._on_overlay_visibility_changed(k, state))
+            checkbox.toggled.connect(
+                lambda state, k=overlay_key: self._on_overlay_visibility_changed(
+                    k, state
+                )
+            )
             scroll_layout.addWidget(checkbox)
 
         self.update_view()
@@ -309,10 +305,26 @@ class WaveformDialog(QDialog):
     def apply_highlight(self):
         """Applies highlighting without filtering the data and scrolls to the first highlighted row."""
         try:
-            self.time_min = parse_value(self.time_min_edit.text()) if self.time_min_edit.text() else None
-            self.time_max = parse_value(self.time_max_edit.text()) if self.time_max_edit.text() else None
-            self.volt_min = parse_value(self.volt_min_edit.text()) if self.volt_min_edit.text() else None
-            self.volt_max = parse_value(self.volt_max_edit.text()) if self.volt_max_edit.text() else None
+            self.time_min = (
+                parse_value(self.time_min_edit.text())
+                if self.time_min_edit.text()
+                else None
+            )
+            self.time_max = (
+                parse_value(self.time_max_edit.text())
+                if self.time_max_edit.text()
+                else None
+            )
+            self.volt_min = (
+                parse_value(self.volt_min_edit.text())
+                if self.volt_min_edit.text()
+                else None
+            )
+            self.volt_max = (
+                parse_value(self.volt_max_edit.text())
+                if self.volt_max_edit.text()
+                else None
+            )
         except ValueError:
             self.reset_view()
             return
@@ -335,10 +347,14 @@ class WaveformDialog(QDialog):
                     break
 
             if self.volt_min is not None or self.volt_max is not None:
-                voltage_keys = [k for k in row.keys() if k.lower() not in ["time", "index"]]
+                voltage_keys = [
+                    k for k in row.keys() if k.lower() not in ["time", "index"]
+                ]
                 for key in voltage_keys:
                     v = row.get(key, 0)
-                    if (self.volt_min is None or v >= self.volt_min) and (self.volt_max is None or v <= self.volt_max):
+                    if (self.volt_min is None or v >= self.volt_min) and (
+                        self.volt_max is None or v <= self.volt_max
+                    ):
                         first_highlight_row = i
                         break
                 if first_highlight_row != -1:
@@ -350,10 +366,26 @@ class WaveformDialog(QDialog):
     def apply_filters(self):
         """Filters the data based on user input and updates the view."""
         try:
-            self.time_min = parse_value(self.time_min_edit.text()) if self.time_min_edit.text() else None
-            self.time_max = parse_value(self.time_max_edit.text()) if self.time_max_edit.text() else None
-            self.volt_min = parse_value(self.volt_min_edit.text()) if self.volt_min_edit.text() else None
-            self.volt_max = parse_value(self.volt_max_edit.text()) if self.volt_max_edit.text() else None
+            self.time_min = (
+                parse_value(self.time_min_edit.text())
+                if self.time_min_edit.text()
+                else None
+            )
+            self.time_max = (
+                parse_value(self.time_max_edit.text())
+                if self.time_max_edit.text()
+                else None
+            )
+            self.volt_min = (
+                parse_value(self.volt_min_edit.text())
+                if self.volt_min_edit.text()
+                else None
+            )
+            self.volt_max = (
+                parse_value(self.volt_max_edit.text())
+                if self.volt_max_edit.text()
+                else None
+            )
         except ValueError:
             self.reset_view()
             return
@@ -361,12 +393,18 @@ class WaveformDialog(QDialog):
         filtered_data = self.full_data
 
         if self.time_min is not None:
-            filtered_data = [row for row in filtered_data if row.get("time", 0) >= self.time_min]
+            filtered_data = [
+                row for row in filtered_data if row.get("time", 0) >= self.time_min
+            ]
         if self.time_max is not None:
-            filtered_data = [row for row in filtered_data if row.get("time", 0) <= self.time_max]
+            filtered_data = [
+                row for row in filtered_data if row.get("time", 0) <= self.time_max
+            ]
 
         if (self.volt_min is not None or self.volt_max is not None) and filtered_data:
-            voltage_keys = [k for k in filtered_data[0].keys() if k.lower() not in ["time", "index"]]
+            voltage_keys = [
+                k for k in filtered_data[0].keys() if k.lower() not in ["time", "index"]
+            ]
 
             def voltage_in_range(row):
                 for key in voltage_keys:
@@ -413,12 +451,18 @@ class WaveformDialog(QDialog):
 
         all_headers = [h for h in self.view_data[0].keys() if h.lower() != "index"]
         # Filter headers based on visibility, always keeping 'time'
-        self.headers = [h for h in all_headers if h == "time" or self.column_visibility.get(h, False)]
+        self.headers = [
+            h
+            for h in all_headers
+            if h == "time" or self.column_visibility.get(h, False)
+        ]
 
         self.table.setColumnCount(len(self.headers))
         self.table.setHorizontalHeaderLabels(self.headers)
 
-        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        self.table.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.Stretch
+        )
 
         # Load the first chunk of rows
         self._load_more_rows()
@@ -453,14 +497,18 @@ class WaveformDialog(QDialog):
         time_full = [row[time_key] for row in data]
 
         # Use only visible keys
-        visible_voltage_keys = [k for k in self.voltage_keys if self.column_visibility.get(k, False)]
+        visible_voltage_keys = [
+            k for k in self.voltage_keys if self.column_visibility.get(k, False)
+        ]
 
         # 1. Plot base lines using persistent colors
         for key in visible_voltage_keys:
             voltage_values = [row[key] for row in data]
             if len(time_full) == len(voltage_values):
                 color = self.plot_colors.get(key, "k")  # Use stored color
-                self.canvas.axes.plot(time_full, voltage_values, label=f"V({key})", color=color)
+                self.canvas.axes.plot(
+                    time_full, voltage_values, label=f"V({key})", color=color
+                )
 
         # 2. Highlighting logic: plot highlighted segments on top
         is_highlighting = (
@@ -532,7 +580,13 @@ class WaveformDialog(QDialog):
             if ov_time_key not in overlay_data[0]:
                 continue
             ov_time = [row[ov_time_key] for row in overlay_data]
-            ov_keys = sorted([k for k in overlay_data[0].keys() if k.lower() not in ["time", "index"]])
+            ov_keys = sorted(
+                [
+                    k
+                    for k in overlay_data[0].keys()
+                    if k.lower() not in ["time", "index"]
+                ]
+            )
             ls = overlay_linestyles[ds_idx % len(overlay_linestyles)]
 
             for key in ov_keys:
@@ -562,7 +616,9 @@ class WaveformDialog(QDialog):
         # Set up measurement cursors (re-attach after axes clear)
         if self._cursors is not None:
             self._cursors.remove()
-        self._cursors = MeasurementCursors(self.canvas.axes, self.canvas, on_cursor_moved=self._on_cursor_moved)
+        self._cursors = MeasurementCursors(
+            self.canvas.axes, self.canvas, on_cursor_moved=self._on_cursor_moved
+        )
         self._cursor_readout.set_cursors(self._cursors)
         if time_full:
             self._cursors.set_data(time_full)
@@ -574,7 +630,9 @@ class WaveformDialog(QDialog):
         from simulation.csv_exporter import export_transient_results, write_csv
 
         csv_content = export_transient_results(self.view_data)
-        filename, _ = QFileDialog.getSaveFileName(self, "Export Results to CSV", "", "CSV Files (*.csv);;All Files (*)")
+        filename, _ = QFileDialog.getSaveFileName(
+            self, "Export Results to CSV", "", "CSV Files (*.csv);;All Files (*)"
+        )
         if filename:
             try:
                 write_csv(csv_content, filename)
@@ -596,7 +654,9 @@ class WaveformDialog(QDialog):
         time = np.array([row.get("time", 0) for row in self.full_data])
 
         # Get list of available signals (exclude time)
-        signal_names = [k for k in self.voltage_keys if self.column_visibility.get(k, True)]
+        signal_names = [
+            k for k in self.voltage_keys if self.column_visibility.get(k, True)
+        ]
 
         if not signal_names:
             QMessageBox.warning(
@@ -717,7 +777,9 @@ class FFTAnalysisDialog(QDialog):
         signal = np.array([row.get(signal_name, 0) for row in self.data])
 
         try:
-            self._fft_result = analyze_signal_spectrum(self.time, signal, signal_name, window_type)
+            self._fft_result = analyze_signal_spectrum(
+                self.time, signal, signal_name, window_type
+            )
             self._replot()
         except Exception as e:
             QMessageBox.critical(self, "FFT Error", f"Failed to compute FFT: {e}")

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -41,10 +41,16 @@ class WireGraphicsItem(QGraphicsPathItem):
         else:
             self.model = WireData(
                 start_component_id=(
-                    start_comp.component_id if hasattr(start_comp, "component_id") else str(start_comp)
+                    start_comp.component_id
+                    if hasattr(start_comp, "component_id")
+                    else str(start_comp)
                 ),
                 start_terminal=start_term,
-                end_component_id=(end_comp.component_id if hasattr(end_comp, "component_id") else str(end_comp)),
+                end_component_id=(
+                    end_comp.component_id
+                    if hasattr(end_comp, "component_id")
+                    else str(end_comp)
+                ),
                 end_terminal=end_term,
                 algorithm=algorithm,
             )
@@ -60,7 +66,9 @@ class WireGraphicsItem(QGraphicsPathItem):
 
         # Algorithm layer support
         self.algorithm = algorithm  # Which algorithm generated this wire
-        self.layer_color = layer_color if layer_color else theme_manager.color("wire_default")
+        self.layer_color = (
+            layer_color if layer_color else theme_manager.color("wire_default")
+        )
 
         self.waypoints = []  # List of QPointF waypoints (computed during routing)
 
@@ -166,7 +174,9 @@ class WireGraphicsItem(QGraphicsPathItem):
             )
 
             pathfinder = IDAStarPathfinder(GRID_SIZE)
-            result = pathfinder.find_path(start, end, obstacles, algorithm=self.algorithm)
+            result = pathfinder.find_path(
+                start, end, obstacles, algorithm=self.algorithm
+            )
 
             # Unpack result (waypoints, runtime, iterations, routing_failed)
             self.waypoints, runtime, iterations, routing_failed = result
@@ -220,7 +230,9 @@ class WireGraphicsItem(QGraphicsPathItem):
         if main_window and hasattr(main_window, "statusBar"):
             status = main_window.statusBar()
             if status:
-                status.showMessage("Wire routing failed — move components to create space", 5000)
+                status.showMessage(
+                    "Wire routing failed — move components to create space", 5000
+                )
 
     def paint(self, painter, option=None, widget=None):
         """Override paint to show selection highlight and layer color"""

--- a/app/cli.py
+++ b/app/cli.py
@@ -26,13 +26,10 @@ from controllers.simulation_controller import SimulationController
 from models.circuit import CircuitModel
 
 __version__ = "0.1.0"
-from simulation.csv_exporter import (
-    export_ac_results,
-    export_dc_sweep_results,
-    export_noise_results,
-    export_op_results,
-    export_transient_results,
-)
+from simulation.csv_exporter import (export_ac_results,
+                                     export_dc_sweep_results,
+                                     export_noise_results, export_op_results,
+                                     export_transient_results)
 
 
 def try_load_circuit(filepath: str) -> tuple[CircuitModel | None, str]:
@@ -267,7 +264,9 @@ def cmd_batch(args: argparse.Namespace) -> int:
         model, error = try_load_circuit(str(filepath))
 
         if model is None:
-            results_summary.append({"file": filepath.name, "status": "LOAD_ERROR", "error": error})
+            results_summary.append(
+                {"file": filepath.name, "status": "LOAD_ERROR", "error": error}
+            )
             any_failed = True
             if args.fail_fast:
                 break
@@ -282,7 +281,9 @@ def cmd_batch(args: argparse.Namespace) -> int:
         result = sim.run_simulation()
 
         if not result.success:
-            results_summary.append({"file": filepath.name, "status": "FAIL", "error": result.error})
+            results_summary.append(
+                {"file": filepath.name, "status": "FAIL", "error": result.error}
+            )
             any_failed = True
             if args.fail_fast:
                 break
@@ -465,16 +466,26 @@ def diff_circuits(model_a: CircuitModel, model_b: CircuitModel) -> dict:
 
     comp_diff = {}
     if added:
-        comp_diff["added"] = [{"id": cid, "type": model_b.components[cid].component_type} for cid in added]
+        comp_diff["added"] = [
+            {"id": cid, "type": model_b.components[cid].component_type} for cid in added
+        ]
     if removed:
-        comp_diff["removed"] = [{"id": cid, "type": model_a.components[cid].component_type} for cid in removed]
+        comp_diff["removed"] = [
+            {"id": cid, "type": model_a.components[cid].component_type}
+            for cid in removed
+        ]
     if changed:
         comp_diff["changed"] = changed
     diff["components"] = comp_diff
 
     # --- Wires ---
     def wire_key(w):
-        return (w.start_component_id, w.start_terminal, w.end_component_id, w.end_terminal)
+        return (
+            w.start_component_id,
+            w.start_terminal,
+            w.end_component_id,
+            w.end_terminal,
+        )
 
     wires_a = {wire_key(w) for w in model_a.wires}
     wires_b = {wire_key(w) for w in model_b.wires}
@@ -484,17 +495,27 @@ def diff_circuits(model_a: CircuitModel, model_b: CircuitModel) -> dict:
 
     wire_diff = {}
     if wire_added:
-        wire_diff["added"] = [{"start": f"{k[0]}:{k[1]}", "end": f"{k[2]}:{k[3]}"} for k in wire_added]
+        wire_diff["added"] = [
+            {"start": f"{k[0]}:{k[1]}", "end": f"{k[2]}:{k[3]}"} for k in wire_added
+        ]
     if wire_removed:
-        wire_diff["removed"] = [{"start": f"{k[0]}:{k[1]}", "end": f"{k[2]}:{k[3]}"} for k in wire_removed]
+        wire_diff["removed"] = [
+            {"start": f"{k[0]}:{k[1]}", "end": f"{k[2]}:{k[3]}"} for k in wire_removed
+        ]
     diff["wires"] = wire_diff
 
     # --- Analysis ---
     analysis_diff = {}
     if model_a.analysis_type != model_b.analysis_type:
-        analysis_diff["type"] = {"from": model_a.analysis_type, "to": model_b.analysis_type}
+        analysis_diff["type"] = {
+            "from": model_a.analysis_type,
+            "to": model_b.analysis_type,
+        }
     if model_a.analysis_params != model_b.analysis_params:
-        analysis_diff["params"] = {"from": model_a.analysis_params, "to": model_b.analysis_params}
+        analysis_diff["params"] = {
+            "from": model_a.analysis_params,
+            "to": model_b.analysis_params,
+        }
     diff["analysis"] = analysis_diff
 
     return diff
@@ -542,9 +563,13 @@ def _format_diff_text(diff: dict, name_a: str, name_b: str) -> str:
     if analysis:
         lines.append("Analysis:")
         if "type" in analysis:
-            lines.append(f"  type: {analysis['type']['from']} -> {analysis['type']['to']}")
+            lines.append(
+                f"  type: {analysis['type']['from']} -> {analysis['type']['to']}"
+            )
         if "params" in analysis:
-            lines.append(f"  params: {analysis['params']['from']} -> {analysis['params']['to']}")
+            lines.append(
+                f"  params: {analysis['params']['from']} -> {analysis['params']['to']}"
+            )
         lines.append("")
 
     return "\n".join(lines)
@@ -562,7 +587,11 @@ def cmd_diff(args: argparse.Namespace) -> int:
     if fmt == "json":
         print(json.dumps(diff, indent=2, default=str))
     else:
-        print(_format_diff_text(diff, Path(args.circuit_a).name, Path(args.circuit_b).name))
+        print(
+            _format_diff_text(
+                diff, Path(args.circuit_a).name, Path(args.circuit_b).name
+            )
+        )
 
     return 0 if identical else 1
 
@@ -634,68 +663,144 @@ def build_parser() -> argparse.ArgumentParser:
         prog="spice-gui-cli",
         description="Spice-GUI batch operations — simulate, validate, and export circuits from the command line.",
     )
-    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # simulate
-    sim_parser = subparsers.add_parser("simulate", help="Run simulation and output results")
-    sim_parser.add_argument("circuit", help="Path to circuit JSON file (use '-' for stdin)")
-    sim_parser.add_argument("--format", choices=["json", "csv"], default="json", help="Output format (default: json)")
-    sim_parser.add_argument("--output", "-o", help="Write results to file instead of stdout")
+    sim_parser = subparsers.add_parser(
+        "simulate", help="Run simulation and output results"
+    )
+    sim_parser.add_argument(
+        "circuit", help="Path to circuit JSON file (use '-' for stdin)"
+    )
+    sim_parser.add_argument(
+        "--format",
+        choices=["json", "csv"],
+        default="json",
+        help="Output format (default: json)",
+    )
+    sim_parser.add_argument(
+        "--output", "-o", help="Write results to file instead of stdout"
+    )
     sim_parser.add_argument(
         "--analysis",
-        choices=["DC Operating Point", "DC Sweep", "AC Sweep", "Transient", "Temperature Sweep", "Noise"],
+        choices=[
+            "DC Operating Point",
+            "DC Sweep",
+            "AC Sweep",
+            "Transient",
+            "Temperature Sweep",
+            "Noise",
+        ],
         help="Override the analysis type configured in the circuit file",
     )
 
     # validate
-    val_parser = subparsers.add_parser("validate", help="Check circuit for errors without simulating")
-    val_parser.add_argument("circuit", help="Path to circuit JSON file (use '-' for stdin)")
+    val_parser = subparsers.add_parser(
+        "validate", help="Check circuit for errors without simulating"
+    )
+    val_parser.add_argument(
+        "circuit", help="Path to circuit JSON file (use '-' for stdin)"
+    )
 
     # export
-    exp_parser = subparsers.add_parser("export", help="Export circuit in specified format")
-    exp_parser.add_argument("circuit", help="Path to circuit JSON file (use '-' for stdin)")
-    exp_parser.add_argument(
-        "--format", "-f", choices=["cir", "json"], default="cir", help="Export format (default: cir)"
+    exp_parser = subparsers.add_parser(
+        "export", help="Export circuit in specified format"
     )
-    exp_parser.add_argument("--output", "-o", help="Write output to file instead of stdout")
+    exp_parser.add_argument(
+        "circuit", help="Path to circuit JSON file (use '-' for stdin)"
+    )
+    exp_parser.add_argument(
+        "--format",
+        "-f",
+        choices=["cir", "json"],
+        default="cir",
+        help="Export format (default: cir)",
+    )
+    exp_parser.add_argument(
+        "--output", "-o", help="Write output to file instead of stdout"
+    )
 
     # batch
-    batch_parser = subparsers.add_parser("batch", help="Run simulations on multiple circuit files")
-    batch_parser.add_argument("path", help="Directory or glob pattern matching circuit JSON files")
-    batch_parser.add_argument(
-        "--format", choices=["json", "csv"], default="json", help="Output format for per-file results (default: json)"
+    batch_parser = subparsers.add_parser(
+        "batch", help="Run simulations on multiple circuit files"
     )
-    batch_parser.add_argument("--output-dir", help="Write per-file results to this directory")
+    batch_parser.add_argument(
+        "path", help="Directory or glob pattern matching circuit JSON files"
+    )
+    batch_parser.add_argument(
+        "--format",
+        choices=["json", "csv"],
+        default="json",
+        help="Output format for per-file results (default: json)",
+    )
+    batch_parser.add_argument(
+        "--output-dir", help="Write per-file results to this directory"
+    )
     batch_parser.add_argument(
         "--analysis",
-        choices=["DC Operating Point", "DC Sweep", "AC Sweep", "Transient", "Temperature Sweep", "Noise"],
+        choices=[
+            "DC Operating Point",
+            "DC Sweep",
+            "AC Sweep",
+            "Transient",
+            "Temperature Sweep",
+            "Noise",
+        ],
         help="Override the analysis type for all circuits",
     )
-    batch_parser.add_argument("--fail-fast", action="store_true", help="Stop on first error")
+    batch_parser.add_argument(
+        "--fail-fast", action="store_true", help="Stop on first error"
+    )
 
     # repl
-    repl_parser = subparsers.add_parser("repl", help="Launch interactive Python REPL with scripting API")
-    repl_parser.add_argument("--load", help="Pre-load a circuit JSON file as 'circuit' variable")
+    repl_parser = subparsers.add_parser(
+        "repl", help="Launch interactive Python REPL with scripting API"
+    )
+    repl_parser.add_argument(
+        "--load", help="Pre-load a circuit JSON file as 'circuit' variable"
+    )
 
     # import
-    import_parser = subparsers.add_parser("import", help="Import a SPICE netlist to circuit JSON")
-    import_parser.add_argument("netlist", help="Path to SPICE netlist file (.cir, .spice, .sp)")
-    import_parser.add_argument("--output", "-o", help="Output JSON file path (default: same name with .json extension)")
+    import_parser = subparsers.add_parser(
+        "import", help="Import a SPICE netlist to circuit JSON"
+    )
+    import_parser.add_argument(
+        "netlist", help="Path to SPICE netlist file (.cir, .spice, .sp)"
+    )
+    import_parser.add_argument(
+        "--output",
+        "-o",
+        help="Output JSON file path (default: same name with .json extension)",
+    )
 
     # diff
-    diff_parser = subparsers.add_parser("diff", help="Compare two circuit files and report differences")
+    diff_parser = subparsers.add_parser(
+        "diff", help="Compare two circuit files and report differences"
+    )
     diff_parser.add_argument("circuit_a", help="Path to reference circuit JSON file")
     diff_parser.add_argument("circuit_b", help="Path to circuit JSON file to compare")
     diff_parser.add_argument(
-        "--format", "-f", choices=["text", "json"], default="text", help="Output format (default: text)"
+        "--format",
+        "-f",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
     )
 
     # stats
-    stats_parser = subparsers.add_parser("stats", help="Display circuit complexity statistics")
+    stats_parser = subparsers.add_parser(
+        "stats", help="Display circuit complexity statistics"
+    )
     stats_parser.add_argument("circuit", help="Path to circuit JSON file")
     stats_parser.add_argument(
-        "--format", "-f", choices=["text", "json"], default="text", help="Output format (default: text)"
+        "--format",
+        "-f",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
     )
 
     return parser

--- a/app/controllers/circuit_controller.py
+++ b/app/controllers/circuit_controller.py
@@ -69,7 +69,9 @@ class CircuitController:
 
     # --- Component operations ---
 
-    def add_component(self, component_type: str, position: tuple[float, float]) -> ComponentData:
+    def add_component(
+        self, component_type: str, position: tuple[float, float]
+    ) -> ComponentData:
         """
         Create and add a new component to the circuit.
 
@@ -209,7 +211,9 @@ class CircuitController:
             self.model.remove_wire(wire_index)
             self._notify("wire_removed", wire_index)
 
-    def update_wire_waypoints(self, wire_index: int, waypoints: list[tuple[float, float]]) -> None:
+    def update_wire_waypoints(
+        self, wire_index: int, waypoints: list[tuple[float, float]]
+    ) -> None:
         """Update a wire's routing path."""
         if 0 <= wire_index < len(self.model.wires):
             wire = self.model.wires[wire_index]
@@ -283,7 +287,10 @@ class CircuitController:
 
         wire_dicts = []
         for wire in self.model.wires:
-            if wire.start_component_id in selected_set and wire.end_component_id in selected_set:
+            if (
+                wire.start_component_id in selected_set
+                and wire.end_component_id in selected_set
+            ):
                 wire_dicts.append(wire.to_dict())
 
         self._clipboard = ClipboardData(
@@ -335,7 +342,11 @@ class CircuitController:
                 position=(comp_data.position[0] + dx, comp_data.position[1] + dy),
                 rotation=comp_data.rotation,
                 waveform_type=comp_data.waveform_type,
-                waveform_params=(comp_data.waveform_params.copy() if comp_data.waveform_params else None),
+                waveform_params=(
+                    comp_data.waveform_params.copy()
+                    if comp_data.waveform_params
+                    else None
+                ),
             )
             self.model.add_component(new_comp)
             self._notify("component_added", new_comp)

--- a/app/controllers/commands.py
+++ b/app/controllers/commands.py
@@ -73,7 +73,10 @@ class DeleteComponentCommand(Command):
         # Store connected wires before deletion (with their indices)
         self.deleted_wires = []
         for idx, wire in enumerate(self.controller.model.wires):
-            if wire.start_component_id == self.component_id or wire.end_component_id == self.component_id:
+            if (
+                wire.start_component_id == self.component_id
+                or wire.end_component_id == self.component_id
+            ):
                 self.deleted_wires.append((idx, WireData.from_dict(wire.to_dict())))
 
         # Delete the component (this also deletes connected wires)
@@ -228,7 +231,9 @@ class AddWireCommand(Command):
 
     def undo(self) -> None:
         """Remove the added wire."""
-        if self.wire_index is not None and self.wire_index < len(self.controller.model.wires):
+        if self.wire_index is not None and self.wire_index < len(
+            self.controller.model.wires
+        ):
             self.controller.remove_wire(self.wire_index)
 
     def get_description(self) -> str:
@@ -331,7 +336,9 @@ class DeleteAnnotationCommand(Command):
 
     def undo(self) -> None:
         if self.annotation_data:
-            self.controller.model.annotations.insert(self.annotation_index, self.annotation_data)
+            self.controller.model.annotations.insert(
+                self.annotation_index, self.annotation_data
+            )
             self.controller._notify("annotation_added", self.annotation_data)
 
     def get_description(self) -> str:
@@ -349,7 +356,9 @@ class EditAnnotationCommand(Command):
 
     def execute(self) -> None:
         if self.annotation_index < len(self.controller.model.annotations):
-            self.old_text = self.controller.model.annotations[self.annotation_index].text
+            self.old_text = self.controller.model.annotations[
+                self.annotation_index
+            ].text
             self.controller.update_annotation_text(self.annotation_index, self.new_text)
 
     def undo(self) -> None:

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -37,12 +37,20 @@ def validate_circuit_data(data) -> None:
     for i, comp in enumerate(data["components"]):
         for key in ("id", "type", "value", "pos"):
             if key not in comp:
-                raise ValueError(f"Component #{i + 1} is missing required field '{key}'.")
+                raise ValueError(
+                    f"Component #{i + 1} is missing required field '{key}'."
+                )
         pos = comp["pos"]
         if not isinstance(pos, dict) or "x" not in pos or "y" not in pos:
-            raise ValueError(f"Component '{comp.get('id', i)}' has invalid position data.")
-        if not isinstance(pos["x"], (int, float)) or not isinstance(pos["y"], (int, float)):
-            raise ValueError(f"Component '{comp['id']}' position values must be numeric.")
+            raise ValueError(
+                f"Component '{comp.get('id', i)}' has invalid position data."
+            )
+        if not isinstance(pos["x"], (int, float)) or not isinstance(
+            pos["y"], (int, float)
+        ):
+            raise ValueError(
+                f"Component '{comp['id']}' position values must be numeric."
+            )
         comp_ids.add(comp["id"])
 
     for i, wire in enumerate(data["wires"]):
@@ -50,9 +58,13 @@ def validate_circuit_data(data) -> None:
             if key not in wire:
                 raise ValueError(f"Wire #{i + 1} is missing required field '{key}'.")
         if wire["start_comp"] not in comp_ids:
-            raise ValueError(f"Wire #{i + 1} references unknown component '{wire['start_comp']}'.")
+            raise ValueError(
+                f"Wire #{i + 1} references unknown component '{wire['start_comp']}'."
+            )
         if wire["end_comp"] not in comp_ids:
-            raise ValueError(f"Wire #{i + 1} references unknown component '{wire['end_comp']}'.")
+            raise ValueError(
+                f"Wire #{i + 1} references unknown component '{wire['end_comp']}'."
+            )
 
 
 class FileController:
@@ -180,7 +192,9 @@ class FileController:
         """Save current file path for session restore."""
         try:
             with open(self._session_file, "w") as f:
-                f.write(os.path.abspath(str(self.current_file)) if self.current_file else "")
+                f.write(
+                    os.path.abspath(str(self.current_file)) if self.current_file else ""
+                )
         except OSError:
             pass  # Session save is best-effort
 
@@ -266,7 +280,9 @@ class FileController:
         """
         try:
             data = self.model.to_dict()
-            data["_autosave_source"] = str(self.current_file) if self.current_file else ""
+            data["_autosave_source"] = (
+                str(self.current_file) if self.current_file else ""
+            )
             with open(self._autosave_file, "w") as f:
                 json.dump(data, f, indent=2)
         except (OSError, TypeError):

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -123,7 +123,9 @@ class SimulationController:
 
         # 2. Generate wrdata path for transient
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        wrdata_filepath = os.path.join(self.runner.output_dir, f"wrdata_{timestamp}.txt")
+        wrdata_filepath = os.path.join(
+            self.runner.output_dir, f"wrdata_{timestamp}.txt"
+        )
 
         # 3. Generate netlist (include .meas directives if configured)
         meas_directives = self.model.analysis_params.get("measurements", [])
@@ -159,7 +161,10 @@ class SimulationController:
         success, output_file, stdout, stderr = self.runner.run_simulation(netlist)
         if not success:
             # Classify the error and attempt retry with relaxed tolerances
-            from simulation.convergence import RELAXED_OPTIONS, diagnose_error, format_user_message, is_retriable
+            from simulation.convergence import (RELAXED_OPTIONS,
+                                                diagnose_error,
+                                                format_user_message,
+                                                is_retriable)
 
             diagnosis = diagnose_error(stderr, stdout)
             friendly_msg = format_user_message(diagnosis)
@@ -175,7 +180,9 @@ class SimulationController:
                     relaxed_netlist = None
 
                 if relaxed_netlist:
-                    retry_ok, retry_out, retry_stdout, retry_stderr = self.runner.run_simulation(relaxed_netlist)
+                    retry_ok, retry_out, retry_stdout, retry_stderr = (
+                        self.runner.run_simulation(relaxed_netlist)
+                    )
                     if retry_ok:
                         # Parse retried results, add warning about relaxed tolerances
                         result = self._parse_results(
@@ -184,7 +191,9 @@ class SimulationController:
                             netlist=relaxed_netlist,
                             raw_output=retry_stdout,
                             warnings=validation.warnings
-                            + ["Simulation converged with relaxed tolerances (results may be less accurate)."],
+                            + [
+                                "Simulation converged with relaxed tolerances (results may be less accurate)."
+                            ],
                         )
                         if self.circuit_ctrl:
                             self.circuit_ctrl._notify("simulation_completed", result)
@@ -287,7 +296,9 @@ class SimulationController:
                 raw_output=raw_output,
             )
 
-    def run_parameter_sweep(self, sweep_config: dict, progress_callback=None) -> SimulationResult:
+    def run_parameter_sweep(
+        self, sweep_config: dict, progress_callback=None
+    ) -> SimulationResult:
         """
         Run a parameter sweep: modify a component's value across a range
         and run the base analysis at each step.
@@ -340,7 +351,9 @@ class SimulationController:
             )
 
         # Calculate sweep values (linear spacing)
-        sweep_values = [start + (stop - start) * i / (num_steps - 1) for i in range(num_steps)]
+        sweep_values = [
+            start + (stop - start) * i / (num_steps - 1) for i in range(num_steps)
+        ]
 
         # Run sweep
         step_results = []
@@ -358,17 +371,25 @@ class SimulationController:
 
                 # Generate netlist
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-                wrdata_filepath = os.path.join(self.runner.output_dir, f"wrdata_sweep_{i}_{timestamp}.txt")
+                wrdata_filepath = os.path.join(
+                    self.runner.output_dir, f"wrdata_sweep_{i}_{timestamp}.txt"
+                )
 
                 try:
                     netlist = self.generate_netlist(wrdata_filepath=wrdata_filepath)
                 except (ValueError, KeyError, TypeError) as e:
-                    step_results.append(SimulationResult(success=False, error=f"Netlist generation failed: {e}"))
+                    step_results.append(
+                        SimulationResult(
+                            success=False, error=f"Netlist generation failed: {e}"
+                        )
+                    )
                     errors.append(f"Step {i + 1} ({comp.value}): netlist failed: {e}")
                     continue
 
                 # Run simulation
-                success, output_file, stdout, stderr = self.runner.run_simulation(netlist)
+                success, output_file, stdout, stderr = self.runner.run_simulation(
+                    netlist
+                )
                 if not success:
                     step_results.append(
                         SimulationResult(
@@ -421,7 +442,9 @@ class SimulationController:
             warnings=validation.warnings,
         )
 
-    def run_monte_carlo(self, mc_config: dict, progress_callback=None) -> SimulationResult:
+    def run_monte_carlo(
+        self, mc_config: dict, progress_callback=None
+    ) -> SimulationResult:
         """
         Run Monte Carlo analysis: vary component values randomly and run
         the base analysis N times.
@@ -496,19 +519,31 @@ class SimulationController:
                 run_values.append(values_this_run)
 
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-                wrdata_filepath = os.path.join(self.runner.output_dir, f"wrdata_mc_{i}_{timestamp}.txt")
+                wrdata_filepath = os.path.join(
+                    self.runner.output_dir, f"wrdata_mc_{i}_{timestamp}.txt"
+                )
 
                 try:
                     netlist = self.generate_netlist(wrdata_filepath=wrdata_filepath)
                 except (ValueError, KeyError, TypeError) as e:
-                    step_results.append(SimulationResult(success=False, error=f"Netlist generation failed: {e}"))
+                    step_results.append(
+                        SimulationResult(
+                            success=False, error=f"Netlist generation failed: {e}"
+                        )
+                    )
                     errors.append(f"Run {i + 1}: netlist failed: {e}")
                     continue
 
-                success, output_file, stdout, stderr = self.runner.run_simulation(netlist)
+                success, output_file, stdout, stderr = self.runner.run_simulation(
+                    netlist
+                )
                 if not success:
                     step_results.append(
-                        SimulationResult(success=False, error=stderr or "Simulation failed", netlist=netlist)
+                        SimulationResult(
+                            success=False,
+                            error=stderr or "Simulation failed",
+                            netlist=netlist,
+                        )
                     )
                     errors.append(f"Run {i + 1}: {stderr or 'failed'}")
                     continue

--- a/app/controllers/template_controller.py
+++ b/app/controllers/template_controller.py
@@ -57,6 +57,7 @@ class TemplateController:
         reference_circuit: Optional[CircuitModel] = None,
         instructions: str = "",
         required_analysis: Optional[dict] = None,
+        locked_components: Optional[list[str]] = None,
     ) -> None:
         """Save a circuit as an assignment template.
 
@@ -67,6 +68,7 @@ class TemplateController:
             reference_circuit: Instructor's solution circuit (optional).
             instructions: Assignment instructions text.
             required_analysis: Expected analysis type and params (optional).
+            locked_components: List of component IDs to lock (optional).
 
         Raises:
             OSError: If the file cannot be written.
@@ -78,8 +80,11 @@ class TemplateController:
             metadata=metadata,
             instructions=instructions,
             starter_circuit=(starter_circuit.to_dict() if starter_circuit else None),
-            reference_circuit=(reference_circuit.to_dict() if reference_circuit else None),
+            reference_circuit=(
+                reference_circuit.to_dict() if reference_circuit else None
+            ),
             required_analysis=required_analysis,
+            locked_components=list(locked_components) if locked_components else [],
         )
 
         with open(filepath, "w") as f:
@@ -112,6 +117,9 @@ class TemplateController:
         If the template has no starter_circuit, returns an empty model
         with the template's required analysis settings applied.
 
+        Components listed in template.locked_components will have their
+        locked flag set to True, preventing student modifications.
+
         Args:
             template: The loaded template data.
 
@@ -131,6 +139,12 @@ class TemplateController:
             analysis_params = template.required_analysis.get("params")
             if analysis_params:
                 model.analysis_params = analysis_params.copy()
+
+        # Apply locked state to specified components
+        if template.locked_components:
+            for comp_id in template.locked_components:
+                if comp_id in model.components:
+                    model.components[comp_id].locked = True
 
         return model
 

--- a/app/grading/batch_grader.py
+++ b/app/grading/batch_grader.py
@@ -84,7 +84,11 @@ class BatchGrader:
             BatchGradingResult with per-student results and aggregate stats.
         """
         folder = Path(folder_path)
-        files = sorted(f for f in folder.iterdir() if f.is_file() and f.suffix in SUPPORTED_EXTENSIONS)
+        files = sorted(
+            f
+            for f in folder.iterdir()
+            if f.is_file() and f.suffix in SUPPORTED_EXTENSIONS
+        )
 
         result = BatchGradingResult(
             rubric_title=rubric.title,

--- a/app/grading/circuit_comparer.py
+++ b/app/grading/circuit_comparer.py
@@ -52,7 +52,9 @@ class ComparisonResult:
             self.mismatches.append(result)
 
 
-def compare_values(expected_str: str, actual_str: str, tolerance_pct: float = 0.0) -> bool:
+def compare_values(
+    expected_str: str, actual_str: str, tolerance_pct: float = 0.0
+) -> bool:
     """Compare two SPICE value strings with optional tolerance.
 
     Args:
@@ -80,7 +82,9 @@ def compare_values(expected_str: str, actual_str: str, tolerance_pct: float = 0.
 class CircuitComparer:
     """Compares two CircuitModel instances structurally and parametrically."""
 
-    def compare(self, reference: CircuitModel, student: CircuitModel) -> ComparisonResult:
+    def compare(
+        self, reference: CircuitModel, student: CircuitModel
+    ) -> ComparisonResult:
         """Run all comparison checks between reference and student circuits.
 
         Args:
@@ -99,7 +103,9 @@ class CircuitComparer:
         self._check_analysis(reference, student, result)
         return result
 
-    def check_component_exists(self, student: CircuitModel, component_id: str, component_type: str) -> CheckResult:
+    def check_component_exists(
+        self, student: CircuitModel, component_id: str, component_type: str
+    ) -> CheckResult:
         """Check if a specific component exists in the student circuit.
 
         Args:
@@ -220,7 +226,9 @@ class CircuitComparer:
             message=f"'{component_a}' and '{component_b}' should share a node",
         )
 
-    def check_analysis_type(self, student: CircuitModel, expected_type: str) -> CheckResult:
+    def check_analysis_type(
+        self, student: CircuitModel, expected_type: str
+    ) -> CheckResult:
         """Check if the analysis type matches.
 
         Args:
@@ -253,9 +261,13 @@ class CircuitComparer:
         for comp_id, comp in reference.components.items():
             if comp.component_type == "Ground":
                 continue
-            result.add(self.check_component_exists(student, comp_id, comp.component_type))
+            result.add(
+                self.check_component_exists(student, comp_id, comp.component_type)
+            )
 
-    def _check_component_values(self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult) -> None:
+    def _check_component_values(
+        self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult
+    ) -> None:
         """Check that matching components have the same values."""
         for comp_id, ref_comp in reference.components.items():
             if ref_comp.component_type == "Ground":
@@ -267,7 +279,9 @@ class CircuitComparer:
                 continue  # Already reported by existence check
             result.add(self.check_component_value(student, comp_id, ref_comp.value))
 
-    def _check_component_counts(self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult) -> None:
+    def _check_component_counts(
+        self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult
+    ) -> None:
         """Check that the count of each component type matches."""
         ref_counts = _count_by_type(reference)
         student_counts = _count_by_type(student)
@@ -290,7 +304,9 @@ class CircuitComparer:
                 )
             )
 
-    def _check_topology(self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult) -> None:
+    def _check_topology(
+        self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult
+    ) -> None:
         """Check that components sharing nodes in the reference also share them in the student."""
         # Find pairs of non-ground components that share a node in the reference
         pairs_checked = set()
@@ -300,7 +316,8 @@ class CircuitComparer:
             comp_ids = {
                 cid
                 for cid in comp_ids
-                if cid in reference.components and reference.components[cid].component_type != "Ground"
+                if cid in reference.components
+                and reference.components[cid].component_type != "Ground"
             }
             for a in sorted(comp_ids):
                 for b in sorted(comp_ids):
@@ -314,7 +331,9 @@ class CircuitComparer:
                     if a in student.components and b in student.components:
                         result.add(self.check_topology(student, a, b))
 
-    def _check_ground(self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult) -> None:
+    def _check_ground(
+        self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult
+    ) -> None:
         """Check that ground is present and connects the expected components."""
         ref_ground_comps = set()
         student_ground_comps = set()
@@ -349,12 +368,14 @@ class CircuitComparer:
             ref_connected = {
                 cid
                 for cid in ref_ground_comps
-                if cid in reference.components and reference.components[cid].component_type != "Ground"
+                if cid in reference.components
+                and reference.components[cid].component_type != "Ground"
             }
             student_connected = {
                 cid
                 for cid in student_ground_comps
-                if cid in student.components and student.components[cid].component_type != "Ground"
+                if cid in student.components
+                and student.components[cid].component_type != "Ground"
             }
 
             for cid in ref_connected:
@@ -375,7 +396,9 @@ class CircuitComparer:
                         )
                     )
 
-    def _check_analysis(self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult) -> None:
+    def _check_analysis(
+        self, reference: CircuitModel, student: CircuitModel, result: ComparisonResult
+    ) -> None:
         """Check that analysis type and parameters match."""
         result.add(self.check_analysis_type(student, reference.analysis_type))
 

--- a/app/grading/grade_exporter.py
+++ b/app/grading/grade_exporter.py
@@ -32,7 +32,9 @@ def export_gradebook_csv(result: BatchGradingResult, filepath: str) -> None:
 
     # Build header from first result's check IDs
     first = result.results[0]
-    check_headers = [f"{cr.check_id} ({cr.points_possible}pts)" for cr in first.check_results]
+    check_headers = [
+        f"{cr.check_id} ({cr.points_possible}pts)" for cr in first.check_results
+    ]
 
     header = ["Student File", "Total Score", "Percentage"] + check_headers
 

--- a/app/grading/grader.py
+++ b/app/grading/grader.py
@@ -74,7 +74,9 @@ class CircuitGrader:
         )
 
         for check in rubric.checks:
-            check_result = self._execute_check(check, student_circuit, reference_circuit)
+            check_result = self._execute_check(
+                check, student_circuit, reference_circuit
+            )
             result.check_results.append(check_result)
             result.earned_points += check_result.points_earned
 
@@ -99,18 +101,27 @@ class CircuitGrader:
         return handler(self, check, student, reference)
 
     def _check_component_exists(
-        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+        self,
+        check: RubricCheck,
+        student: CircuitModel,
+        reference: Optional[CircuitModel],
     ) -> CheckGradeResult:
         component_id = check.params.get("component_id", "")
         component_type = check.params.get("component_type", "")
 
         if component_id:
-            cr = self._comparer.check_component_exists(student, component_id, component_type)
+            cr = self._comparer.check_component_exists(
+                student, component_id, component_type
+            )
             passed = cr.passed
         elif component_type:
             # Check by type count
             min_count = check.params.get("min_count", 1)
-            count = sum(1 for c in student.components.values() if c.component_type == component_type)
+            count = sum(
+                1
+                for c in student.components.values()
+                if c.component_type == component_type
+            )
             passed = count >= min_count
         else:
             passed = False
@@ -124,13 +135,18 @@ class CircuitGrader:
         )
 
     def _check_component_value(
-        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+        self,
+        check: RubricCheck,
+        student: CircuitModel,
+        reference: Optional[CircuitModel],
     ) -> CheckGradeResult:
         component_id = check.params.get("component_id", "")
         expected_value = check.params.get("expected_value", "")
         tolerance_pct = check.params.get("tolerance_pct", 0.0)
 
-        cr = self._comparer.check_component_value(student, component_id, expected_value, tolerance_pct)
+        cr = self._comparer.check_component_value(
+            student, component_id, expected_value, tolerance_pct
+        )
 
         return CheckGradeResult(
             check_id=check.check_id,
@@ -141,12 +157,17 @@ class CircuitGrader:
         )
 
     def _check_component_count(
-        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+        self,
+        check: RubricCheck,
+        student: CircuitModel,
+        reference: Optional[CircuitModel],
     ) -> CheckGradeResult:
         component_type = check.params.get("component_type", "")
         expected_count = check.params.get("expected_count", 0)
 
-        actual_count = sum(1 for c in student.components.values() if c.component_type == component_type)
+        actual_count = sum(
+            1 for c in student.components.values() if c.component_type == component_type
+        )
         passed = actual_count == expected_count
 
         return CheckGradeResult(
@@ -158,7 +179,10 @@ class CircuitGrader:
         )
 
     def _check_topology(
-        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+        self,
+        check: RubricCheck,
+        student: CircuitModel,
+        reference: Optional[CircuitModel],
     ) -> CheckGradeResult:
         component_a = check.params.get("component_a", "")
         component_b = check.params.get("component_b", "")
@@ -176,7 +200,10 @@ class CircuitGrader:
         )
 
     def _check_ground(
-        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+        self,
+        check: RubricCheck,
+        student: CircuitModel,
+        reference: Optional[CircuitModel],
     ) -> CheckGradeResult:
         has_ground = any(n.is_ground for n in student.nodes)
         component_id = check.params.get("component_id", "")
@@ -202,7 +229,10 @@ class CircuitGrader:
         )
 
     def _check_analysis_type(
-        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+        self,
+        check: RubricCheck,
+        student: CircuitModel,
+        reference: Optional[CircuitModel],
     ) -> CheckGradeResult:
         expected_type = check.params.get("expected_type", "")
         cr = self._comparer.check_analysis_type(student, expected_type)

--- a/app/grading/rubric.py
+++ b/app/grading/rubric.py
@@ -110,7 +110,9 @@ def validate_rubric(data: dict) -> None:
 
         for required in ("check_id", "check_type", "points"):
             if required not in check:
-                raise ValueError(f"Check #{i + 1} is missing required field '{required}'.")
+                raise ValueError(
+                    f"Check #{i + 1} is missing required field '{required}'."
+                )
 
         if check["check_type"] not in VALID_CHECK_TYPES:
             raise ValueError(
@@ -125,7 +127,9 @@ def validate_rubric(data: dict) -> None:
         points_sum += check["points"]
 
     if points_sum != data["total_points"]:
-        raise ValueError(f"Check points sum to {points_sum}, but total_points is {data['total_points']}.")
+        raise ValueError(
+            f"Check points sum to {points_sum}, but total_points is {data['total_points']}."
+        )
 
 
 def save_rubric(rubric: Rubric, filepath) -> None:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -6,15 +6,9 @@ All models use only Python standard library types (no PyQt6 dependencies).
 """
 
 from .circuit import CircuitModel
-from .component import (
-    COMPONENT_COLORS,
-    COMPONENT_TYPES,
-    DEFAULT_VALUES,
-    SPICE_SYMBOLS,
-    TERMINAL_COUNTS,
-    TERMINAL_GEOMETRY,
-    ComponentData,
-)
+from .component import (COMPONENT_COLORS, COMPONENT_TYPES, DEFAULT_VALUES,
+                        SPICE_SYMBOLS, TERMINAL_COUNTS, TERMINAL_GEOMETRY,
+                        ComponentData)
 from .node import NodeData
 from .wire import WireData
 

--- a/app/models/circuit.py
+++ b/app/models/circuit.py
@@ -53,7 +53,11 @@ class CircuitModel:
             return []
 
         # Find wires connected to this component
-        wire_indices = [i for i, wire in enumerate(self.wires) if wire.connects_component(component_id)]
+        wire_indices = [
+            i
+            for i, wire in enumerate(self.wires)
+            if wire.connects_component(component_id)
+        ]
 
         del self.components[component_id]
         return wire_indices
@@ -75,7 +79,9 @@ class CircuitModel:
         end_terminal = (wire.end_component_id, wire.end_terminal)
 
         # Find the affected node (both terminals should be in the same node)
-        affected_node = self.terminal_to_node.get(start_terminal) or self.terminal_to_node.get(end_terminal)
+        affected_node = self.terminal_to_node.get(
+            start_terminal
+        ) or self.terminal_to_node.get(end_terminal)
 
         del self.wires[wire_index]
 
@@ -150,7 +156,9 @@ class CircuitModel:
         ground_node.add_terminal(ground_comp.component_id, 0)
         self.terminal_to_node[terminal_key] = ground_node
 
-    def _update_nodes_for_wire(self, wire: WireData, wire_index: int | None = None) -> None:
+    def _update_nodes_for_wire(
+        self, wire: WireData, wire_index: int | None = None
+    ) -> None:
         """Update node connectivity when a wire is added.
 
         Args:

--- a/app/models/component.py
+++ b/app/models/component.py
@@ -110,7 +110,9 @@ OPAMP_MODELS = ["Ideal", "LM741", "TL081", "LM358"]
 # SPICE subcircuit definitions for each op-amp model.
 # Keys match OPAMP_MODELS entries; "Ideal" is the built-in high-gain model.
 OPAMP_SUBCIRCUITS = {
-    "Ideal": (".subckt OPAMP_IDEAL inp inn out\nE_amp out 0 inp inn 1e6\nR_out out 0 1e-3\n.ends"),
+    "Ideal": (
+        ".subckt OPAMP_IDEAL inp inn out\nE_amp out 0 inp inn 1e6\nR_out out 0 1e-3\n.ends"
+    ),
     "LM741": (
         ".subckt LM741 inp inn out\n"
         "* Simplified LM741 behavioral model\n"
@@ -263,6 +265,9 @@ class ComponentData:
 
     # Initial condition (Capacitor: voltage, Inductor: current). None = use default.
     initial_condition: Optional[str] = None
+
+    # Locked flag (template use only - prevents student modifications)
+    locked: bool = False
 
     def __post_init__(self):
         """Initialize waveform parameters for waveform sources."""
@@ -423,6 +428,10 @@ class ComponentData:
         if self.initial_condition:
             data["initial_condition"] = self.initial_condition
 
+        # Add locked flag (only if True to minimize file size)
+        if self.locked:
+            data["locked"] = True
+
         return data
 
     @classmethod
@@ -456,6 +465,9 @@ class ComponentData:
         # Load initial condition if present
         if "initial_condition" in data:
             component.initial_condition = data["initial_condition"]
+
+        # Load locked flag if present
+        component.locked = data.get("locked", False)
 
         return component
 

--- a/app/models/template.py
+++ b/app/models/template.py
@@ -49,6 +49,7 @@ class TemplateData:
     starter_circuit: Optional[dict] = None
     reference_circuit: Optional[dict] = None
     required_analysis: Optional[dict] = None
+    locked_components: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         data = {
@@ -62,6 +63,8 @@ class TemplateData:
             data["reference_circuit"] = self.reference_circuit
         if self.required_analysis is not None:
             data["required_analysis"] = self.required_analysis
+        if self.locked_components:
+            data["locked_components"] = list(self.locked_components)
         return data
 
     @classmethod
@@ -73,4 +76,5 @@ class TemplateData:
             starter_circuit=data.get("starter_circuit"),
             reference_circuit=data.get("reference_circuit"),
             required_analysis=data.get("required_analysis"),
+            locked_components=list(data.get("locked_components", [])),
         )

--- a/app/models/wire.py
+++ b/app/models/wire.py
@@ -42,13 +42,16 @@ class WireData:
 
     def connects_component(self, component_id: str) -> bool:
         """Check if this wire connects to the given component."""
-        return self.start_component_id == component_id or self.end_component_id == component_id
+        return (
+            self.start_component_id == component_id
+            or self.end_component_id == component_id
+        )
 
     def connects_terminal(self, component_id: str, terminal: int) -> bool:
         """Check if this wire connects to the given terminal."""
-        return (self.start_component_id == component_id and self.start_terminal == terminal) or (
-            self.end_component_id == component_id and self.end_terminal == terminal
-        )
+        return (
+            self.start_component_id == component_id and self.start_terminal == terminal
+        ) or (self.end_component_id == component_id and self.end_terminal == terminal)
 
     def to_dict(self) -> dict:
         """

--- a/app/scripting/__init__.py
+++ b/app/scripting/__init__.py
@@ -26,6 +26,13 @@ Usage::
 # Re-export SimulationResult for convenience
 from controllers.simulation_controller import SimulationResult
 from scripting.circuit import Circuit
-from scripting.jupyter import circuit_to_svg, plot_result, register_jupyter_formatters
+from scripting.jupyter import (circuit_to_svg, plot_result,
+                               register_jupyter_formatters)
 
-__all__ = ["Circuit", "SimulationResult", "circuit_to_svg", "plot_result", "register_jupyter_formatters"]
+__all__ = [
+    "Circuit",
+    "SimulationResult",
+    "circuit_to_svg",
+    "plot_result",
+    "register_jupyter_formatters",
+]

--- a/app/scripting/circuit.py
+++ b/app/scripting/circuit.py
@@ -11,7 +11,8 @@ from pathlib import Path
 from typing import Optional, Union
 
 from controllers.circuit_controller import CircuitController
-from controllers.simulation_controller import SimulationController, SimulationResult
+from controllers.simulation_controller import (SimulationController,
+                                               SimulationResult)
 from models.circuit import CircuitModel
 from models.component import COMPONENT_TYPES, ComponentData
 
@@ -115,7 +116,9 @@ class Circuit:
             ValueError: If the component_type is not recognized.
         """
         if component_type not in COMPONENT_TYPES:
-            raise ValueError(f"Unknown component type '{component_type}'. Valid types: {', '.join(COMPONENT_TYPES)}")
+            raise ValueError(
+                f"Unknown component type '{component_type}'. Valid types: {', '.join(COMPONENT_TYPES)}"
+            )
 
         comp = self._controller.add_component(component_type, position)
 
@@ -169,7 +172,9 @@ class Circuit:
         Returns:
             True if the wire was added, False if a duplicate wire exists.
         """
-        wire = self._controller.add_wire(start_component, start_terminal, end_component, end_terminal)
+        wire = self._controller.add_wire(
+            start_component, start_terminal, end_component, end_terminal
+        )
         return wire is not None
 
     # --- Analysis ---

--- a/app/scripting/jupyter.py
+++ b/app/scripting/jupyter.py
@@ -84,7 +84,9 @@ def circuit_to_svg(model: CircuitModel, width: int = 600, height: int = 400) -> 
         start_terminals = start_comp.get_terminal_positions()
         end_terminals = end_comp.get_terminal_positions()
 
-        if wire.start_terminal < len(start_terminals) and wire.end_terminal < len(end_terminals):
+        if wire.start_terminal < len(start_terminals) and wire.end_terminal < len(
+            end_terminals
+        ):
             sx, sy = to_svg_coords(*start_terminals[wire.start_terminal])
             ex, ey = to_svg_coords(*end_terminals[wire.end_terminal])
             ET.SubElement(
@@ -163,7 +165,12 @@ def _empty_svg(width: int, height: int) -> str:
         "text",
         x=str(width // 2),
         y=str(height // 2),
-        **{"text-anchor": "middle", "fill": "#999", "font-family": "sans-serif", "font-size": "14"},
+        **{
+            "text-anchor": "middle",
+            "fill": "#999",
+            "font-family": "sans-serif",
+            "font-size": "14",
+        },
     )
     text.text = "(empty circuit)"
     return ET.tostring(svg, encoding="unicode")
@@ -255,7 +262,9 @@ def _plot_ac(data, title: str, plt):
     if not isinstance(data, list) or not data:
         return None
 
-    freq_key = next((k for k in data[0] if k.lower() in ("frequency", "freq", "f")), None)
+    freq_key = next(
+        (k for k in data[0] if k.lower() in ("frequency", "freq", "f")), None
+    )
     if freq_key is None:
         return None
 

--- a/app/simulation/asc_exporter.py
+++ b/app/simulation/asc_exporter.py
@@ -164,7 +164,9 @@ def export_asc(model):
 
     # Export analysis directive
     if model.analysis_type:
-        directive = _format_analysis_directive(model.analysis_type, model.analysis_params)
+        directive = _format_analysis_directive(
+            model.analysis_type, model.analysis_params
+        )
         if directive:
             lines.append(f"TEXT -32 280 Left 2 !{directive}")
 

--- a/app/simulation/asc_parser.py
+++ b/app/simulation/asc_parser.py
@@ -176,7 +176,12 @@ def parse_asc(text):
             parts = stripped.split()
             if len(parts) >= 5:
                 try:
-                    x1, y1, x2, y2 = int(parts[1]), int(parts[2]), int(parts[3]), int(parts[4])
+                    x1, y1, x2, y2 = (
+                        int(parts[1]),
+                        int(parts[2]),
+                        int(parts[3]),
+                        int(parts[4]),
+                    )
                     wires.append((x1, y1, x2, y2))
                 except ValueError:
                     pass

--- a/app/simulation/circuit_validator.py
+++ b/app/simulation/circuit_validator.py
@@ -78,11 +78,19 @@ def validate_circuit(components, wires, analysis_type):
             )
 
     # 5. Analysis-specific checks
-    voltage_sources = [c for c in components.values() if c.component_type in ("Voltage Source", "Waveform Source")]
-    current_sources = [c for c in components.values() if c.component_type == "Current Source"]
+    voltage_sources = [
+        c
+        for c in components.values()
+        if c.component_type in ("Voltage Source", "Waveform Source")
+    ]
+    current_sources = [
+        c for c in components.values() if c.component_type == "Current Source"
+    ]
 
     if analysis_type == "DC Sweep":
-        dc_sources = [c for c in components.values() if c.component_type == "Voltage Source"]
+        dc_sources = [
+            c for c in components.values() if c.component_type == "Voltage Source"
+        ]
         if not dc_sources:
             errors.append(
                 "DC Sweep analysis requires a Voltage Source to sweep. "

--- a/app/simulation/circuitikz_exporter.py
+++ b/app/simulation/circuitikz_exporter.py
@@ -225,7 +225,9 @@ def _emit_bipole(lines, comp, tikz_name, transform, include_ids, include_values)
         opt_str = ", ".join([tikz_name] + opts)
 
         lines.append(f"  \\draw {_coord(*out_start)} to[{opt_str}] {_coord(*out_end)};")
-        lines.append(f"  \\draw[dashed] {_coord(*ctrl_start)} to[short] {_coord(*ctrl_end)};")
+        lines.append(
+            f"  \\draw[dashed] {_coord(*ctrl_start)} to[short] {_coord(*ctrl_end)};"
+        )
         return
 
     # Standard 2-terminal bipole
@@ -258,7 +260,9 @@ def _emit_tripole(lines, comp, tikz_name, transform, include_ids):
     if include_ids:
         label_opt = f", label={{right:{comp.component_id}}}"
 
-    lines.append(f"  \\node[{tikz_name}{rotate_opt}{xscale}{label_opt}] ({node_id}) at {_coord(cx, cy)} {{}};")
+    lines.append(
+        f"  \\node[{tikz_name}{rotate_opt}{xscale}{label_opt}] ({node_id}) at {_coord(cx, cy)} {{}};"
+    )
 
     # Draw short wires from tripole anchors to terminal positions
     terminals = comp.get_terminal_positions()
@@ -278,7 +282,9 @@ def _emit_wires(wires, components, transform):
 
         start_terminals = start_comp.get_terminal_positions()
         end_terminals = end_comp.get_terminal_positions()
-        if wire.start_terminal >= len(start_terminals) or wire.end_terminal >= len(end_terminals):
+        if wire.start_terminal >= len(start_terminals) or wire.end_terminal >= len(
+            end_terminals
+        ):
             continue
 
         start_pos = transform(*start_terminals[wire.start_terminal])

--- a/app/simulation/convergence.py
+++ b/app/simulation/convergence.py
@@ -55,7 +55,9 @@ class ErrorDiagnosis:
 _DIAGNOSES: dict[ErrorCategory, ErrorDiagnosis] = {
     ErrorCategory.DC_CONVERGENCE: ErrorDiagnosis(
         category=ErrorCategory.DC_CONVERGENCE,
-        message=("The simulator could not find a stable DC operating point for your circuit."),
+        message=(
+            "The simulator could not find a stable DC operating point for your circuit."
+        ),
         causes=[
             "A node is not connected to ground (floating node)",
             "Component values are unrealistic (e.g. 0 ohm resistor, extremely large gain)",
@@ -69,7 +71,9 @@ _DIAGNOSES: dict[ErrorCategory, ErrorDiagnosis] = {
     ),
     ErrorCategory.TIMESTEP_TOO_SMALL: ErrorDiagnosis(
         category=ErrorCategory.TIMESTEP_TOO_SMALL,
-        message=("The transient simulation could not advance in time — the required timestep became too small."),
+        message=(
+            "The transient simulation could not advance in time — the required timestep became too small."
+        ),
         causes=[
             "Very fast switching edges combined with large time constants",
             "Numerical oscillation in a feedback loop",
@@ -97,7 +101,9 @@ _DIAGNOSES: dict[ErrorCategory, ErrorDiagnosis] = {
     ),
     ErrorCategory.SOURCE_STEPPING_FAILED: ErrorDiagnosis(
         category=ErrorCategory.SOURCE_STEPPING_FAILED,
-        message=("The simulator tried ramping sources gradually but still could not converge."),
+        message=(
+            "The simulator tried ramping sources gradually but still could not converge."
+        ),
         causes=[
             "Circuit has a very sensitive operating point",
             "Non-linear devices (diodes, transistors) with difficult bias conditions",

--- a/app/simulation/excel_exporter.py
+++ b/app/simulation/excel_exporter.py
@@ -32,7 +32,9 @@ def _add_metadata_sheet(wb, analysis_type, circuit_name=""):
 
 def _style_header_row(ws, row_num=1):
     """Apply header styling to the first row of a worksheet."""
-    header_fill = PatternFill(start_color="4472C4", end_color="4472C4", fill_type="solid")
+    header_fill = PatternFill(
+        start_color="4472C4", end_color="4472C4", fill_type="solid"
+    )
     header_font = Font(bold=True, color="FFFFFF")
     for cell in ws[row_num]:
         cell.font = header_font

--- a/app/simulation/fft_analysis.py
+++ b/app/simulation/fft_analysis.py
@@ -77,7 +77,9 @@ def compute_fft(
     elif window.lower() == "none":
         window_func = np.ones(n_samples)
     else:
-        raise ValueError(f"Unknown window type: {window}. Use 'hanning', 'hamming', 'blackman', or 'none'")
+        raise ValueError(
+            f"Unknown window type: {window}. Use 'hanning', 'hamming', 'blackman', or 'none'"
+        )
 
     # Apply window and compensate for window power loss
     windowed_signal = signal * window_func
@@ -136,7 +138,9 @@ def find_fundamental_frequency(fft_result: FFTResult, min_freq: float = 10.0) ->
     return valid_freqs[peak_idx]
 
 
-def compute_thd(fft_result: FFTResult, fundamental_freq: float, num_harmonics: int = 5) -> float:
+def compute_thd(
+    fft_result: FFTResult, fundamental_freq: float, num_harmonics: int = 5
+) -> float:
     """
     Compute Total Harmonic Distortion (THD).
 
@@ -185,7 +189,9 @@ def compute_thd(fft_result: FFTResult, fundamental_freq: float, num_harmonics: i
     return thd
 
 
-def find_harmonics(fft_result: FFTResult, fundamental_freq: float, num_harmonics: int = 5) -> list:
+def find_harmonics(
+    fft_result: FFTResult, fundamental_freq: float, num_harmonics: int = 5
+) -> list:
     """
     Identify harmonic frequencies and their magnitudes.
 

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -60,7 +60,9 @@ class NetlistGenerator:
         opamp_models_used = set()
         for c in self.components.values():
             if c.component_type == "Op-Amp":
-                opamp_models_used.add(c.value if c.value in OPAMP_SUBCIRCUITS else "Ideal")
+                opamp_models_used.add(
+                    c.value if c.value in OPAMP_SUBCIRCUITS else "Ideal"
+                )
         for model_name in sorted(opamp_models_used):
             lines.append(f"* {model_name} Op-Amp Subcircuit")
             lines.append(OPAMP_SUBCIRCUITS[model_name])
@@ -93,7 +95,9 @@ class NetlistGenerator:
                         node_map[key] = merged_node
 
         # Ground nodes should be 0
-        ground_comps = [c for c in self.components.values() if c.component_type == "Ground"]
+        ground_comps = [
+            c for c in self.components.values() if c.component_type == "Ground"
+        ]
         for gnd in ground_comps:
             key = (gnd.component_id, 0)
             if key in node_map:
@@ -149,10 +153,18 @@ class NetlistGenerator:
             if comp.component_type == "Resistor":
                 lines.append(f"{comp_id} {' '.join(nodes)} {comp.value}")
             elif comp.component_type == "Capacitor":
-                ic = f" IC={comp.initial_condition}" if getattr(comp, "initial_condition", None) else ""
+                ic = (
+                    f" IC={comp.initial_condition}"
+                    if getattr(comp, "initial_condition", None)
+                    else ""
+                )
                 lines.append(f"{comp_id} {' '.join(nodes)} {comp.value}{ic}")
             elif comp.component_type == "Inductor":
-                ic = f" IC={comp.initial_condition}" if getattr(comp, "initial_condition", None) else ""
+                ic = (
+                    f" IC={comp.initial_condition}"
+                    if getattr(comp, "initial_condition", None)
+                    else ""
+                )
                 lines.append(f"{comp_id} {' '.join(nodes)} {comp.value}{ic}")
             elif comp.component_type == "Voltage Source":
                 lines.append(f"{comp_id} {' '.join(nodes)} DC {comp.value}")
@@ -175,25 +187,33 @@ class NetlistGenerator:
             elif comp.component_type == "VCVS":
                 # E<name> out+ out- ctrl+ ctrl- gain
                 # Terminals: 0=ctrl+, 1=ctrl-, 2=out+, 3=out-
-                lines.append(f"{comp_id} {nodes[2]} {nodes[3]} {nodes[0]} {nodes[1]} {comp.value}")
+                lines.append(
+                    f"{comp_id} {nodes[2]} {nodes[3]} {nodes[0]} {nodes[1]} {comp.value}"
+                )
             elif comp.component_type == "VCCS":
                 # G<name> out+ out- ctrl+ ctrl- transconductance
                 # Terminals: 0=ctrl+, 1=ctrl-, 2=out+, 3=out-
-                lines.append(f"{comp_id} {nodes[2]} {nodes[3]} {nodes[0]} {nodes[1]} {comp.value}")
+                lines.append(
+                    f"{comp_id} {nodes[2]} {nodes[3]} {nodes[0]} {nodes[1]} {comp.value}"
+                )
             elif comp.component_type == "CCVS":
                 # H<name> out+ out- Vname transresistance
                 # Insert hidden 0V voltage source for current sensing
                 # Terminals: 0=ctrl+, 1=ctrl-, 2=out+, 3=out-
                 sense_name = f"Vsense_{comp_id}"
                 lines.append(f"{sense_name} {nodes[0]} {nodes[1]} 0")
-                lines.append(f"{comp_id} {nodes[2]} {nodes[3]} {sense_name} {comp.value}")
+                lines.append(
+                    f"{comp_id} {nodes[2]} {nodes[3]} {sense_name} {comp.value}"
+                )
             elif comp.component_type == "CCCS":
                 # F<name> out+ out- Vname gain
                 # Insert hidden 0V voltage source for current sensing
                 # Terminals: 0=ctrl+, 1=ctrl-, 2=out+, 3=out-
                 sense_name = f"Vsense_{comp_id}"
                 lines.append(f"{sense_name} {nodes[0]} {nodes[1]} 0")
-                lines.append(f"{comp_id} {nodes[2]} {nodes[3]} {sense_name} {comp.value}")
+                lines.append(
+                    f"{comp_id} {nodes[2]} {nodes[3]} {sense_name} {comp.value}"
+                )
             elif comp.component_type == "BJT NPN":
                 # Q<name> collector base emitter model_name
                 # Terminals: 0=collector, 1=base, 2=emitter
@@ -205,16 +225,22 @@ class NetlistGenerator:
                 # M<name> drain gate source bulk model_name
                 # Terminals: 0=drain, 1=gate, 2=source
                 # Bulk (body) tied to source for simplicity
-                lines.append(f"{comp_id} {nodes[0]} {nodes[1]} {nodes[2]} {nodes[2]} {comp.value}")
+                lines.append(
+                    f"{comp_id} {nodes[0]} {nodes[1]} {nodes[2]} {nodes[2]} {comp.value}"
+                )
             elif comp.component_type == "VC Switch":
                 # S<name> switch+ switch- ctrl+ ctrl- model_name
                 # Terminals: 0=ctrl+, 1=ctrl-, 2=switch+, 3=switch-
                 model_name = f"SW_{comp_id}"
-                lines.append(f"{comp_id} {nodes[2]} {nodes[3]} {nodes[0]} {nodes[1]} {model_name}")
+                lines.append(
+                    f"{comp_id} {nodes[2]} {nodes[3]} {nodes[0]} {nodes[1]} {model_name}"
+                )
             elif comp.component_type in ("Diode", "LED", "Zener Diode"):
                 # D<name> anode cathode model_name
                 # Terminals: 0=anode, 1=cathode
-                model_name = self._diode_model_map.get((comp.component_type, comp.value), f"D_{comp_id}")
+                model_name = self._diode_model_map.get(
+                    (comp.component_type, comp.value), f"D_{comp_id}"
+                )
                 lines.append(f"{comp_id} {nodes[0]} {nodes[1]} {model_name}")
             elif comp.component_type == "Transformer":
                 # Transformer modeled as two coupled inductors + K coupling
@@ -265,7 +291,9 @@ class NetlistGenerator:
                     lines.append(f".model {model_name} PMOS(VTO=-0.7 KP=50u)")
 
         # Add VC Switch model directives
-        vc_switches = [c for c in self.components.values() if c.component_type == "VC Switch"]
+        vc_switches = [
+            c for c in self.components.values() if c.component_type == "VC Switch"
+        ]
         if vc_switches:
             lines.append("")
             lines.append("* Voltage-Controlled Switch Model Definitions")
@@ -277,7 +305,9 @@ class NetlistGenerator:
         if self._diode_model_map:
             lines.append("")
             lines.append("* Diode Model Definitions")
-            for (_dtype, params), model_name in sorted(self._diode_model_map.items(), key=lambda kv: kv[1]):
+            for (_dtype, params), model_name in sorted(
+                self._diode_model_map.items(), key=lambda kv: kv[1]
+            ):
                 lines.append(f".model {model_name} D({params})")
 
         # Add comments about labeled nodes
@@ -325,10 +355,16 @@ class NetlistGenerator:
 
         elif self.analysis_type == "DC Sweep":
             params = self.analysis_params
-            voltage_sources = [c for c in self.components.values() if c.component_type == "Voltage Source"]
+            voltage_sources = [
+                c
+                for c in self.components.values()
+                if c.component_type == "Voltage Source"
+            ]
             if voltage_sources:
                 source_name = voltage_sources[0].component_id
-                lines.append(f".dc {source_name} {params['min']} {params['max']} {params['step']}")
+                lines.append(
+                    f".dc {source_name} {params['min']} {params['max']} {params['step']}"
+                )
             else:
                 lines.append("* Warning: DC Sweep requires a voltage source")
                 lines.append(".op")
@@ -336,7 +372,9 @@ class NetlistGenerator:
         elif self.analysis_type == "AC Sweep":
             params = self.analysis_params
             sweep_type = params.get("sweep_type", "dec")
-            lines.append(f".ac {sweep_type} {params['points']} {params['fStart']} {params['fStop']}")
+            lines.append(
+                f".ac {sweep_type} {params['points']} {params['fStart']} {params['fStop']}"
+            )
 
         elif self.analysis_type == "Transient":
             params = self.analysis_params
@@ -360,7 +398,9 @@ class NetlistGenerator:
             pts = params.get("points", 100)
             fstart = params.get("fStart", 1)
             fstop = params.get("fStop", 1e6)
-            lines.append(f".noise v({output_node}) {source} {sweep_type} {pts} {fstart} {fstop}")
+            lines.append(
+                f".noise v({output_node}) {source} {sweep_type} {pts} {fstart} {fstop}"
+            )
 
         elif self.analysis_type == "Sensitivity":
             params = self.analysis_params
@@ -399,7 +439,9 @@ class NetlistGenerator:
         # Define variables for voltages across resistors
         resistor_voltages_let = []
         resistor_voltages_print = []
-        resistors = [c for c in self.components.values() if c.component_type == "Resistor"]
+        resistors = [
+            c for c in self.components.values() if c.component_type == "Resistor"
+        ]
         for res in resistors:
             try:
                 node1_num = node_map.get((res.component_id, 0))
@@ -448,13 +490,19 @@ class NetlistGenerator:
             # Generate appropriate print commands, excluding ground node 0.
             nodes_to_print = set(node_map.values())
             nodes_to_print.discard(0)
-            labeled_nodes_to_print = {num: label for num, label in node_labels.items() if num != 0}
+            labeled_nodes_to_print = {
+                num: label for num, label in node_labels.items() if num != 0
+            }
 
             all_print_vars = []
             if labeled_nodes_to_print:
-                all_print_vars.extend([f"v({label})" for label in sorted(labeled_nodes_to_print.values())])
+                all_print_vars.extend(
+                    [f"v({label})" for label in sorted(labeled_nodes_to_print.values())]
+                )
             elif nodes_to_print:
-                all_print_vars.extend([f"v({node})" for node in sorted(list(nodes_to_print))])
+                all_print_vars.extend(
+                    [f"v({node})" for node in sorted(list(nodes_to_print))]
+                )
 
             # Add resistor voltages to the print list
             all_print_vars.extend(resistor_voltages_print)

--- a/app/simulation/netlist_parser.py
+++ b/app/simulation/netlist_parser.py
@@ -158,7 +158,9 @@ def _parse_component_line(line, models):
         node_names = tokens[1:-1]
         comp_type = "Op-Amp" if "OPAMP" in subckt_name else None
         if comp_type is None:
-            logger.warning("Unknown subcircuit '%s' - skipping %s", subckt_name, comp_id)
+            logger.warning(
+                "Unknown subcircuit '%s' - skipping %s", subckt_name, comp_id
+            )
             return None
         return {
             "id": comp_id,

--- a/app/simulation/power_calculator.py
+++ b/app/simulation/power_calculator.py
@@ -46,7 +46,9 @@ def calculate_power(components, nodes, node_voltages, branch_currents=None):
             continue
 
         try:
-            p = _calc_component_power(comp, cid, ctype, term_to_label, node_voltages, branch_currents)
+            p = _calc_component_power(
+                comp, cid, ctype, term_to_label, node_voltages, branch_currents
+            )
             if p is not None:
                 power[cid] = p
         except (ValueError, KeyError, ZeroDivisionError) as e:
@@ -55,7 +57,9 @@ def calculate_power(components, nodes, node_voltages, branch_currents=None):
     return power
 
 
-def _calc_component_power(comp, cid, ctype, term_to_label, node_voltages, branch_currents):
+def _calc_component_power(
+    comp, cid, ctype, term_to_label, node_voltages, branch_currents
+):
     """Calculate power for a single component. Returns watts or None."""
     # Get node labels for terminal 0 and 1 (2-terminal components)
     label0 = term_to_label.get((cid, 0))

--- a/app/simulation/power_metrics.py
+++ b/app/simulation/power_metrics.py
@@ -107,7 +107,9 @@ def format_power_summary(metrics):
     lines.append("")
     lines.append("POWER SUMMARY")
     lines.append("=" * 70)
-    lines.append(f"  {'Component':<12s} {'Value':>8s} {'Vrms':>12s} {'Irms':>12s} {'Pavg':>12s} {'Ppeak':>12s}")
+    lines.append(
+        f"  {'Component':<12s} {'Value':>8s} {'Vrms':>12s} {'Irms':>12s} {'Pavg':>12s} {'Ppeak':>12s}"
+    )
     lines.append("-" * 70)
 
     total_pavg = 0.0
@@ -122,7 +124,9 @@ def format_power_summary(metrics):
         )
 
     lines.append("-" * 70)
-    lines.append(f"  {'Total Pavg':<12s} {'':>8s} {'':>12s} {'':>12s} {_fmt_eng(total_pavg, 'W'):>12s}")
+    lines.append(
+        f"  {'Total Pavg':<12s} {'':>8s} {'':>12s} {'':>12s} {_fmt_eng(total_pavg, 'W'):>12s}"
+    )
     lines.append("=" * 70)
 
     return "\n".join(lines)

--- a/app/simulation/preset_manager.py
+++ b/app/simulation/preset_manager.py
@@ -98,7 +98,9 @@ class PresetManager:
             return [p for p in all_presets if p["analysis_type"] == analysis_type]
         return list(all_presets)
 
-    def get_preset_by_name(self, name: str, analysis_type: Optional[str] = None) -> Optional[dict]:
+    def get_preset_by_name(
+        self, name: str, analysis_type: Optional[str] = None
+    ) -> Optional[dict]:
         """Look up a preset by name (and optionally analysis type)."""
         for p in self.get_presets(analysis_type):
             if p["name"] == name:
@@ -114,7 +116,9 @@ class PresetManager:
 
         # Remove existing user preset with same name+type
         self._user_presets = [
-            p for p in self._user_presets if not (p["name"] == name and p["analysis_type"] == analysis_type)
+            p
+            for p in self._user_presets
+            if not (p["name"] == name and p["analysis_type"] == analysis_type)
         ]
 
         preset = {
@@ -129,14 +133,19 @@ class PresetManager:
     def delete_preset(self, name: str, analysis_type: Optional[str] = None) -> bool:
         """Delete a user preset. Returns True if deleted, False if not found or built-in."""
         for bp in BUILTIN_PRESETS:
-            if bp["name"] == name and (analysis_type is None or bp["analysis_type"] == analysis_type):
+            if bp["name"] == name and (
+                analysis_type is None or bp["analysis_type"] == analysis_type
+            ):
                 return False  # Can't delete built-in
 
         before = len(self._user_presets)
         self._user_presets = [
             p
             for p in self._user_presets
-            if not (p["name"] == name and (analysis_type is None or p["analysis_type"] == analysis_type))
+            if not (
+                p["name"] == name
+                and (analysis_type is None or p["analysis_type"] == analysis_type)
+            )
         ]
         if len(self._user_presets) < before:
             self._save()

--- a/app/simulation/result_parser.py
+++ b/app/simulation/result_parser.py
@@ -66,7 +66,9 @@ class ResultParser:
 
             for i, line in enumerate(lines):
                 # Pattern 1: v(nodename) = voltage
-                match = re.search(r"v\((\w+)\)\s*[=:]\s*([-+]?[\d.]+e?[-+]?\d*)", line, re.IGNORECASE)
+                match = re.search(
+                    r"v\((\w+)\)\s*[=:]\s*([-+]?[\d.]+e?[-+]?\d*)", line, re.IGNORECASE
+                )
                 if match:
                     node_name = match.group(1)
                     voltage = float(match.group(2))
@@ -75,7 +77,9 @@ class ResultParser:
 
                 # Branch current patterns: i(device) = current or @device[current]
                 i_match = re.search(
-                    r"(?:i\((\w+)\)|@(\w+)\[current\])\s*[=:]\s*([-+]?[\d.]+e?[-+]?\d*)", line, re.IGNORECASE
+                    r"(?:i\((\w+)\)|@(\w+)\[current\])\s*[=:]\s*([-+]?[\d.]+e?[-+]?\d*)",
+                    line,
+                    re.IGNORECASE,
                 )
                 if i_match:
                     device = i_match.group(1) or i_match.group(2)
@@ -89,7 +93,9 @@ class ResultParser:
                         result_line = lines[j].strip()
                         if not result_line or result_line.startswith("-"):
                             continue
-                        if result_line.startswith("*") or result_line.lower().startswith("source"):
+                        if result_line.startswith(
+                            "*"
+                        ) or result_line.lower().startswith("source"):
                             break
 
                         parts = result_line.split()
@@ -104,14 +110,18 @@ class ResultParser:
             # Pattern 3: ngspice print output format
             for line in lines:
                 # Voltages: " V(5)   1.000000e-06 "
-                match = re.match(r"^\s*V\((\w+)\)\s+([-+]?[\d.]+e?[-+]?\d*)\s*", line, re.IGNORECASE)
+                match = re.match(
+                    r"^\s*V\((\w+)\)\s+([-+]?[\d.]+e?[-+]?\d*)\s*", line, re.IGNORECASE
+                )
                 if match:
                     node_name = match.group(1)
                     voltage = float(match.group(2))
                     node_voltages[node_name] = voltage
                     continue
                 # Currents: " I(v1)   -2.100000e-03 "
-                i_match = re.match(r"^\s*I\((\w+)\)\s+([-+]?[\d.]+e?[-+]?\d*)\s*", line, re.IGNORECASE)
+                i_match = re.match(
+                    r"^\s*I\((\w+)\)\s+([-+]?[\d.]+e?[-+]?\d*)\s*", line, re.IGNORECASE
+                )
                 if i_match:
                     device = i_match.group(1)
                     current = float(i_match.group(2))
@@ -137,7 +147,9 @@ class ResultParser:
 
             for i, line in enumerate(lines):
                 # Look for table headers
-                if "index" in line.lower() or ("sweep" in line.lower() and "v(" in line.lower()):
+                if "index" in line.lower() or (
+                    "sweep" in line.lower() and "v(" in line.lower()
+                ):
                     headers = line.split()
                     header_found = True
                     sweep_data["headers"] = headers
@@ -185,7 +197,9 @@ class ResultParser:
                     parts = line.strip().split()
                     if len(parts) >= 2:
                         try:
-                            freq = float(parts[1]) if len(parts) > 1 else float(parts[0])
+                            freq = (
+                                float(parts[1]) if len(parts) > 1 else float(parts[0])
+                            )
                             ac_data["frequencies"].append(freq)
 
                             # Parse voltage magnitudes and phases
@@ -193,7 +207,9 @@ class ResultParser:
                                 if j < len(parts):
                                     if "vp(" in header.lower():
                                         # Phase data
-                                        node = header.replace("vp(", "").replace(")", "")
+                                        node = header.replace("vp(", "").replace(
+                                            ")", ""
+                                        )
                                         if node not in ac_data["phase"]:
                                             ac_data["phase"][node] = []
                                         ac_data["phase"][node].append(float(parts[j]))
@@ -202,7 +218,9 @@ class ResultParser:
                                         node = header.replace("v(", "").replace(")", "")
                                         if node not in ac_data["magnitude"]:
                                             ac_data["magnitude"][node] = []
-                                        ac_data["magnitude"][node].append(float(parts[j]))
+                                        ac_data["magnitude"][node].append(
+                                            float(parts[j])
+                                        )
                         except (ValueError, IndexError):
                             continue
 
@@ -222,13 +240,19 @@ class ResultParser:
         """
         try:
             lines = output.split("\n")
-            noise_data = {"frequencies": [], "onoise_spectrum": [], "inoise_spectrum": []}
+            noise_data = {
+                "frequencies": [],
+                "onoise_spectrum": [],
+                "inoise_spectrum": [],
+            }
 
             header_found = False
             headers = []
 
             for line in lines:
-                if "frequency" in line.lower() and ("onoise" in line.lower() or "inoise" in line.lower()):
+                if "frequency" in line.lower() and (
+                    "onoise" in line.lower() or "inoise" in line.lower()
+                ):
                     headers = line.split()
                     header_found = True
                     continue
@@ -238,16 +262,22 @@ class ResultParser:
                     if len(parts) >= 2:
                         try:
                             # Index column + frequency + noise values
-                            freq = float(parts[1]) if len(parts) > 2 else float(parts[0])
+                            freq = (
+                                float(parts[1]) if len(parts) > 2 else float(parts[0])
+                            )
                             noise_data["frequencies"].append(freq)
 
                             for j, header in enumerate(headers):
                                 if j < len(parts):
                                     h_lower = header.lower()
                                     if "onoise" in h_lower:
-                                        noise_data["onoise_spectrum"].append(float(parts[j]))
+                                        noise_data["onoise_spectrum"].append(
+                                            float(parts[j])
+                                        )
                                     elif "inoise" in h_lower:
-                                        noise_data["inoise_spectrum"].append(float(parts[j]))
+                                        noise_data["inoise_spectrum"].append(
+                                            float(parts[j])
+                                        )
                         except (ValueError, IndexError):
                             continue
 
@@ -282,7 +312,11 @@ class ResultParser:
 
                 if in_header_zone and not in_data:
                     # Skip header lines (element/name/units) and blanks
-                    if not stripped or "element" in stripped.lower() or "name" in stripped.lower():
+                    if (
+                        not stripped
+                        or "element" in stripped.lower()
+                        or "name" in stripped.lower()
+                    ):
                         continue
                     if "volts/" in stripped.lower() or "amps/" in stripped.lower():
                         continue
@@ -455,7 +489,9 @@ class ResultParser:
             for h in raw_headers:
                 # Sanitize headers: v(node) -> node, i(branch) -> i_branch
                 sanitized_h = re.sub(r"^v\((.*?)\)$", r"\1", h, flags=re.IGNORECASE)
-                sanitized_h = re.sub(r"^i\((.*?)\)$", r"i_\1", sanitized_h, flags=re.IGNORECASE)
+                sanitized_h = re.sub(
+                    r"^i\((.*?)\)$", r"i_\1", sanitized_h, flags=re.IGNORECASE
+                )
                 headers.append(sanitized_h)
 
             results = []
@@ -464,7 +500,9 @@ class ResultParser:
                 parts = line.strip().split()
                 if len(parts) == len(headers):
                     try:
-                        row_data = {headers[i]: float(parts[i]) for i in range(len(parts))}
+                        row_data = {
+                            headers[i]: float(parts[i]) for i in range(len(parts))
+                        }
                         results.append(row_data)
                     except (ValueError, IndexError):
                         continue
@@ -538,7 +576,9 @@ class ResultParser:
         results = {}
         for line in stdout.split("\n"):
             # Match: "  rise_time  =  1.23456e-06"
-            match = re.match(r"^\s*(\w+)\s*=\s*([-+]?[\d.]+(?:e[-+]?\d+)?)\s*$", line, re.IGNORECASE)
+            match = re.match(
+                r"^\s*(\w+)\s*=\s*([-+]?[\d.]+(?:e[-+]?\d+)?)\s*$", line, re.IGNORECASE
+            )
             if match:
                 name = match.group(1)
                 value = float(match.group(2))

--- a/app/tests/integration/test_phase4_mvc_integration.py
+++ b/app/tests/integration/test_phase4_mvc_integration.py
@@ -94,7 +94,9 @@ class TestMVCFileOperations:
             file_ctrl.save_circuit(temp_path)
 
             # Create new controller and check session
-            new_file_ctrl = FileController(CircuitModel(), session_file="test_session.txt")
+            new_file_ctrl = FileController(
+                CircuitModel(), session_file="test_session.txt"
+            )
             last_file = new_file_ctrl.load_last_session()
 
             # Verify session file returns correct path
@@ -332,7 +334,8 @@ class TestMVCBackwardCompatibility:
         """Test that old import names still work after Phase 4"""
         # These should all work due to backward compatibility
         # Old names should map to new classes
-        from GUI import CircuitCanvas, CircuitCanvasView, WireGraphicsItem, WireItem
+        from GUI import (CircuitCanvas, CircuitCanvasView, WireGraphicsItem,
+                         WireItem)
 
         assert CircuitCanvas is CircuitCanvasView
         assert WireItem is WireGraphicsItem

--- a/app/tests/integration/test_save_load.py
+++ b/app/tests/integration/test_save_load.py
@@ -7,7 +7,8 @@ Tests ComponentData and WireData without any Qt dependencies.
 import json
 
 import pytest
-from models.component import _CLASS_TO_DISPLAY, _DISPLAY_TO_CLASS, COMPONENT_TYPES, DEFAULT_VALUES, ComponentData
+from models.component import (_CLASS_TO_DISPLAY, _DISPLAY_TO_CLASS,
+                              COMPONENT_TYPES, DEFAULT_VALUES, ComponentData)
 from models.wire import WireData
 from tests.conftest import make_component, make_wire
 

--- a/app/tests/unit/test_annotation_undo.py
+++ b/app/tests/unit/test_annotation_undo.py
@@ -8,11 +8,9 @@ through the CircuitController rather than directly on the canvas.
 import inspect
 
 from controllers.circuit_controller import CircuitController
-from controllers.commands import (
-    AddAnnotationCommand,
-    DeleteAnnotationCommand,
-    EditAnnotationCommand,
-)
+from controllers.commands import (AddAnnotationCommand,
+                                  DeleteAnnotationCommand,
+                                  EditAnnotationCommand)
 from models.annotation import AnnotationData
 from models.circuit import CircuitModel
 

--- a/app/tests/unit/test_annotations.py
+++ b/app/tests/unit/test_annotations.py
@@ -6,7 +6,9 @@ controller, persisted via CircuitModel, and undone/redone via commands.
 
 import pytest
 from controllers.circuit_controller import CircuitController
-from controllers.commands import AddAnnotationCommand, DeleteAnnotationCommand, EditAnnotationCommand
+from controllers.commands import (AddAnnotationCommand,
+                                  DeleteAnnotationCommand,
+                                  EditAnnotationCommand)
 from models.annotation import AnnotationData
 from models.circuit import CircuitModel
 
@@ -24,7 +26,9 @@ class TestAnnotationData:
         assert ann.color == "#FFFFFF"
 
     def test_custom_values(self):
-        ann = AnnotationData(text="Hello", x=100.0, y=200.0, font_size=14, bold=True, color="#FF0000")
+        ann = AnnotationData(
+            text="Hello", x=100.0, y=200.0, font_size=14, bold=True, color="#FF0000"
+        )
         assert ann.text == "Hello"
         assert ann.x == 100.0
         assert ann.y == 200.0
@@ -43,7 +47,14 @@ class TestAnnotationData:
         assert d["color"] == "#FFFFFF"
 
     def test_from_dict(self):
-        d = {"text": "Loaded", "x": 10.0, "y": 20.0, "font_size": 12, "bold": True, "color": "#00FF00"}
+        d = {
+            "text": "Loaded",
+            "x": 10.0,
+            "y": 20.0,
+            "font_size": 12,
+            "bold": True,
+            "color": "#00FF00",
+        }
         ann = AnnotationData.from_dict(d)
         assert ann.text == "Loaded"
         assert ann.x == 10.0
@@ -113,7 +124,9 @@ class TestCircuitModelAnnotations:
 
     def test_model_roundtrip_with_annotations(self):
         model = CircuitModel()
-        model.annotations.append(AnnotationData(text="Persist", x=100.0, y=200.0, bold=True))
+        model.annotations.append(
+            AnnotationData(text="Persist", x=100.0, y=200.0, bold=True)
+        )
         d = model.to_dict()
         restored = CircuitModel.from_dict(d)
         assert len(restored.annotations) == 1
@@ -299,7 +312,9 @@ class TestAnnotationPersistence:
     def test_save_load_preserves_annotations(self):
         model = CircuitModel()
         model.annotations.append(AnnotationData(text="Saved", x=10.0, y=20.0))
-        model.annotations.append(AnnotationData(text="Also Saved", x=30.0, y=40.0, bold=True))
+        model.annotations.append(
+            AnnotationData(text="Also Saved", x=30.0, y=40.0, bold=True)
+        )
 
         data = model.to_dict()
         restored = CircuitModel.from_dict(data)

--- a/app/tests/unit/test_asc_exporter.py
+++ b/app/tests/unit/test_asc_exporter.py
@@ -213,8 +213,16 @@ class TestImportExportRoundTrip:
         reimported, _analysis, _warnings = import_asc(asc_text)
 
         # Check component names are preserved
-        original_ids = {cid for cid in model.components if model.components[cid].component_type != "Ground"}
-        reimported_ids = {cid for cid in reimported.components if reimported.components[cid].component_type != "Ground"}
+        original_ids = {
+            cid
+            for cid in model.components
+            if model.components[cid].component_type != "Ground"
+        }
+        reimported_ids = {
+            cid
+            for cid in reimported.components
+            if reimported.components[cid].component_type != "Ground"
+        }
         assert original_ids == reimported_ids
 
     def test_values_preserved(self):

--- a/app/tests/unit/test_asc_parser.py
+++ b/app/tests/unit/test_asc_parser.py
@@ -1,7 +1,8 @@
 """Tests for LTspice .asc file parser."""
 
 import pytest
-from simulation.asc_parser import AscParseError, _transform_pin, import_asc, parse_asc
+from simulation.asc_parser import (AscParseError, _transform_pin, import_asc,
+                                   parse_asc)
 
 # --- Sample .asc content for tests ---
 
@@ -293,7 +294,9 @@ class TestImportAsc:
 
     def test_creates_ground_components(self):
         model, _analysis, _warnings = import_asc(SIMPLE_RC)
-        ground_comps = [c for c in model.components.values() if c.component_type == "Ground"]
+        ground_comps = [
+            c for c in model.components.values() if c.component_type == "Ground"
+        ]
         assert len(ground_comps) >= 1
 
     def test_sets_analysis_type(self):
@@ -346,7 +349,9 @@ class TestImportAsc:
 
     def test_multiple_grounds(self):
         model, _analysis, _warnings = import_asc(MULTIPLE_GROUNDS)
-        ground_comps = [c for c in model.components.values() if c.component_type == "Ground"]
+        ground_comps = [
+            c for c in model.components.values() if c.component_type == "Ground"
+        ]
         assert len(ground_comps) >= 1
 
     def test_waveform_source_detection(self):

--- a/app/tests/unit/test_auto_save.py
+++ b/app/tests/unit/test_auto_save.py
@@ -32,9 +32,24 @@ def _build_simple_circuit():
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.component_counter = {"V": 1, "R": 1, "GND": 1}
     model.rebuild_nodes()

--- a/app/tests/unit/test_batch_grading.py
+++ b/app/tests/unit/test_batch_grading.py
@@ -40,10 +40,30 @@ def _build_circuit(r_value="1k", c_value="100n"):
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="C1", end_terminal=0),
-        WireData(start_component_id="C1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="C1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="C1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.component_counter = {"V": 1, "R": 1, "C": 1, "GND": 1}
     model.analysis_type = "AC Sweep"
@@ -68,7 +88,11 @@ def _build_rubric():
                 check_id="r1_value",
                 check_type="component_value",
                 points=25,
-                params={"component_id": "R1", "expected_value": "1k", "tolerance_pct": 10},
+                params={
+                    "component_id": "R1",
+                    "expected_value": "1k",
+                    "tolerance_pct": 10,
+                },
                 feedback_pass="R1 value OK",
                 feedback_fail="R1 value wrong",
             ),

--- a/app/tests/unit/test_batch_reroute.py
+++ b/app/tests/unit/test_batch_reroute.py
@@ -67,7 +67,11 @@ class TestObserverMoveDedup:
         r2 = ctrl.add_component("Resistor", (100, 0))
 
         events = []
-        ctrl.add_observer(lambda e, d: events.append((e, d.component_id)) if e == "component_moved" else None)
+        ctrl.add_observer(
+            lambda e, d: (
+                events.append((e, d.component_id)) if e == "component_moved" else None
+            )
+        )
 
         # Simulate group drag: both components move
         ctrl.move_component(r1.component_id, (50, 50))

--- a/app/tests/unit/test_canvas_sync.py
+++ b/app/tests/unit/test_canvas_sync.py
@@ -34,7 +34,9 @@ class TestCanvasSyncMethods:
         """Create a mock ComponentGraphicsItem"""
         comp = Mock()
         comp.component_id = "R1"
-        comp.pos = Mock(return_value=Mock(x=Mock(return_value=100), y=Mock(return_value=200)))
+        comp.pos = Mock(
+            return_value=Mock(x=Mock(return_value=100), y=Mock(return_value=200))
+        )
         comp.model = ComponentData(
             component_id="R1",
             component_type="Resistor",
@@ -55,11 +57,15 @@ class TestCanvasSyncMethods:
         model.component_counter = {"Resistor": 2, "Capacitor": 0}
         return model
 
-    def test_sync_to_model_updates_components(self, mock_canvas, mock_component_item, sample_model):
+    def test_sync_to_model_updates_components(
+        self, mock_canvas, mock_component_item, sample_model
+    ):
         """Test that sync_to_model copies component data to model"""
         # Setup
         mock_canvas.components = {"R1": mock_component_item}
-        mock_canvas.get_model_components = Mock(return_value={"R1": mock_component_item.model})
+        mock_canvas.get_model_components = Mock(
+            return_value={"R1": mock_component_item.model}
+        )
 
         # Import the actual method logic (can't instantiate Qt objects in tests)
         # We'll verify the logic conceptually
@@ -89,7 +95,9 @@ class TestCanvasSyncMethods:
         node = NodeData(terminals={("R1", 0), ("R2", 0)}, wire_indices={0})
         terminal_map = {("R1", 0): node, ("R2", 0): node}
 
-        mock_canvas.get_model_nodes_and_terminal_map = Mock(return_value=([node], terminal_map))
+        mock_canvas.get_model_nodes_and_terminal_map = Mock(
+            return_value=([node], terminal_map)
+        )
 
         # Verify node structure
         nodes, term_map = mock_canvas.get_model_nodes_and_terminal_map()

--- a/app/tests/unit/test_circuit_comparer.py
+++ b/app/tests/unit/test_circuit_comparer.py
@@ -1,7 +1,8 @@
 """Tests for the circuit comparison engine."""
 
 import pytest
-from grading.circuit_comparer import CheckResult, CircuitComparer, ComparisonResult, compare_values
+from grading.circuit_comparer import (CheckResult, CircuitComparer,
+                                      ComparisonResult, compare_values)
 from models.circuit import CircuitModel
 from models.component import ComponentData
 from models.wire import WireData
@@ -335,7 +336,9 @@ class TestFullComparison:
         comparer = CircuitComparer()
         result = comparer.compare(ref, student)
         assert result.score < 1.0
-        value_mismatches = [m for m in result.mismatches if m.check_type == "component_value"]
+        value_mismatches = [
+            m for m in result.mismatches if m.check_type == "component_value"
+        ]
         assert len(value_mismatches) == 1
         assert value_mismatches[0].component_id == "R1"
 
@@ -346,7 +349,9 @@ class TestFullComparison:
 
         comparer = CircuitComparer()
         result = comparer.compare(ref, student)
-        analysis_mismatches = [m for m in result.mismatches if m.check_type == "analysis_type"]
+        analysis_mismatches = [
+            m for m in result.mismatches if m.check_type == "analysis_type"
+        ]
         assert len(analysis_mismatches) == 1
 
     def test_topology_mismatch(self):
@@ -403,9 +408,14 @@ class TestFullComparison:
 
         comparer = CircuitComparer()
         result = comparer.compare(ref, student)
-        topology_mismatches = [m for m in result.mismatches if m.check_type == "topology"]
+        topology_mismatches = [
+            m for m in result.mismatches if m.check_type == "topology"
+        ]
         # R1 and R2 should be reported as not connected
-        assert any("R1" in m.component_id and "R2" in m.component_id for m in topology_mismatches)
+        assert any(
+            "R1" in m.component_id and "R2" in m.component_id
+            for m in topology_mismatches
+        )
 
 
 class TestComparisonResult:
@@ -454,5 +464,7 @@ class TestRealisticScenarios:
         comparer = CircuitComparer()
         result = comparer.compare(ref, student)
         assert result.score < 1.0
-        value_mismatches = [m for m in result.mismatches if m.check_type == "component_value"]
+        value_mismatches = [
+            m for m in result.mismatches if m.check_type == "component_value"
+        ]
         assert any(m.component_id == "C1" for m in value_mismatches)

--- a/app/tests/unit/test_circuit_validator.py
+++ b/app/tests/unit/test_circuit_validator.py
@@ -10,13 +10,17 @@ from tests.conftest import make_component, make_wire
 class TestValidCircuit:
     def test_simple_valid_circuit(self, simple_resistor_circuit):
         components, wires, _, _ = simple_resistor_circuit
-        is_valid, errors, warnings = validate_circuit(components, wires, "DC Operating Point")
+        is_valid, errors, warnings = validate_circuit(
+            components, wires, "DC Operating Point"
+        )
         assert is_valid
         assert len(errors) == 0
 
     def test_resistor_divider_valid(self, resistor_divider_circuit):
         components, wires, _, _ = resistor_divider_circuit
-        is_valid, errors, warnings = validate_circuit(components, wires, "DC Operating Point")
+        is_valid, errors, warnings = validate_circuit(
+            components, wires, "DC Operating Point"
+        )
         assert is_valid
 
 
@@ -25,7 +29,9 @@ class TestNoComponents:
         components = {
             "GND1": make_component("Ground", "GND1", "0V"),
         }
-        is_valid, errors, warnings = validate_circuit(components, [], "DC Operating Point")
+        is_valid, errors, warnings = validate_circuit(
+            components, [], "DC Operating Point"
+        )
         assert not is_valid
         assert any("no components" in e.lower() for e in errors)
 
@@ -41,7 +47,9 @@ class TestNoGround:
             "V1": make_component("Voltage Source", "V1", "5V"),
         }
         wires = [make_wire("V1", 0, "R1", 0)]
-        is_valid, errors, warnings = validate_circuit(components, wires, "DC Operating Point")
+        is_valid, errors, warnings = validate_circuit(
+            components, wires, "DC Operating Point"
+        )
         assert not is_valid
         assert any("ground" in e.lower() for e in errors)
 
@@ -55,7 +63,9 @@ class TestUnconnectedTerminals:
         }
         # Only V1 and GND connected; R1 has no wires
         wires = [make_wire("V1", 0, "GND1", 0)]
-        is_valid, errors, warnings = validate_circuit(components, wires, "DC Operating Point")
+        is_valid, errors, warnings = validate_circuit(
+            components, wires, "DC Operating Point"
+        )
         assert not is_valid
         assert any("R1" in e and "no connections" in e.lower() for e in errors)
 
@@ -70,7 +80,9 @@ class TestUnconnectedTerminals:
             make_wire("V1", 0, "R1", 0),
             make_wire("V1", 1, "GND1", 0),
         ]
-        is_valid, errors, warnings = validate_circuit(components, wires, "DC Operating Point")
+        is_valid, errors, warnings = validate_circuit(
+            components, wires, "DC Operating Point"
+        )
         assert any("R1" in w and "unconnected" in w.lower() for w in warnings)
 
 
@@ -98,5 +110,7 @@ class TestNoSources:
             "GND1": make_component("Ground", "GND1", "0V"),
         }
         wires = [make_wire("R1", 0, "GND1", 0)]
-        is_valid, errors, warnings = validate_circuit(components, wires, "DC Operating Point")
+        is_valid, errors, warnings = validate_circuit(
+            components, wires, "DC Operating Point"
+        )
         assert any("no voltage or current" in w.lower() for w in warnings)

--- a/app/tests/unit/test_circuitikz_exporter.py
+++ b/app/tests/unit/test_circuitikz_exporter.py
@@ -6,15 +6,10 @@ from models.circuit import CircuitModel
 from models.component import ComponentData
 from models.node import NodeData
 from models.wire import WireData
-from simulation.circuitikz_exporter import (
-    CIRCUITIKZ_BIPOLES,
-    CIRCUITIKZ_TRIPOLES,
-    _coord,
-    _escape_latex,
-    _fmt,
-    _transform_coords,
-    generate,
-)
+from simulation.circuitikz_exporter import (CIRCUITIKZ_BIPOLES,
+                                            CIRCUITIKZ_TRIPOLES, _coord,
+                                            _escape_latex, _fmt,
+                                            _transform_coords, generate)
 
 
 def _simple_circuit():
@@ -151,7 +146,9 @@ class TestBipoleExport:
 
     def test_capacitor_draw(self):
         model = CircuitModel()
-        model.add_component(ComponentData("C1", "Capacitor", "100n", position=(100, 100)))
+        model.add_component(
+            ComponentData("C1", "Capacitor", "100n", position=(100, 100))
+        )
         model.rebuild_nodes()
         output = generate(
             model.components,
@@ -163,7 +160,9 @@ class TestBipoleExport:
 
     def test_voltage_source_draw(self):
         model = CircuitModel()
-        model.add_component(ComponentData("V1", "Voltage Source", "5", position=(100, 100)))
+        model.add_component(
+            ComponentData("V1", "Voltage Source", "5", position=(100, 100))
+        )
         model.rebuild_nodes()
         output = generate(
             model.components,
@@ -209,7 +208,9 @@ class TestBipoleExport:
 class TestTripoleExport:
     def test_npn_node(self):
         model = CircuitModel()
-        model.add_component(ComponentData("Q1", "BJT NPN", "2N3904", position=(100, 100)))
+        model.add_component(
+            ComponentData("Q1", "BJT NPN", "2N3904", position=(100, 100))
+        )
         model.rebuild_nodes()
         output = generate(
             model.components,
@@ -225,7 +226,9 @@ class TestTripoleExport:
 
     def test_opamp_node(self):
         model = CircuitModel()
-        model.add_component(ComponentData("OA1", "Op-Amp", "Ideal", position=(100, 100)))
+        model.add_component(
+            ComponentData("OA1", "Op-Amp", "Ideal", position=(100, 100))
+        )
         model.rebuild_nodes()
         output = generate(
             model.components,
@@ -400,7 +403,9 @@ class TestFourTerminalExport:
 
     def test_vc_switch_exports(self):
         model = CircuitModel()
-        model.add_component(ComponentData("S1", "VC Switch", "VON=1 VOFF=0", position=(100, 100)))
+        model.add_component(
+            ComponentData("S1", "VC Switch", "VON=1 VOFF=0", position=(100, 100))
+        )
         model.rebuild_nodes()
         output = generate(
             model.components,
@@ -415,7 +420,9 @@ class TestCompleteCircuit:
     def test_voltage_divider_compiles_structure(self):
         """Full voltage divider: V1, R1, R2, GND with wires."""
         model = CircuitModel()
-        model.add_component(ComponentData("V1", "Voltage Source", "5", position=(0, 100)))
+        model.add_component(
+            ComponentData("V1", "Voltage Source", "5", position=(0, 100))
+        )
         model.add_component(ComponentData("R1", "Resistor", "1k", position=(100, 0)))
         model.add_component(ComponentData("R2", "Resistor", "2k", position=(100, 200)))
         model.add_component(ComponentData("GND1", "Ground", "", position=(0, 300)))

--- a/app/tests/unit/test_cli.py
+++ b/app/tests/unit/test_cli.py
@@ -6,24 +6,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from cli import (
-    REPL_BANNER,
-    __version__,
-    build_parser,
-    build_repl_namespace,
-    circuit_stats,
-    cmd_batch,
-    cmd_diff,
-    cmd_export,
-    cmd_import,
-    cmd_simulate,
-    cmd_stats,
-    cmd_validate,
-    diff_circuits,
-    load_circuit,
-    main,
-    try_load_circuit,
-)
+from cli import (REPL_BANNER, __version__, build_parser, build_repl_namespace,
+                 circuit_stats, cmd_batch, cmd_diff, cmd_export, cmd_import,
+                 cmd_simulate, cmd_stats, cmd_validate, diff_circuits,
+                 load_circuit, main, try_load_circuit)
 from models.circuit import CircuitModel
 from scripting.circuit import Circuit
 
@@ -33,10 +19,34 @@ def voltage_divider(tmp_path):
     """Create a valid voltage divider circuit file."""
     circuit = {
         "components": [
-            {"type": "Voltage Source", "id": "V1", "value": "5V", "pos": {"x": 0, "y": 0}, "rotation": 0},
-            {"type": "Resistor", "id": "R1", "value": "1k", "pos": {"x": 200, "y": 0}, "rotation": 0},
-            {"type": "Resistor", "id": "R2", "value": "1k", "pos": {"x": 300, "y": 0}, "rotation": 0},
-            {"type": "Ground", "id": "GND1", "value": "0V", "pos": {"x": 350, "y": 150}, "rotation": 0},
+            {
+                "type": "Voltage Source",
+                "id": "V1",
+                "value": "5V",
+                "pos": {"x": 0, "y": 0},
+                "rotation": 0,
+            },
+            {
+                "type": "Resistor",
+                "id": "R1",
+                "value": "1k",
+                "pos": {"x": 200, "y": 0},
+                "rotation": 0,
+            },
+            {
+                "type": "Resistor",
+                "id": "R2",
+                "value": "1k",
+                "pos": {"x": 300, "y": 0},
+                "rotation": 0,
+            },
+            {
+                "type": "Ground",
+                "id": "GND1",
+                "value": "0V",
+                "pos": {"x": 350, "y": 150},
+                "rotation": 0,
+            },
         ],
         "wires": [
             {"start_comp": "V1", "start_term": 0, "end_comp": "R1", "end_term": 0},
@@ -111,14 +121,18 @@ class TestExportCommand:
 
     def test_export_netlist_to_file(self, voltage_divider, tmp_path):
         outfile = str(tmp_path / "output.cir")
-        args = build_parser().parse_args(["export", voltage_divider, "-f", "cir", "-o", outfile])
+        args = build_parser().parse_args(
+            ["export", voltage_divider, "-f", "cir", "-o", outfile]
+        )
         code = cmd_export(args)
         assert code == 0
         content = (tmp_path / "output.cir").read_text()
         assert "V1" in content
 
     def test_export_json(self, voltage_divider, capsys):
-        args = build_parser().parse_args(["export", voltage_divider, "--format", "json"])
+        args = build_parser().parse_args(
+            ["export", voltage_divider, "--format", "json"]
+        )
         code = cmd_export(args)
         assert code == 0
         captured = capsys.readouterr()
@@ -151,7 +165,9 @@ class TestSimulateCommand:
         assert code == 1  # validation should fail
 
     def test_simulate_json_output(self, voltage_divider, capsys):
-        args = build_parser().parse_args(["simulate", voltage_divider, "--format", "json"])
+        args = build_parser().parse_args(
+            ["simulate", voltage_divider, "--format", "json"]
+        )
         code = cmd_simulate(args)
         if code == 0:
             captured = capsys.readouterr()
@@ -160,7 +176,9 @@ class TestSimulateCommand:
             assert "data" in data
 
     def test_simulate_csv_output(self, voltage_divider, capsys):
-        args = build_parser().parse_args(["simulate", voltage_divider, "--format", "csv"])
+        args = build_parser().parse_args(
+            ["simulate", voltage_divider, "--format", "csv"]
+        )
         code = cmd_simulate(args)
         if code == 0:
             captured = capsys.readouterr()
@@ -192,7 +210,9 @@ class TestParser:
             build_parser().parse_args(["export"])
 
     def test_simulate_analysis_override(self, voltage_divider):
-        args = build_parser().parse_args(["simulate", voltage_divider, "--analysis", "DC Operating Point"])
+        args = build_parser().parse_args(
+            ["simulate", voltage_divider, "--analysis", "DC Operating Point"]
+        )
         assert args.analysis == "DC Operating Point"
 
     def test_batch_requires_path(self):
@@ -225,14 +245,42 @@ class TestBatchCommand:
         """Create a directory with multiple circuit files."""
         base = {
             "components": [
-                {"type": "Voltage Source", "id": "V1", "value": "5V", "pos": {"x": 0, "y": 0}, "rotation": 0},
-                {"type": "Resistor", "id": "R1", "value": "1k", "pos": {"x": 200, "y": 0}, "rotation": 0},
-                {"type": "Ground", "id": "GND1", "value": "0V", "pos": {"x": 0, "y": 200}, "rotation": 0},
+                {
+                    "type": "Voltage Source",
+                    "id": "V1",
+                    "value": "5V",
+                    "pos": {"x": 0, "y": 0},
+                    "rotation": 0,
+                },
+                {
+                    "type": "Resistor",
+                    "id": "R1",
+                    "value": "1k",
+                    "pos": {"x": 200, "y": 0},
+                    "rotation": 0,
+                },
+                {
+                    "type": "Ground",
+                    "id": "GND1",
+                    "value": "0V",
+                    "pos": {"x": 0, "y": 200},
+                    "rotation": 0,
+                },
             ],
             "wires": [
                 {"start_comp": "V1", "start_term": 0, "end_comp": "R1", "end_term": 0},
-                {"start_comp": "R1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
-                {"start_comp": "V1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+                {
+                    "start_comp": "R1",
+                    "start_term": 1,
+                    "end_comp": "GND1",
+                    "end_term": 0,
+                },
+                {
+                    "start_comp": "V1",
+                    "start_term": 1,
+                    "end_comp": "GND1",
+                    "end_term": 0,
+                },
             ],
             "counters": {"R": 1, "V": 1, "GND": 1},
         }
@@ -256,21 +304,51 @@ class TestBatchCommand:
         # Valid circuit
         valid = {
             "components": [
-                {"type": "Voltage Source", "id": "V1", "value": "5V", "pos": {"x": 0, "y": 0}, "rotation": 0},
-                {"type": "Resistor", "id": "R1", "value": "1k", "pos": {"x": 200, "y": 0}, "rotation": 0},
-                {"type": "Ground", "id": "GND1", "value": "0V", "pos": {"x": 0, "y": 200}, "rotation": 0},
+                {
+                    "type": "Voltage Source",
+                    "id": "V1",
+                    "value": "5V",
+                    "pos": {"x": 0, "y": 0},
+                    "rotation": 0,
+                },
+                {
+                    "type": "Resistor",
+                    "id": "R1",
+                    "value": "1k",
+                    "pos": {"x": 200, "y": 0},
+                    "rotation": 0,
+                },
+                {
+                    "type": "Ground",
+                    "id": "GND1",
+                    "value": "0V",
+                    "pos": {"x": 0, "y": 200},
+                    "rotation": 0,
+                },
             ],
             "wires": [
                 {"start_comp": "V1", "start_term": 0, "end_comp": "R1", "end_term": 0},
-                {"start_comp": "R1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
-                {"start_comp": "V1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+                {
+                    "start_comp": "R1",
+                    "start_term": 1,
+                    "end_comp": "GND1",
+                    "end_term": 0,
+                },
+                {
+                    "start_comp": "V1",
+                    "start_term": 1,
+                    "end_comp": "GND1",
+                    "end_term": 0,
+                },
             ],
             "counters": {"R": 1, "V": 1, "GND": 1},
         }
         (circuits_dir / "good.json").write_text(json.dumps(valid))
 
         # Invalid circuit (empty)
-        (circuits_dir / "bad.json").write_text(json.dumps({"components": [], "wires": [], "counters": {}}))
+        (circuits_dir / "bad.json").write_text(
+            json.dumps({"components": [], "wires": [], "counters": {}})
+        )
 
         return str(circuits_dir)
 
@@ -285,7 +363,9 @@ class TestBatchCommand:
 
     def test_batch_with_output_dir(self, circuit_dir, tmp_path):
         out_dir = str(tmp_path / "results")
-        args = build_parser().parse_args(["batch", circuit_dir, "--output-dir", out_dir])
+        args = build_parser().parse_args(
+            ["batch", circuit_dir, "--output-dir", out_dir]
+        )
         cmd_batch(args)
         # Output directory should be created
         assert Path(out_dir).exists()
@@ -327,7 +407,9 @@ class TestBatchCommand:
 
     def test_batch_csv_format(self, circuit_dir, tmp_path):
         out_dir = str(tmp_path / "csv_results")
-        args = build_parser().parse_args(["batch", circuit_dir, "--format", "csv", "--output-dir", out_dir])
+        args = build_parser().parse_args(
+            ["batch", circuit_dir, "--format", "csv", "--output-dir", out_dir]
+        )
         code = cmd_batch(args)
         # If simulations succeeded, check CSV files exist
         if code == 0:
@@ -490,14 +572,42 @@ class TestDiffCommand:
     def base_circuit_data(self):
         return {
             "components": [
-                {"type": "Voltage Source", "id": "V1", "value": "5V", "pos": {"x": 0, "y": 0}, "rotation": 0},
-                {"type": "Resistor", "id": "R1", "value": "1k", "pos": {"x": 200, "y": 0}, "rotation": 0},
-                {"type": "Ground", "id": "GND1", "value": "0V", "pos": {"x": 0, "y": 200}, "rotation": 0},
+                {
+                    "type": "Voltage Source",
+                    "id": "V1",
+                    "value": "5V",
+                    "pos": {"x": 0, "y": 0},
+                    "rotation": 0,
+                },
+                {
+                    "type": "Resistor",
+                    "id": "R1",
+                    "value": "1k",
+                    "pos": {"x": 200, "y": 0},
+                    "rotation": 0,
+                },
+                {
+                    "type": "Ground",
+                    "id": "GND1",
+                    "value": "0V",
+                    "pos": {"x": 0, "y": 200},
+                    "rotation": 0,
+                },
             ],
             "wires": [
                 {"start_comp": "V1", "start_term": 0, "end_comp": "R1", "end_term": 0},
-                {"start_comp": "R1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
-                {"start_comp": "V1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+                {
+                    "start_comp": "R1",
+                    "start_term": 1,
+                    "end_comp": "GND1",
+                    "end_term": 0,
+                },
+                {
+                    "start_comp": "V1",
+                    "start_term": 1,
+                    "end_comp": "GND1",
+                    "end_term": 0,
+                },
             ],
             "counters": {"R": 1, "V": 1, "GND": 1},
         }
@@ -526,7 +636,13 @@ class TestDiffCommand:
     def circuit_b_component_added(self, tmp_path, base_circuit_data):
         data = json.loads(json.dumps(base_circuit_data))
         data["components"].append(
-            {"type": "Resistor", "id": "R2", "value": "4.7k", "pos": {"x": 300, "y": 0}, "rotation": 0}
+            {
+                "type": "Resistor",
+                "id": "R2",
+                "value": "4.7k",
+                "pos": {"x": 300, "y": 0},
+                "rotation": 0,
+            }
         )
         data["counters"]["R"] = 2
         filepath = tmp_path / "circuit_b_added.json"
@@ -538,7 +654,9 @@ class TestDiffCommand:
         data = json.loads(json.dumps(base_circuit_data))
         # Remove one wire and add a different one
         data["wires"] = data["wires"][:2]
-        data["wires"].append({"start_comp": "V1", "start_term": 1, "end_comp": "R1", "end_term": 1})
+        data["wires"].append(
+            {"start_comp": "V1", "start_term": 1, "end_comp": "R1", "end_term": 1}
+        )
         filepath = tmp_path / "circuit_b_wire.json"
         filepath.write_text(json.dumps(data))
         return str(filepath)
@@ -547,7 +665,11 @@ class TestDiffCommand:
     def circuit_b_analysis_changed(self, tmp_path, base_circuit_data):
         data = json.loads(json.dumps(base_circuit_data))
         data["analysis_type"] = "AC Sweep"
-        data["analysis_params"] = {"start_freq": "1", "stop_freq": "1MEG", "points": "100"}
+        data["analysis_params"] = {
+            "start_freq": "1",
+            "stop_freq": "1MEG",
+            "points": "100",
+        }
         filepath = tmp_path / "circuit_b_analysis.json"
         filepath.write_text(json.dumps(data))
         return str(filepath)
@@ -605,7 +727,10 @@ class TestDiffCommand:
         model_a = load_circuit(circuit_a)
         model_b = load_circuit(circuit_b_analysis_changed)
         diff = diff_circuits(model_a, model_b)
-        assert diff["analysis"]["type"] == {"from": "DC Operating Point", "to": "AC Sweep"}
+        assert diff["analysis"]["type"] == {
+            "from": "DC Operating Point",
+            "to": "AC Sweep",
+        }
         assert "params" in diff["analysis"]
 
     def test_text_format(self, circuit_a, circuit_b_value_changed, capsys):
@@ -617,7 +742,9 @@ class TestDiffCommand:
         assert "2.2k" in captured.out
 
     def test_json_format(self, circuit_a, circuit_b_value_changed, capsys):
-        args = build_parser().parse_args(["diff", circuit_a, circuit_b_value_changed, "-f", "json"])
+        args = build_parser().parse_args(
+            ["diff", circuit_a, circuit_b_value_changed, "-f", "json"]
+        )
         cmd_diff(args)
         captured = capsys.readouterr()
         data = json.loads(captured.out)

--- a/app/tests/unit/test_component_palette.py
+++ b/app/tests/unit/test_component_palette.py
@@ -63,14 +63,18 @@ class TestComponentPaletteSearch:
     def test_filter_hides_non_matching(self, palette):
         palette.search_input.setText("resistor")
         lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = [
+            lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()
+        ]
         assert "Resistor" in visible
         assert "Capacitor" not in visible
 
     def test_filter_is_case_insensitive(self, palette):
         palette.search_input.setText("CAPACITOR")
         lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = [
+            lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()
+        ]
         assert "Capacitor" in visible
 
     def test_empty_filter_shows_all(self, palette):
@@ -84,7 +88,9 @@ class TestComponentPaletteSearch:
         # "Resists" appears in the Resistor tooltip
         palette.search_input.setText("resists")
         lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = [
+            lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()
+        ]
         assert "Resistor" in visible
 
     def test_filter_no_matches(self, palette):

--- a/app/tests/unit/test_convergence.py
+++ b/app/tests/unit/test_convergence.py
@@ -1,16 +1,10 @@
 """Tests for simulation.convergence error classification and retry helpers."""
 
 import pytest
-from simulation.convergence import (
-    RELAXED_OPTIONS,
-    ErrorCategory,
-    ErrorDiagnosis,
-    classify_error,
-    diagnose_error,
-    format_options_lines,
-    format_user_message,
-    is_retriable,
-)
+from simulation.convergence import (RELAXED_OPTIONS, ErrorCategory,
+                                    ErrorDiagnosis, classify_error,
+                                    diagnose_error, format_options_lines,
+                                    format_user_message, is_retriable)
 
 
 class TestClassifyError:

--- a/app/tests/unit/test_cross_platform.py
+++ b/app/tests/unit/test_cross_platform.py
@@ -32,7 +32,10 @@ class TestNgspiceRunnerPlatformDetection:
         with (
             patch("shutil.which", return_value=None),
             patch("platform.system", return_value="Linux"),
-            patch("os.path.exists", side_effect=lambda p: (checked_paths.append(p), False)[1]),
+            patch(
+                "os.path.exists",
+                side_effect=lambda p: (checked_paths.append(p), False)[1],
+            ),
         ):
             runner.find_ngspice()
         assert "/usr/bin/ngspice" in checked_paths
@@ -44,7 +47,10 @@ class TestNgspiceRunnerPlatformDetection:
         with (
             patch("shutil.which", return_value=None),
             patch("platform.system", return_value="Darwin"),
-            patch("os.path.exists", side_effect=lambda p: (checked_paths.append(p), False)[1]),
+            patch(
+                "os.path.exists",
+                side_effect=lambda p: (checked_paths.append(p), False)[1],
+            ),
         ):
             runner.find_ngspice()
         assert "/usr/local/bin/ngspice" in checked_paths
@@ -56,7 +62,10 @@ class TestNgspiceRunnerPlatformDetection:
         with (
             patch("shutil.which", return_value=None),
             patch("platform.system", return_value="Windows"),
-            patch("os.path.exists", side_effect=lambda p: (checked_paths.append(p), False)[1]),
+            patch(
+                "os.path.exists",
+                side_effect=lambda p: (checked_paths.append(p), False)[1],
+            ),
         ):
             runner.find_ngspice()
         assert any("ngspice" in p.lower() for p in checked_paths)

--- a/app/tests/unit/test_csv_exporter.py
+++ b/app/tests/unit/test_csv_exporter.py
@@ -4,13 +4,10 @@ import csv
 import io
 
 import pytest
-from simulation.csv_exporter import (
-    export_ac_results,
-    export_dc_sweep_results,
-    export_op_results,
-    export_transient_results,
-    write_csv,
-)
+from simulation.csv_exporter import (export_ac_results,
+                                     export_dc_sweep_results,
+                                     export_op_results,
+                                     export_transient_results, write_csv)
 
 
 class TestExportOpResults:
@@ -34,7 +31,9 @@ class TestExportOpResults:
         voltages = {"z_node": 1.0, "a_node": 2.0}
         result = export_op_results(voltages)
         lines = result.strip().split("\n")
-        data_lines = [l for l in lines if not l.startswith("#") and l.strip() and "Node" not in l]
+        data_lines = [
+            l for l in lines if not l.startswith("#") and l.strip() and "Node" not in l
+        ]
         assert "a_node" in data_lines[0]
         assert "z_node" in data_lines[1]
 
@@ -71,7 +70,9 @@ class TestExportDcSweepResults:
         reader = csv.reader(io.StringIO(result))
         rows = list(reader)
         # metadata (3) + blank + header + 3 data = 8
-        data_rows = [r for r in rows if r and not r[0].startswith("#") and r[0] != "Index"]
+        data_rows = [
+            r for r in rows if r and not r[0].startswith("#") and r[0] != "Index"
+        ]
         assert len(data_rows) == 3
 
     def test_empty_data(self):
@@ -133,7 +134,9 @@ class TestExportTransientResults:
         result = export_transient_results(data)
         reader = csv.reader(io.StringIO(result))
         rows = list(reader)
-        data_rows = [r for r in rows if r and not r[0].startswith("#") and r[0] != "time"]
+        data_rows = [
+            r for r in rows if r and not r[0].startswith("#") and r[0] != "time"
+        ]
         assert len(data_rows) == 10
 
     def test_empty_data(self):

--- a/app/tests/unit/test_custom_theme.py
+++ b/app/tests/unit/test_custom_theme.py
@@ -26,14 +26,18 @@ class TestColorOverrides:
     """Verify color overrides are applied correctly."""
 
     def test_override_applied(self):
-        theme = CustomTheme("Test", "light", {"background_primary": "#123456"}, theme_is_dark=False)
+        theme = CustomTheme(
+            "Test", "light", {"background_primary": "#123456"}, theme_is_dark=False
+        )
         assert theme.color_hex("background_primary") == "#123456"
 
     def test_fallback_to_base(self):
         """Keys not in overrides should come from the base theme."""
         theme = CustomTheme("Test", "light", {}, theme_is_dark=False)
         light = LightTheme()
-        assert theme.color_hex("background_primary") == light.color_hex("background_primary")
+        assert theme.color_hex("background_primary") == light.color_hex(
+            "background_primary"
+        )
 
     def test_get_color_overrides_returns_only_changes(self):
         overrides = {"wire_default": "#AABBCC"}
@@ -83,6 +87,8 @@ class TestDarkStylesheet:
         assert ss == ""
 
     def test_dark_stylesheet_uses_theme_colors(self):
-        theme = CustomTheme("D", "dark", {"background_primary": "#1A1A2E"}, theme_is_dark=True)
+        theme = CustomTheme(
+            "D", "dark", {"background_primary": "#1A1A2E"}, theme_is_dark=True
+        )
         ss = theme.generate_dark_stylesheet()
         assert "#1a1a2e" in ss.lower()

--- a/app/tests/unit/test_data_roundtrips_and_undo.py
+++ b/app/tests/unit/test_data_roundtrips_and_undo.py
@@ -15,17 +15,11 @@ import json
 
 import pytest
 from controllers.circuit_controller import CircuitController
-from controllers.commands import (
-    AddAnnotationCommand,
-    AddComponentCommand,
-    ChangeValueCommand,
-    DeleteAnnotationCommand,
-    DeleteComponentCommand,
-    EditAnnotationCommand,
-    FlipComponentCommand,
-    MoveComponentCommand,
-    RotateComponentCommand,
-)
+from controllers.commands import (AddAnnotationCommand, AddComponentCommand,
+                                  ChangeValueCommand, DeleteAnnotationCommand,
+                                  DeleteComponentCommand,
+                                  EditAnnotationCommand, FlipComponentCommand,
+                                  MoveComponentCommand, RotateComponentCommand)
 from controllers.file_controller import FileController
 from models.annotation import AnnotationData
 from models.circuit import CircuitModel
@@ -91,7 +85,9 @@ def _build_circuit_with_all_fields():
 
     # Add annotation
     model.annotations.append(
-        AnnotationData(text="Test Label", x=50.0, y=50.0, font_size=14, bold=True, color="#FF0000")
+        AnnotationData(
+            text="Test Label", x=50.0, y=50.0, font_size=14, bold=True, color="#FF0000"
+        )
     )
 
     return model
@@ -121,10 +117,14 @@ class TestSerializationRoundTrips:
         restored = ComponentData.from_dict(data)
         assert restored.rotation == rotation
 
-    @pytest.mark.parametrize("flip_h,flip_v", [(True, False), (False, True), (True, True)])
+    @pytest.mark.parametrize(
+        "flip_h,flip_v", [(True, False), (False, True), (True, True)]
+    )
     def test_flip_state_round_trip(self, flip_h, flip_v):
         """Component flip states are preserved through serialization."""
-        comp = ComponentData("R1", "Resistor", "1k", (0, 0), flip_h=flip_h, flip_v=flip_v)
+        comp = ComponentData(
+            "R1", "Resistor", "1k", (0, 0), flip_h=flip_h, flip_v=flip_v
+        )
         data = comp.to_dict()
         restored = ComponentData.from_dict(data)
         assert restored.flip_h == flip_h
@@ -146,7 +146,9 @@ class TestSerializationRoundTrips:
 
     def test_waveform_pulse_params_round_trip(self):
         """PULSE waveform type and params survive round-trip."""
-        comp = ComponentData("VW1", "Waveform Source", "PULSE(0 5 0 1n 1n 500u 1m)", (0, 0))
+        comp = ComponentData(
+            "VW1", "Waveform Source", "PULSE(0 5 0 1n 1n 500u 1m)", (0, 0)
+        )
         comp.waveform_type = "PULSE"
         comp.waveform_params["PULSE"]["v2"] = "3.3"
 
@@ -198,7 +200,12 @@ class TestSerializationRoundTrips:
         """Analysis type and params survive circuit round-trip."""
         model = CircuitModel()
         model.analysis_type = "AC Sweep"
-        model.analysis_params = {"variation": "dec", "points": "10", "fstart": "1", "fstop": "1e6"}
+        model.analysis_params = {
+            "variation": "dec",
+            "points": "10",
+            "fstart": "1",
+            "fstop": "1e6",
+        }
 
         data = model.to_dict()
         restored = CircuitModel.from_dict(data)
@@ -215,7 +222,11 @@ class TestSerializationRoundTrips:
     def test_annotation_round_trip(self):
         """Annotation data survives circuit round-trip."""
         model = CircuitModel()
-        model.annotations.append(AnnotationData(text="Note", x=10.0, y=20.0, font_size=16, bold=True, color="#00FF00"))
+        model.annotations.append(
+            AnnotationData(
+                text="Note", x=10.0, y=20.0, font_size=16, bold=True, color="#00FF00"
+            )
+        )
         data = model.to_dict()
         restored = CircuitModel.from_dict(data)
         assert len(restored.annotations) == 1

--- a/app/tests/unit/test_drag_undo.py
+++ b/app/tests/unit/test_drag_undo.py
@@ -184,7 +184,9 @@ class TestDragUndoViaUndoManager:
 
         # Simulate drag commit
         controller.move_component(comp_id, (50, 50))
-        drag_cmd = MoveComponentCommand(controller, comp_id, (50, 50), old_position=(0, 0))
+        drag_cmd = MoveComponentCommand(
+            controller, comp_id, (50, 50), old_position=(0, 0)
+        )
         controller.undo_manager._undo_stack.append(drag_cmd)
         controller.undo_manager._redo_stack.clear()
 
@@ -198,8 +200,12 @@ class TestDragUndoViaUndoManager:
         r1 = controller.add_component("Resistor", (0, 0))
         r2 = controller.add_component("Capacitor", (100, 0))
 
-        cmd1 = MoveComponentCommand(controller, r1.component_id, (50, 50), old_position=(0, 0))
-        cmd2 = MoveComponentCommand(controller, r2.component_id, (150, 50), old_position=(100, 0))
+        cmd1 = MoveComponentCommand(
+            controller, r1.component_id, (50, 50), old_position=(0, 0)
+        )
+        cmd2 = MoveComponentCommand(
+            controller, r2.component_id, (150, 50), old_position=(100, 0)
+        )
         compound = CompoundCommand([cmd1, cmd2], "Move 2 components")
 
         assert compound.get_description() == "Move 2 components"

--- a/app/tests/unit/test_excel_exporter.py
+++ b/app/tests/unit/test_excel_exporter.py
@@ -200,7 +200,9 @@ class TestMetadataSheet:
 
     def test_circuit_name_in_summary(self, tmp_path):
         path = tmp_path / "meta.xlsx"
-        export_to_excel({"1": 1.0}, "DC Operating Point", str(path), circuit_name="test.json")
+        export_to_excel(
+            {"1": 1.0}, "DC Operating Point", str(path), circuit_name="test.json"
+        )
         wb = load_workbook(str(path))
         ws = wb["Summary"]
         values = [ws.cell(row=r, column=2).value for r in range(1, ws.max_row + 1)]

--- a/app/tests/unit/test_fft_analysis.py
+++ b/app/tests/unit/test_fft_analysis.py
@@ -2,14 +2,10 @@
 
 import numpy as np
 import pytest
-from simulation.fft_analysis import (
-    FFTResult,
-    analyze_signal_spectrum,
-    compute_fft,
-    compute_thd,
-    find_fundamental_frequency,
-    find_harmonics,
-)
+from simulation.fft_analysis import (FFTResult, analyze_signal_spectrum,
+                                     compute_fft, compute_thd,
+                                     find_fundamental_frequency,
+                                     find_harmonics)
 
 
 class TestComputeFFT:

--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -266,7 +266,9 @@ class TestHasFile:
 class TestValidateCircuitData:
     def test_valid_data_passes(self):
         data = {
-            "components": [{"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}}],
+            "components": [
+                {"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}}
+            ],
             "wires": [],
         }
         validate_circuit_data(data)  # Should not raise
@@ -277,7 +279,9 @@ class TestValidateCircuitData:
 
     def test_wire_references_unknown_component(self):
         data = {
-            "components": [{"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}}],
+            "components": [
+                {"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}}
+            ],
             "wires": [
                 {
                     "start_comp": "R1",
@@ -325,7 +329,9 @@ class TestRecentFiles:
 
     @patch("controllers.file_controller.os.path.exists")
     @patch("controllers.file_controller.QSettings")
-    def test_add_recent_file_moves_to_front_if_exists(self, mock_qsettings, mock_exists, tmp_path):
+    def test_add_recent_file_moves_to_front_if_exists(
+        self, mock_qsettings, mock_exists, tmp_path
+    ):
         """add_recent_file should move existing file to front."""
         file1 = str((tmp_path / "file1.json").absolute())
         file2 = str((tmp_path / "file2.json").absolute())
@@ -348,10 +354,14 @@ class TestRecentFiles:
 
     @patch("controllers.file_controller.os.path.exists")
     @patch("controllers.file_controller.QSettings")
-    def test_add_recent_file_maintains_max_limit(self, mock_qsettings, mock_exists, tmp_path):
+    def test_add_recent_file_maintains_max_limit(
+        self, mock_qsettings, mock_exists, tmp_path
+    ):
         """add_recent_file should keep only MAX_RECENT_FILES (10) files."""
         # Create 11 file paths
-        existing_files = [str((tmp_path / f"file{i}.json").absolute()) for i in range(10)]
+        existing_files = [
+            str((tmp_path / f"file{i}.json").absolute()) for i in range(10)
+        ]
         new_file = tmp_path / "file11.json"
 
         # Mock: all files exist
@@ -372,7 +382,9 @@ class TestRecentFiles:
 
     @patch("controllers.file_controller.QSettings")
     @patch("controllers.file_controller.os.path.exists")
-    def test_get_recent_files_filters_missing_files(self, mock_exists, mock_qsettings, tmp_path):
+    def test_get_recent_files_filters_missing_files(
+        self, mock_exists, mock_qsettings, tmp_path
+    ):
         """get_recent_files should filter out files that no longer exist."""
         file1 = str((tmp_path / "exists.json").absolute())
         file2 = str((tmp_path / "missing.json").absolute())

--- a/app/tests/unit/test_format_utils.py
+++ b/app/tests/unit/test_format_utils.py
@@ -3,7 +3,8 @@ Tests for GUI/format_utils.py — SI prefix parsing, formatting, and validation.
 """
 
 import pytest
-from GUI.format_utils import format_value, parse_value, validate_component_value
+from GUI.format_utils import (format_value, parse_value,
+                              validate_component_value)
 
 # ── parse_value ──────────────────────────────────────────────────────
 

--- a/app/tests/unit/test_freq_markers.py
+++ b/app/tests/unit/test_freq_markers.py
@@ -6,7 +6,8 @@ gain/phase margin, and edge cases.
 
 import numpy as np
 import pytest
-from simulation.freq_markers import _find_crossing, compute_markers, format_frequency
+from simulation.freq_markers import (_find_crossing, compute_markers,
+                                     format_frequency)
 
 # ── Crossing detection ───────────────────────────────────────────────
 

--- a/app/tests/unit/test_grading_panel.py
+++ b/app/tests/unit/test_grading_panel.py
@@ -41,10 +41,30 @@ def _build_rc_filter(r_value="1k", c_value="100n"):
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="C1", end_terminal=0),
-        WireData(start_component_id="C1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="C1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="C1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.component_counter = {"V": 1, "R": 1, "C": 1, "GND": 1}
     model.analysis_type = "AC Sweep"
@@ -69,7 +89,11 @@ def _build_rubric():
                 check_id="r1_value",
                 check_type="component_value",
                 points=25,
-                params={"component_id": "R1", "expected_value": "1k", "tolerance_pct": 10},
+                params={
+                    "component_id": "R1",
+                    "expected_value": "1k",
+                    "tolerance_pct": 10,
+                },
                 feedback_pass="R1 value OK",
                 feedback_fail="R1 value wrong",
             ),

--- a/app/tests/unit/test_grid_snap_group_drag.py
+++ b/app/tests/unit/test_grid_snap_group_drag.py
@@ -84,7 +84,9 @@ class TestOnGridGroupDrag:
 
         leader_x = new_pos.x()
         follower_x = follower.pos().x()
-        assert follower_x - leader_x == 50, f"Expected offset 50, got {follower_x - leader_x}"
+        assert (
+            follower_x - leader_x == 50
+        ), f"Expected offset 50, got {follower_x - leader_x}"
 
 
 class TestOffGridGroupDrag:
@@ -185,7 +187,9 @@ class TestGroupDragGuard:
             QPointF(210, 0),
         )
 
-        assert leader.pos().x() == 100, "Leader should not move when follower has _group_moving"
+        assert (
+            leader.pos().x() == 100
+        ), "Leader should not move when follower has _group_moving"
 
     def test_multiple_followers_all_snap(self, qtbot):
         """All followers in a group should snap independently to grid."""

--- a/app/tests/unit/test_initial_conditions.py
+++ b/app/tests/unit/test_initial_conditions.py
@@ -22,7 +22,9 @@ class TestComponentDataIC:
         assert comp.initial_condition == "5"
 
     def test_ic_in_constructor(self):
-        comp = ComponentData("L1", "Inductor", "10m", (0.0, 0.0), initial_condition="0.1")
+        comp = ComponentData(
+            "L1", "Inductor", "10m", (0.0, 0.0), initial_condition="0.1"
+        )
         assert comp.initial_condition == "0.1"
 
 
@@ -49,7 +51,13 @@ class TestICSerializer:
         assert comp.initial_condition is None
 
     def test_from_dict_with_ic(self):
-        d = {"type": "Capacitor", "id": "C1", "value": "1u", "pos": {"x": 0, "y": 0}, "initial_condition": "5"}
+        d = {
+            "type": "Capacitor",
+            "id": "C1",
+            "value": "1u",
+            "pos": {"x": 0, "y": 0},
+            "initial_condition": "5",
+        }
         comp = ComponentData.from_dict(d)
         assert comp.initial_condition == "5"
 

--- a/app/tests/unit/test_locked_components.py
+++ b/app/tests/unit/test_locked_components.py
@@ -1,0 +1,307 @@
+"""Tests for locked components in assignment templates.
+
+Covers:
+- ComponentData locked flag serialization
+- TemplateData locked_components serialization
+- TemplateController applying locks on circuit creation
+- ComponentGraphicsItem locked visual/interaction behavior
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from controllers.template_controller import TemplateController
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from models.template import TemplateData, TemplateMetadata
+
+# ---------------------------------------------------------------------------
+# ComponentData locked flag
+# ---------------------------------------------------------------------------
+
+
+class TestComponentDataLocked:
+    """Tests for ComponentData.locked field."""
+
+    def test_default_not_locked(self):
+        comp = ComponentData(
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(0, 0),
+        )
+        assert comp.locked is False
+
+    def test_locked_field(self):
+        comp = ComponentData(
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(0, 0),
+            locked=True,
+        )
+        assert comp.locked is True
+
+    def test_locked_serialized_when_true(self):
+        comp = ComponentData(
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(0, 0),
+            locked=True,
+        )
+        d = comp.to_dict()
+        assert d["locked"] is True
+
+    def test_locked_omitted_when_false(self):
+        comp = ComponentData(
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(0, 0),
+            locked=False,
+        )
+        d = comp.to_dict()
+        assert "locked" not in d
+
+    def test_locked_roundtrip(self):
+        comp = ComponentData(
+            component_id="V1",
+            component_type="Voltage Source",
+            value="5V",
+            position=(100, 200),
+            locked=True,
+        )
+        d = comp.to_dict()
+        restored = ComponentData.from_dict(d)
+        assert restored.locked is True
+
+    def test_from_dict_missing_locked_defaults_false(self):
+        d = {
+            "type": "Resistor",
+            "id": "R1",
+            "value": "1k",
+            "pos": {"x": 0, "y": 0},
+            "rotation": 0,
+            "flip_h": False,
+            "flip_v": False,
+        }
+        comp = ComponentData.from_dict(d)
+        assert comp.locked is False
+
+
+# ---------------------------------------------------------------------------
+# TemplateData locked_components
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateDataLockedComponents:
+    """Tests for TemplateData.locked_components field."""
+
+    def test_default_empty(self):
+        td = TemplateData()
+        assert td.locked_components == []
+
+    def test_with_locked_components(self):
+        td = TemplateData(locked_components=["R1", "V1"])
+        assert td.locked_components == ["R1", "V1"]
+
+    def test_serialized_when_present(self):
+        td = TemplateData(locked_components=["R1", "C1"])
+        d = td.to_dict()
+        assert d["locked_components"] == ["R1", "C1"]
+
+    def test_omitted_when_empty(self):
+        td = TemplateData()
+        d = td.to_dict()
+        assert "locked_components" not in d
+
+    def test_roundtrip(self):
+        td = TemplateData(
+            metadata=TemplateMetadata(title="Test"),
+            locked_components=["R1", "V1", "C1"],
+        )
+        d = td.to_dict()
+        restored = TemplateData.from_dict(d)
+        assert restored.locked_components == ["R1", "V1", "C1"]
+
+    def test_from_dict_missing_locked_components(self):
+        d = {"template_version": "1.0", "metadata": {"title": "Test"}}
+        td = TemplateData.from_dict(d)
+        assert td.locked_components == []
+
+
+# ---------------------------------------------------------------------------
+# TemplateController - applying locks
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateControllerLockedComponents:
+    """Tests for TemplateController applying locked state."""
+
+    def _make_circuit_dict(self, component_ids):
+        """Create a minimal circuit dict with the given component IDs."""
+        components = []
+        for cid in component_ids:
+            components.append(
+                {
+                    "type": "Resistor",
+                    "id": cid,
+                    "value": "1k",
+                    "pos": {"x": 0, "y": 0},
+                    "rotation": 0,
+                    "flip_h": False,
+                    "flip_v": False,
+                }
+            )
+        return {
+            "components": components,
+            "wires": [],
+            "counters": {},
+        }
+
+    def test_locks_applied_to_listed_components(self):
+        ctrl = TemplateController()
+        circuit_dict = self._make_circuit_dict(["R1", "R2", "R3"])
+        template = TemplateData(
+            metadata=TemplateMetadata(title="Test"),
+            starter_circuit=circuit_dict,
+            locked_components=["R1", "R3"],
+        )
+        model = ctrl.create_circuit_from_template(template)
+        assert model.components["R1"].locked is True
+        assert model.components["R2"].locked is False
+        assert model.components["R3"].locked is True
+
+    def test_no_locks_when_empty_list(self):
+        ctrl = TemplateController()
+        circuit_dict = self._make_circuit_dict(["R1", "R2"])
+        template = TemplateData(
+            metadata=TemplateMetadata(title="Test"),
+            starter_circuit=circuit_dict,
+            locked_components=[],
+        )
+        model = ctrl.create_circuit_from_template(template)
+        assert model.components["R1"].locked is False
+        assert model.components["R2"].locked is False
+
+    def test_missing_component_id_ignored(self):
+        """Locked component IDs that don't exist in the circuit are silently ignored."""
+        ctrl = TemplateController()
+        circuit_dict = self._make_circuit_dict(["R1"])
+        template = TemplateData(
+            metadata=TemplateMetadata(title="Test"),
+            starter_circuit=circuit_dict,
+            locked_components=["R1", "NONEXISTENT"],
+        )
+        model = ctrl.create_circuit_from_template(template)
+        assert model.components["R1"].locked is True
+        assert "NONEXISTENT" not in model.components
+
+    def test_no_starter_circuit_with_locks(self):
+        """When there's no starter circuit, locked_components has no effect."""
+        ctrl = TemplateController()
+        template = TemplateData(
+            metadata=TemplateMetadata(title="Test"),
+            locked_components=["R1"],
+        )
+        model = ctrl.create_circuit_from_template(template)
+        assert len(model.components) == 0
+
+    def test_save_and_load_locked_components(self):
+        """Round-trip test: save template with locked components, reload it."""
+        ctrl = TemplateController()
+        metadata = TemplateMetadata(title="Lock Test")
+        circuit = CircuitModel()
+        circuit.components["R1"] = ComponentData(
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(0, 0),
+        )
+        circuit.components["V1"] = ComponentData(
+            component_id="V1",
+            component_type="Voltage Source",
+            value="5V",
+            position=(100, 0),
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".spice-template", delete=False) as f:
+            filepath = Path(f.name)
+
+        try:
+            ctrl.save_as_template(
+                filepath,
+                metadata=metadata,
+                starter_circuit=circuit,
+                locked_components=["R1"],
+            )
+
+            loaded = ctrl.load_template(filepath)
+            assert loaded.locked_components == ["R1"]
+
+            model = ctrl.create_circuit_from_template(loaded)
+            assert model.components["R1"].locked is True
+            assert model.components["V1"].locked is False
+        finally:
+            filepath.unlink(missing_ok=True)
+
+    def test_save_template_without_locked_components(self):
+        """When no locked_components provided, field is empty list."""
+        ctrl = TemplateController()
+        metadata = TemplateMetadata(title="No Lock Test")
+
+        with tempfile.NamedTemporaryFile(suffix=".spice-template", delete=False) as f:
+            filepath = Path(f.name)
+
+        try:
+            ctrl.save_as_template(filepath, metadata=metadata)
+
+            loaded = ctrl.load_template(filepath)
+            assert loaded.locked_components == []
+        finally:
+            filepath.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# ComponentGraphicsItem locked behavior (structural tests)
+# ---------------------------------------------------------------------------
+
+
+class TestComponentGraphicsItemLocked:
+    """Structural tests for locked component visual/interaction behavior."""
+
+    @pytest.fixture(autouse=True)
+    def _load_component_item_module(self):
+        """Load component_item module directly to avoid GUI.__init__ matplotlib chain."""
+        import importlib
+        import sys
+
+        spec = importlib.util.spec_from_file_location(
+            "component_item",
+            Path(__file__).parents[2] / "GUI" / "component_item.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        # Need the module in sys.modules before exec for relative imports
+        sys.modules["component_item"] = mod
+        self._source_path = Path(__file__).parents[2] / "GUI" / "component_item.py"
+
+    def test_apply_locked_state_exists(self):
+        """Verify apply_locked_state is defined in component_item.py source."""
+        source = self._source_path.read_text()
+        assert "def apply_locked_state" in source
+
+    def test_locked_model_flag_check_in_paint(self):
+        """Verify paint method references model.locked for overlay drawing."""
+        source = self._source_path.read_text()
+        assert "model.locked" in source
+
+    def test_apply_locked_state_in_init(self):
+        """Verify __init__ checks model.locked and calls apply_locked_state."""
+        source = self._source_path.read_text()
+        # Both should appear in the source
+        assert "model.locked" in source
+        assert "apply_locked_state" in source

--- a/app/tests/unit/test_main_window_mvc.py
+++ b/app/tests/unit/test_main_window_mvc.py
@@ -78,14 +78,18 @@ class TestMainWindowControllerIntegration:
         file_ctrl.load_circuit.assert_called_once_with(test_path)
         file_ctrl.new_circuit.assert_called_once()
 
-    def test_simulation_operations_delegated_to_simulation_controller(self, mock_controllers):
+    def test_simulation_operations_delegated_to_simulation_controller(
+        self, mock_controllers
+    ):
         """Test that simulation is delegated to SimulationController"""
         model, circuit_ctrl, file_ctrl, simulation_ctrl = mock_controllers
 
         # Mock simulation operations
         from controllers.simulation_controller import SimulationResult
 
-        mock_result = SimulationResult(success=True, analysis_type="DC Operating Point", raw_output="test output")
+        mock_result = SimulationResult(
+            success=True, analysis_type="DC Operating Point", raw_output="test output"
+        )
         simulation_ctrl.run_simulation = Mock(return_value=mock_result)
         simulation_ctrl.generate_netlist = Mock(return_value="* Test Netlist")
         simulation_ctrl.set_analysis = Mock()
@@ -98,7 +102,9 @@ class TestMainWindowControllerIntegration:
         # Verify delegation
         assert result.success is True
         assert netlist == "* Test Netlist"
-        simulation_ctrl.set_analysis.assert_called_once_with("Transient", {"duration": "1ms"})
+        simulation_ctrl.set_analysis.assert_called_once_with(
+            "Transient", {"duration": "1ms"}
+        )
 
     def test_canvas_syncs_before_save(self, mock_controllers):
         """Test that canvas syncs to model before saving"""
@@ -130,7 +136,9 @@ class TestMainWindowControllerIntegration:
         # Verify sync was called after load
         mock_canvas.sync_from_model.assert_called_once_with(model)
 
-    def test_analysis_settings_delegated_to_simulation_controller(self, mock_controllers):
+    def test_analysis_settings_delegated_to_simulation_controller(
+        self, mock_controllers
+    ):
         """Test that analysis settings are managed by SimulationController"""
         model, circuit_ctrl, file_ctrl, simulation_ctrl = mock_controllers
 
@@ -140,7 +148,9 @@ class TestMainWindowControllerIntegration:
         # Set different analysis types
         simulation_ctrl.set_analysis("DC Operating Point", {})
         simulation_ctrl.set_analysis("DC Sweep", {"min": 0, "max": 10, "step": 1})
-        simulation_ctrl.set_analysis("AC Sweep", {"fStart": 1, "fStop": 1000, "points": 10})
+        simulation_ctrl.set_analysis(
+            "AC Sweep", {"fStart": 1, "fStop": 1000, "points": 10}
+        )
         simulation_ctrl.set_analysis("Transient", {"duration": "1ms", "step": "1us"})
 
         # Verify all were called
@@ -272,14 +282,17 @@ class TestMainWindowErrorHandling:
 
     def test_mainwindow_handles_simulation_errors(self):
         """Test that MainWindow handles simulation errors gracefully"""
-        from controllers.simulation_controller import SimulationController, SimulationResult
+        from controllers.simulation_controller import (SimulationController,
+                                                       SimulationResult)
         from models.circuit import CircuitModel
 
         model = CircuitModel()
         SimulationController(model)
 
         # Mock simulation failure
-        error_result = SimulationResult(success=False, errors=["Circuit has no ground"], error="Simulation failed")
+        error_result = SimulationResult(
+            success=False, errors=["Circuit has no ground"], error="Simulation failed"
+        )
 
         # MainWindow should check result.success and display errors
         assert error_result.success is False

--- a/app/tests/unit/test_main_window_refactor.py
+++ b/app/tests/unit/test_main_window_refactor.py
@@ -118,7 +118,11 @@ class TestMainWindowHasAllExpectedMethods:
     def test_menu_methods(self):
         from GUI.main_window import MainWindow
 
-        for method in ["create_menu_bar", "_open_keybindings_dialog", "_apply_keybindings"]:
+        for method in [
+            "create_menu_bar",
+            "_open_keybindings_dialog",
+            "_apply_keybindings",
+        ]:
             assert hasattr(MainWindow, method), f"Missing: {method}"
 
     def test_file_operation_methods(self):
@@ -258,7 +262,9 @@ class TestQMainWindowIsLastInMRO:
                 qmw_index = i
         assert qmw_index is not None, "QMainWindow not in MRO"
         for mi in mixin_indices:
-            assert mi < qmw_index, f"Mixin at index {mi} should come before QMainWindow at {qmw_index}"
+            assert (
+                mi < qmw_index
+            ), f"Mixin at index {mi} should come before QMainWindow at {qmw_index}"
 
 
 class TestSimulationResultHandlersExist:
@@ -302,7 +308,9 @@ class TestMixinClassesHaveNoInit:
             PrintExportMixin,
             SettingsMixin,
         ]:
-            assert "__init__" not in mixin_cls.__dict__, f"{mixin_cls.__name__} should not define __init__"
+            assert (
+                "__init__" not in mixin_cls.__dict__
+            ), f"{mixin_cls.__name__} should not define __init__"
 
 
 class TestNoCircularImportsBetweenMixins:

--- a/app/tests/unit/test_meas_dialog.py
+++ b/app/tests/unit/test_meas_dialog.py
@@ -1,7 +1,8 @@
 """Tests for the .meas directive GUI builder (meas_dialog.py)."""
 
 import pytest
-from GUI.meas_dialog import ANALYSIS_DOMAIN_MAP, MeasurementDialog, MeasurementEntryDialog, build_directive
+from GUI.meas_dialog import (ANALYSIS_DOMAIN_MAP, MeasurementDialog,
+                             MeasurementEntryDialog, build_directive)
 
 # ---------------------------------------------------------------------------
 # build_directive unit tests
@@ -16,7 +17,12 @@ class TestBuildDirective:
         assert d == ".meas tran avg_out AVG v(out)"
 
     def test_rms_with_range(self):
-        d = build_directive("tran", "rms_out", "RMS", {"variable": "v(out)", "from_val": "1m", "to_val": "10m"})
+        d = build_directive(
+            "tran",
+            "rms_out",
+            "RMS",
+            {"variable": "v(out)", "from_val": "1m", "to_val": "10m"},
+        )
         assert d == ".meas tran rms_out RMS v(out) FROM=1m TO=10m"
 
     def test_min_no_range(self):
@@ -24,7 +30,9 @@ class TestBuildDirective:
         assert d == ".meas ac min_gain MIN vdb(out)"
 
     def test_max_partial_range(self):
-        d = build_directive("dc", "peak", "MAX", {"variable": "v(2)", "from_val": "0", "to_val": ""})
+        d = build_directive(
+            "dc", "peak", "MAX", {"variable": "v(2)", "from_val": "0", "to_val": ""}
+        )
         assert d == ".meas dc peak MAX v(2) FROM=0"
 
     def test_pp(self):
@@ -32,11 +40,18 @@ class TestBuildDirective:
         assert d == ".meas tran swing PP v(out)"
 
     def test_integ(self):
-        d = build_directive("tran", "charge", "INTEG", {"variable": "i(R1)", "from_val": "0", "to_val": "5m"})
+        d = build_directive(
+            "tran",
+            "charge",
+            "INTEG",
+            {"variable": "i(R1)", "from_val": "0", "to_val": "5m"},
+        )
         assert d == ".meas tran charge INTEG i(R1) FROM=0 TO=5m"
 
     def test_find_at(self):
-        d = build_directive("tran", "val_at_1m", "FIND_AT", {"variable": "v(out)", "at_val": "1m"})
+        d = build_directive(
+            "tran", "val_at_1m", "FIND_AT", {"variable": "v(out)", "at_val": "1m"}
+        )
         assert d == ".meas tran val_at_1m FIND v(out) AT=1m"
 
     def test_find_when(self):
@@ -44,13 +59,21 @@ class TestBuildDirective:
             "tran",
             "crossing",
             "FIND_WHEN",
-            {"variable": "v(out)", "when_var": "v(in)", "when_val": "0.5", "cross": "RISE=1"},
+            {
+                "variable": "v(out)",
+                "when_var": "v(in)",
+                "when_val": "0.5",
+                "cross": "RISE=1",
+            },
         )
         assert d == ".meas tran crossing FIND v(out) WHEN v(in)=0.5 RISE=1"
 
     def test_find_when_no_cross(self):
         d = build_directive(
-            "tran", "thresh", "FIND_WHEN", {"variable": "v(out)", "when_var": "v(in)", "when_val": "2.5", "cross": ""}
+            "tran",
+            "thresh",
+            "FIND_WHEN",
+            {"variable": "v(out)", "when_var": "v(in)", "when_val": "2.5", "cross": ""},
         )
         assert d == ".meas tran thresh FIND v(out) WHEN v(in)=2.5"
 
@@ -69,14 +92,19 @@ class TestBuildDirective:
                 "targ_edge": "RISE=1",
             },
         )
-        assert d == ".meas tran rise_time TRIG v(out) VAL=0.1 RISE=1 TARG v(out) VAL=0.9 RISE=1"
+        assert (
+            d
+            == ".meas tran rise_time TRIG v(out) VAL=0.1 RISE=1 TARG v(out) VAL=0.9 RISE=1"
+        )
 
     def test_domain_ac(self):
         d = build_directive("ac", "bw3db", "MAX", {"variable": "vdb(out)"})
         assert d.startswith(".meas ac")
 
     def test_domain_dc(self):
-        d = build_directive("dc", "gain", "FIND_AT", {"variable": "v(out)", "at_val": "5"})
+        d = build_directive(
+            "dc", "gain", "FIND_AT", {"variable": "v(out)", "at_val": "5"}
+        )
         assert d.startswith(".meas dc")
 
 
@@ -288,13 +316,23 @@ class TestAnalysisDialogMeasIntegration:
         assert "No measurements" in dialog.meas_label.text()
 
         dialog._measurements = [
-            {"name": "m1", "meas_type": "AVG", "params": {}, "directive": ".meas tran m1 AVG v(out)"},
+            {
+                "name": "m1",
+                "meas_type": "AVG",
+                "params": {},
+                "directive": ".meas tran m1 AVG v(out)",
+            },
         ]
         dialog._update_meas_label()
         assert "1 measurement" in dialog.meas_label.text()
 
         dialog._measurements.append(
-            {"name": "m2", "meas_type": "MAX", "params": {}, "directive": ".meas tran m2 MAX v(out)"},
+            {
+                "name": "m2",
+                "meas_type": "MAX",
+                "params": {},
+                "directive": ".meas tran m2 MAX v(out)",
+            },
         )
         dialog._update_meas_label()
         assert "2 measurements" in dialog.meas_label.text()

--- a/app/tests/unit/test_meas_directive.py
+++ b/app/tests/unit/test_meas_directive.py
@@ -29,9 +29,24 @@ def _build_transient_circuit():
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.analysis_type = "Transient"
     model.analysis_params = {"step": "1u", "duration": "10m"}
@@ -168,9 +183,7 @@ class TestParseMeasurementResults:
         assert results["delay"] == pytest.approx(-1.23456e-6)
 
     def test_ignores_non_measurement_lines(self):
-        stdout = (
-            "Circuit: My Test Circuit\nDoing transient analysis...\navg_v  =  2.50000e+00\nNo. of Data Rows : 100\n"
-        )
+        stdout = "Circuit: My Test Circuit\nDoing transient analysis...\navg_v  =  2.50000e+00\nNo. of Data Rows : 100\n"
         results = ResultParser.parse_measurement_results(stdout)
         assert results is not None
         assert len(results) == 1
@@ -186,5 +199,7 @@ class TestMeasControllerIntegration:
         model = _build_transient_circuit()
         model.analysis_params["measurements"] = [".meas tran avg_v AVG V(1)"]
         ctrl = SimulationController(model)
-        netlist = ctrl.generate_netlist(measurements=model.analysis_params.get("measurements"))
+        netlist = ctrl.generate_netlist(
+            measurements=model.analysis_params.get("measurements")
+        )
         assert ".meas tran avg_v AVG V(1)" in netlist

--- a/app/tests/unit/test_measurement_cursors.py
+++ b/app/tests/unit/test_measurement_cursors.py
@@ -85,7 +85,9 @@ class TestMeasurementCursors:
     def test_callback_called(self):
         fig, canvas, ax, x = _make_axes_with_data()
         calls = []
-        mc = MeasurementCursors(ax, canvas, on_cursor_moved=lambda a, b: calls.append((a, b)))
+        mc = MeasurementCursors(
+            ax, canvas, on_cursor_moved=lambda a, b: calls.append((a, b))
+        )
         mc._notify()
         assert len(calls) == 1
 

--- a/app/tests/unit/test_monte_carlo.py
+++ b/app/tests/unit/test_monte_carlo.py
@@ -4,18 +4,14 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
-from controllers.simulation_controller import SimulationController, SimulationResult
+from controllers.simulation_controller import (SimulationController,
+                                               SimulationResult)
 from models.circuit import CircuitModel
 from models.component import ComponentData
 from models.wire import WireData
-from simulation.monte_carlo import (
-    DEFAULT_TOLERANCES,
-    MC_ELIGIBLE_TYPES,
-    apply_tolerance,
-    compute_mc_statistics,
-    format_spice_value,
-    parse_spice_value,
-)
+from simulation.monte_carlo import (DEFAULT_TOLERANCES, MC_ELIGIBLE_TYPES,
+                                    apply_tolerance, compute_mc_statistics,
+                                    format_spice_value, parse_spice_value)
 
 
 class TestParseSpiceValue:
@@ -160,9 +156,24 @@ def _build_simple_circuit():
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.analysis_type = "DC Operating Point"
     model.rebuild_nodes()
@@ -176,7 +187,12 @@ class TestMonteCarloController:
         mock_runner = MagicMock()
         mock_runner.find_ngspice.return_value = "/usr/bin/ngspice"
         mock_runner.output_dir = "/tmp/sim_output"
-        mock_runner.run_simulation.return_value = (True, "/tmp/output.txt", "stdout", "")
+        mock_runner.run_simulation.return_value = (
+            True,
+            "/tmp/output.txt",
+            "stdout",
+            "",
+        )
         mock_runner.read_output.return_value = (
             "Node                      Voltage\n"
             "----                      -------\n"
@@ -318,7 +334,9 @@ class TestSpiceValueConsolidation:
         for val in test_values:
             formatted = format_spice_value(val)
             parsed = parse_spice_value(formatted)
-            assert parsed == pytest.approx(val), f"Round-trip failed: {val} -> {formatted!r} -> {parsed}"
+            assert parsed == pytest.approx(
+                val
+            ), f"Round-trip failed: {val} -> {formatted!r} -> {parsed}"
 
     def test_negative_values(self):
         """Negative values should format with a minus sign."""

--- a/app/tests/unit/test_netlist_generator.py
+++ b/app/tests/unit/test_netlist_generator.py
@@ -55,7 +55,9 @@ class TestGroundNode:
 class TestAnalysisCommands:
     def test_op_analysis(self, simple_resistor_circuit):
         components, wires, nodes, t2n = simple_resistor_circuit
-        netlist = _generate(components, wires, nodes, t2n, analysis_type="DC Operating Point")
+        netlist = _generate(
+            components, wires, nodes, t2n, analysis_type="DC Operating Point"
+        )
         assert ".op" in netlist
 
     def test_dc_sweep(self, simple_resistor_circuit):

--- a/app/tests/unit/test_netlist_parser.py
+++ b/app/tests/unit/test_netlist_parser.py
@@ -1,13 +1,10 @@
 """Tests for SPICE netlist parser and import functionality."""
 
 import pytest
-from simulation.netlist_parser import (
-    NetlistParseError,
-    _extract_paren_params,
-    _tokenize_spice_line,
-    import_netlist,
-    parse_netlist,
-)
+from simulation.netlist_parser import (NetlistParseError,
+                                       _extract_paren_params,
+                                       _tokenize_spice_line, import_netlist,
+                                       parse_netlist)
 
 # ── Tokenizer ─────────────────────────────────────────────────────────
 
@@ -56,7 +53,9 @@ class TestParseNetlist:
         assert result["analysis"]["type"] == "DC Operating Point"
 
     def test_rc_circuit(self):
-        netlist = "RC Circuit\nr1 1 2 1k\nc1 2 0 1u\nvin 1 0 DC 5\n.tran 0.02ms 20ms\n.end\n"
+        netlist = (
+            "RC Circuit\nr1 1 2 1k\nc1 2 0 1u\nvin 1 0 DC 5\n.tran 0.02ms 20ms\n.end\n"
+        )
         result = parse_netlist(netlist)
         assert len(result["components"]) == 3
         assert result["analysis"]["type"] == "Transient"
@@ -100,7 +99,9 @@ class TestParseNetlist:
         assert result["analysis"]["params"]["source"] == "Vin"
 
     def test_subcircuit_skipped(self):
-        netlist = "Sub test\n.subckt MYBLOCK in out\nR1 in out 1k\n.ends\nR2 1 0 10k\n.end\n"
+        netlist = (
+            "Sub test\n.subckt MYBLOCK in out\nR1 in out 1k\n.ends\nR2 1 0 10k\n.end\n"
+        )
         result = parse_netlist(netlist)
         # Only R2 should be parsed (R1 is inside subcircuit)
         assert len(result["components"]) == 1
@@ -267,7 +268,8 @@ class TestImportNetlist:
         non_gnd_wires = [
             w
             for w in model.wires
-            if not w.start_component_id.startswith("GND") and not w.end_component_id.startswith("GND")
+            if not w.start_component_id.startswith("GND")
+            and not w.end_component_id.startswith("GND")
         ]
         # Should have at least 2 signal wires (node 1 and node 2)
         assert len(non_gnd_wires) >= 2
@@ -283,15 +285,15 @@ class TestImportNetlist:
 
     def test_four_resistor_example(self):
         """Test with the actual Simple4ResistorCircuit example."""
-        netlist = (
-            "Simple 4 Resistor Circuit\nVin 1 0 DC 10\nR1 1 2 250\nR2 2 3 250\nR3 2 0 500\nR4 3 0 250\n.op\n.end\n"
-        )
+        netlist = "Simple 4 Resistor Circuit\nVin 1 0 DC 10\nR1 1 2 250\nR2 2 3 250\nR3 2 0 500\nR4 3 0 250\n.op\n.end\n"
         model, analysis = import_netlist(netlist)
         assert len([c for c in model.components if not c.startswith("GND")]) == 5
         assert analysis["type"] == "DC Operating Point"
 
     def test_diode_circuit(self):
-        netlist = "Diode Test\nVin 1 0 DC 5\nD1 1 2 DMOD\nR1 2 0 100k\n.model DMOD D\n.end\n"
+        netlist = (
+            "Diode Test\nVin 1 0 DC 5\nD1 1 2 DMOD\nR1 2 0 100k\n.model DMOD D\n.end\n"
+        )
         model, _ = import_netlist(netlist)
         assert "D1" in model.components
         assert model.components["D1"].component_type == "Diode"

--- a/app/tests/unit/test_netlist_snapshots.py
+++ b/app/tests/unit/test_netlist_snapshots.py
@@ -19,7 +19,9 @@ from simulation.netlist_generator import NetlistGenerator
 # ---------------------------------------------------------------------------
 
 
-def _model_with_circuit(*components_and_wires, analysis_type="DC Operating Point", analysis_params=None):
+def _model_with_circuit(
+    *components_and_wires, analysis_type="DC Operating Point", analysis_params=None
+):
     """Build a CircuitModel, add components and wires, rebuild nodes."""
     model = CircuitModel()
     model.analysis_type = analysis_type
@@ -125,7 +127,9 @@ class TestSources:
         assert "10" in netlist
 
     def test_waveform_source_pulse(self):
-        vw1 = ComponentData("VW1", "Waveform Source", "PULSE(0 5 0 1n 1n 500u 1m)", (0, 0))
+        vw1 = ComponentData(
+            "VW1", "Waveform Source", "PULSE(0 5 0 1n 1n 500u 1m)", (0, 0)
+        )
         vw1.waveform_type = "PULSE"
         gnd = ComponentData("GND1", "Ground", "0V", (0, 100))
         w1 = WireData("VW1", 1, "GND1", 0)
@@ -153,7 +157,9 @@ class TestDiodes:
         assert ".model" in netlist.lower()
 
     def test_zener_with_model(self):
-        model = _simple_two_terminal_circuit("Zener Diode", "D1", "IS=1e-14 N=1 BV=5.1 IBV=1e-3")
+        model = _simple_two_terminal_circuit(
+            "Zener Diode", "D1", "IS=1e-14 N=1 BV=5.1 IBV=1e-3"
+        )
         netlist = _generate_from_model(model)
         assert "D1" in netlist
         assert "D_Zener" in netlist
@@ -317,7 +323,9 @@ class TestModelDeduplication:
         netlist = _generate_from_model(model)
 
         # Should have exactly one .model D_Ideal D(...) line
-        model_lines = [line for line in netlist.split("\n") if line.startswith(".model D_Ideal")]
+        model_lines = [
+            line for line in netlist.split("\n") if line.startswith(".model D_Ideal")
+        ]
         assert len(model_lines) == 1
 
     def test_mixed_diode_types_separate_models(self):
@@ -354,7 +362,14 @@ class TestAnalysisDirectives:
         w2 = WireData("R1", 1, "GND1", 0)
         w3 = WireData("V1", 1, "GND1", 0)
         return _model_with_circuit(
-            v1, r1, gnd, w1, w2, w3, analysis_type=analysis_type, analysis_params=analysis_params
+            v1,
+            r1,
+            gnd,
+            w1,
+            w2,
+            w3,
+            analysis_type=analysis_type,
+            analysis_params=analysis_params,
         )
 
     def test_dc_operating_point(self):
@@ -363,22 +378,31 @@ class TestAnalysisDirectives:
         assert ".op" in netlist
 
     def test_dc_sweep(self):
-        model = self._basic_circuit("DC Sweep", {"min": "0", "max": "10", "step": "0.1"})
+        model = self._basic_circuit(
+            "DC Sweep", {"min": "0", "max": "10", "step": "0.1"}
+        )
         netlist = _generate_from_model(model)
         assert ".dc V1 0 10 0.1" in netlist
 
     def test_ac_sweep(self):
-        model = self._basic_circuit("AC Sweep", {"sweep_type": "dec", "points": "10", "fStart": "1", "fStop": "1MEG"})
+        model = self._basic_circuit(
+            "AC Sweep",
+            {"sweep_type": "dec", "points": "10", "fStart": "1", "fStop": "1MEG"},
+        )
         netlist = _generate_from_model(model)
         assert ".ac dec 10 1 1MEG" in netlist
 
     def test_transient(self):
-        model = self._basic_circuit("Transient", {"step": "1u", "duration": "10m", "start": "0"})
+        model = self._basic_circuit(
+            "Transient", {"step": "1u", "duration": "10m", "start": "0"}
+        )
         netlist = _generate_from_model(model)
         assert ".tran 1u 10m 0" in netlist
 
     def test_temperature_sweep(self):
-        model = self._basic_circuit("Temperature Sweep", {"tempStart": -40, "tempStop": 85, "tempStep": 25})
+        model = self._basic_circuit(
+            "Temperature Sweep", {"tempStart": -40, "tempStop": 85, "tempStep": 25}
+        )
         netlist = _generate_from_model(model)
         assert ".op" in netlist
         assert ".step temp -40 85 25" in netlist
@@ -467,9 +491,15 @@ class TestImportRoundTrip:
         imported_model, analysis = import_netlist(netlist)
 
         # The imported model should have matching component types
-        comp_types_original = {c.component_type for c in model.components.values() if c.component_type != "Ground"}
+        comp_types_original = {
+            c.component_type
+            for c in model.components.values()
+            if c.component_type != "Ground"
+        }
         comp_types_imported = {
-            c.component_type for c in imported_model.components.values() if c.component_type != "Ground"
+            c.component_type
+            for c in imported_model.components.values()
+            if c.component_type != "Ground"
         }
         assert comp_types_original == comp_types_imported
 

--- a/app/tests/unit/test_new_components.py
+++ b/app/tests/unit/test_new_components.py
@@ -8,16 +8,10 @@ serialization round-trips, and CircuitModel integration.
 
 import pytest
 from models.circuit import CircuitModel
-from models.component import (
-    _CLASS_TO_DISPLAY,
-    _DISPLAY_TO_CLASS,
-    COMPONENT_TYPES,
-    DEFAULT_VALUES,
-    SPICE_SYMBOLS,
-    TERMINAL_COUNTS,
-    TERMINAL_GEOMETRY,
-    ComponentData,
-)
+from models.component import (_CLASS_TO_DISPLAY, _DISPLAY_TO_CLASS,
+                              COMPONENT_TYPES, DEFAULT_VALUES, SPICE_SYMBOLS,
+                              TERMINAL_COUNTS, TERMINAL_GEOMETRY,
+                              ComponentData)
 from models.node import NodeData, reset_node_counter
 from models.wire import WireData
 from simulation.netlist_generator import NetlistGenerator
@@ -263,20 +257,26 @@ class TestMOSFETNetlist:
     """Netlist generation tests for MOSFET NMOS and PMOS."""
 
     def test_nmos_component_line(self):
-        components, wires, nodes, t2n = _make_3term_circuit("MOSFET NMOS", "M1", "NMOS1")
+        components, wires, nodes, t2n = _make_3term_circuit(
+            "MOSFET NMOS", "M1", "NMOS1"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert "M1" in netlist
         assert "NMOS1" in netlist
 
     def test_pmos_component_line(self):
-        components, wires, nodes, t2n = _make_3term_circuit("MOSFET PMOS", "M2", "PMOS1")
+        components, wires, nodes, t2n = _make_3term_circuit(
+            "MOSFET PMOS", "M2", "PMOS1"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert "M2" in netlist
         assert "PMOS1" in netlist
 
     def test_nmos_bulk_tied_to_source(self):
         """MOSFET netlist should have 4 node refs (drain gate source bulk=source)."""
-        components, wires, nodes, t2n = _make_3term_circuit("MOSFET NMOS", "M1", "NMOS1")
+        components, wires, nodes, t2n = _make_3term_circuit(
+            "MOSFET NMOS", "M1", "NMOS1"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         # Find the M1 line and check it has the source node repeated (bulk=source)
         for line in netlist.split("\n"):
@@ -290,21 +290,27 @@ class TestMOSFETNetlist:
             pytest.fail("M1 line not found in netlist")
 
     def test_nmos_model_directive(self):
-        components, wires, nodes, t2n = _make_3term_circuit("MOSFET NMOS", "M1", "NMOS1")
+        components, wires, nodes, t2n = _make_3term_circuit(
+            "MOSFET NMOS", "M1", "NMOS1"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert ".model NMOS1 NMOS" in netlist
         assert "VTO=0.7" in netlist
         assert "KP=110u" in netlist
 
     def test_pmos_model_directive(self):
-        components, wires, nodes, t2n = _make_3term_circuit("MOSFET PMOS", "M2", "PMOS1")
+        components, wires, nodes, t2n = _make_3term_circuit(
+            "MOSFET PMOS", "M2", "PMOS1"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert ".model PMOS1 PMOS" in netlist
         assert "VTO=-0.7" in netlist
         assert "KP=50u" in netlist
 
     def test_mosfet_model_section_header(self):
-        components, wires, nodes, t2n = _make_3term_circuit("MOSFET NMOS", "M1", "NMOS1")
+        components, wires, nodes, t2n = _make_3term_circuit(
+            "MOSFET NMOS", "M1", "NMOS1"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert "* MOSFET Model Definitions" in netlist
 
@@ -355,29 +361,39 @@ class TestVCSwitchNetlist:
     """Netlist generation tests for voltage-controlled switch."""
 
     def test_switch_component_line(self):
-        components, wires, nodes, t2n = _make_4term_circuit("VC Switch", "S1", "VT=2.5 RON=1 ROFF=1e6")
+        components, wires, nodes, t2n = _make_4term_circuit(
+            "VC Switch", "S1", "VT=2.5 RON=1 ROFF=1e6"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert "S1" in netlist
 
     def test_switch_uses_per_instance_model(self):
         """Each switch should get its own model name (SW_<id>)."""
-        components, wires, nodes, t2n = _make_4term_circuit("VC Switch", "S1", "VT=2.5 RON=1 ROFF=1e6")
+        components, wires, nodes, t2n = _make_4term_circuit(
+            "VC Switch", "S1", "VT=2.5 RON=1 ROFF=1e6"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert "SW_S1" in netlist
 
     def test_switch_model_directive(self):
-        components, wires, nodes, t2n = _make_4term_circuit("VC Switch", "S1", "VT=2.5 RON=1 ROFF=1e6")
+        components, wires, nodes, t2n = _make_4term_circuit(
+            "VC Switch", "S1", "VT=2.5 RON=1 ROFF=1e6"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert ".model SW_S1 SW(VT=2.5 RON=1 ROFF=1e6)" in netlist
 
     def test_switch_model_section_header(self):
-        components, wires, nodes, t2n = _make_4term_circuit("VC Switch", "S1", "VT=2.5 RON=1 ROFF=1e6")
+        components, wires, nodes, t2n = _make_4term_circuit(
+            "VC Switch", "S1", "VT=2.5 RON=1 ROFF=1e6"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert "* Voltage-Controlled Switch Model Definitions" in netlist
 
     def test_switch_line_format(self):
         """S<name> switch+ switch- ctrl+ ctrl- model."""
-        components, wires, nodes, t2n = _make_4term_circuit("VC Switch", "S1", "VT=2.5 RON=1 ROFF=1e6")
+        components, wires, nodes, t2n = _make_4term_circuit(
+            "VC Switch", "S1", "VT=2.5 RON=1 ROFF=1e6"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         for line in netlist.split("\n"):
             if line.startswith("S1 "):
@@ -422,51 +438,69 @@ class TestDiodeNetlist:
     """Netlist generation tests for Diode, LED, and Zener Diode."""
 
     def test_diode_component_line(self):
-        components, wires, nodes, t2n = _make_2term_circuit("Diode", "D1", "IS=1e-14 N=1")
+        components, wires, nodes, t2n = _make_2term_circuit(
+            "Diode", "D1", "IS=1e-14 N=1"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert "D1" in netlist
 
     def test_diode_shared_model(self):
-        components, wires, nodes, t2n = _make_2term_circuit("Diode", "D1", "IS=1e-14 N=1")
+        components, wires, nodes, t2n = _make_2term_circuit(
+            "Diode", "D1", "IS=1e-14 N=1"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert "D_Ideal" in netlist
 
     def test_diode_model_directive(self):
-        components, wires, nodes, t2n = _make_2term_circuit("Diode", "D1", "IS=1e-14 N=1")
+        components, wires, nodes, t2n = _make_2term_circuit(
+            "Diode", "D1", "IS=1e-14 N=1"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert ".model D_Ideal D(IS=1e-14 N=1)" in netlist
 
     def test_led_component_line(self):
-        components, wires, nodes, t2n = _make_2term_circuit("LED", "D2", "IS=1e-20 N=1.8 EG=1.9")
+        components, wires, nodes, t2n = _make_2term_circuit(
+            "LED", "D2", "IS=1e-20 N=1.8 EG=1.9"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert "D2" in netlist
         assert "D_LED" in netlist
 
     def test_led_model_directive(self):
-        components, wires, nodes, t2n = _make_2term_circuit("LED", "D2", "IS=1e-20 N=1.8 EG=1.9")
+        components, wires, nodes, t2n = _make_2term_circuit(
+            "LED", "D2", "IS=1e-20 N=1.8 EG=1.9"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert ".model D_LED D(IS=1e-20 N=1.8 EG=1.9)" in netlist
 
     def test_zener_component_line(self):
-        components, wires, nodes, t2n = _make_2term_circuit("Zener Diode", "D3", "IS=1e-14 N=1 BV=5.1 IBV=1e-3")
+        components, wires, nodes, t2n = _make_2term_circuit(
+            "Zener Diode", "D3", "IS=1e-14 N=1 BV=5.1 IBV=1e-3"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert "D3" in netlist
         assert "D_Zener" in netlist
 
     def test_zener_model_has_breakdown_voltage(self):
-        components, wires, nodes, t2n = _make_2term_circuit("Zener Diode", "D3", "IS=1e-14 N=1 BV=5.1 IBV=1e-3")
+        components, wires, nodes, t2n = _make_2term_circuit(
+            "Zener Diode", "D3", "IS=1e-14 N=1 BV=5.1 IBV=1e-3"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert "BV=5.1" in netlist
         assert "IBV=1e-3" in netlist
 
     def test_diode_model_section_header(self):
-        components, wires, nodes, t2n = _make_2term_circuit("Diode", "D1", "IS=1e-14 N=1")
+        components, wires, nodes, t2n = _make_2term_circuit(
+            "Diode", "D1", "IS=1e-14 N=1"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert "* Diode Model Definitions" in netlist
 
     def test_diode_line_format(self):
         """D<name> anode cathode model."""
-        components, wires, nodes, t2n = _make_2term_circuit("Diode", "D1", "IS=1e-14 N=1")
+        components, wires, nodes, t2n = _make_2term_circuit(
+            "Diode", "D1", "IS=1e-14 N=1"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         for line in netlist.split("\n"):
             if line.startswith("D1 "):
@@ -497,9 +531,15 @@ class TestDiodeModelDeduplication:
             make_wire("D3", 1, "GND1", 0),
             make_wire("V1", 1, "GND1", 0),
         ]
-        node_a = NodeData(terminals={("V1", 0), ("D1", 0)}, wire_indices={0}, auto_label="nodeA")
-        node_b = NodeData(terminals={("D1", 1), ("D2", 0)}, wire_indices={1}, auto_label="nodeB")
-        node_c = NodeData(terminals={("D2", 1), ("D3", 0)}, wire_indices={2}, auto_label="nodeC")
+        node_a = NodeData(
+            terminals={("V1", 0), ("D1", 0)}, wire_indices={0}, auto_label="nodeA"
+        )
+        node_b = NodeData(
+            terminals={("D1", 1), ("D2", 0)}, wire_indices={1}, auto_label="nodeB"
+        )
+        node_c = NodeData(
+            terminals={("D2", 1), ("D3", 0)}, wire_indices={2}, auto_label="nodeC"
+        )
         node_gnd = NodeData(
             terminals={("D3", 1), ("GND1", 0), ("V1", 1)},
             wire_indices={3, 4},
@@ -535,7 +575,9 @@ class TestDiodeModelDeduplication:
         components = {
             "D1": make_component("Diode", "D1", "IS=1e-14 N=1", (0, 0)),
             "D2": make_component("LED", "D2", "IS=1e-20 N=1.8 EG=1.9", (100, 0)),
-            "D3": make_component("Zener Diode", "D3", "IS=1e-14 N=1 BV=5.1 IBV=1e-3", (200, 0)),
+            "D3": make_component(
+                "Zener Diode", "D3", "IS=1e-14 N=1 BV=5.1 IBV=1e-3", (200, 0)
+            ),
             "V1": make_component("Voltage Source", "V1", "5V", (-100, 0)),
             "GND1": make_component("Ground", "GND1", "0V", (0, 100)),
         }
@@ -546,9 +588,15 @@ class TestDiodeModelDeduplication:
             make_wire("D3", 1, "GND1", 0),
             make_wire("V1", 1, "GND1", 0),
         ]
-        node_a = NodeData(terminals={("V1", 0), ("D1", 0)}, wire_indices={0}, auto_label="nodeA")
-        node_b = NodeData(terminals={("D1", 1), ("D2", 0)}, wire_indices={1}, auto_label="nodeB")
-        node_c = NodeData(terminals={("D2", 1), ("D3", 0)}, wire_indices={2}, auto_label="nodeC")
+        node_a = NodeData(
+            terminals={("V1", 0), ("D1", 0)}, wire_indices={0}, auto_label="nodeA"
+        )
+        node_b = NodeData(
+            terminals={("D1", 1), ("D2", 0)}, wire_indices={1}, auto_label="nodeB"
+        )
+        node_c = NodeData(
+            terminals={("D2", 1), ("D3", 0)}, wire_indices={2}, auto_label="nodeC"
+        )
         node_gnd = NodeData(
             terminals={("D3", 1), ("GND1", 0), ("V1", 1)},
             wire_indices={3, 4},
@@ -578,9 +626,13 @@ class TestDiodeModelDeduplication:
 
     def test_multiple_leds_share_model(self):
         """Multiple LEDs with same params should share one model."""
-        components, wires, nodes, t2n = _make_2term_circuit("LED", "D1", "IS=1e-20 N=1.8 EG=1.9")
+        components, wires, nodes, t2n = _make_2term_circuit(
+            "LED", "D1", "IS=1e-20 N=1.8 EG=1.9"
+        )
         # Add a second LED to the circuit
-        components["D2"] = make_component("LED", "D2", "IS=1e-20 N=1.8 EG=1.9", (200, 0))
+        components["D2"] = make_component(
+            "LED", "D2", "IS=1e-20 N=1.8 EG=1.9", (200, 0)
+        )
         wires.append(make_wire("D2", 0, "V1", 0))
         wires.append(make_wire("D2", 1, "GND1", 0))
         nodes[0].terminals.add(("D2", 0))
@@ -596,13 +648,17 @@ class TestDiodeModelDeduplication:
 
     def test_no_per_instance_model_names(self):
         """Model names should not contain component IDs."""
-        components, wires, nodes, t2n = _make_2term_circuit("Diode", "D1", "IS=1e-14 N=1")
+        components, wires, nodes, t2n = _make_2term_circuit(
+            "Diode", "D1", "IS=1e-14 N=1"
+        )
         netlist = _generate(components, wires, nodes, t2n)
         assert "D_D1" not in netlist
 
     def test_diode_with_custom_value_gets_own_model(self):
         """If one diode has different params, it gets a separate model."""
-        components, wires, nodes, t2n = _make_2term_circuit("Diode", "D1", "IS=1e-14 N=1")
+        components, wires, nodes, t2n = _make_2term_circuit(
+            "Diode", "D1", "IS=1e-14 N=1"
+        )
         # Add a second diode with different params
         components["D2"] = make_component("Diode", "D2", "IS=1e-12 N=2", (200, 0))
         wires.append(make_wire("D2", 0, "V1", 0))

--- a/app/tests/unit/test_node.py
+++ b/app/tests/unit/test_node.py
@@ -257,4 +257,6 @@ class TestSetNetNamePublicAPI:
         from GUI.circuit_canvas import CircuitCanvas
 
         source = inspect.getsource(CircuitCanvas.label_node)
-        assert "_notify" not in source, "label_node still calls _notify directly — use set_net_name instead"
+        assert (
+            "_notify" not in source
+        ), "label_node still calls _notify directly — use set_net_name instead"

--- a/app/tests/unit/test_noise_analysis.py
+++ b/app/tests/unit/test_noise_analysis.py
@@ -318,7 +318,9 @@ class TestNoisePresets:
         required = {"output_node", "source", "fStart", "fStop", "points", "sweepType"}
         for preset in BUILTIN_PRESETS:
             if preset["analysis_type"] == "Noise":
-                assert required <= set(preset["params"].keys()), f"Preset {preset['name']} missing keys"
+                assert required <= set(
+                    preset["params"].keys()
+                ), f"Preset {preset['name']} missing keys"
 
 
 class TestNoiseCSVExport:

--- a/app/tests/unit/test_opamp_models.py
+++ b/app/tests/unit/test_opamp_models.py
@@ -201,7 +201,10 @@ class TestOpampPropertiesPanel:
 
         panel = PropertiesPanel()
         qtbot.addWidget(panel)
-        items = [panel.opamp_model_combo.itemText(i) for i in range(panel.opamp_model_combo.count())]
+        items = [
+            panel.opamp_model_combo.itemText(i)
+            for i in range(panel.opamp_model_combo.count())
+        ]
         for model in OPAMP_MODELS:
             assert model in items
 

--- a/app/tests/unit/test_parameter_sweep.py
+++ b/app/tests/unit/test_parameter_sweep.py
@@ -3,7 +3,8 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from controllers.simulation_controller import SimulationController, SimulationResult
+from controllers.simulation_controller import (SimulationController,
+                                               SimulationResult)
 from models.circuit import CircuitModel
 from models.component import ComponentData
 from models.wire import WireData
@@ -31,9 +32,24 @@ def _build_simple_circuit():
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.analysis_type = "DC Operating Point"
     model.rebuild_nodes()
@@ -152,7 +168,12 @@ class TestParameterSweepExecution:
         mock_runner = MagicMock()
         mock_runner.find_ngspice.return_value = "/usr/bin/ngspice"
         mock_runner.output_dir = "/tmp/sim_output"
-        mock_runner.run_simulation.return_value = (True, "/tmp/output.txt", "stdout", "")
+        mock_runner.run_simulation.return_value = (
+            True,
+            "/tmp/output.txt",
+            "stdout",
+            "",
+        )
         mock_runner.read_output.return_value = (
             "Node                      Voltage\n"
             "----                      -------\n"

--- a/app/tests/unit/test_path_finding.py
+++ b/app/tests/unit/test_path_finding.py
@@ -128,7 +128,9 @@ class TestBasicRouting:
     def test_same_start_and_end(self, pathfinder):
         """Same point should return a trivial path."""
         start = end = _grid(0, 0)
-        waypoints, runtime, iters, _ = pathfinder.find_path(start, end, set(), bounds=BOUNDS)
+        waypoints, runtime, iters, _ = pathfinder.find_path(
+            start, end, set(), bounds=BOUNDS
+        )
         grid_pts = _to_grid_tuples(waypoints)
         assert grid_pts[0] == (0, 0)
         assert grid_pts[-1] == (0, 0)
@@ -259,7 +261,9 @@ class TestRoutingFailure:
     def test_successful_route_returns_false(self, pathfinder):
         """Successful pathfinding should return routing_failed=False."""
         start, end = _grid(0, 0), _grid(3, 0)
-        waypoints, runtime, iterations, routing_failed = pathfinder.find_path(start, end, set(), bounds=BOUNDS)
+        waypoints, runtime, iterations, routing_failed = pathfinder.find_path(
+            start, end, set(), bounds=BOUNDS
+        )
         assert routing_failed is False
         assert len(waypoints) >= 2
 
@@ -273,7 +277,9 @@ class TestRoutingFailure:
                     obstacles.add((x, y))
         # Only (0,0) is free, goal at (5,0) is blocked
         start, end = _grid(0, 0), _grid(5, 0)
-        waypoints, runtime, iterations, routing_failed = pathfinder.find_path(start, end, obstacles, bounds=BOUNDS)
+        waypoints, runtime, iterations, routing_failed = pathfinder.find_path(
+            start, end, obstacles, bounds=BOUNDS
+        )
         assert routing_failed is True
 
     def test_failed_route_returns_straight_line(self, pathfinder):
@@ -285,7 +291,9 @@ class TestRoutingFailure:
                 if not (x == 0 and y == 0):
                     obstacles.add((x, y))
         start, end = _grid(0, 0), _grid(5, 0)
-        waypoints, _, _, routing_failed = pathfinder.find_path(start, end, obstacles, bounds=BOUNDS)
+        waypoints, _, _, routing_failed = pathfinder.find_path(
+            start, end, obstacles, bounds=BOUNDS
+        )
         assert routing_failed is True
         assert len(waypoints) == 2
         assert waypoints[0] == start
@@ -296,7 +304,9 @@ class TestRoutingFailure:
         # Block a single column but leave room to route around
         obstacles = {(3, y) for y in range(-2, 3)}
         start, end = _grid(0, 0), _grid(6, 0)
-        waypoints, _, _, routing_failed = pathfinder.find_path(start, end, obstacles, bounds=BOUNDS)
+        waypoints, _, _, routing_failed = pathfinder.find_path(
+            start, end, obstacles, bounds=BOUNDS
+        )
         assert routing_failed is False
         grid_pts = _to_grid_tuples(waypoints)
         assert grid_pts[0] == (0, 0)

--- a/app/tests/unit/test_phase3_renaming.py
+++ b/app/tests/unit/test_phase3_renaming.py
@@ -37,7 +37,8 @@ def test_circuit_canvas_backward_compatibility():
 
 def test_gui_module_exports_both_names():
     """Test that GUI.__init__ exports both old and new names"""
-    from GUI import CircuitCanvas, CircuitCanvasView, ComponentGraphicsItem, WireGraphicsItem, WireItem
+    from GUI import (CircuitCanvas, CircuitCanvasView, ComponentGraphicsItem,
+                     WireGraphicsItem, WireItem)
 
     # New names should work
     assert ComponentGraphicsItem is not None
@@ -96,7 +97,8 @@ def test_wire_data_integration():
 
 def test_component_graphics_item_inheritance():
     """Test that component subclasses work with new name"""
-    from GUI.component_item import Capacitor, ComponentGraphicsItem, Ground, Resistor, VoltageSource
+    from GUI.component_item import (Capacitor, ComponentGraphicsItem, Ground,
+                                    Resistor, VoltageSource)
 
     # All component types should be subclasses of ComponentGraphicsItem
     assert issubclass(Resistor, ComponentGraphicsItem)
@@ -129,9 +131,13 @@ def test_phase3_no_functionality_regression():
     from models.wire import WireData
 
     # Create basic model objects
-    comp = ComponentData(component_id="R1", component_type="Resistor", value="1k", position=(0, 0))
+    comp = ComponentData(
+        component_id="R1", component_type="Resistor", value="1k", position=(0, 0)
+    )
 
-    wire = WireData(start_component_id="R1", start_terminal=0, end_component_id="R2", end_terminal=0)
+    wire = WireData(
+        start_component_id="R1", start_terminal=0, end_component_id="R2", end_terminal=0
+    )
 
     node = NodeData(terminals={("R1", 0), ("R2", 0)}, wire_indices={0})
 

--- a/app/tests/unit/test_pole_zero.py
+++ b/app/tests/unit/test_pole_zero.py
@@ -197,7 +197,9 @@ class TestPZController:
         model.analysis_type = "Pole-Zero"
         ctrl = SimulationController(model=model)
 
-        mock_output = "pole(1) = -1.00000e+03, 0.00000e+00\nzero(1) = -2.00000e+04, 0.00000e+00\n"
+        mock_output = (
+            "pole(1) = -1.00000e+03, 0.00000e+00\nzero(1) = -2.00000e+04, 0.00000e+00\n"
+        )
         ctrl._runner = MagicMock()
         ctrl._runner.read_output.return_value = mock_output
 

--- a/app/tests/unit/test_power_dissipation.py
+++ b/app/tests/unit/test_power_dissipation.py
@@ -147,7 +147,9 @@ class TestCalculatePowerDictInput:
         nodeC = _make_node([("R2", 1)], "nodeC")
         voltages = {"nodeA": 10.0, "nodeB": 0.0, "nodeC": 0.0}
 
-        result = calculate_power(list(comp_dict.values()), [nodeA, nodeB, nodeC], voltages)
+        result = calculate_power(
+            list(comp_dict.values()), [nodeA, nodeB, nodeC], voltages
+        )
         assert "R1" in result
         assert "R2" in result
         assert result["R1"] == pytest.approx(0.1)  # 10V^2 / 1k = 0.1W
@@ -174,7 +176,9 @@ class TestCalculatePowerDictInput:
         voltages = {"nodeA": 5.0, "0": 0.0}
         currents = {"v1": -0.005}
 
-        result = calculate_power(list(comp_dict.values()), [node_pos, node_gnd], voltages, currents)
+        result = calculate_power(
+            list(comp_dict.values()), [node_pos, node_gnd], voltages, currents
+        )
         assert result["R1"] == pytest.approx(0.025)
         assert result["V1"] == pytest.approx(-0.025)
         assert total_power(result) == pytest.approx(0.0)

--- a/app/tests/unit/test_power_metrics.py
+++ b/app/tests/unit/test_power_metrics.py
@@ -3,7 +3,9 @@
 import math
 
 from models.component import ComponentData
-from simulation.power_metrics import _fmt_eng, compute_rms, compute_transient_power_metrics, format_power_summary
+from simulation.power_metrics import (_fmt_eng, compute_rms,
+                                      compute_transient_power_metrics,
+                                      format_power_summary)
 
 # ---------------------------------------------------------------------------
 # compute_rms tests

--- a/app/tests/unit/test_preferences_dialog.py
+++ b/app/tests/unit/test_preferences_dialog.py
@@ -6,7 +6,8 @@ import pytest
 from GUI.preferences_dialog import PreferencesDialog
 from GUI.styles import LightTheme, theme_manager
 from PyQt6.QtCore import QSettings
-from PyQt6.QtWidgets import QCheckBox, QComboBox, QPushButton, QSpinBox, QTabWidget
+from PyQt6.QtWidgets import (QCheckBox, QComboBox, QPushButton, QSpinBox,
+                             QTabWidget)
 
 
 @pytest.fixture(autouse=True)

--- a/app/tests/unit/test_print_export.py
+++ b/app/tests/unit/test_print_export.py
@@ -109,7 +109,8 @@ class TestPdfExportEndToEnd:
         from PyQt6.QtCore import Qt
         from PyQt6.QtGui import QPainter
         from PyQt6.QtPrintSupport import QPrinter
-        from PyQt6.QtWidgets import QGraphicsLineItem, QGraphicsRectItem, QGraphicsScene
+        from PyQt6.QtWidgets import (QGraphicsLineItem, QGraphicsRectItem,
+                                     QGraphicsScene)
 
         scene = QGraphicsScene()
         # Simulate a component (rect) and wire (line)

--- a/app/tests/unit/test_qtbot_widget_interactions.py
+++ b/app/tests/unit/test_qtbot_widget_interactions.py
@@ -36,7 +36,14 @@ class TestAnalysisDialogInteractions:
 
     @pytest.mark.parametrize(
         "analysis_type",
-        ["DC Operating Point", "DC Sweep", "AC Sweep", "Transient", "Temperature Sweep", "Noise"],
+        [
+            "DC Operating Point",
+            "DC Sweep",
+            "AC Sweep",
+            "Transient",
+            "Temperature Sweep",
+            "Noise",
+        ],
     )
     def test_each_analysis_type_opens(self, qtbot, analysis_type):
         """Every analysis type dialog opens without error."""
@@ -54,7 +61,9 @@ class TestAnalysisDialogInteractions:
         assert dialog.desc_label.text() == expected
 
         dialog.type_combo.setCurrentText("DC Operating Point")
-        expected_dc = AnalysisDialog.ANALYSIS_CONFIGS["DC Operating Point"]["description"]
+        expected_dc = AnalysisDialog.ANALYSIS_CONFIGS["DC Operating Point"][
+            "description"
+        ]
         assert dialog.desc_label.text() == expected_dc
 
     def test_transient_fields_have_defaults(self, qtbot):
@@ -79,7 +88,14 @@ class TestAnalysisDialogInteractions:
         """Noise analysis has all 6 parameter fields."""
         dialog = AnalysisDialog(analysis_type="Noise")
         qtbot.addWidget(dialog)
-        expected_keys = {"output_node", "source", "fStart", "fStop", "points", "sweepType"}
+        expected_keys = {
+            "output_node",
+            "source",
+            "fStart",
+            "fStop",
+            "points",
+            "sweepType",
+        }
         assert set(dialog.field_widgets.keys()) == expected_keys
 
     def test_temp_sweep_command_generation(self, qtbot):
@@ -124,14 +140,18 @@ class TestComponentPaletteInteractions:
         """Searching 'op' shows Op-Amp."""
         palette.search_input.setText("op")
         lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = [
+            lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()
+        ]
         assert "Op-Amp" in visible
 
     def test_search_for_diode(self, palette):
         """Searching 'diode' shows Diode, LED, and Zener Diode."""
         palette.search_input.setText("diode")
         lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = [
+            lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()
+        ]
         assert "Diode" in visible
         assert "Zener Diode" in visible
 
@@ -305,7 +325,9 @@ class TestComponentTerminalGeometry:
         terminals = comp.get_terminal_positions()
         if len(terminals) > 1:
             positions = set(terminals)
-            assert len(positions) == len(terminals), f"{comp_type} has overlapping terminals"
+            assert len(positions) == len(
+                terminals
+            ), f"{comp_type} has overlapping terminals"
 
     @pytest.mark.parametrize("rotation", [0, 90, 180, 270])
     def test_rotation_preserves_terminal_count(self, rotation):
@@ -355,7 +377,18 @@ class TestComponentTerminalGeometry:
 
     @pytest.mark.parametrize(
         "comp_type",
-        ["Op-Amp", "VCVS", "CCVS", "VCCS", "CCCS", "BJT NPN", "BJT PNP", "MOSFET NMOS", "MOSFET PMOS", "VC Switch"],
+        [
+            "Op-Amp",
+            "VCVS",
+            "CCVS",
+            "VCCS",
+            "CCCS",
+            "BJT NPN",
+            "BJT PNP",
+            "MOSFET NMOS",
+            "MOSFET PMOS",
+            "VC Switch",
+        ],
     )
     def test_multi_terminal_component_geometry(self, comp_type):
         """Multi-terminal components have correct terminal count and non-overlapping positions."""

--- a/app/tests/unit/test_qtimer_reuse.py
+++ b/app/tests/unit/test_qtimer_reuse.py
@@ -16,7 +16,9 @@ def _make_mock_comp():
     comp = MagicMock(spec=ComponentGraphicsItem)
     comp._position_update_timer = None
     comp._pending_position = None
-    comp._schedule_controller_update = lambda: ComponentGraphicsItem._schedule_controller_update(comp)
+    comp._schedule_controller_update = (
+        lambda: ComponentGraphicsItem._schedule_controller_update(comp)
+    )
     return comp
 
 

--- a/app/tests/unit/test_result_parser.py
+++ b/app/tests/unit/test_result_parser.py
@@ -54,9 +54,7 @@ class TestParseOpResults:
 
 class TestParseDcResults:
     def test_valid_sweep(self):
-        output = (
-            "Index   v-sweep   v(nodeA)\n0       0.000     0.000\n1       1.000     0.500\n2       2.000     1.000\n"
-        )
+        output = "Index   v-sweep   v(nodeA)\n0       0.000     0.000\n1       1.000     0.500\n2       2.000     1.000\n"
         result = ResultParser.parse_dc_results(output)
         assert result is not None
         assert len(result["data"]) == 3

--- a/app/tests/unit/test_results_plot_dialog.py
+++ b/app/tests/unit/test_results_plot_dialog.py
@@ -6,7 +6,8 @@ import os
 from unittest.mock import patch
 
 import pytest
-from GUI.results_plot_dialog import ACSweepPlotDialog, DCSweepPlotDialog, save_plot
+from GUI.results_plot_dialog import (ACSweepPlotDialog, DCSweepPlotDialog,
+                                     save_plot)
 from matplotlib.figure import Figure
 
 # ---------------------------------------------------------------------------
@@ -209,7 +210,10 @@ class TestSavePlot:
         ax.set_title("Test")
 
         out = tmp_path / "plot.png"
-        with patch("GUI.results_plot_dialog.QFileDialog.getSaveFileName", return_value=(str(out), "")):
+        with patch(
+            "GUI.results_plot_dialog.QFileDialog.getSaveFileName",
+            return_value=(str(out), ""),
+        ):
             result = save_plot(fig)
 
         assert result == str(out)
@@ -222,7 +226,10 @@ class TestSavePlot:
         ax.plot([0, 1], [0, 1])
 
         out = tmp_path / "plot.svg"
-        with patch("GUI.results_plot_dialog.QFileDialog.getSaveFileName", return_value=(str(out), "")):
+        with patch(
+            "GUI.results_plot_dialog.QFileDialog.getSaveFileName",
+            return_value=(str(out), ""),
+        ):
             result = save_plot(fig)
 
         assert result == str(out)
@@ -233,7 +240,9 @@ class TestSavePlot:
 
     def test_cancel_returns_empty(self):
         fig = Figure()
-        with patch("GUI.results_plot_dialog.QFileDialog.getSaveFileName", return_value=("", "")):
+        with patch(
+            "GUI.results_plot_dialog.QFileDialog.getSaveFileName", return_value=("", "")
+        ):
             result = save_plot(fig)
         assert result == ""
 

--- a/app/tests/unit/test_rubric_grader.py
+++ b/app/tests/unit/test_rubric_grader.py
@@ -4,7 +4,8 @@ import json
 
 import pytest
 from grading.grader import CircuitGrader, GradingResult
-from grading.rubric import Rubric, RubricCheck, load_rubric, save_rubric, validate_rubric
+from grading.rubric import (Rubric, RubricCheck, load_rubric, save_rubric,
+                            validate_rubric)
 from models.circuit import CircuitModel
 from models.component import ComponentData
 from models.wire import WireData
@@ -40,10 +41,30 @@ def _build_rc_filter(r_value="1k", c_value="100n", analysis="AC Sweep"):
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="C1", end_terminal=0),
-        WireData(start_component_id="C1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="C1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="C1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.component_counter = {"V": 1, "R": 1, "C": 1, "GND": 1}
     model.analysis_type = analysis
@@ -77,7 +98,11 @@ def _build_rc_rubric():
                 check_id="r1_value",
                 check_type="component_value",
                 points=20,
-                params={"component_id": "R1", "expected_value": "1k", "tolerance_pct": 10},
+                params={
+                    "component_id": "R1",
+                    "expected_value": "1k",
+                    "tolerance_pct": 10,
+                },
                 feedback_pass="R1 value correct",
                 feedback_fail="R1 value should be approximately 1k",
             ),
@@ -289,7 +314,9 @@ class TestCircuitGraderPartialMarks:
         result = grader.grade(student, rubric)
 
         # C1 existence check should fail
-        c1_result = next(cr for cr in result.check_results if cr.check_id == "c1_exists")
+        c1_result = next(
+            cr for cr in result.check_results if cr.check_id == "c1_exists"
+        )
         assert c1_result.passed is False
         assert c1_result.points_earned == 0
 
@@ -331,22 +358,49 @@ class TestCircuitGraderTopology:
         """R1 and C1 not connected should fail topology check."""
         model = CircuitModel()
         model.components["V1"] = ComponentData(
-            component_id="V1", component_type="Voltage Source", value="5V", position=(0.0, 0.0)
+            component_id="V1",
+            component_type="Voltage Source",
+            value="5V",
+            position=(0.0, 0.0),
         )
         model.components["R1"] = ComponentData(
-            component_id="R1", component_type="Resistor", value="1k", position=(100.0, 0.0)
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(100.0, 0.0),
         )
         model.components["C1"] = ComponentData(
-            component_id="C1", component_type="Capacitor", value="100n", position=(200.0, 0.0)
+            component_id="C1",
+            component_type="Capacitor",
+            value="100n",
+            position=(200.0, 0.0),
         )
         model.components["GND1"] = ComponentData(
-            component_id="GND1", component_type="Ground", value="0V", position=(0.0, 100.0)
+            component_id="GND1",
+            component_type="Ground",
+            value="0V",
+            position=(0.0, 100.0),
         )
         # Wire V1-R1 and C1-GND but NOT R1-C1
         model.wires = [
-            WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-            WireData(start_component_id="C1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-            WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+            WireData(
+                start_component_id="V1",
+                start_terminal=1,
+                end_component_id="R1",
+                end_terminal=0,
+            ),
+            WireData(
+                start_component_id="C1",
+                start_terminal=1,
+                end_component_id="GND1",
+                end_terminal=0,
+            ),
+            WireData(
+                start_component_id="V1",
+                start_terminal=0,
+                end_component_id="GND1",
+                end_terminal=0,
+            ),
         ]
         model.analysis_type = "AC Sweep"
         model.rebuild_nodes()
@@ -355,7 +409,9 @@ class TestCircuitGraderTopology:
         grader = CircuitGrader()
         result = grader.grade(model, rubric)
 
-        topo_check = next(cr for cr in result.check_results if cr.check_id == "rc_connected")
+        topo_check = next(
+            cr for cr in result.check_results if cr.check_id == "rc_connected"
+        )
         assert topo_check.passed is False
 
 
@@ -363,7 +419,10 @@ class TestCircuitGraderGround:
     def test_missing_ground_fails(self):
         model = CircuitModel()
         model.components["R1"] = ComponentData(
-            component_id="R1", component_type="Resistor", value="1k", position=(0.0, 0.0)
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(0.0, 0.0),
         )
         model.rebuild_nodes()
 

--- a/app/tests/unit/test_sensitivity_analysis.py
+++ b/app/tests/unit/test_sensitivity_analysis.py
@@ -35,10 +35,30 @@ def _build_divider_model(analysis_type="Sensitivity", analysis_params=None):
         position=(0.0, 200.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="R2", end_terminal=0),
-        WireData(start_component_id="R2", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="R2",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R2",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.analysis_type = analysis_type
     model.analysis_params = analysis_params or {"output_node": "2"}

--- a/app/tests/unit/test_simulation_controller.py
+++ b/app/tests/unit/test_simulation_controller.py
@@ -3,7 +3,8 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from controllers.simulation_controller import SimulationController, SimulationResult
+from controllers.simulation_controller import (SimulationController,
+                                               SimulationResult)
 from models.circuit import CircuitModel
 from models.component import ComponentData
 from models.wire import WireData
@@ -125,7 +126,9 @@ class TestGenerateNetlist:
 
 class TestSimulationResult:
     def test_success_result(self):
-        r = SimulationResult(success=True, analysis_type="DC Operating Point", data={"nodeA": 5.0})
+        r = SimulationResult(
+            success=True, analysis_type="DC Operating Point", data={"nodeA": 5.0}
+        )
         assert r.success
         assert r.data["nodeA"] == 5.0
 

--- a/app/tests/unit/test_simulation_presets.py
+++ b/app/tests/unit/test_simulation_presets.py
@@ -52,14 +52,20 @@ class TestBuiltinPresets:
 
 class TestUserPresets:
     def test_save_user_preset(self, mgr):
-        mgr.save_preset("My Sweep", "DC Sweep", {"source": "V2", "min": 0, "max": 3, "step": 0.5})
+        mgr.save_preset(
+            "My Sweep", "DC Sweep", {"source": "V2", "min": 0, "max": 3, "step": 0.5}
+        )
         p = mgr.get_preset_by_name("My Sweep", "DC Sweep")
         assert p is not None
         assert p["params"]["source"] == "V2"
 
     def test_save_overwrites_existing(self, mgr):
-        mgr.save_preset("My Sweep", "DC Sweep", {"source": "V1", "min": 0, "max": 5, "step": 0.1})
-        mgr.save_preset("My Sweep", "DC Sweep", {"source": "V2", "min": 0, "max": 10, "step": 1})
+        mgr.save_preset(
+            "My Sweep", "DC Sweep", {"source": "V1", "min": 0, "max": 5, "step": 0.1}
+        )
+        mgr.save_preset(
+            "My Sweep", "DC Sweep", {"source": "V2", "min": 0, "max": 10, "step": 1}
+        )
         presets = mgr.get_presets("DC Sweep")
         my_presets = [p for p in presets if p["name"] == "My Sweep"]
         assert len(my_presets) == 1
@@ -67,10 +73,16 @@ class TestUserPresets:
 
     def test_cannot_overwrite_builtin(self, mgr):
         with pytest.raises(ValueError, match="built-in"):
-            mgr.save_preset("Quick Transient", "Transient", {"duration": 1, "step": 0.001, "startTime": 0})
+            mgr.save_preset(
+                "Quick Transient",
+                "Transient",
+                {"duration": 1, "step": 0.001, "startTime": 0},
+            )
 
     def test_delete_user_preset(self, mgr):
-        mgr.save_preset("Temp", "DC Sweep", {"source": "V1", "min": 0, "max": 5, "step": 0.1})
+        mgr.save_preset(
+            "Temp", "DC Sweep", {"source": "V1", "min": 0, "max": 5, "step": 0.1}
+        )
         assert mgr.delete_preset("Temp", "DC Sweep") is True
         assert mgr.get_preset_by_name("Temp", "DC Sweep") is None
 
@@ -84,7 +96,9 @@ class TestUserPresets:
 class TestPresetPersistence:
     def test_presets_persist_to_disk(self, preset_file):
         mgr1 = PresetManager(preset_file)
-        mgr1.save_preset("Saved", "Transient", {"duration": 0.1, "step": 1e-06, "startTime": 0})
+        mgr1.save_preset(
+            "Saved", "Transient", {"duration": 0.1, "step": 1e-06, "startTime": 0}
+        )
 
         mgr2 = PresetManager(preset_file)
         p = mgr2.get_preset_by_name("Saved", "Transient")
@@ -103,7 +117,11 @@ class TestPresetPersistence:
 
     def test_file_format_is_json(self, preset_file):
         mgr = PresetManager(preset_file)
-        mgr.save_preset("Test", "AC Sweep", {"fStart": 10, "fStop": 1000, "points": 50, "sweepType": "dec"})
+        mgr.save_preset(
+            "Test",
+            "AC Sweep",
+            {"fStart": 10, "fStop": 1000, "points": 50, "sweepType": "dec"},
+        )
         data = json.loads(preset_file.read_text())
         assert "presets" in data
         assert len(data["presets"]) == 1
@@ -127,7 +145,9 @@ class TestDialogPresetUI:
         mgr = PresetManager(preset_file)
         dialog = AnalysisDialog("AC Sweep", preset_manager=mgr)
         qtbot.addWidget(dialog)
-        items = [dialog.preset_combo.itemText(i) for i in range(dialog.preset_combo.count())]
+        items = [
+            dialog.preset_combo.itemText(i) for i in range(dialog.preset_combo.count())
+        ]
         assert any("Audio AC Sweep" in item for item in items)
         assert any("Wide AC Sweep" in item for item in items)
 
@@ -166,7 +186,9 @@ class TestDialogPresetUI:
         mgr = PresetManager(preset_file)
         dialog = AnalysisDialog("DC Sweep", preset_manager=mgr)
         qtbot.addWidget(dialog)
-        items = [dialog.preset_combo.itemText(i) for i in range(dialog.preset_combo.count())]
+        items = [
+            dialog.preset_combo.itemText(i) for i in range(dialog.preset_combo.count())
+        ]
         # Should not show AC Sweep presets
         assert not any("Audio AC Sweep" in item for item in items)
         # Should show DC Sweep presets

--- a/app/tests/unit/test_svg_export.py
+++ b/app/tests/unit/test_svg_export.py
@@ -146,7 +146,10 @@ class TestSVGFileOutput:
 
         content = (tmp_path / "elements.svg").read_text()
         # SVG should have drawing elements (lines, paths, etc.)
-        has_drawing = any(tag in content for tag in ["<line", "<path", "<polyline", "<circle", "<rect", "<ellipse"])
+        has_drawing = any(
+            tag in content
+            for tag in ["<line", "<path", "<polyline", "<circle", "<rect", "<ellipse"]
+        )
         assert has_drawing, "SVG should contain drawing elements"
 
     def test_svg_multiple_components(self, qtbot, tmp_path):

--- a/app/tests/unit/test_symbol_style.py
+++ b/app/tests/unit/test_symbol_style.py
@@ -2,28 +2,12 @@
 and renderer strategy pattern (#327)."""
 
 import pytest
-from GUI.component_item import (
-    BJTNPN,
-    BJTPNP,
-    CCCS,
-    CCVS,
-    MOSFETNMOS,
-    MOSFETPMOS,
-    VCCS,
-    VCVS,
-    Capacitor,
-    CurrentSource,
-    Diode,
-    Ground,
-    Inductor,
-    LEDComponent,
-    OpAmp,
-    Resistor,
-    VCSwitch,
-    VoltageSource,
-    WaveformVoltageSource,
-    ZenerDiode,
-)
+from GUI.component_item import (BJTNPN, BJTPNP, CCCS, CCVS, MOSFETNMOS,
+                                MOSFETPMOS, VCCS, VCVS, Capacitor,
+                                CurrentSource, Diode, Ground, Inductor,
+                                LEDComponent, OpAmp, Resistor, VCSwitch,
+                                VoltageSource, WaveformVoltageSource,
+                                ZenerDiode)
 from GUI.renderers import get_renderer
 from GUI.styles import LightTheme, theme_manager
 from GUI.styles.theme_manager import COLOR_MODES, SYMBOL_STYLES

--- a/app/tests/unit/test_template_controller.py
+++ b/app/tests/unit/test_template_controller.py
@@ -3,7 +3,8 @@
 import json
 
 import pytest
-from controllers.template_controller import TemplateController, validate_template_data
+from controllers.template_controller import (TemplateController,
+                                             validate_template_data)
 from models.circuit import CircuitModel
 from models.component import ComponentData
 from models.template import TemplateData, TemplateMetadata
@@ -266,7 +267,9 @@ class TestTemplateControllerSaveLoad:
 
     def test_load_missing_title_raises(self, tmp_path):
         filepath = tmp_path / "bad.spice-template"
-        filepath.write_text(json.dumps({"template_version": "1.0", "metadata": {"title": ""}}))
+        filepath.write_text(
+            json.dumps({"template_version": "1.0", "metadata": {"title": ""}})
+        )
         ctrl = TemplateController()
         with pytest.raises(ValueError, match="title"):
             ctrl.load_template(filepath)

--- a/app/tests/unit/test_template_manager.py
+++ b/app/tests/unit/test_template_manager.py
@@ -166,8 +166,18 @@ class TestLoadTemplate:
             "name": "Test",
             "category": "Test",
             "components": [
-                {"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}},
-                {"id": "R2", "type": "Resistor", "value": "2k", "pos": {"x": 100, "y": 0}},
+                {
+                    "id": "R1",
+                    "type": "Resistor",
+                    "value": "1k",
+                    "pos": {"x": 0, "y": 0},
+                },
+                {
+                    "id": "R2",
+                    "type": "Resistor",
+                    "value": "2k",
+                    "pos": {"x": 100, "y": 0},
+                },
             ],
             "wires": [],
             "counters": {"R": 2},
@@ -189,9 +199,24 @@ class TestLoadTemplate:
             "name": "Test",
             "category": "Test",
             "components": [
-                {"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}},
-                {"id": "R3", "type": "Resistor", "value": "2k", "pos": {"x": 100, "y": 0}},
-                {"id": "V1", "type": "VoltageSource", "value": "5V", "pos": {"x": 200, "y": 0}},
+                {
+                    "id": "R1",
+                    "type": "Resistor",
+                    "value": "1k",
+                    "pos": {"x": 0, "y": 0},
+                },
+                {
+                    "id": "R3",
+                    "type": "Resistor",
+                    "value": "2k",
+                    "pos": {"x": 100, "y": 0},
+                },
+                {
+                    "id": "V1",
+                    "type": "VoltageSource",
+                    "value": "5V",
+                    "pos": {"x": 200, "y": 0},
+                },
             ],
             "wires": [],
             "counters": {"R": 999, "V": 999},
@@ -247,7 +272,9 @@ class TestSaveTemplate:
         user = tmp_path / "user"
         mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=user)
 
-        filepath = mgr.save_template(_build_test_circuit(), "My Filter", "An RC filter", "Filters")
+        filepath = mgr.save_template(
+            _build_test_circuit(), "My Filter", "An RC filter", "Filters"
+        )
 
         data = json.loads(filepath.read_text())
         assert data["name"] == "My Filter"
@@ -349,7 +376,9 @@ class TestDeleteTemplate:
         assert filepath.exists()
 
     def test_delete_nonexistent_returns_false(self, tmp_path):
-        mgr = TemplateManager(builtin_dir=tmp_path / "builtin", user_dir=tmp_path / "user")
+        mgr = TemplateManager(
+            builtin_dir=tmp_path / "builtin", user_dir=tmp_path / "user"
+        )
         result = mgr.delete_template(tmp_path / "nonexistent.json")
         assert result is False
 
@@ -368,7 +397,9 @@ class TestCalculateCounters:
         model = CircuitModel()
         model.components["OA1"] = ComponentData("OA1", "Op-Amp", "Ideal", (0, 0))
         model.components["GND1"] = ComponentData("GND1", "Ground", "0V", (100, 0))
-        model.components["VW1"] = ComponentData("VW1", "Waveform Source", "SIN(0 5 1k)", (200, 0))
+        model.components["VW1"] = ComponentData(
+            "VW1", "Waveform Source", "SIN(0 5 1k)", (200, 0)
+        )
 
         counters = TemplateManager._calculate_counters(model)
         assert counters == {"OA": 1, "GND": 1, "VW": 1}
@@ -412,13 +443,21 @@ class TestBuiltinTemplatesValid:
             pytest.skip("Built-in templates directory not found")
 
         templates = mgr._scan_directory(mgr.builtin_dir, is_builtin=True)
-        assert len(templates) >= 5, f"Expected at least 5 built-in templates, found {len(templates)}"
+        assert (
+            len(templates) >= 5
+        ), f"Expected at least 5 built-in templates, found {len(templates)}"
 
         for template_info in templates:
             model = mgr.load_template(template_info.filepath)
-            assert len(model.components) > 0, f"Template {template_info.name} has no components"
-            assert template_info.name, f"Template at {template_info.filepath} has no name"
-            assert template_info.category, f"Template {template_info.name} has no category"
+            assert (
+                len(model.components) > 0
+            ), f"Template {template_info.name} has no components"
+            assert (
+                template_info.name
+            ), f"Template at {template_info.filepath} has no name"
+            assert (
+                template_info.category
+            ), f"Template {template_info.name} has no category"
 
     def test_builtin_templates_have_descriptions(self):
         """All built-in templates should have descriptions."""

--- a/app/tests/unit/test_theme_editor_dialog.py
+++ b/app/tests/unit/test_theme_editor_dialog.py
@@ -79,4 +79,6 @@ class TestResetButton:
         editor._colors["background_primary"] = "#FF0000"
         editor._on_reset()
         light = LightTheme()
-        assert editor._colors["background_primary"] == light.color_hex("background_primary")
+        assert editor._colors["background_primary"] == light.color_hex(
+            "background_primary"
+        )

--- a/app/tests/unit/test_theme_store.py
+++ b/app/tests/unit/test_theme_store.py
@@ -4,15 +4,9 @@ import json
 
 import pytest
 from GUI.styles.custom_theme import CustomTheme
-from GUI.styles.theme_store import (
-    _filename_safe,
-    delete_theme,
-    export_theme,
-    import_theme,
-    list_custom_themes,
-    load_theme,
-    save_theme,
-)
+from GUI.styles.theme_store import (_filename_safe, delete_theme, export_theme,
+                                    import_theme, list_custom_themes,
+                                    load_theme, save_theme)
 
 
 class TestFilenameSafe:
@@ -35,7 +29,9 @@ class TestSaveLoadRoundTrip:
     """Verify save + load round-trip."""
 
     def test_round_trip(self, tmp_path):
-        theme = CustomTheme("Ocean Blue", "dark", {"background_primary": "#0A1628"}, theme_is_dark=True)
+        theme = CustomTheme(
+            "Ocean Blue", "dark", {"background_primary": "#0A1628"}, theme_is_dark=True
+        )
         stem = save_theme(theme, themes_dir=tmp_path)
         assert stem == "ocean-blue"
         assert (tmp_path / "ocean-blue.json").exists()
@@ -82,7 +78,9 @@ class TestExportImport:
     """Verify export + import round-trip."""
 
     def test_export_import(self, tmp_path):
-        theme = CustomTheme("Portable", "light", {"grid_minor": "#AAAAAA"}, theme_is_dark=False)
+        theme = CustomTheme(
+            "Portable", "light", {"grid_minor": "#AAAAAA"}, theme_is_dark=False
+        )
         export_path = tmp_path / "exported.json"
         export_theme(theme, export_path)
         assert export_path.exists()

--- a/app/tests/unit/test_transformer.py
+++ b/app/tests/unit/test_transformer.py
@@ -5,15 +5,9 @@ Covers model registration, netlist generation, and structural assertions.
 """
 
 import pytest
-from models.component import (
-    COMPONENT_COLORS,
-    COMPONENT_TYPES,
-    DEFAULT_VALUES,
-    SPICE_SYMBOLS,
-    TERMINAL_COUNTS,
-    TERMINAL_GEOMETRY,
-    ComponentData,
-)
+from models.component import (COMPONENT_COLORS, COMPONENT_TYPES,
+                              DEFAULT_VALUES, SPICE_SYMBOLS, TERMINAL_COUNTS,
+                              TERMINAL_GEOMETRY, ComponentData)
 from models.node import NodeData
 from models.wire import WireData
 from simulation.netlist_generator import NetlistGenerator

--- a/app/tests/unit/test_undo_redo.py
+++ b/app/tests/unit/test_undo_redo.py
@@ -2,18 +2,11 @@
 
 import pytest
 from controllers.circuit_controller import CircuitController
-from controllers.commands import (
-    AddComponentCommand,
-    AddWireCommand,
-    ChangeValueCommand,
-    CompoundCommand,
-    DeleteComponentCommand,
-    DeleteWireCommand,
-    FlipComponentCommand,
-    MoveComponentCommand,
-    PasteCommand,
-    RotateComponentCommand,
-)
+from controllers.commands import (AddComponentCommand, AddWireCommand,
+                                  ChangeValueCommand, CompoundCommand,
+                                  DeleteComponentCommand, DeleteWireCommand,
+                                  FlipComponentCommand, MoveComponentCommand,
+                                  PasteCommand, RotateComponentCommand)
 from controllers.undo_manager import UndoManager
 from models.circuit import CircuitModel
 

--- a/app/tests/unit/test_waveform_config_dialog.py
+++ b/app/tests/unit/test_waveform_config_dialog.py
@@ -52,7 +52,9 @@ class TestWaveformConfigDialogParams:
         assert sin_inputs["amplitude"].text() == "5"
         assert sin_inputs["frequency"].text() == "1k"
 
-    def test_get_parameters_returns_current_type_and_values(self, qtbot, waveform_component):
+    def test_get_parameters_returns_current_type_and_values(
+        self, qtbot, waveform_component
+    ):
         dialog = WaveformConfigDialog(waveform_component)
         qtbot.addWidget(dialog)
         wtype, params = dialog.get_parameters()

--- a/app/tests/unit/test_wire_reroute_dedup.py
+++ b/app/tests/unit/test_wire_reroute_dedup.py
@@ -42,7 +42,9 @@ class TestObserverRerouteOnMove:
         comp = ctrl.add_component("Resistor", (0, 0))
 
         data_received = []
-        ctrl.add_observer(lambda e, d: data_received.append(d) if e == "component_moved" else None)
+        ctrl.add_observer(
+            lambda e, d: data_received.append(d) if e == "component_moved" else None
+        )
 
         ctrl.move_component(comp.component_id, (50, 75))
 

--- a/app/tests/unit/test_wire_z_order.py
+++ b/app/tests/unit/test_wire_z_order.py
@@ -13,7 +13,9 @@ def _make_mock_component(comp_id, terminal_pos=None):
     """Create a mock component with terminal positions."""
     comp = MagicMock()
     comp.component_id = comp_id
-    comp.get_terminal_pos = MagicMock(return_value=terminal_pos if terminal_pos else QPointF(0, 0))
+    comp.get_terminal_pos = MagicMock(
+        return_value=terminal_pos if terminal_pos else QPointF(0, 0)
+    )
     return comp
 
 
@@ -104,5 +106,7 @@ class TestWireZOrder:
             end_terminal=0,
         )
         components_dict = {"R1": start, "R2": end}
-        wire = WireGraphicsItem.from_dict(wire_data.to_dict(), components_dict, canvas=None)
+        wire = WireGraphicsItem.from_dict(
+            wire_data.to_dict(), components_dict, canvas=None
+        )
         assert wire.zValue() == 1


### PR DESCRIPTION
## Summary
- Add `locked: bool` field to ComponentData for marking components as non-modifiable
- Add `locked_components: list[str]` to TemplateData for specifying which components to lock
- TemplateController applies locked state when creating circuits from templates
- Visual lock indicator (dashed border + lock icon) on locked components in canvas
- Locked components are non-movable and non-selectable

Closes #378

## Test plan
- [x] 21 unit tests covering model serialization, template roundtrip, and structural checks
- [x] Backwards compatibility: missing locked field defaults to False
- [x] Nonexistent component IDs in locked_components are silently ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)