### PR TITLE
Add collapsible category groups to component palette (#259)

### DIFF
--- a/app/GUI/component_palette.py
+++ b/app/GUI/component_palette.py
@@ -1,6 +1,7 @@
-from PyQt6.QtCore import QMimeData, QSize, Qt, pyqtSignal
-from PyQt6.QtGui import QBrush, QDrag, QIcon, QPainter, QPen, QPixmap
-from PyQt6.QtWidgets import QLineEdit, QListWidget, QListWidgetItem, QVBoxLayout, QWidget
+from models.component import COMPONENT_CATEGORIES
+from PyQt6.QtCore import QMimeData, QSettings, QSize, Qt, pyqtSignal
+from PyQt6.QtGui import QBrush, QDrag, QFont, QIcon, QPainter, QPen, QPixmap
+from PyQt6.QtWidgets import QLineEdit, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 
 from .component_item import COMPONENT_CLASSES
 from .styles import COMPONENTS, theme_manager
@@ -65,7 +66,7 @@ def create_component_icon(component_type, size=48):
 
 
 class ComponentPalette(QWidget):
-    """Component palette with search filter and drag support"""
+    """Component palette with collapsible category groups, search filter, and drag support"""
 
     # Signal emitted when component is double-clicked
     componentDoubleClicked = pyqtSignal(str)  # component_type
@@ -84,46 +85,119 @@ class ComponentPalette(QWidget):
         self.search_input.textChanged.connect(self._filter_components)
         layout.addWidget(self.search_input)
 
-        # Component list
-        self.list_widget = _PaletteListWidget()
-        self.list_widget.setDragEnabled(True)
-        self.list_widget.setDefaultDropAction(Qt.DropAction.CopyAction)
-        self.list_widget.setIconSize(QSize(48, 48))
-        self.list_widget.setSpacing(4)
+        # Component tree with collapsible categories
+        self.tree_widget = _PaletteTreeWidget()
+        self.tree_widget.setHeaderHidden(True)
+        self.tree_widget.setDragEnabled(True)
+        self.tree_widget.setDefaultDropAction(Qt.DropAction.CopyAction)
+        self.tree_widget.setIconSize(QSize(48, 48))
+        self.tree_widget.setIndentation(16)
+        self.tree_widget.setAnimated(True)
 
-        for component_name in COMPONENTS.keys():
-            item = QListWidgetItem(component_name)
-            item.setIcon(create_component_icon(component_name))
-            item.setToolTip(COMPONENT_TOOLTIPS.get(component_name, component_name))
-            self.list_widget.addItem(item)
+        # Track category items for persistence and search
+        self._category_items: dict[str, QTreeWidgetItem] = {}
 
-        self.list_widget.itemDoubleClicked.connect(self._on_item_double_clicked)
-        layout.addWidget(self.list_widget)
+        # Load saved expanded state
+        expanded_state = self._load_expanded_state()
 
-    def _on_item_double_clicked(self, item):
-        """Handle double-click on palette item"""
-        self.componentDoubleClicked.emit(item.text())
+        for category_name, component_names in COMPONENT_CATEGORIES.items():
+            category_item = QTreeWidgetItem(self.tree_widget, [category_name])
+            category_item.setFlags(Qt.ItemFlag.ItemIsEnabled)  # clickable but not selectable/draggable
+            bold_font = QFont()
+            bold_font.setBold(True)
+            category_item.setFont(0, bold_font)
+            self._category_items[category_name] = category_item
+
+            for component_name in component_names:
+                if component_name not in COMPONENTS:
+                    continue
+                child = QTreeWidgetItem(category_item, [component_name])
+                child.setIcon(0, create_component_icon(component_name))
+                child.setToolTip(0, COMPONENT_TOOLTIPS.get(component_name, component_name))
+                child.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsDragEnabled)
+
+            # Restore expanded state (default: expanded)
+            is_expanded = expanded_state.get(category_name, True)
+            category_item.setExpanded(is_expanded)
+
+        self.tree_widget.itemDoubleClicked.connect(self._on_item_double_clicked)
+        self.tree_widget.itemExpanded.connect(self._save_expanded_state)
+        self.tree_widget.itemCollapsed.connect(self._save_expanded_state)
+        layout.addWidget(self.tree_widget)
+
+    def _on_item_double_clicked(self, item, column):
+        """Handle double-click on palette item (ignore category headers)."""
+        if item.parent() is not None:
+            self.componentDoubleClicked.emit(item.text(0))
 
     def _filter_components(self, text):
