### PR TITLE
Add simulation result history for before/after comparison (#232)

### DIFF
--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -6,6 +6,7 @@ configuration, circuit validation, netlist generation, ngspice
 execution, and result parsing.
 """
 
+import hashlib
 import logging
 import os
 from dataclasses import dataclass, field
@@ -13,6 +14,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 from models.circuit import CircuitModel
+from models.simulation_history import SimulationHistoryManager
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +47,7 @@ class SimulationController:
         self.model = model or CircuitModel()
         self.circuit_ctrl = circuit_ctrl  # Phase 5: For observer notifications
         self._runner = None
+        self.history = SimulationHistoryManager()
 
     @property
     def runner(self):
@@ -186,6 +189,7 @@ class SimulationController:
                             warnings=validation.warnings
                             + ["Simulation converged with relaxed tolerances (results may be less accurate)."],
                         )
+                        self._record_to_history(result)
                         if self.circuit_ctrl:
                             self.circuit_ctrl._notify("simulation_completed", result)
                         return result
@@ -209,6 +213,9 @@ class SimulationController:
             raw_output=stdout,
             warnings=validation.warnings,
         )
+
+        # Record successful result in history
+        self._record_to_history(result)
 
         # Phase 5: Notify simulation completed
         if self.circuit_ctrl:
@@ -547,6 +554,35 @@ class SimulationController:
             data=mc_data,
             errors=errors,
             warnings=validation.warnings,
+        )
+
+    def _compute_component_hash(self) -> str:
+        """Compute a hash of the circuit structure (components + wires).
+
+        This changes when components are added/removed or wires change,
+        but is stable across value-only modifications.
+        """
+        parts = []
+        for comp_id in sorted(self.model.components):
+            comp = self.model.components[comp_id]
+            parts.append(f"{comp_id}:{comp.component_type}")
+        for wire in self.model.wires:
+            parts.append(
+                f"W:{wire.start_component_id}:{wire.start_terminal}-{wire.end_component_id}:{wire.end_terminal}"
+            )
+        return hashlib.sha256("|".join(parts).encode()).hexdigest()[:16]
+
+    def _record_to_history(self, result: "SimulationResult") -> None:
+        """Record a successful simulation result in history."""
+        if not result.success or result.data is None:
+            return
+        comp_hash = self._compute_component_hash()
+        self.history.clear_on_structural_change(comp_hash)
+        self.history.add(
+            analysis_type=result.analysis_type,
+            data=result.data,
+            netlist=result.netlist,
+            component_hash=comp_hash,
         )
 
     @staticmethod

--- a/app/models/simulation_history.py
+++ b/app/models/simulation_history.py
@@ -1,0 +1,205 @@
+"""
+SimulationHistoryManager - Stores recent simulation results for comparison.
+
+This module contains no Qt dependencies. It manages a bounded list of
+simulation snapshots that can be overlaid in the waveform viewer.
+"""
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+
+
+@dataclass
+class SimulationSnapshot:
+    """A single stored simulation result.
+
+    Attributes:
+        timestamp: When the simulation was run.
+        label: User-provided or auto-generated description.
+        analysis_type: The type of analysis (e.g. "Transient", "DC Sweep").
+        data: Parsed result data (same format as SimulationResult.data).
+        netlist: The netlist used for this simulation.
+        pinned: If True, this snapshot is protected from eviction.
+        component_hash: Hash of circuit structure for detecting structural changes.
+    """
+
+    timestamp: datetime
+    label: str
+    analysis_type: str
+    data: Any
+    netlist: str = ""
+    pinned: bool = False
+    component_hash: str = ""
+
+    def to_summary(self) -> dict:
+        """Return a summary dict suitable for display in the UI."""
+        return {
+            "timestamp": self.timestamp.isoformat(),
+            "label": self.label,
+            "analysis_type": self.analysis_type,
+            "pinned": self.pinned,
+        }
+
+
+class SimulationHistoryManager:
+    """Manages a bounded collection of simulation result snapshots.
+
+    Stores the last N results so users can compare before/after changes.
+    History clears on structural circuit changes (add/remove components)
+    but persists across value-only changes. Pinned results survive clearing.
+
+    Args:
+        max_size: Maximum number of snapshots to retain (default 5).
+    """
+
+    def __init__(self, max_size: int = 5):
+        self._max_size = max_size
+        self._snapshots: deque[SimulationSnapshot] = deque()
+
+    @property
+    def max_size(self) -> int:
+        return self._max_size
+
+    @max_size.setter
+    def max_size(self, value: int) -> None:
+        if value < 1:
+            raise ValueError("max_size must be at least 1")
+        self._max_size = value
+        self._evict()
+
+    def add(
+        self,
+        analysis_type: str,
+        data: Any,
+        netlist: str = "",
+        label: Optional[str] = None,
+        component_hash: str = "",
+    ) -> SimulationSnapshot:
+        """Add a simulation result to history.
+
+        If the history is full, the oldest unpinned snapshot is evicted.
+
+        Args:
+            analysis_type: Analysis type string.
+            data: Parsed result data.
+            netlist: The netlist used.
+            label: Optional description. Auto-generated from timestamp if None.
+            component_hash: Hash of circuit structure.
+
+        Returns:
+            The created SimulationSnapshot.
+        """
+        now = datetime.now()
+        if label is None:
+            label = now.strftime("Run %H:%M:%S")
+
+        snapshot = SimulationSnapshot(
+            timestamp=now,
+            label=label,
+            analysis_type=analysis_type,
+            data=data,
+            netlist=netlist,
+            component_hash=component_hash,
+        )
+        self._snapshots.append(snapshot)
+        self._evict()
+        return snapshot
+
+    def get_all(self) -> list[SimulationSnapshot]:
+        """Return all snapshots in chronological order (oldest first)."""
+        return list(self._snapshots)
+
+    def get_latest(self) -> Optional[SimulationSnapshot]:
+        """Return the most recent snapshot, or None if empty."""
+        return self._snapshots[-1] if self._snapshots else None
+
+    def get_by_index(self, index: int) -> SimulationSnapshot:
+        """Return a snapshot by index (0 = oldest).
+
+        Raises:
+            IndexError: If index is out of range.
+        """
+        return self._snapshots[index]
+
+    def count(self) -> int:
+        """Return the number of stored snapshots."""
+        return len(self._snapshots)
+
+    def pin(self, index: int) -> None:
+        """Pin a snapshot to prevent eviction.
+
+        Raises:
+            IndexError: If index is out of range.
+        """
+        self._snapshots[index].pinned = True
+
+    def unpin(self, index: int) -> None:
+        """Unpin a snapshot, allowing eviction.
+
+        Raises:
+            IndexError: If index is out of range.
+        """
+        self._snapshots[index].pinned = False
+
+    def remove(self, index: int) -> SimulationSnapshot:
+        """Remove a snapshot by index.
+
+        Raises:
+            IndexError: If index is out of range.
+        """
+        snapshot = self._snapshots[index]
+        del self._snapshots[index]
+        return snapshot
+
+    def clear(self, keep_pinned: bool = True) -> None:
+        """Remove all snapshots.
+
+        Args:
+            keep_pinned: If True (default), pinned snapshots are preserved.
+        """
+        if keep_pinned:
+            pinned = [s for s in self._snapshots if s.pinned]
+            self._snapshots.clear()
+            self._snapshots.extend(pinned)
+        else:
+            self._snapshots.clear()
+
+    def clear_on_structural_change(self, new_component_hash: str) -> bool:
+        """Clear non-pinned history if circuit structure has changed.
+
+        Compares the new component hash to the most recent snapshot's hash.
+        If they differ, non-pinned snapshots are removed.
+
+        Args:
+            new_component_hash: Hash of the current circuit structure.
+
+        Returns:
+            True if history was cleared, False if unchanged.
+        """
+        latest = self.get_latest()
+        if latest is None:
+            return False
+        if latest.component_hash and latest.component_hash != new_component_hash:
+            self.clear(keep_pinned=True)
+            return True
+        return False
+
+    def get_summaries(self) -> list[dict]:
+        """Return summary dicts for all snapshots (for UI display)."""
+        return [s.to_summary() for s in self._snapshots]
+
+    def _evict(self) -> None:
+        """Remove oldest unpinned snapshots until within max_size."""
+        while len(self._snapshots) > self._max_size:
+            # Find oldest unpinned snapshot
+            evicted = False
+            for i, s in enumerate(self._snapshots):
+                if not s.pinned:
+                    del self._snapshots[i]
+                    evicted = True
+                    break
+            if not evicted:
+                # All remaining snapshots are pinned; allow over-limit
+                break

--- a/app/tests/unit/test_simulation_history.py
+++ b/app/tests/unit/test_simulation_history.py
@@ -1,0 +1,371 @@
+"""Tests for simulation result history and comparison (issue #232).
+
+Covers: history storage, eviction, pinning, structural change detection,
+and integration with SimulationController.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from controllers.circuit_controller import CircuitController
+from controllers.simulation_controller import SimulationController
+from models.circuit import CircuitModel
+from models.simulation_history import SimulationHistoryManager, SimulationSnapshot
+
+# ---------------------------------------------------------------------------
+# SimulationSnapshot tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationSnapshot:
+    """Test the SimulationSnapshot dataclass."""
+
+    def test_create_snapshot(self):
+        snap = SimulationSnapshot(
+            timestamp=datetime(2026, 1, 1, 12, 0),
+            label="Test Run",
+            analysis_type="Transient",
+            data={"time": [0, 1], "v(out)": [0, 5]},
+        )
+        assert snap.label == "Test Run"
+        assert snap.analysis_type == "Transient"
+        assert snap.pinned is False
+
+    def test_snapshot_to_summary(self):
+        snap = SimulationSnapshot(
+            timestamp=datetime(2026, 1, 1, 12, 0),
+            label="Test Run",
+            analysis_type="DC Operating Point",
+            data={},
+            pinned=True,
+        )
+        summary = snap.to_summary()
+        assert summary["label"] == "Test Run"
+        assert summary["analysis_type"] == "DC Operating Point"
+        assert summary["pinned"] is True
+        assert "timestamp" in summary
+
+
+# ---------------------------------------------------------------------------
+# SimulationHistoryManager tests
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryManagerBasic:
+    """Test basic history storage operations."""
+
+    def test_empty_history(self):
+        mgr = SimulationHistoryManager()
+        assert mgr.count() == 0
+        assert mgr.get_latest() is None
+        assert mgr.get_all() == []
+
+    def test_add_single_result(self):
+        mgr = SimulationHistoryManager()
+        snap = mgr.add(
+            analysis_type="DC Operating Point",
+            data={"v(1)": 5.0},
+            label="Run 1",
+        )
+        assert mgr.count() == 1
+        assert snap.label == "Run 1"
+        assert snap.analysis_type == "DC Operating Point"
+
+    def test_add_auto_label(self):
+        mgr = SimulationHistoryManager()
+        snap = mgr.add(analysis_type="Transient", data={})
+        assert snap.label.startswith("Run ")
+
+    def test_add_multiple_results(self):
+        mgr = SimulationHistoryManager(max_size=5)
+        for i in range(3):
+            mgr.add(analysis_type="Transient", data={"run": i}, label=f"Run {i}")
+        assert mgr.count() == 3
+
+    def test_get_latest(self):
+        mgr = SimulationHistoryManager()
+        mgr.add(analysis_type="Transient", data={"run": 0}, label="First")
+        mgr.add(analysis_type="Transient", data={"run": 1}, label="Second")
+        assert mgr.get_latest().label == "Second"
+
+    def test_get_by_index(self):
+        mgr = SimulationHistoryManager()
+        mgr.add(analysis_type="Transient", data={}, label="First")
+        mgr.add(analysis_type="Transient", data={}, label="Second")
+        assert mgr.get_by_index(0).label == "First"
+        assert mgr.get_by_index(1).label == "Second"
+
+    def test_get_by_index_out_of_range(self):
+        mgr = SimulationHistoryManager()
+        with pytest.raises(IndexError):
+            mgr.get_by_index(0)
+
+    def test_remove_by_index(self):
+        mgr = SimulationHistoryManager()
+        mgr.add(analysis_type="Transient", data={}, label="First")
+        mgr.add(analysis_type="Transient", data={}, label="Second")
+        removed = mgr.remove(0)
+        assert removed.label == "First"
+        assert mgr.count() == 1
+        assert mgr.get_by_index(0).label == "Second"
+
+    def test_get_summaries(self):
+        mgr = SimulationHistoryManager()
+        mgr.add(analysis_type="Transient", data={}, label="Run A")
+        mgr.add(analysis_type="DC Sweep", data={}, label="Run B")
+        summaries = mgr.get_summaries()
+        assert len(summaries) == 2
+        assert summaries[0]["label"] == "Run A"
+        assert summaries[1]["analysis_type"] == "DC Sweep"
+
+
+# ---------------------------------------------------------------------------
+# Eviction tests
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryEviction:
+    """Test eviction behavior when history exceeds max_size."""
+
+    def test_eviction_on_overflow(self):
+        mgr = SimulationHistoryManager(max_size=3)
+        for i in range(5):
+            mgr.add(analysis_type="Transient", data={"run": i}, label=f"Run {i}")
+        assert mgr.count() == 3
+        # Oldest unpinned should be evicted
+        assert mgr.get_by_index(0).label == "Run 2"
+
+    def test_eviction_preserves_pinned(self):
+        mgr = SimulationHistoryManager(max_size=3)
+        mgr.add(analysis_type="Transient", data={}, label="Run 0")
+        mgr.pin(0)  # Pin the first
+        for i in range(1, 5):
+            mgr.add(analysis_type="Transient", data={}, label=f"Run {i}")
+        # Pinned Run 0 should still be there
+        labels = [s.label for s in mgr.get_all()]
+        assert "Run 0" in labels
+        assert mgr.count() == 3
+
+    def test_change_max_size(self):
+        mgr = SimulationHistoryManager(max_size=5)
+        for i in range(5):
+            mgr.add(analysis_type="Transient", data={}, label=f"Run {i}")
+        assert mgr.count() == 5
+        mgr.max_size = 2
+        assert mgr.count() == 2
+
+    def test_max_size_validation(self):
+        mgr = SimulationHistoryManager()
+        with pytest.raises(ValueError, match="at least 1"):
+            mgr.max_size = 0
+
+
+# ---------------------------------------------------------------------------
+# Pinning tests
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryPinning:
+    """Test snapshot pinning/unpinning."""
+
+    def test_pin_snapshot(self):
+        mgr = SimulationHistoryManager()
+        mgr.add(analysis_type="Transient", data={}, label="Run 0")
+        mgr.pin(0)
+        assert mgr.get_by_index(0).pinned is True
+
+    def test_unpin_snapshot(self):
+        mgr = SimulationHistoryManager()
+        mgr.add(analysis_type="Transient", data={}, label="Run 0")
+        mgr.pin(0)
+        mgr.unpin(0)
+        assert mgr.get_by_index(0).pinned is False
+
+    def test_pin_out_of_range(self):
+        mgr = SimulationHistoryManager()
+        with pytest.raises(IndexError):
+            mgr.pin(0)
+
+
+# ---------------------------------------------------------------------------
+# Clear tests
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryClear:
+    """Test clearing behavior."""
+
+    def test_clear_all(self):
+        mgr = SimulationHistoryManager()
+        for i in range(3):
+            mgr.add(analysis_type="Transient", data={}, label=f"Run {i}")
+        mgr.clear(keep_pinned=False)
+        assert mgr.count() == 0
+
+    def test_clear_keeps_pinned(self):
+        mgr = SimulationHistoryManager()
+        mgr.add(analysis_type="Transient", data={}, label="Run 0")
+        mgr.pin(0)
+        mgr.add(analysis_type="Transient", data={}, label="Run 1")
+        mgr.clear(keep_pinned=True)
+        assert mgr.count() == 1
+        assert mgr.get_by_index(0).label == "Run 0"
+
+    def test_clear_default_keeps_pinned(self):
+        mgr = SimulationHistoryManager()
+        mgr.add(analysis_type="Transient", data={}, label="Run 0")
+        mgr.pin(0)
+        mgr.add(analysis_type="Transient", data={}, label="Run 1")
+        mgr.clear()
+        assert mgr.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Structural change detection
+# ---------------------------------------------------------------------------
+
+
+class TestStructuralChangeDetection:
+    """Test clearing on structural changes."""
+
+    def test_clear_on_different_hash(self):
+        mgr = SimulationHistoryManager()
+        mgr.add(analysis_type="Transient", data={}, component_hash="hash_v1")
+        mgr.add(analysis_type="Transient", data={}, component_hash="hash_v1")
+        assert mgr.count() == 2
+
+        cleared = mgr.clear_on_structural_change("hash_v2")
+        assert cleared is True
+        assert mgr.count() == 0
+
+    def test_no_clear_on_same_hash(self):
+        mgr = SimulationHistoryManager()
+        mgr.add(analysis_type="Transient", data={}, component_hash="hash_v1")
+        mgr.add(analysis_type="Transient", data={}, component_hash="hash_v1")
+
+        cleared = mgr.clear_on_structural_change("hash_v1")
+        assert cleared is False
+        assert mgr.count() == 2
+
+    def test_clear_on_change_preserves_pinned(self):
+        mgr = SimulationHistoryManager()
+        mgr.add(analysis_type="Transient", data={}, label="Pinned", component_hash="hash_v1")
+        mgr.pin(0)
+        mgr.add(analysis_type="Transient", data={}, label="Not pinned", component_hash="hash_v1")
+
+        cleared = mgr.clear_on_structural_change("hash_v2")
+        assert cleared is True
+        assert mgr.count() == 1
+        assert mgr.get_by_index(0).label == "Pinned"
+
+    def test_no_clear_on_empty_history(self):
+        mgr = SimulationHistoryManager()
+        cleared = mgr.clear_on_structural_change("any_hash")
+        assert cleared is False
+
+
+# ---------------------------------------------------------------------------
+# SimulationController integration
+# ---------------------------------------------------------------------------
+
+
+class TestControllerHistoryIntegration:
+    """Test that SimulationController has history and component hash."""
+
+    def test_controller_has_history(self):
+        model = CircuitModel()
+        ctrl = SimulationController(model)
+        assert isinstance(ctrl.history, SimulationHistoryManager)
+        assert ctrl.history.count() == 0
+
+    def test_compute_component_hash_deterministic(self):
+        model = CircuitModel()
+        cc = CircuitController(model)
+        sim = SimulationController(model, circuit_ctrl=cc)
+
+        cc.add_component("Voltage Source", (0, 0))
+        cc.add_component("Resistor", (100, 0))
+        cc.add_component("Ground", (0, 100))
+        cc.add_wire("V1", 0, "R1", 0)
+
+        hash1 = sim._compute_component_hash()
+        hash2 = sim._compute_component_hash()
+        assert hash1 == hash2
+
+    def test_component_hash_changes_on_add(self):
+        model = CircuitModel()
+        cc = CircuitController(model)
+        sim = SimulationController(model, circuit_ctrl=cc)
+
+        cc.add_component("Voltage Source", (0, 0))
+        hash_before = sim._compute_component_hash()
+
+        cc.add_component("Resistor", (100, 0))
+        hash_after = sim._compute_component_hash()
+
+        assert hash_before != hash_after
+
+    def test_component_hash_stable_on_value_change(self):
+        model = CircuitModel()
+        cc = CircuitController(model)
+        sim = SimulationController(model, circuit_ctrl=cc)
+
+        r1 = cc.add_component("Resistor", (100, 0))
+        hash_before = sim._compute_component_hash()
+
+        r1.value = "10k"
+        hash_after = sim._compute_component_hash()
+
+        assert hash_before == hash_after
+
+    def test_record_to_history(self):
+        """Test _record_to_history adds successful results."""
+        from controllers.simulation_controller import SimulationResult
+
+        model = CircuitModel()
+        cc = CircuitController(model)
+        sim = SimulationController(model, circuit_ctrl=cc)
+
+        cc.add_component("Voltage Source", (0, 0))
+        cc.add_component("Resistor", (100, 0))
+        gnd = cc.add_component("Ground", (0, 100))
+        cc.add_wire("V1", 0, "R1", 0)
+        cc.add_wire("R1", 1, gnd.component_id, 0)
+        cc.add_wire("V1", 1, gnd.component_id, 0)
+
+        result = SimulationResult(
+            success=True,
+            analysis_type="DC Operating Point",
+            data={"v(1)": 5.0},
+            netlist="test netlist",
+        )
+        sim._record_to_history(result)
+        assert sim.history.count() == 1
+
+    def test_record_skips_failed_results(self):
+        """Failed results should not be stored in history."""
+        from controllers.simulation_controller import SimulationResult
+
+        model = CircuitModel()
+        sim = SimulationController(model)
+
+        result = SimulationResult(success=False, error="Failed")
+        sim._record_to_history(result)
+        assert sim.history.count() == 0
+
+    def test_record_skips_null_data(self):
+        """Results with no data should not be stored."""
+        from controllers.simulation_controller import SimulationResult
+
+        model = CircuitModel()
+        sim = SimulationController(model)
+
+        result = SimulationResult(success=True, analysis_type="DC Operating Point", data=None)
+        sim._record_to_history(result)
+        assert sim.history.count() == 0
+
+    def test_history_default_max_size(self):
+        """Default history size should be 5."""
+        model = CircuitModel()
+        sim = SimulationController(model)
+        assert sim.history.max_size == 5


### PR DESCRIPTION
## Summary
- Adds `SimulationHistoryManager` model (`app/models/simulation_history.py`) that stores the last N simulation results (default 5)
- Supports eviction (oldest unpinned removed when full), pinning (protect results from eviction), and structural change detection (auto-clear on circuit topology changes)
- Integrates with `SimulationController` to automatically record successful results
- Component hash tracks circuit structure (components + wires) to distinguish structural changes from value-only changes
- 33 new tests covering storage, eviction, pinning, clearing, structural change detection, and controller integration

## Test plan
- [x] 33 unit tests pass
- [x] Existing tests unaffected
- [ ] Manual: Run multiple simulations, verify history accumulates
- [ ] Manual: Pin a result, verify it survives eviction and structural changes

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)