### PR TITLE
feat: add coverage threshold to CI (closes #360)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,12 @@ jobs:
         working-directory: app
         env:
           QT_QPA_PLATFORM: offscreen
-        run: xvfb-run python -m pytest tests/ -v --tb=short --cov=. --cov-report=term-missing
+        run: xvfb-run python -m pytest tests/ -v --tb=short --cov=. --cov-report=term-missing --cov-fail-under=80
 
       - name: Run tests with coverage (Windows)
         if: runner.os == 'Windows'
         working-directory: app
-        run: python -m pytest tests/ -v --tb=short --cov=. --cov-report=term-missing
+        run: python -m pytest tests/ -v --tb=short --cov=. --cov-report=term-missing --cov-fail-under=80
 
   import-check:
     name: Import Check

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ help:  ## Show this help message
 	@echo 'Available targets:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-test:  ## Run pytest test suite
-	cd app && python -m pytest tests/ -v --tb=short
+test:  ## Run pytest test suite with coverage
+	cd app && python -m pytest tests/ -v --tb=short --cov=. --cov-report=term-missing --cov-fail-under=80
 
 lint:  ## Run linting checks (ruff + isort + ruff-format + black)
 	ruff check app/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,19 @@
 [tool.pytest.ini_options]
 pythonpath = ["app"]
 testpaths = ["app/tests"]
+
+[tool.coverage.run]
+source = ["."]
+omit = [
+    "tests/*",
+    "conftest.py",
+]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+]


### PR DESCRIPTION
## Summary
- Add `--cov-fail-under=80` to CI test steps (both Linux and Windows) to prevent coverage regressions
- Add `[tool.coverage.run]` and `[tool.coverage.report]` configuration to `pyproject.toml` (source paths, omit patterns, excluded lines, fail threshold)
- Update `Makefile` test target to include coverage reporting (`--cov`, `--cov-report=term-missing`, `--cov-fail-under=80`) so developers see coverage locally

Current coverage is ~85%. The 80% threshold is intentionally permissive to accommodate variance across Python versions (3.11/3.12/3.13) and platforms (Linux/Windows), as recommended in the issue. It can be ratcheted up as test coverage improves.

## Test plan
- [x] `--cov-fail-under=80` passes locally (84.60% actual coverage, 2849 tests pass)
- [x] All pre-commit hooks pass (yaml check, toml check, etc.)
- [x] Formatting and linting clean
- [x] CI workflow syntax validated by pre-commit yaml check

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)