-        """Show/hide components based on search text."""
+        """Show/hide components based on search text. Auto-expand matching categories."""
         text = text.lower()
-        for i in range(self.list_widget.count()):
-            item = self.list_widget.item(i)
-            if item is not None:
-                name = item.text().lower()
-                tooltip = (item.toolTip() or "").lower()
-                item.setHidden(text not in name and text not in tooltip)
+        is_searching = bool(text)
+
+        for category_name, category_item in self._category_items.items():
+            any_child_visible = False
+            for i in range(category_item.childCount()):
+                child = category_item.child(i)
+                name = child.text(0).lower()
+                tooltip = (child.toolTip(0) or "").lower()
+                matches = text in name or text in tooltip
+                child.setHidden(not matches)
+                if matches:
+                    any_child_visible = True
+
+            # Hide entire category if no children match
+            category_item.setHidden(not any_child_visible)
+
+            # Auto-expand categories with matches during search
+            if is_searching and any_child_visible:
+                category_item.setExpanded(True)
+
+        # Restore saved expanded state when search is cleared
+        if not is_searching:
+            saved_state = self._load_expanded_state()
+            for category_name, category_item in self._category_items.items():
+                category_item.setExpanded(saved_state.get(category_name, True))
+
+    def _load_expanded_state(self) -> dict[str, bool]:
+        """Load category expanded/collapsed state from QSettings."""
+        settings = QSettings("SDSMT", "SDM Spice")
+        state = {}
+        for category_name in COMPONENT_CATEGORIES:
+            val = settings.value(f"palette/expanded/{category_name}")
+            if val is not None:
+                state[category_name] = val == "true" or val is True
+            else:
+                state[category_name] = True  # default expanded
+        return state
+
+    def _save_expanded_state(self, _item=None):
+        """Save category expanded/collapsed state to QSettings."""
+        # Don't save while searching (search auto-expands categories)
+        if self.search_input.text():
+            return
+        settings = QSettings("SDSMT", "SDM Spice")
+        for category_name, category_item in self._category_items.items():
+            settings.setValue(f"palette/expanded/{category_name}", category_item.isExpanded())
+
+    def get_all_component_items(self) -> list[QTreeWidgetItem]:
+        """Return all component (leaf) items across all categories."""
+        items = []
+        for category_item in self._category_items.values():
+            for i in range(category_item.childCount()):
+                items.append(category_item.child(i))
+        return items
 
 
-class _PaletteListWidget(QListWidget):
-    """Internal list widget with drag support for the component palette."""
+class _PaletteTreeWidget(QTreeWidget):
+    """Internal tree widget with drag support for the component palette."""
 
     def startDrag(self, supportedActions):
-        """Start drag operation"""
+        """Start drag operation for component items only."""
         item = self.currentItem()
-        if item:
+        if item and item.parent() is not None:
             drag = QDrag(self)
             mime_data = QMimeData()
-            mime_data.setText(item.text())
+            mime_data.setText(item.text(0))
             drag.setMimeData(mime_data)
             drag.exec(Qt.DropAction.CopyAction)

--- a/app/models/component.py
+++ b/app/models/component.py
@@ -38,6 +38,23 @@ COMPONENT_TYPES = [
     "Transformer",
 ]
 
