### PR TITLE
Add partial credit scoring to grading engine (#370)

### DIFF
--- a/app/GUI/grading_panel.py
+++ b/app/GUI/grading_panel.py
@@ -226,17 +226,19 @@ class GradingPanel(QWidget):
             if cr.passed:
                 icon = "\u2714"  # checkmark
                 text = f"{icon} {cr.check_id}: +{cr.points_earned}/{cr.points_possible}"
+                color = QColor("green")
+            elif cr.points_earned > 0:
+                icon = "\u25d1"  # half circle — partial credit
+                text = f"{icon} {cr.check_id}: +{cr.points_earned}/{cr.points_possible}"
+                color = QColor("#CC8800")
             else:
                 icon = "\u2718"  # X mark
                 text = f"{icon} {cr.check_id}: 0/{cr.points_possible}"
+                color = QColor("red")
 
             item = QListWidgetItem(text)
             item.setData(Qt.ItemDataRole.UserRole, cr)
-
-            if cr.passed:
-                item.setForeground(QColor("green"))
-            else:
-                item.setForeground(QColor("red"))
+            item.setForeground(color)
 
             self.results_list.addItem(item)
 

--- a/app/grading/circuit_comparer.py
+++ b/app/grading/circuit_comparer.py
@@ -52,6 +52,29 @@ class ComparisonResult:
             self.mismatches.append(result)
 
 
+def compute_value_deviation(expected_str: str, actual_str: str) -> float | None:
+    """Compute the percentage deviation between two SPICE value strings.
+
+    Args:
+        expected_str: Expected value (e.g., "1k", "4.7u").
+        actual_str: Actual value to check.
+
+    Returns:
+        Percentage deviation as a float, or None if either value
+        cannot be parsed as a number.
+    """
+    expected = parse_spice_value(expected_str)
+    actual = parse_spice_value(actual_str)
+
+    if expected is None or actual is None:
+        return None
+
+    if expected == 0:
+        return 0.0 if actual == 0 else float("inf")
+
+    return abs(actual - expected) / abs(expected) * 100
+
+
 def compare_values(expected_str: str, actual_str: str, tolerance_pct: float = 0.0) -> bool:
     """Compare two SPICE value strings with optional tolerance.
 

--- a/app/grading/grader.py
+++ b/app/grading/grader.py
@@ -9,7 +9,7 @@ No Qt dependencies — pure Python module.
 from dataclasses import dataclass, field
 from typing import Optional
 
-from grading.circuit_comparer import CircuitComparer
+from grading.circuit_comparer import CircuitComparer, compute_value_deviation
 from grading.rubric import Rubric, RubricCheck
 from models.circuit import CircuitModel
 
@@ -132,12 +132,37 @@ class CircuitGrader:
 
         cr = self._comparer.check_component_value(student, component_id, expected_value, tolerance_pct)
 
+        if cr.passed:
+            return CheckGradeResult(
+                check_id=check.check_id,
+                passed=True,
+                points_earned=check.points,
+                points_possible=check.points,
+                feedback=check.feedback_pass,
+            )
+
+        # Check failed — try partial credit tiers if configured
+        if check.partial_credit and cr.actual != "component not found":
+            deviation = compute_value_deviation(expected_value, cr.actual)
+            if deviation is not None:
+                for threshold, credit in sorted(check.partial_credit, key=lambda t: t[0]):
+                    if deviation <= threshold:
+                        earned = round(credit / 100.0 * check.points)
+                        return CheckGradeResult(
+                            check_id=check.check_id,
+                            passed=False,
+                            points_earned=earned,
+                            points_possible=check.points,
+                            feedback=f"Partial credit ({credit}%): "
+                            f"{cr.actual} is within {threshold}% of expected {expected_value}",
+                        )
+
         return CheckGradeResult(
             check_id=check.check_id,
-            passed=cr.passed,
-            points_earned=check.points if cr.passed else 0,
+            passed=False,
+            points_earned=0,
             points_possible=check.points,
-            feedback=check.feedback_pass if cr.passed else check.feedback_fail,
+            feedback=check.feedback_fail,
         )
 
     def _check_component_count(

--- a/app/grading/rubric.py
+++ b/app/grading/rubric.py
@@ -27,7 +27,18 @@ VALID_CHECK_TYPES = frozenset(
 
 @dataclass
 class RubricCheck:
-    """A single check in a grading rubric."""
+    """A single check in a grading rubric.
+
+    Attributes:
+        partial_credit: Optional list of [threshold_pct, credit_pct] tiers
+            for graduated scoring on component_value checks. Tiers are
+            evaluated in ascending threshold order; the first tier whose
+            threshold >= the actual deviation is used.
+            Example: [[10, 100], [25, 75], [50, 50]]
+              - within 10% → full credit
+              - within 25% → 75% credit
+              - within 50% → 50% credit
+    """
 
     check_id: str
     check_type: str
@@ -35,9 +46,10 @@ class RubricCheck:
     params: dict = field(default_factory=dict)
     feedback_pass: str = ""
     feedback_fail: str = ""
+    partial_credit: list = field(default_factory=list)
 
     def to_dict(self) -> dict:
-        return {
+        d = {
             "check_id": self.check_id,
             "check_type": self.check_type,
             "points": self.points,
@@ -45,6 +57,9 @@ class RubricCheck:
             "feedback_pass": self.feedback_pass,
             "feedback_fail": self.feedback_fail,
         }
+        if self.partial_credit:
+            d["partial_credit"] = [list(tier) for tier in self.partial_credit]
+        return d
 
     @classmethod
     def from_dict(cls, data: dict) -> "RubricCheck":
@@ -55,6 +70,7 @@ class RubricCheck:
             params=dict(data.get("params", {})),
             feedback_pass=data.get("feedback_pass", ""),
             feedback_fail=data.get("feedback_fail", ""),
+            partial_credit=[list(tier) for tier in data.get("partial_credit", [])],
         )
 
 
@@ -123,6 +139,29 @@ def validate_rubric(data: dict) -> None:
         check_ids.add(check["check_id"])
 
         points_sum += check["points"]
+
+        # Validate partial_credit if present
+        partial_credit = check.get("partial_credit")
+        if partial_credit is not None:
+            if not isinstance(partial_credit, list):
+                raise ValueError(f"Check '{check['check_id']}': partial_credit must be a list.")
+            for j, tier in enumerate(partial_credit):
+                if not isinstance(tier, (list, tuple)) or len(tier) != 2:
+                    raise ValueError(
+                        f"Check '{check['check_id']}': partial_credit tier #{j + 1} "
+                        f"must be a [threshold_pct, credit_pct] pair."
+                    )
+                threshold, credit = tier
+                if not isinstance(threshold, (int, float)) or threshold < 0:
+                    raise ValueError(
+                        f"Check '{check['check_id']}': partial_credit tier #{j + 1} "
+                        f"threshold must be a non-negative number."
+                    )
+                if not isinstance(credit, (int, float)) or credit < 0 or credit > 100:
+                    raise ValueError(
+                        f"Check '{check['check_id']}': partial_credit tier #{j + 1} "
+                        f"credit_pct must be between 0 and 100."
+                    )
 
     if points_sum != data["total_points"]:
         raise ValueError(f"Check points sum to {points_sum}, but total_points is {data['total_points']}.")

--- a/app/tests/unit/test_rubric_grader.py
+++ b/app/tests/unit/test_rubric_grader.py
@@ -489,3 +489,328 @@ class TestGradingResult:
             earned_points=75,
         )
         assert result.percentage == 75.0
+
+
+# --- Tests: Partial credit ---
+
+
+class TestPartialCreditSerialization:
+    def test_partial_credit_to_dict_empty(self):
+        check = RubricCheck(check_id="v1", check_type="component_value", points=20)
+        d = check.to_dict()
+        assert "partial_credit" not in d
+
+    def test_partial_credit_to_dict_with_tiers(self):
+        check = RubricCheck(
+            check_id="v1",
+            check_type="component_value",
+            points=20,
+            partial_credit=[[10, 100], [25, 75], [50, 50]],
+        )
+        d = check.to_dict()
+        assert d["partial_credit"] == [[10, 100], [25, 75], [50, 50]]
+
+    def test_partial_credit_from_dict_missing(self):
+        data = {"check_id": "v1", "check_type": "component_value", "points": 20}
+        check = RubricCheck.from_dict(data)
+        assert check.partial_credit == []
+
+    def test_partial_credit_from_dict_round_trip(self):
+        tiers = [[10, 100], [25, 75], [50, 50]]
+        check = RubricCheck(
+            check_id="v1",
+            check_type="component_value",
+            points=20,
+            partial_credit=tiers,
+        )
+        restored = RubricCheck.from_dict(check.to_dict())
+        assert restored.partial_credit == tiers
+
+    def test_rubric_round_trip_with_partial_credit(self, tmp_path):
+        rubric = Rubric(
+            title="Partial Test",
+            total_points=20,
+            checks=[
+                RubricCheck(
+                    check_id="r1_val",
+                    check_type="component_value",
+                    points=20,
+                    params={"component_id": "R1", "expected_value": "1k"},
+                    partial_credit=[[10, 100], [25, 75], [50, 50]],
+                )
+            ],
+        )
+        filepath = tmp_path / "partial.spice-rubric"
+        save_rubric(rubric, filepath)
+        loaded = load_rubric(filepath)
+        assert loaded.checks[0].partial_credit == [[10, 100], [25, 75], [50, 50]]
+
+
+class TestValidatePartialCredit:
+    def test_valid_partial_credit(self):
+        data = {
+            "title": "Test",
+            "total_points": 10,
+            "checks": [
+                {
+                    "check_id": "v1",
+                    "check_type": "component_value",
+                    "points": 10,
+                    "partial_credit": [[10, 100], [25, 75], [50, 50]],
+                }
+            ],
+        }
+        validate_rubric(data)  # Should not raise
+
+    def test_partial_credit_not_a_list(self):
+        data = {
+            "title": "Test",
+            "total_points": 10,
+            "checks": [
+                {
+                    "check_id": "v1",
+                    "check_type": "component_value",
+                    "points": 10,
+                    "partial_credit": "invalid",
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="must be a list"):
+            validate_rubric(data)
+
+    def test_partial_credit_tier_not_a_pair(self):
+        data = {
+            "title": "Test",
+            "total_points": 10,
+            "checks": [
+                {
+                    "check_id": "v1",
+                    "check_type": "component_value",
+                    "points": 10,
+                    "partial_credit": [[10]],
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="pair"):
+            validate_rubric(data)
+
+    def test_partial_credit_negative_threshold(self):
+        data = {
+            "title": "Test",
+            "total_points": 10,
+            "checks": [
+                {
+                    "check_id": "v1",
+                    "check_type": "component_value",
+                    "points": 10,
+                    "partial_credit": [[-5, 50]],
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="non-negative"):
+            validate_rubric(data)
+
+    def test_partial_credit_credit_over_100(self):
+        data = {
+            "title": "Test",
+            "total_points": 10,
+            "checks": [
+                {
+                    "check_id": "v1",
+                    "check_type": "component_value",
+                    "points": 10,
+                    "partial_credit": [[10, 150]],
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="between 0 and 100"):
+            validate_rubric(data)
+
+    def test_rubric_without_partial_credit_still_valid(self):
+        data = {
+            "title": "Test",
+            "total_points": 10,
+            "checks": [
+                {"check_id": "g", "check_type": "ground", "points": 10},
+            ],
+        }
+        validate_rubric(data)  # Should not raise
+
+
+class TestPartialCreditGrading:
+    """Test graduated partial credit scoring for component_value checks."""
+
+    def _make_partial_rubric(self, tiers):
+        """Build a single-check rubric with partial credit tiers."""
+        return Rubric(
+            title="Partial Credit Test",
+            total_points=20,
+            checks=[
+                RubricCheck(
+                    check_id="r1_value",
+                    check_type="component_value",
+                    points=20,
+                    params={"component_id": "R1", "expected_value": "1k", "tolerance_pct": 5},
+                    feedback_pass="R1 value correct",
+                    feedback_fail="R1 value incorrect",
+                    partial_credit=tiers,
+                )
+            ],
+        )
+
+    def test_exact_value_gets_full_credit(self):
+        """Exact match still gets full credit with partial tiers configured."""
+        student = _build_rc_filter(r_value="1k")
+        rubric = self._make_partial_rubric([[10, 100], [25, 75], [50, 50]])
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        assert result.earned_points == 20
+        assert result.check_results[0].passed is True
+
+    def test_within_tolerance_gets_full_credit(self):
+        """Value within tolerance_pct passes regardless of partial tiers."""
+        student = _build_rc_filter(r_value="1.04k")  # 4% off, within 5% tolerance
+        rubric = self._make_partial_rubric([[10, 100], [25, 75], [50, 50]])
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        assert result.earned_points == 20
+        assert result.check_results[0].passed is True
+
+    def test_first_tier_partial_credit(self):
+        """Value within first tier but outside tolerance gets tier credit."""
+        student = _build_rc_filter(r_value="1.08k")  # 8% off, within 10% tier
+        rubric = self._make_partial_rubric([[10, 100], [25, 75], [50, 50]])
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        # 8% deviation > 5% tolerance → fails binary check
+        # 8% deviation <= 10% tier → 100% credit = 20 points
+        assert result.earned_points == 20
+        assert result.check_results[0].points_earned == 20
+
+    def test_second_tier_partial_credit(self):
+        """Value within second tier gets reduced credit."""
+        student = _build_rc_filter(r_value="1.2k")  # 20% off
+        rubric = self._make_partial_rubric([[10, 100], [25, 75], [50, 50]])
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        # 20% deviation → second tier (25%, 75%) → 75% of 20 = 15 points
+        assert result.check_results[0].points_earned == 15
+        assert result.check_results[0].passed is False
+        assert "Partial credit" in result.check_results[0].feedback
+        assert result.earned_points == 15
+
+    def test_third_tier_partial_credit(self):
+        """Value within third tier gets minimum credit."""
+        student = _build_rc_filter(r_value="1.4k")  # 40% off
+        rubric = self._make_partial_rubric([[10, 100], [25, 75], [50, 50]])
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        # 40% deviation → third tier (50%, 50%) → 50% of 20 = 10 points
+        assert result.check_results[0].points_earned == 10
+        assert result.earned_points == 10
+
+    def test_beyond_all_tiers_gets_zero(self):
+        """Value beyond all tiers gets zero points."""
+        student = _build_rc_filter(r_value="10k")  # 900% off
+        rubric = self._make_partial_rubric([[10, 100], [25, 75], [50, 50]])
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        assert result.check_results[0].points_earned == 0
+        assert result.check_results[0].passed is False
+
+    def test_missing_component_gets_zero_with_partial(self):
+        """Missing component gets zero even with partial credit configured."""
+        student = _build_rc_filter()
+        del student.components["R1"]
+        student.rebuild_nodes()
+        rubric = self._make_partial_rubric([[10, 100], [25, 75], [50, 50]])
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        assert result.check_results[0].points_earned == 0
+
+    def test_no_partial_credit_backward_compatible(self):
+        """Without partial_credit, binary pass/fail behavior is unchanged."""
+        student = _build_rc_filter(r_value="1.2k")  # 20% off, outside 5% tolerance
+        rubric = Rubric(
+            title="Binary Test",
+            total_points=20,
+            checks=[
+                RubricCheck(
+                    check_id="r1_value",
+                    check_type="component_value",
+                    points=20,
+                    params={"component_id": "R1", "expected_value": "1k", "tolerance_pct": 5},
+                    feedback_pass="OK",
+                    feedback_fail="Wrong",
+                )
+            ],
+        )
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        assert result.check_results[0].points_earned == 0
+        assert result.check_results[0].passed is False
+
+    def test_partial_credit_rounding(self):
+        """Partial credit points are rounded to nearest integer."""
+        # 75% of 7 = 5.25, should round to 5
+        rubric = Rubric(
+            title="Rounding Test",
+            total_points=7,
+            checks=[
+                RubricCheck(
+                    check_id="r1_value",
+                    check_type="component_value",
+                    points=7,
+                    params={"component_id": "R1", "expected_value": "1k", "tolerance_pct": 5},
+                    feedback_pass="OK",
+                    feedback_fail="Wrong",
+                    partial_credit=[[50, 75]],
+                )
+            ],
+        )
+        student = _build_rc_filter(r_value="1.2k")  # 20% off
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        assert result.check_results[0].points_earned == 5  # round(5.25)
+
+    def test_partial_credit_tiers_evaluated_in_threshold_order(self):
+        """Tiers are sorted by threshold — first matching tier wins."""
+        # Define tiers out of order; grader should still sort by threshold
+        rubric = self._make_partial_rubric([[50, 50], [10, 100], [25, 75]])
+        student = _build_rc_filter(r_value="1.08k")  # 8% off
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        # Should match 10% tier (100% credit) even though 50% tier was listed first
+        assert result.check_results[0].points_earned == 20
+
+
+class TestComputeValueDeviation:
+    """Tests for the compute_value_deviation helper."""
+
+    def test_exact_match(self):
+        from grading.circuit_comparer import compute_value_deviation
+
+        assert compute_value_deviation("1k", "1k") == 0.0
+
+    def test_percentage_deviation(self):
+        from grading.circuit_comparer import compute_value_deviation
+
+        dev = compute_value_deviation("1k", "1.1k")
+        assert dev is not None
+        assert abs(dev - 10.0) < 0.01
+
+    def test_unparseable_returns_none(self):
+        from grading.circuit_comparer import compute_value_deviation
+
+        assert compute_value_deviation("abc", "1k") is None
+
+    def test_zero_expected_zero_actual(self):
+        from grading.circuit_comparer import compute_value_deviation
+
+        assert compute_value_deviation("0", "0") == 0.0
+
+    def test_zero_expected_nonzero_actual(self):
+        from grading.circuit_comparer import compute_value_deviation
+
+        dev = compute_value_deviation("0", "1k")
+        assert dev == float("inf")


### PR DESCRIPTION
## Summary
- Add optional partial_credit tolerance tiers to RubricCheck for graduated scoring on component_value checks
- Update CircuitGrader to evaluate tiers and award proportional points (e.g., 75% credit for values within 25% of expected)
- Update GradingPanel to display partial scores with orange color coding alongside green (pass) and red (fail)
- Add compute_value_deviation() helper to circuit_comparer for calculating percentage deviation between SPICE values
- Add validation for partial_credit structure in validate_rubric()
- Fully backward compatible -- rubrics without partial_credit behave exactly as before

Closes #370

## Test plan
- [x] Verify exact match and within-tolerance values still get full credit
- [x] Verify graduated tiers award correct partial points (100%, 75%, 50%)
- [x] Verify values beyond all tiers get zero points
- [x] Verify missing components get zero even with partial credit configured
- [x] Verify backward compatibility (no partial_credit = binary pass/fail)
- [x] Verify rounding behavior for fractional points
- [x] Verify tiers are sorted by threshold regardless of input order
- [x] Verify rubric serialization/deserialization preserves partial_credit
- [x] Verify validation catches invalid partial_credit structures
- [ ] Manual: load a rubric with partial_credit tiers in GradingPanel and verify orange display

Generated with Claude Code