+# Category groupings for the component palette
+COMPONENT_CATEGORIES = {
+    "Passive": ["Resistor", "Capacitor", "Inductor"],
+    "Sources": ["Voltage Source", "Current Source", "Waveform Source"],
+    "Semiconductors": [
+        "Diode",
+        "LED",
+        "Zener Diode",
+        "BJT NPN",
+        "BJT PNP",
+        "MOSFET NMOS",
+        "MOSFET PMOS",
+    ],
+    "Controlled Sources": ["VCVS", "CCVS", "VCCS", "CCCS"],
+    "Other": ["Op-Amp", "VC Switch", "Ground", "Transformer"],
+}
+
 # Mapping of component types to SPICE symbols
 SPICE_SYMBOLS = {
     "Resistor": "R",

--- a/app/tests/unit/test_component_palette.py
+++ b/app/tests/unit/test_component_palette.py
@@ -2,13 +2,26 @@
 Unit tests for ComponentPalette.
 
 Tests component listing, signal emission on double-click,
-drag support configuration, and search filtering.
+drag support configuration, search filtering, and collapsible categories.
 """
 
 import pytest
 from GUI.component_palette import ComponentPalette
 from GUI.styles import COMPONENTS
-from PyQt6.QtCore import Qt
+from models.component import COMPONENT_CATEGORIES
+from PyQt6.QtCore import QSettings, Qt
+
+
+@pytest.fixture(autouse=True)
+def _clear_palette_settings():
+    """Clear palette QSettings before each test to avoid cross-test contamination."""
+    settings = QSettings("SDSMT", "SDM Spice")
+    for category_name in COMPONENT_CATEGORIES:
+        settings.remove(f"palette/expanded/{category_name}")
+    yield
+    # Cleanup after test too
+    for category_name in COMPONENT_CATEGORIES:
+        settings.remove(f"palette/expanded/{category_name}")
 
 
 @pytest.fixture
@@ -18,43 +31,56 @@ def palette(qtbot):
     return p
 
 
+def _visible_component_names(palette):
+    """Return names of all visible (non-hidden) component items."""
+    names = []
+    for item in palette.get_all_component_items():
+        if not item.isHidden():
+            parent = item.parent()
+            if parent is not None and not parent.isHidden():
+                names.append(item.text(0))
+    return names
+
+
 class TestComponentPaletteContents:
     """Test that palette lists all expected components."""
 
     def test_lists_all_component_types(self, palette):
-        lw = palette.list_widget
-        item_texts = [lw.item(i).text() for i in range(lw.count())]
+        item_texts = [item.text(0) for item in palette.get_all_component_items()]
         for comp_type in COMPONENTS:
             assert comp_type in item_texts
 
     def test_item_count_matches_components(self, palette):
-        assert palette.list_widget.count() == len(COMPONENTS)
+        assert len(palette.get_all_component_items()) == len(COMPONENTS)
 
     def test_items_have_icons(self, palette):
-        lw = palette.list_widget
-        for i in range(lw.count()):
-            assert not lw.item(i).icon().isNull()
+        for item in palette.get_all_component_items():
+            assert not item.icon(0).isNull()
 
 
 class TestComponentPaletteSignals:
     """Test signal emission on interaction."""
 
     def test_double_click_emits_component_type(self, palette, qtbot):
-        lw = palette.list_widget
-        first_item = lw.item(0)
+        first_item = palette.get_all_component_items()[0]
         with qtbot.waitSignal(palette.componentDoubleClicked, timeout=1000) as blocker:
-            lw.itemDoubleClicked.emit(first_item)
-        assert blocker.args == [first_item.text()]
+            palette.tree_widget.itemDoubleClicked.emit(first_item, 0)
+        assert blocker.args == [first_item.text(0)]
+
+    def test_double_click_on_category_does_not_emit(self, palette, qtbot):
+        category_item = list(palette._category_items.values())[0]
+        with qtbot.assertNotEmitted(palette.componentDoubleClicked):
+            palette.tree_widget.itemDoubleClicked.emit(category_item, 0)
 
 
 class TestComponentPaletteDragConfig:
     """Test drag-and-drop configuration."""
 
     def test_drag_enabled(self, palette):
-        assert palette.list_widget.dragEnabled()
+        assert palette.tree_widget.dragEnabled()
 
     def test_default_drop_action_is_copy(self, palette):
-        assert palette.list_widget.defaultDropAction() == Qt.DropAction.CopyAction
+        assert palette.tree_widget.defaultDropAction() == Qt.DropAction.CopyAction
 
 
 class TestComponentPaletteSearch:
@@ -62,36 +88,122 @@ class TestComponentPaletteSearch:
 
     def test_filter_hides_non_matching(self, palette):
         palette.search_input.setText("resistor")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = _visible_component_names(palette)
         assert "Resistor" in visible
         assert "Capacitor" not in visible
 
     def test_filter_is_case_insensitive(self, palette):
         palette.search_input.setText("CAPACITOR")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = _visible_component_names(palette)
         assert "Capacitor" in visible
 
     def test_empty_filter_shows_all(self, palette):
         palette.search_input.setText("xyz")
         palette.search_input.setText("")
-        lw = palette.list_widget
-        visible_count = sum(1 for i in range(lw.count()) if not lw.item(i).isHidden())
-        assert visible_count == len(COMPONENTS)
+        visible = _visible_component_names(palette)
+        assert len(visible) == len(COMPONENTS)
 
     def test_filter_matches_tooltip(self, palette):
         # "Resists" appears in the Resistor tooltip
         palette.search_input.setText("resists")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = _visible_component_names(palette)
         assert "Resistor" in visible
 
     def test_filter_no_matches(self, palette):
         palette.search_input.setText("xyznonexistent")
-        lw = palette.list_widget
-        visible_count = sum(1 for i in range(lw.count()) if not lw.item(i).isHidden())
-        assert visible_count == 0
+        visible = _visible_component_names(palette)
+        assert len(visible) == 0
 
     def test_search_input_has_placeholder(self, palette):
         assert "filter" in palette.search_input.placeholderText().lower()
+
+
+class TestComponentPaletteCategories:
+    """Test collapsible category group functionality."""
+
+    def test_all_categories_present(self, palette):
+        for category_name in COMPONENT_CATEGORIES:
+            assert category_name in palette._category_items
+
+    def test_category_count(self, palette):
+        assert len(palette._category_items) == len(COMPONENT_CATEGORIES)
+
+    def test_categories_default_expanded(self, palette):
+        for category_item in palette._category_items.values():
+            assert category_item.isExpanded()
+
+    def test_category_collapse_and_expand(self, palette):
+        cat_item = list(palette._category_items.values())[0]
+        cat_item.setExpanded(False)
+        assert not cat_item.isExpanded()
+        cat_item.setExpanded(True)
+        assert cat_item.isExpanded()
+
+    def test_category_items_are_not_draggable(self, palette):
+        for category_item in palette._category_items.values():
+            flags = category_item.flags()
+            assert not (flags & Qt.ItemFlag.ItemIsDragEnabled)
+
+    def test_component_items_are_draggable(self, palette):
+        for item in palette.get_all_component_items():
+            flags = item.flags()
+            assert flags & Qt.ItemFlag.ItemIsDragEnabled
+
+    def test_search_auto_expands_matching_categories(self, palette):
+        # Collapse all categories first
+        for cat_item in palette._category_items.values():
+            cat_item.setExpanded(False)
+        # Search for a passive component
+        palette.search_input.setText("resistor")
+        assert palette._category_items["Passive"].isExpanded()
+
+    def test_search_hides_non_matching_categories(self, palette):
+        palette.search_input.setText("resistor")
+        # Semiconductors category should be hidden (no match)
+        assert palette._category_items["Semiconductors"].isHidden()
+        # Passive category should be visible
+        assert not palette._category_items["Passive"].isHidden()
+
+    def test_clear_search_restores_collapsed_state(self, palette):
+        # Collapse one category
+        palette._category_items["Passive"].setExpanded(False)
+        palette._save_expanded_state()
+        # Search expands it
+        palette.search_input.setText("resistor")
+        assert palette._category_items["Passive"].isExpanded()
+        # Clear search restores collapsed state
+        palette.search_input.setText("")
+        assert not palette._category_items["Passive"].isExpanded()
+
+    def test_components_grouped_correctly(self, palette):
+        for category_name, expected_components in COMPONENT_CATEGORIES.items():
+            category_item = palette._category_items[category_name]
+            actual_names = [category_item.child(i).text(0) for i in range(category_item.childCount())]
+            for comp_name in expected_components:
+                if comp_name in COMPONENTS:
+                    assert comp_name in actual_names
+
+
+class TestComponentPaletteSettingsPersistence:
+    """Test QSettings persistence of expanded/collapsed state."""
+
+    def test_save_and_load_expanded_state(self, palette):
+        # Collapse a category
+        palette._category_items["Passive"].setExpanded(False)
+        palette._save_expanded_state()
+        # Verify saved state
+        state = palette._load_expanded_state()
+        assert state["Passive"] is False
+        # Verify others remain expanded
+        assert state["Sources"] is True
+
+    def test_new_palette_loads_saved_state(self, qtbot):
+        # Save collapsed state
+        settings = QSettings("SDSMT", "SDM Spice")
+        settings.setValue("palette/expanded/Passive", False)
+        settings.setValue("palette/expanded/Sources", True)
+        # Create new palette instance
+        p2 = ComponentPalette()
+        qtbot.addWidget(p2)
+        assert not p2._category_items["Passive"].isExpanded()
+        assert p2._category_items["Sources"].isExpanded()

--- a/app/tests/unit/test_keyboard_navigation.py
+++ b/app/tests/unit/test_keyboard_navigation.py
@@ -84,7 +84,7 @@ class TestTabOrder:
 
         palette = ComponentPalette()
         qtbot.addWidget(palette)
-        # QListWidget default or set by MainWindow
+        # QTreeWidget default or set by MainWindow
         policy = palette.focusPolicy()
         # Should accept some form of focus
         assert policy != Qt.FocusPolicy.NoFocus

--- a/app/tests/unit/test_qtbot_widget_interactions.py
+++ b/app/tests/unit/test_qtbot_widget_interactions.py
@@ -123,15 +123,21 @@ class TestComponentPaletteInteractions:
     def test_search_for_op_amp(self, palette):
         """Searching 'op' shows Op-Amp."""
         palette.search_input.setText("op")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = [
+            item.text(0)
+            for item in palette.get_all_component_items()
+            if not item.isHidden() and not item.parent().isHidden()
+        ]
         assert "Op-Amp" in visible
 
     def test_search_for_diode(self, palette):
         """Searching 'diode' shows Diode, LED, and Zener Diode."""
         palette.search_input.setText("diode")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = [
+            item.text(0)
+            for item in palette.get_all_component_items()
+            if not item.isHidden() and not item.parent().isHidden()
+        ]
         assert "Diode" in visible
         assert "Zener Diode" in visible
 
@@ -139,9 +145,12 @@ class TestComponentPaletteInteractions:
         """Clearing search shows all items again."""
         palette.search_input.setText("xyz_no_match")
         palette.search_input.clear()
-        lw = palette.list_widget
-        visible = sum(1 for i in range(lw.count()) if not lw.item(i).isHidden())
-        assert visible == lw.count()
+        visible = [
+            item.text(0)
+            for item in palette.get_all_component_items()
+            if not item.isHidden() and not item.parent().isHidden()
+        ]
+        assert len(visible) == len(palette.get_all_component_items())
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Replace flat QListWidget with QTreeWidget organized into 5 collapsible categories: Passive, Sources, Semiconductors, Controlled Sources, Other
- Add COMPONENT_CATEGORIES mapping to models/component.py as canonical category definition
- Expanded/collapsed state persists across sessions via QSettings
- Search filter auto-expands matching categories and hides non-matching ones
- Drag-and-drop and double-click still work (category headers not draggable)
- 25 unit tests total (13 new tests covering categories, persistence, signals, and drag behavior)

## Test plan
- [x] All 2505 existing tests pass
- [x] 25 palette-specific tests pass including 13 new ones
- [ ] Manual: verify categories collapse/expand with click
- [ ] Manual: verify search auto-expands matching categories
- [ ] Manual: verify collapsed state persists after restart
- [ ] Manual: verify drag-and-drop from palette to canvas
- [ ] Manual: verify double-click placement still works

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)