### PR TITLE
fix component flip not rendering visually (#113)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -616,7 +616,10 @@ class CircuitCanvasView(QGraphicsView):
                 if main_window and hasattr(main_window, "statusBar"):
                     status = main_window.statusBar()
                     if status:
-                        status.showMessage("No simulation results available. Run a simulation first.", 3000)
+                        status.showMessage(
+                            "No simulation results available. Run a simulation first.",
+                            3000,
+                        )
             event.accept()
             return
 
@@ -845,6 +848,19 @@ class CircuitCanvasView(QGraphicsView):
     def zoom_out(self, center_point=None):
         """Zoom out by one step, optionally centered on a point."""
         self._apply_zoom(1.0 / ZOOM_FACTOR, center_point)
+
+    def set_default_zoom(self, percent):
+        """Set the zoom level to the given percentage (e.g. 100 = 100%).
+
+        Used to apply the user's preferred default zoom level when
+        opening a new circuit or launching the application.
+        """
+        scale_factor = percent / 100.0
+        # Clamp to allowed zoom range
+        scale_factor = max(ZOOM_MIN, min(ZOOM_MAX, scale_factor))
+        self.resetTransform()
+        self.scale(scale_factor, scale_factor)
+        self.zoomChanged.emit(self.get_zoom_level())
 
     def zoom_reset(self):
         """Reset zoom to 100%."""

--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -152,6 +152,7 @@ class CircuitCanvasView(QGraphicsView):
             "wire_added": self._handle_wire_added,
             "wire_removed": self._handle_wire_removed,
             "wire_routed": self._handle_wire_routed,
+            "wire_lock_changed": self._handle_wire_lock_changed,
             "circuit_cleared": self._handle_circuit_cleared,
             "nodes_rebuilt": self._handle_nodes_rebuilt,
             "model_loaded": self._handle_model_loaded,
@@ -314,6 +315,12 @@ class CircuitCanvasView(QGraphicsView):
                 wire.waypoints = [QPointF(x, y) for x, y in wire_data.waypoints]
                 if hasattr(wire, "update_path"):
                     wire.update_path()
+
+    def _handle_wire_lock_changed(self, data) -> None:
+        """Update wire visual when lock state changes."""
+        wire_index, locked = data
+        if 0 <= wire_index < len(self.wires):
+            self.wires[wire_index].update()
 
     def _handle_annotation_added(self, annotation_data) -> None:
         """Create AnnotationItem when annotation added to model."""
@@ -502,6 +509,9 @@ class CircuitCanvasView(QGraphicsView):
         wire_count = 0
         for wire in self.wires:
             if wire.start_comp == component or wire.end_comp == component:
+                # Skip locked wires (user pinned the path)
+                if wire.model.locked:
+                    continue
                 # Skip if both endpoints are co-selected and the other has lower ID
                 # (that endpoint's reroute call will handle this wire)
                 other = wire.end_comp if wire.start_comp == component else wire.start_comp
@@ -537,6 +547,8 @@ class CircuitCanvasView(QGraphicsView):
         rerouted = 0
         for wire in self.wires:
             if wire.start_comp in components or wire.end_comp in components:
+                if wire.model.locked:
+                    continue
                 wire.update_position()
                 rerouted += 1
         if rerouted > 0:
@@ -966,13 +978,23 @@ class CircuitCanvasView(QGraphicsView):
             delete_action.triggered.connect(lambda: self.delete_wire(item))
             menu.addAction(delete_action)
 
+            menu.addSeparator()
+
+            # Lock/Unlock wire path toggle
+            if item.model.locked:
+                lock_action = QAction("Unlock Wire Path", self)
+                lock_action.triggered.connect(lambda: self.toggle_wire_lock(item, False))
+            else:
+                lock_action = QAction("Lock Wire Path", self)
+                lock_action.triggered.connect(lambda: self.toggle_wire_lock(item, True))
+            menu.addAction(lock_action)
+
             if item.node:
                 menu.addSeparator()
                 current = item.node.get_label()
                 label_action = QAction(f"Set Net Name ({current})...", self)
                 label_action.triggered.connect(lambda: self.label_node(item.node))
                 menu.addAction(label_action)
-            pass
         else:
             # Check if we clicked near a terminal to set its net name
             clicked_node = self.find_node_at_position(scene_pos)
@@ -1087,6 +1109,22 @@ class CircuitCanvasView(QGraphicsView):
 
         wire_index = self.wires.index(wire)
         cmd = DeleteWireCommand(self.controller, wire_index)
+        self.controller.execute_command(cmd)
+
+    def toggle_wire_lock(self, wire, locked):
+        """Lock or unlock a wire's path via undo/redo command."""
+        if wire is None:
+            return
+        if not self.controller:
+            logger.warning("Cannot toggle wire lock: no controller available")
+            return
+        if wire not in self.wires:
+            return
+
+        from controllers.commands import ToggleWireLockCommand
+
+        wire_index = self.wires.index(wire)
+        cmd = ToggleWireLockCommand(self.controller, wire_index, locked)
         self.controller.execute_command(cmd)
 
     def rotate_component(self, component, clockwise=True):

--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -152,6 +152,7 @@ class CircuitCanvasView(QGraphicsView):
             "wire_added": self._handle_wire_added,
             "wire_removed": self._handle_wire_removed,
             "wire_routed": self._handle_wire_routed,
+            "wire_reroute_requested": self._handle_wire_reroute_requested,
             "circuit_cleared": self._handle_circuit_cleared,
             "nodes_rebuilt": self._handle_nodes_rebuilt,
             "model_loaded": self._handle_model_loaded,
@@ -314,6 +315,15 @@ class CircuitCanvasView(QGraphicsView):
                 wire.waypoints = [QPointF(x, y) for x, y in wire_data.waypoints]
                 if hasattr(wire, "update_path"):
                     wire.update_path()
+
+    def _handle_wire_reroute_requested(self, wire_index) -> None:
+        """Force fresh pathfinding on a wire."""
+        if 0 <= wire_index < len(self.wires):
+            wire = self.wires[wire_index]
+            wire.update_position()
+            # Sync the new waypoints back to the model
+            model_wire = self.controller.model.wires[wire_index]
+            model_wire.waypoints = [(wp.x(), wp.y()) for wp in wire.waypoints]
 
     def _handle_annotation_added(self, annotation_data) -> None:
         """Create AnnotationItem when annotation added to model."""
@@ -966,13 +976,24 @@ class CircuitCanvasView(QGraphicsView):
             delete_action.triggered.connect(lambda: self.delete_wire(item))
             menu.addAction(delete_action)
 
+            menu.addSeparator()
+
+            # Check if multiple wires are selected
+            selected_wires = [i for i in self.scene.selectedItems() if isinstance(i, WireItem)]
+            if len(selected_wires) > 1 and item in selected_wires:
+                reroute_action = QAction(f"Reroute Selected Wires ({len(selected_wires)})", self)
+                reroute_action.triggered.connect(lambda: self.reroute_selected_wires(selected_wires))
+            else:
+                reroute_action = QAction("Reroute Wire", self)
+                reroute_action.triggered.connect(lambda: self.reroute_wire(item))
+            menu.addAction(reroute_action)
+
             if item.node:
                 menu.addSeparator()
                 current = item.node.get_label()
                 label_action = QAction(f"Set Net Name ({current})...", self)
                 label_action.triggered.connect(lambda: self.label_node(item.node))
                 menu.addAction(label_action)
-            pass
         else:
             # Check if we clicked near a terminal to set its net name
             clicked_node = self.find_node_at_position(scene_pos)
@@ -1088,6 +1109,40 @@ class CircuitCanvasView(QGraphicsView):
         wire_index = self.wires.index(wire)
         cmd = DeleteWireCommand(self.controller, wire_index)
         self.controller.execute_command(cmd)
+
+    def reroute_wire(self, wire):
+        """Reroute a single wire via undo/redo command."""
+        if wire is None:
+            return
+        if not self.controller:
+            logger.warning("Cannot reroute wire: no controller available")
+            return
+        if wire not in self.wires:
+            return
+
+        from controllers.commands import RerouteWireCommand
+
+        wire_index = self.wires.index(wire)
+        cmd = RerouteWireCommand(self.controller, wire_index)
+        self.controller.execute_command(cmd)
+
+    def reroute_selected_wires(self, selected_wires):
+        """Reroute multiple selected wires as a single undoable operation."""
+        if not self.controller:
+            logger.warning("Cannot reroute wires: no controller available")
+            return
+
+        from controllers.commands import CompoundCommand, RerouteWireCommand
+
+        commands = []
+        for wire in selected_wires:
+            if wire in self.wires:
+                wire_index = self.wires.index(wire)
+                commands.append(RerouteWireCommand(self.controller, wire_index))
+
+        if commands:
+            compound = CompoundCommand(commands, f"Reroute {len(commands)} wires")
+            self.controller.execute_command(compound)
 
     def rotate_component(self, component, clockwise=True):
         """Rotate a single component - Phase 5: uses controller"""

--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -263,6 +263,12 @@ class CircuitCanvasView(QGraphicsView):
         """Update graphics item flip"""
         comp = self.components.get(component_data.component_id)
         if comp:
+            # Sync flip state: the graphics item holds a separate ComponentData
+            # copy (created via from_dict in _handle_component_added), so we
+            # must propagate the controller model's flip values explicitly before
+            # calling update_terminals() or paint().
+            comp.model.flip_h = component_data.flip_h
+            comp.model.flip_v = component_data.flip_v
             comp.update_terminals()
             comp.update()
             self.reroute_connected_wires(comp)

--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -538,6 +538,10 @@ class Ground(ComponentGraphicsItem):
 
         painter.save()
         painter.rotate(self.rotation_angle)
+        sx = -1 if self.model.flip_h else 1
+        sy = -1 if self.model.flip_v else 1
+        if sx != 1 or sy != 1:
+            painter.scale(sx, sy)
 
         if self.isSelected():
             painter.setPen(theme_manager.pen("component_selected"))

--- a/app/GUI/component_palette.py
+++ b/app/GUI/component_palette.py
@@ -1,6 +1,7 @@
-from PyQt6.QtCore import QMimeData, QSize, Qt, pyqtSignal
-from PyQt6.QtGui import QBrush, QDrag, QIcon, QPainter, QPen, QPixmap
-from PyQt6.QtWidgets import QLineEdit, QListWidget, QListWidgetItem, QVBoxLayout, QWidget
+from models.component import COMPONENT_CATEGORIES
+from PyQt6.QtCore import QMimeData, QSettings, QSize, Qt, pyqtSignal
+from PyQt6.QtGui import QBrush, QDrag, QFont, QIcon, QPainter, QPen, QPixmap
+from PyQt6.QtWidgets import QLineEdit, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 
 from .component_item import COMPONENT_CLASSES
 from .styles import COMPONENTS, theme_manager
@@ -65,7 +66,7 @@ def create_component_icon(component_type, size=48):
 
 
 class ComponentPalette(QWidget):
-    """Component palette with search filter and drag support"""
+    """Component palette with collapsible category groups, search filter, and drag support"""
 
     # Signal emitted when component is double-clicked
     componentDoubleClicked = pyqtSignal(str)  # component_type
@@ -84,46 +85,119 @@ class ComponentPalette(QWidget):
         self.search_input.textChanged.connect(self._filter_components)
         layout.addWidget(self.search_input)
 
-        # Component list
-        self.list_widget = _PaletteListWidget()
-        self.list_widget.setDragEnabled(True)
-        self.list_widget.setDefaultDropAction(Qt.DropAction.CopyAction)
-        self.list_widget.setIconSize(QSize(48, 48))
-        self.list_widget.setSpacing(4)
+        # Component tree with collapsible categories
+        self.tree_widget = _PaletteTreeWidget()
+        self.tree_widget.setHeaderHidden(True)
+        self.tree_widget.setDragEnabled(True)
+        self.tree_widget.setDefaultDropAction(Qt.DropAction.CopyAction)
+        self.tree_widget.setIconSize(QSize(48, 48))
+        self.tree_widget.setIndentation(16)
+        self.tree_widget.setAnimated(True)
 
-        for component_name in COMPONENTS.keys():
-            item = QListWidgetItem(component_name)
-            item.setIcon(create_component_icon(component_name))
-            item.setToolTip(COMPONENT_TOOLTIPS.get(component_name, component_name))
-            self.list_widget.addItem(item)
+        # Track category items for persistence and search
+        self._category_items: dict[str, QTreeWidgetItem] = {}
 
-        self.list_widget.itemDoubleClicked.connect(self._on_item_double_clicked)
-        layout.addWidget(self.list_widget)
+        # Load saved expanded state
+        expanded_state = self._load_expanded_state()
 
-    def _on_item_double_clicked(self, item):
-        """Handle double-click on palette item"""
-        self.componentDoubleClicked.emit(item.text())
+        for category_name, component_names in COMPONENT_CATEGORIES.items():
+            category_item = QTreeWidgetItem(self.tree_widget, [category_name])
+            category_item.setFlags(Qt.ItemFlag.ItemIsEnabled)  # clickable but not selectable/draggable
+            bold_font = QFont()
+            bold_font.setBold(True)
+            category_item.setFont(0, bold_font)
+            self._category_items[category_name] = category_item
+
+            for component_name in component_names:
+                if component_name not in COMPONENTS:
+                    continue
+                child = QTreeWidgetItem(category_item, [component_name])
+                child.setIcon(0, create_component_icon(component_name))
+                child.setToolTip(0, COMPONENT_TOOLTIPS.get(component_name, component_name))
+                child.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsDragEnabled)
+
+            # Restore expanded state (default: expanded)
+            is_expanded = expanded_state.get(category_name, True)
+            category_item.setExpanded(is_expanded)
+
+        self.tree_widget.itemDoubleClicked.connect(self._on_item_double_clicked)
+        self.tree_widget.itemExpanded.connect(self._save_expanded_state)
+        self.tree_widget.itemCollapsed.connect(self._save_expanded_state)
+        layout.addWidget(self.tree_widget)
+
+    def _on_item_double_clicked(self, item, column):
+        """Handle double-click on palette item (ignore category headers)."""
+        if item.parent() is not None:
+            self.componentDoubleClicked.emit(item.text(0))
 
     def _filter_components(self, text):
-        """Show/hide components based on search text."""
+        """Show/hide components based on search text. Auto-expand matching categories."""
         text = text.lower()
-        for i in range(self.list_widget.count()):
-            item = self.list_widget.item(i)
-            if item is not None:
-                name = item.text().lower()
-                tooltip = (item.toolTip() or "").lower()
-                item.setHidden(text not in name and text not in tooltip)
+        is_searching = bool(text)
+
+        for category_name, category_item in self._category_items.items():
+            any_child_visible = False
+            for i in range(category_item.childCount()):
+                child = category_item.child(i)
+                name = child.text(0).lower()
+                tooltip = (child.toolTip(0) or "").lower()
+                matches = text in name or text in tooltip
+                child.setHidden(not matches)
+                if matches:
+                    any_child_visible = True
+
+            # Hide entire category if no children match
+            category_item.setHidden(not any_child_visible)
+
+            # Auto-expand categories with matches during search
+            if is_searching and any_child_visible:
+                category_item.setExpanded(True)
+
+        # Restore saved expanded state when search is cleared
+        if not is_searching:
+            saved_state = self._load_expanded_state()
+            for category_name, category_item in self._category_items.items():
+                category_item.setExpanded(saved_state.get(category_name, True))
+
+    def _load_expanded_state(self) -> dict[str, bool]:
+        """Load category expanded/collapsed state from QSettings."""
+        settings = QSettings("SDSMT", "SDM Spice")
+        state = {}
+        for category_name in COMPONENT_CATEGORIES:
+            val = settings.value(f"palette/expanded/{category_name}")
+            if val is not None:
+                state[category_name] = val == "true" or val is True
+            else:
+                state[category_name] = True  # default expanded
+        return state
+
+    def _save_expanded_state(self, _item=None):
+        """Save category expanded/collapsed state to QSettings."""
+        # Don't save while searching (search auto-expands categories)
+        if self.search_input.text():
+            return
+        settings = QSettings("SDSMT", "SDM Spice")
+        for category_name, category_item in self._category_items.items():
+            settings.setValue(f"palette/expanded/{category_name}", category_item.isExpanded())
+
+    def get_all_component_items(self) -> list[QTreeWidgetItem]:
+        """Return all component (leaf) items across all categories."""
+        items = []
+        for category_item in self._category_items.values():
+            for i in range(category_item.childCount()):
+                items.append(category_item.child(i))
+        return items
 
 
-class _PaletteListWidget(QListWidget):
-    """Internal list widget with drag support for the component palette."""
+class _PaletteTreeWidget(QTreeWidget):
+    """Internal tree widget with drag support for the component palette."""
 
     def startDrag(self, supportedActions):
-        """Start drag operation"""
+        """Start drag operation for component items only."""
         item = self.currentItem()
-        if item:
+        if item and item.parent() is not None:
             drag = QDrag(self)
             mime_data = QMimeData()
-            mime_data.setText(item.text())
+            mime_data.setText(item.text(0))
             drag.setMimeData(mime_data)
             drag.exec(Qt.DropAction.CopyAction)

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -321,6 +321,41 @@ class MenuBarMixin:
         self.color_mode_group.addAction(self.color_mode_action)
         self.color_mode_group.addAction(self.monochrome_mode_action)
 
+        # Wire Thickness submenu
+        wire_thickness_menu = view_menu.addMenu("&Wire Thickness")
+        self.wire_thickness_actions = {}
+
+        thin_action = QAction("&Thin (1px)", self)
+        thin_action.setCheckable(True)
+        thin_action.triggered.connect(lambda: self._set_wire_thickness("thin"))
+        wire_thickness_menu.addAction(thin_action)
+        self.wire_thickness_actions["thin"] = thin_action
+
+        normal_action = QAction("&Normal (2px)", self)
+        normal_action.setCheckable(True)
+        normal_action.setChecked(True)
+        normal_action.triggered.connect(lambda: self._set_wire_thickness("normal"))
+        wire_thickness_menu.addAction(normal_action)
+        self.wire_thickness_actions["normal"] = normal_action
+
+        thick_action = QAction("Thic&k (3px)", self)
+        thick_action.setCheckable(True)
+        thick_action.triggered.connect(lambda: self._set_wire_thickness("thick"))
+        wire_thickness_menu.addAction(thick_action)
+        self.wire_thickness_actions["thick"] = thick_action
+
+        self.wire_thickness_group = QActionGroup(self)
+        self.wire_thickness_group.addAction(thin_action)
+        self.wire_thickness_group.addAction(normal_action)
+        self.wire_thickness_group.addAction(thick_action)
+
+        # Junction dots toggle
+        self.show_junction_dots_action = QAction("Show &Junction Dots", self)
+        self.show_junction_dots_action.setCheckable(True)
+        self.show_junction_dots_action.setChecked(True)
+        self.show_junction_dots_action.triggered.connect(self._set_show_junction_dots)
+        view_menu.addAction(self.show_junction_dots_action)
+
         view_menu.addSeparator()
 
         zoom_in_action = QAction("Zoom &In", self)

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -356,6 +356,27 @@ class MenuBarMixin:
         self.show_junction_dots_action.triggered.connect(self._set_show_junction_dots)
         view_menu.addAction(self.show_junction_dots_action)
 
+        # Wire Routing Mode submenu
+        routing_mode_menu = view_menu.addMenu("Wire &Routing Mode")
+        self.routing_mode_actions = {}
+
+        orthogonal_action = QAction("&Orthogonal (4-direction)", self)
+        orthogonal_action.setCheckable(True)
+        orthogonal_action.setChecked(True)
+        orthogonal_action.triggered.connect(lambda: self._set_routing_mode("orthogonal"))
+        routing_mode_menu.addAction(orthogonal_action)
+        self.routing_mode_actions["orthogonal"] = orthogonal_action
+
+        diagonal_action = QAction("&Diagonal (8-direction, 45°)", self)
+        diagonal_action.setCheckable(True)
+        diagonal_action.triggered.connect(lambda: self._set_routing_mode("diagonal"))
+        routing_mode_menu.addAction(diagonal_action)
+        self.routing_mode_actions["diagonal"] = diagonal_action
+
+        self.routing_mode_group = QActionGroup(self)
+        self.routing_mode_group.addAction(orthogonal_action)
+        self.routing_mode_group.addAction(diagonal_action)
+
         view_menu.addSeparator()
 
         zoom_in_action = QAction("Zoom &In", self)

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -25,6 +25,9 @@ class SettingsMixin:
         if settings.value("autosave/enabled") is None:
             settings.setValue("autosave/enabled", True)
         settings.setValue("view/show_statistics", self.statistics_panel.isVisible())
+        # Preserve default zoom if not yet set
+        if settings.value("view/default_zoom") is None:
+            settings.setValue("view/default_zoom", 100)
         settings.setValue("view/theme_key", theme_manager.get_theme_key())
         settings.setValue("view/theme", theme_manager.current_theme.name)
         settings.setValue("view/symbol_style", theme_manager.symbol_style)
@@ -79,6 +82,10 @@ class SettingsMixin:
             checked = show_stats == "true" or show_stats is True
             self.statistics_panel.setVisible(checked)
             self.show_statistics_action.setChecked(checked)
+
+        default_zoom = settings.value("view/default_zoom")
+        if default_zoom is not None:
+            self.canvas.set_default_zoom(int(default_zoom))
 
         saved_theme_key = settings.value("view/theme_key")
         if saved_theme_key and saved_theme_key != "light":

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -29,6 +29,8 @@ class SettingsMixin:
         settings.setValue("view/theme", theme_manager.current_theme.name)
         settings.setValue("view/symbol_style", theme_manager.symbol_style)
         settings.setValue("view/color_mode", theme_manager.color_mode)
+        settings.setValue("view/wire_thickness", theme_manager.wire_thickness)
+        settings.setValue("view/show_junction_dots", theme_manager.show_junction_dots)
 
     def _restore_settings(self):
         """Restore user preferences from QSettings"""
@@ -97,6 +99,15 @@ class SettingsMixin:
         saved_color_mode = settings.value("view/color_mode")
         if saved_color_mode in ("color", "monochrome"):
             self._set_color_mode(saved_color_mode)
+
+        saved_wire_thickness = settings.value("view/wire_thickness")
+        if saved_wire_thickness in ("thin", "normal", "thick"):
+            self._set_wire_thickness(saved_wire_thickness)
+
+        saved_junction_dots = settings.value("view/show_junction_dots")
+        if saved_junction_dots is not None:
+            show = saved_junction_dots == "true" or saved_junction_dots is True
+            self._set_show_junction_dots(show)
 
     def closeEvent(self, event):
         """Save settings before closing"""

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -34,6 +34,7 @@ class SettingsMixin:
         settings.setValue("view/color_mode", theme_manager.color_mode)
         settings.setValue("view/wire_thickness", theme_manager.wire_thickness)
         settings.setValue("view/show_junction_dots", theme_manager.show_junction_dots)
+        settings.setValue("view/routing_mode", theme_manager.routing_mode)
 
     def _restore_settings(self):
         """Restore user preferences from QSettings"""
@@ -115,6 +116,10 @@ class SettingsMixin:
         if saved_junction_dots is not None:
             show = saved_junction_dots == "true" or saved_junction_dots is True
             self._set_show_junction_dots(show)
+
+        saved_routing_mode = settings.value("view/routing_mode")
+        if saved_routing_mode in ("orthogonal", "diagonal"):
+            self._set_routing_mode(saved_routing_mode)
 
     def closeEvent(self, event):
         """Save settings before closing"""

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -48,6 +48,21 @@ class ViewOperationsMixin:
             self.color_mode_action.setChecked(True)
         self.canvas.scene.update()
 
+    def _set_wire_thickness(self, thickness: str):
+        """Switch wire rendering thickness."""
+        theme_manager.set_wire_thickness(thickness)
+        if hasattr(self, "wire_thickness_actions"):
+            for t, action in self.wire_thickness_actions.items():
+                action.setChecked(t == thickness)
+        self.canvas.scene.update()
+
+    def _set_show_junction_dots(self, show: bool):
+        """Toggle junction dot visibility at wire intersections."""
+        theme_manager.set_show_junction_dots(show)
+        if hasattr(self, "show_junction_dots_action"):
+            self.show_junction_dots_action.setChecked(show)
+        self.canvas.scene.update()
+
     def _toggle_statistics_panel(self, checked):
         """Toggle the circuit statistics panel visibility."""
         self.statistics_panel.setVisible(checked)

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -63,6 +63,14 @@ class ViewOperationsMixin:
             self.show_junction_dots_action.setChecked(show)
         self.canvas.scene.update()
 
+    def _set_routing_mode(self, mode: str):
+        """Switch wire routing mode between orthogonal and diagonal."""
+        theme_manager.set_routing_mode(mode)
+        if hasattr(self, "routing_mode_actions"):
+            for m, action in self.routing_mode_actions.items():
+                action.setChecked(m == mode)
+        self.canvas.scene.update()
+
     def _toggle_statistics_panel(self, checked):
         """Toggle the circuit statistics panel visibility."""
         self.statistics_panel.setVisible(checked)

--- a/app/GUI/path_finding.py
+++ b/app/GUI/path_finding.py
@@ -4,6 +4,7 @@ pathfinding.py
 IDA* pathfinding for grid-aligned wire routing in circuit schematics.
 """
 
+import math
 import time
 from abc import ABC, abstractmethod
 from typing import Set, Tuple
@@ -19,14 +20,22 @@ class WeightedPathfinder(ABC):
     used by the IDA* implementation.
     """
 
-    def __init__(self, grid_size=20):
+    # 4-direction orthogonal moves
+    ORTHOGONAL_DIRS = [(0, 1), (0, -1), (1, 0), (-1, 0)]
+    # 8-direction moves (orthogonal + diagonal)
+    DIAGONAL_DIRS = [(0, 1), (0, -1), (1, 0), (-1, 0), (1, 1), (1, -1), (-1, 1), (-1, -1)]
+    SQRT2 = math.sqrt(2)
+
+    def __init__(self, grid_size=20, allow_diagonal=False):
         """
         Initialize the pathfinder with grid configuration and weight parameters.
 
         Args:
             grid_size: Size of grid cells in pixels
+            allow_diagonal: If True, allow 45-degree diagonal wire segments
         """
         self.grid_size = grid_size
+        self.allow_diagonal = allow_diagonal
 
         # Edge weight parameters
         self.bend_penalty_base = 2  # Exponential base for bend penalties (2^n)
@@ -123,16 +132,24 @@ class WeightedPathfinder(ABC):
 
     def _heuristic(self, a, b):
         """
-        Manhattan distance heuristic for A* algorithms.
+        Distance heuristic for A* algorithms.
+
+        Uses Manhattan distance for orthogonal routing, octile distance
+        for diagonal routing (consistent with 8-direction movement).
 
         Args:
             a: (x, y) tuple - start position
             b: (x, y) tuple - goal position
 
         Returns:
-            float: Manhattan distance
+            float: Estimated distance
         """
-        return abs(a[0] - b[0]) + abs(a[1] - b[1])
+        dx = abs(a[0] - b[0])
+        dy = abs(a[1] - b[1])
+        if self.allow_diagonal:
+            # Octile distance: min(dx,dy) diagonal steps + remaining straight steps
+            return (dx + dy) + (self.SQRT2 - 2) * min(dx, dy)
+        return dx + dy
 
     def _reconstruct_path(self, came_from, current):
         """
@@ -206,8 +223,8 @@ class WeightedPathfinder(ABC):
 class IDAStarPathfinder(WeightedPathfinder):
     """IDA* (Iterative Deepening A*) algorithm - memory-efficient A* variant"""
 
-    def __init__(self, grid_size=20):
-        super().__init__(grid_size)
+    def __init__(self, grid_size=20, allow_diagonal=False):
+        super().__init__(grid_size, allow_diagonal=allow_diagonal)
 
     def find_path(
         self,
@@ -347,7 +364,8 @@ class IDAStarPathfinder(WeightedPathfinder):
 
         min_threshold = float("inf")
 
-        for dx, dy in [(0, 1), (0, -1), (1, 0), (-1, 0)]:
+        directions = self.DIAGONAL_DIRS if self.allow_diagonal else self.ORTHOGONAL_DIRS
+        for dx, dy in directions:
             neighbor = (current[0] + dx, current[1] + dy)
             new_direction = (dx, dy)
 
@@ -358,7 +376,17 @@ class IDAStarPathfinder(WeightedPathfinder):
             if neighbor in obstacles:
                 continue
 
-            edge_cost = 1
+            # For diagonal moves, check that both adjacent orthogonal cells are clear
+            # (prevents corner-cutting through obstacles)
+            is_diagonal = dx != 0 and dy != 0
+            if is_diagonal:
+                adj1 = (current[0] + dx, current[1])
+                adj2 = (current[0], current[1] + dy)
+                if adj1 in obstacles or adj2 in obstacles:
+                    continue
+
+            # Diagonal moves cost √2, orthogonal moves cost 1
+            edge_cost = self.SQRT2 if is_diagonal else 1
             new_bend_count = bend_count
 
             if direction is not None and direction != new_direction:

--- a/app/GUI/styles/__init__.py
+++ b/app/GUI/styles/__init__.py
@@ -54,7 +54,7 @@ from .light_theme import LightTheme
 
 # Theme system
 from .theme import BaseTheme, ThemeProtocol
-from .theme_manager import COLOR_MODES, SYMBOL_STYLES, ThemeManager, theme_manager
+from .theme_manager import COLOR_MODES, SYMBOL_STYLES, WIRE_THICKNESS_PX, WIRE_THICKNESSES, ThemeManager, theme_manager
 
 __all__ = [
     # Constants
@@ -87,4 +87,6 @@ __all__ = [
     "theme_store",
     "SYMBOL_STYLES",
     "COLOR_MODES",
+    "WIRE_THICKNESSES",
+    "WIRE_THICKNESS_PX",
 ]

--- a/app/GUI/styles/__init__.py
+++ b/app/GUI/styles/__init__.py
@@ -54,7 +54,15 @@ from .light_theme import LightTheme
 
 # Theme system
 from .theme import BaseTheme, ThemeProtocol
-from .theme_manager import COLOR_MODES, SYMBOL_STYLES, WIRE_THICKNESS_PX, WIRE_THICKNESSES, ThemeManager, theme_manager
+from .theme_manager import (
+    COLOR_MODES,
+    ROUTING_MODES,
+    SYMBOL_STYLES,
+    WIRE_THICKNESS_PX,
+    WIRE_THICKNESSES,
+    ThemeManager,
+    theme_manager,
+)
 
 __all__ = [
     # Constants
@@ -89,4 +97,5 @@ __all__ = [
     "COLOR_MODES",
     "WIRE_THICKNESSES",
     "WIRE_THICKNESS_PX",
+    "ROUTING_MODES",
 ]

--- a/app/GUI/styles/theme_manager.py
+++ b/app/GUI/styles/theme_manager.py
@@ -23,6 +23,9 @@ COLOR_MODES = ("color", "monochrome")
 WIRE_THICKNESSES = ("thin", "normal", "thick")
 WIRE_THICKNESS_PX = {"thin": 1, "normal": 2, "thick": 3}
 
+# Valid wire routing modes
+ROUTING_MODES = ("orthogonal", "diagonal")
+
 
 class ThemeManager:
     """
@@ -65,6 +68,7 @@ class ThemeManager:
     _color_mode: str
     _wire_thickness: str
     _show_junction_dots: bool
+    _routing_mode: str
 
     def __new__(cls) -> "ThemeManager":
         if cls._instance is None:
@@ -75,6 +79,7 @@ class ThemeManager:
             cls._instance._color_mode = "color"
             cls._instance._wire_thickness = "normal"
             cls._instance._show_junction_dots = True
+            cls._instance._routing_mode = "orthogonal"
         return cls._instance
 
     @property
@@ -166,6 +171,26 @@ class ThemeManager:
         """
         if show != self._show_junction_dots:
             self._show_junction_dots = show
+            self._notify_listeners()
+
+    # ===== Wire routing preferences =====
+
+    @property
+    def routing_mode(self) -> str:
+        """Get the current wire routing mode ('orthogonal' or 'diagonal')."""
+        return self._routing_mode
+
+    def set_routing_mode(self, mode: str) -> None:
+        """Set the wire routing mode and notify listeners.
+
+        Args:
+            mode: 'orthogonal' for 4-direction or 'diagonal' for 8-direction routing
+        """
+        if mode not in ROUTING_MODES:
+            logger.warning("Unknown routing mode %r, ignoring", mode)
+            return
+        if mode != self._routing_mode:
+            self._routing_mode = mode
             self._notify_listeners()
 
     def on_theme_changed(self, callback: Callable[[ThemeProtocol], None]) -> None:

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -67,7 +67,11 @@ class WireGraphicsItem(QGraphicsPathItem):
         self.setPen(QPen(self.layer_color, theme_manager.wire_thickness_px))
         self.setFlag(QGraphicsPathItem.GraphicsItemFlag.ItemIsSelectable)
         self.setZValue(1)  # Render wires above components (z=0)
-        self.update_position()
+
+        if self.model.waypoints:
+            self._restore_waypoints()
+        else:
+            self.update_position()
 
     # --- Data delegation properties ---
 
@@ -211,6 +215,16 @@ class WireGraphicsItem(QGraphicsPathItem):
             self.scene().update(self.boundingRect())
 
         self.update()  # Force item redraw
+
+    def _restore_waypoints(self):
+        """Restore wire path from persisted waypoints without running pathfinding."""
+        self.waypoints = [QPointF(x, y) for x, y in self.model.waypoints]
+        path = QPainterPath()
+        if self.waypoints:
+            path.moveTo(self.waypoints[0])
+            for waypoint in self.waypoints[1:]:
+                path.lineTo(waypoint)
+        self.setPath(path)
 
     def _notify_routing_failed(self):
         """Show status bar message when wire routing fails."""

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -169,7 +169,8 @@ class WireGraphicsItem(QGraphicsPathItem):
                 current_node=self.node,
             )
 
-            pathfinder = IDAStarPathfinder(GRID_SIZE)
+            allow_diagonal = theme_manager.routing_mode == "diagonal"
+            pathfinder = IDAStarPathfinder(GRID_SIZE, allow_diagonal=allow_diagonal)
             result = pathfinder.find_path(start, end, obstacles, algorithm=self.algorithm)
 
             # Unpack result (waypoints, runtime, iterations, routing_failed)

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -235,6 +235,9 @@ class WireGraphicsItem(QGraphicsPathItem):
         elif self.model.routing_failed:
             pen = QPen(Qt.GlobalColor.red, width, Qt.PenStyle.DashLine)
             painter.setPen(pen)
+        elif self.model.locked:
+            pen = QPen(self.layer_color, width, Qt.PenStyle.DotLine)
+            painter.setPen(pen)
         else:
             painter.setPen(QPen(self.layer_color, width))
 

--- a/app/controllers/commands.py
+++ b/app/controllers/commands.py
@@ -261,6 +261,30 @@ class DeleteWireCommand(Command):
         return "Delete wire"
 
 
+class ToggleWireLockCommand(Command):
+    """Command to lock or unlock a wire's path."""
+
+    def __init__(self, controller, wire_index: int, locked: bool):
+        self.controller = controller
+        self.wire_index = wire_index
+        self.locked = locked
+
+    def execute(self) -> None:
+        """Set the wire's locked state."""
+        if self.wire_index < len(self.controller.model.wires):
+            self.controller.model.wires[self.wire_index].locked = self.locked
+            self.controller._notify("wire_lock_changed", (self.wire_index, self.locked))
+
+    def undo(self) -> None:
+        """Restore previous locked state."""
+        if self.wire_index < len(self.controller.model.wires):
+            self.controller.model.wires[self.wire_index].locked = not self.locked
+            self.controller._notify("wire_lock_changed", (self.wire_index, not self.locked))
+
+    def get_description(self) -> str:
+        return "Lock wire" if self.locked else "Unlock wire"
+
+
 class PasteCommand(Command):
     """Command to paste clipboard contents."""
 

--- a/app/controllers/commands.py
+++ b/app/controllers/commands.py
@@ -261,6 +261,32 @@ class DeleteWireCommand(Command):
         return "Delete wire"
 
 
+class RerouteWireCommand(Command):
+    """Command to reroute a wire (force fresh pathfinding)."""
+
+    def __init__(self, controller, wire_index: int):
+        self.controller = controller
+        self.wire_index = wire_index
+        self.old_waypoints: list[tuple[float, float]] = []
+
+    def execute(self) -> None:
+        """Save old waypoints and signal that the wire needs rerouting."""
+        if self.wire_index < len(self.controller.model.wires):
+            wire = self.controller.model.wires[self.wire_index]
+            self.old_waypoints = list(wire.waypoints)
+            # Clear waypoints to force fresh pathfinding
+            wire.waypoints = []
+            self.controller._notify("wire_reroute_requested", self.wire_index)
+
+    def undo(self) -> None:
+        """Restore old waypoints."""
+        if self.wire_index < len(self.controller.model.wires):
+            self.controller.update_wire_waypoints(self.wire_index, self.old_waypoints)
+
+    def get_description(self) -> str:
+        return "Reroute wire"
+
+
 class PasteCommand(Command):
     """Command to paste clipboard contents."""
 

--- a/app/models/component.py
+++ b/app/models/component.py
@@ -38,6 +38,23 @@ COMPONENT_TYPES = [
     "Transformer",
 ]
 
+# Category groupings for the component palette
+COMPONENT_CATEGORIES = {
+    "Passive": ["Resistor", "Capacitor", "Inductor"],
+    "Sources": ["Voltage Source", "Current Source", "Waveform Source"],
+    "Semiconductors": [
+        "Diode",
+        "LED",
+        "Zener Diode",
+        "BJT NPN",
+        "BJT PNP",
+        "MOSFET NMOS",
+        "MOSFET PMOS",
+    ],
+    "Controlled Sources": ["VCVS", "CCVS", "VCCS", "CCCS"],
+    "Other": ["Op-Amp", "VC Switch", "Ground", "Transformer"],
+}
+
 # Mapping of component types to SPICE symbols
 SPICE_SYMBOLS = {
     "Resistor": "R",

--- a/app/models/wire.py
+++ b/app/models/wire.py
@@ -55,28 +55,34 @@ class WireData:
         Serialize wire to dictionary.
 
         Format matches the existing JSON circuit file format for compatibility.
-        Note: waypoints are NOT serialized (they are recomputed on load).
+        Waypoints are persisted so wire layouts survive save/load.
         """
-        return {
+        data = {
             "start_comp": self.start_component_id,
             "start_term": self.start_terminal,
             "end_comp": self.end_component_id,
             "end_term": self.end_terminal,
         }
+        if self.waypoints:
+            data["waypoints"] = [[x, y] for x, y in self.waypoints]
+        return data
 
     @classmethod
     def from_dict(cls, data: dict) -> "WireData":
         """
         Deserialize wire from dictionary.
 
-        Handles the existing JSON circuit file format.
+        Handles both old format (no waypoints) and new format (with waypoints).
         """
-        return cls(
+        wire = cls(
             start_component_id=data["start_comp"],
             start_terminal=data["start_term"],
             end_component_id=data["end_comp"],
             end_terminal=data["end_term"],
         )
+        if "waypoints" in data:
+            wire.waypoints = [(float(x), float(y)) for x, y in data["waypoints"]]
+        return wire
 
     def __repr__(self) -> str:
         return (

--- a/app/models/wire.py
+++ b/app/models/wire.py
@@ -27,6 +27,7 @@ class WireData:
     runtime: float = 0.0  # Time taken to route (seconds)
     iterations: int = 0  # Pathfinding iterations
     routing_failed: bool = False  # True when pathfinding fell back to straight line
+    locked: bool = False  # True when wire path is locked (skip auto-reroute)
 
     def get_terminals(self) -> list[tuple[str, int]]:
         """
@@ -57,12 +58,15 @@ class WireData:
         Format matches the existing JSON circuit file format for compatibility.
         Note: waypoints are NOT serialized (they are recomputed on load).
         """
-        return {
+        d = {
             "start_comp": self.start_component_id,
             "start_term": self.start_terminal,
             "end_comp": self.end_component_id,
             "end_term": self.end_terminal,
         }
+        if self.locked:
+            d["locked"] = True
+        return d
 
     @classmethod
     def from_dict(cls, data: dict) -> "WireData":
@@ -76,6 +80,7 @@ class WireData:
             start_terminal=data["start_term"],
             end_component_id=data["end_comp"],
             end_terminal=data["end_term"],
+            locked=data.get("locked", False),
         )
 
     def __repr__(self) -> str:

--- a/app/tests/integration/test_save_load.py
+++ b/app/tests/integration/test_save_load.py
@@ -164,6 +164,38 @@ class TestWireRoundTrip:
         assert wire.connects_terminal("V1", 1)
         assert not wire.connects_terminal("R1", 1)
 
+    def test_locked_wire_round_trip(self):
+        """Locked flag persists through to_dict/from_dict."""
+        wire = WireData(
+            start_component_id="R1",
+            start_terminal=0,
+            end_component_id="V1",
+            end_terminal=1,
+            locked=True,
+        )
+        data = wire.to_dict()
+        assert data["locked"] is True
+
+        restored = WireData.from_dict(data)
+        assert restored.locked is True
+
+    def test_unlocked_wire_omits_locked_from_dict(self):
+        """Unlocked wires don't include 'locked' key to keep files compact."""
+        wire = make_wire("R1", 0, "V1", 1)
+        data = wire.to_dict()
+        assert "locked" not in data
+
+    def test_old_format_without_locked_defaults_false(self):
+        """Files saved before lock feature load with locked=False."""
+        data = {
+            "start_comp": "R1",
+            "start_term": 0,
+            "end_comp": "V1",
+            "end_term": 1,
+        }
+        wire = WireData.from_dict(data)
+        assert wire.locked is False
+
 
 # ── Full circuit dict round-trip ─────────────────────────────────────
 

--- a/app/tests/unit/test_component_flip.py
+++ b/app/tests/unit/test_component_flip.py
@@ -6,6 +6,77 @@ import pytest
 from models.component import ComponentData
 
 
+class TestFlipHandlerSync:
+    """Regression tests for issue #113 (human testing failure).
+
+    _handle_component_flipped in circuit_canvas creates graphics items with a
+    *separate* ComponentData copy (via from_dict).  Before the fix, the handler
+    called update_terminals() without first syncing flip_h/flip_v from the
+    controller model, so the visual transform was never applied.
+
+    These tests verify the correct behaviour at the model layer: after syncing
+    flip state from the "controller model" to the "graphics item model" and
+    recomputing terminal positions, the terminals reflect the flip.
+    """
+
+    def test_sync_flip_h_then_update_terminals(self):
+        """Syncing flip_h and recomputing terminals produces mirrored x positions."""
+        ctrl_model = ComponentData("R1", "Resistor", "1k", (0.0, 0.0))
+        item_model = ComponentData("R1", "Resistor", "1k", (0.0, 0.0))
+        base = item_model.get_base_terminal_positions()
+
+        # Simulate controller flip_component():
+        ctrl_model.flip_h = not ctrl_model.flip_h  # True
+
+        # Simulate the fixed _handle_component_flipped handler:
+        item_model.flip_h = ctrl_model.flip_h
+        item_model.flip_v = ctrl_model.flip_v
+
+        # Recompute terminal positions as update_terminals() would
+        world = item_model.get_terminal_positions()
+
+        for (bx, by), (wx, wy) in zip(base, world):
+            assert wx == pytest.approx(-bx), "flip_h must negate the x terminal offset"
+            assert wy == pytest.approx(by)
+
+    def test_sync_flip_v_then_update_terminals(self):
+        """Syncing flip_v and recomputing terminals produces mirrored y positions."""
+        ctrl_model = ComponentData("R1", "Resistor", "1k", (0.0, 0.0))
+        item_model = ComponentData("R1", "Resistor", "1k", (0.0, 0.0))
+        base = item_model.get_base_terminal_positions()
+
+        ctrl_model.flip_v = not ctrl_model.flip_v
+
+        item_model.flip_h = ctrl_model.flip_h
+        item_model.flip_v = ctrl_model.flip_v
+
+        world = item_model.get_terminal_positions()
+
+        for (bx, by), (wx, wy) in zip(base, world):
+            assert wx == pytest.approx(bx)
+            assert wy == pytest.approx(-by), "flip_v must negate the y terminal offset"
+
+    def test_without_sync_terminals_are_unchanged(self):
+        """Without the sync step, item model terminals do not reflect the flip.
+
+        This documents the pre-fix bug: update_terminals() called on an item
+        whose model still has flip_h=False produces unchanged positions.
+        """
+        ctrl_model = ComponentData("R1", "Resistor", "1k", (0.0, 0.0))
+        item_model = ComponentData("R1", "Resistor", "1k", (0.0, 0.0))
+        base = item_model.get_base_terminal_positions()
+
+        ctrl_model.flip_h = True
+        # NOT syncing: item_model.flip_h remains False
+
+        world = item_model.get_terminal_positions()
+
+        # Terminals should be unchanged (bug: they look unflipped)
+        for (bx, by), (wx, wy) in zip(base, world):
+            assert wx == pytest.approx(bx), "without sync, x is unchanged (the old bug)"
+            assert wy == pytest.approx(by)
+
+
 @pytest.fixture
 def resistor():
     """A standard 2-terminal resistor at origin."""

--- a/app/tests/unit/test_component_palette.py
+++ b/app/tests/unit/test_component_palette.py
@@ -2,13 +2,26 @@
 Unit tests for ComponentPalette.
 
 Tests component listing, signal emission on double-click,
-drag support configuration, and search filtering.
+drag support configuration, search filtering, and collapsible categories.
 """
 
 import pytest
 from GUI.component_palette import ComponentPalette
 from GUI.styles import COMPONENTS
-from PyQt6.QtCore import Qt
+from models.component import COMPONENT_CATEGORIES
+from PyQt6.QtCore import QSettings, Qt
+
+
+@pytest.fixture(autouse=True)
+def _clear_palette_settings():
+    """Clear palette QSettings before each test to avoid cross-test contamination."""
+    settings = QSettings("SDSMT", "SDM Spice")
+    for category_name in COMPONENT_CATEGORIES:
+        settings.remove(f"palette/expanded/{category_name}")
+    yield
+    # Cleanup after test too
+    for category_name in COMPONENT_CATEGORIES:
+        settings.remove(f"palette/expanded/{category_name}")
 
 
 @pytest.fixture
@@ -18,43 +31,56 @@ def palette(qtbot):
     return p
 
 
+def _visible_component_names(palette):
+    """Return names of all visible (non-hidden) component items."""
+    names = []
+    for item in palette.get_all_component_items():
+        if not item.isHidden():
+            parent = item.parent()
+            if parent is not None and not parent.isHidden():
+                names.append(item.text(0))
+    return names
+
+
 class TestComponentPaletteContents:
     """Test that palette lists all expected components."""
 
     def test_lists_all_component_types(self, palette):
-        lw = palette.list_widget
-        item_texts = [lw.item(i).text() for i in range(lw.count())]
+        item_texts = [item.text(0) for item in palette.get_all_component_items()]
         for comp_type in COMPONENTS:
             assert comp_type in item_texts
 
     def test_item_count_matches_components(self, palette):
-        assert palette.list_widget.count() == len(COMPONENTS)
+        assert len(palette.get_all_component_items()) == len(COMPONENTS)
 
     def test_items_have_icons(self, palette):
-        lw = palette.list_widget
-        for i in range(lw.count()):
-            assert not lw.item(i).icon().isNull()
+        for item in palette.get_all_component_items():
+            assert not item.icon(0).isNull()
 
 
 class TestComponentPaletteSignals:
     """Test signal emission on interaction."""
 
     def test_double_click_emits_component_type(self, palette, qtbot):
-        lw = palette.list_widget
-        first_item = lw.item(0)
+        first_item = palette.get_all_component_items()[0]
         with qtbot.waitSignal(palette.componentDoubleClicked, timeout=1000) as blocker:
-            lw.itemDoubleClicked.emit(first_item)
-        assert blocker.args == [first_item.text()]
+            palette.tree_widget.itemDoubleClicked.emit(first_item, 0)
+        assert blocker.args == [first_item.text(0)]
+
+    def test_double_click_on_category_does_not_emit(self, palette, qtbot):
+        category_item = list(palette._category_items.values())[0]
+        with qtbot.assertNotEmitted(palette.componentDoubleClicked):
+            palette.tree_widget.itemDoubleClicked.emit(category_item, 0)
 
 
 class TestComponentPaletteDragConfig:
     """Test drag-and-drop configuration."""
 
     def test_drag_enabled(self, palette):
-        assert palette.list_widget.dragEnabled()
+        assert palette.tree_widget.dragEnabled()
 
     def test_default_drop_action_is_copy(self, palette):
-        assert palette.list_widget.defaultDropAction() == Qt.DropAction.CopyAction
+        assert palette.tree_widget.defaultDropAction() == Qt.DropAction.CopyAction
 
 
 class TestComponentPaletteSearch:
@@ -62,36 +88,122 @@ class TestComponentPaletteSearch:
 
     def test_filter_hides_non_matching(self, palette):
         palette.search_input.setText("resistor")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = _visible_component_names(palette)
         assert "Resistor" in visible
         assert "Capacitor" not in visible
 
     def test_filter_is_case_insensitive(self, palette):
         palette.search_input.setText("CAPACITOR")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = _visible_component_names(palette)
         assert "Capacitor" in visible
 
     def test_empty_filter_shows_all(self, palette):
         palette.search_input.setText("xyz")
         palette.search_input.setText("")
-        lw = palette.list_widget
-        visible_count = sum(1 for i in range(lw.count()) if not lw.item(i).isHidden())
-        assert visible_count == len(COMPONENTS)
+        visible = _visible_component_names(palette)
+        assert len(visible) == len(COMPONENTS)
 
     def test_filter_matches_tooltip(self, palette):
         # "Resists" appears in the Resistor tooltip
         palette.search_input.setText("resists")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = _visible_component_names(palette)
         assert "Resistor" in visible
 
     def test_filter_no_matches(self, palette):
         palette.search_input.setText("xyznonexistent")
-        lw = palette.list_widget
-        visible_count = sum(1 for i in range(lw.count()) if not lw.item(i).isHidden())
-        assert visible_count == 0
+        visible = _visible_component_names(palette)
+        assert len(visible) == 0
 
     def test_search_input_has_placeholder(self, palette):
         assert "filter" in palette.search_input.placeholderText().lower()
+
+
+class TestComponentPaletteCategories:
+    """Test collapsible category group functionality."""
+
+    def test_all_categories_present(self, palette):
+        for category_name in COMPONENT_CATEGORIES:
+            assert category_name in palette._category_items
+
+    def test_category_count(self, palette):
+        assert len(palette._category_items) == len(COMPONENT_CATEGORIES)
+
+    def test_categories_default_expanded(self, palette):
+        for category_item in palette._category_items.values():
+            assert category_item.isExpanded()
+
+    def test_category_collapse_and_expand(self, palette):
+        cat_item = list(palette._category_items.values())[0]
+        cat_item.setExpanded(False)
+        assert not cat_item.isExpanded()
+        cat_item.setExpanded(True)
+        assert cat_item.isExpanded()
+
+    def test_category_items_are_not_draggable(self, palette):
+        for category_item in palette._category_items.values():
+            flags = category_item.flags()
+            assert not (flags & Qt.ItemFlag.ItemIsDragEnabled)
+
+    def test_component_items_are_draggable(self, palette):
+        for item in palette.get_all_component_items():
+            flags = item.flags()
+            assert flags & Qt.ItemFlag.ItemIsDragEnabled
+
+    def test_search_auto_expands_matching_categories(self, palette):
+        # Collapse all categories first
+        for cat_item in palette._category_items.values():
+            cat_item.setExpanded(False)
+        # Search for a passive component
+        palette.search_input.setText("resistor")
+        assert palette._category_items["Passive"].isExpanded()
+
+    def test_search_hides_non_matching_categories(self, palette):
+        palette.search_input.setText("resistor")
+        # Semiconductors category should be hidden (no match)
+        assert palette._category_items["Semiconductors"].isHidden()
+        # Passive category should be visible
+        assert not palette._category_items["Passive"].isHidden()
+
+    def test_clear_search_restores_collapsed_state(self, palette):
+        # Collapse one category
+        palette._category_items["Passive"].setExpanded(False)
+        palette._save_expanded_state()
+        # Search expands it
+        palette.search_input.setText("resistor")
+        assert palette._category_items["Passive"].isExpanded()
+        # Clear search restores collapsed state
+        palette.search_input.setText("")
+        assert not palette._category_items["Passive"].isExpanded()
+
+    def test_components_grouped_correctly(self, palette):
+        for category_name, expected_components in COMPONENT_CATEGORIES.items():
+            category_item = palette._category_items[category_name]
+            actual_names = [category_item.child(i).text(0) for i in range(category_item.childCount())]
+            for comp_name in expected_components:
+                if comp_name in COMPONENTS:
+                    assert comp_name in actual_names
+
+
+class TestComponentPaletteSettingsPersistence:
+    """Test QSettings persistence of expanded/collapsed state."""
+
+    def test_save_and_load_expanded_state(self, palette):
+        # Collapse a category
+        palette._category_items["Passive"].setExpanded(False)
+        palette._save_expanded_state()
+        # Verify saved state
+        state = palette._load_expanded_state()
+        assert state["Passive"] is False
+        # Verify others remain expanded
+        assert state["Sources"] is True
+
+    def test_new_palette_loads_saved_state(self, qtbot):
+        # Save collapsed state
+        settings = QSettings("SDSMT", "SDM Spice")
+        settings.setValue("palette/expanded/Passive", False)
+        settings.setValue("palette/expanded/Sources", True)
+        # Create new palette instance
+        p2 = ComponentPalette()
+        qtbot.addWidget(p2)
+        assert not p2._category_items["Passive"].isExpanded()
+        assert p2._category_items["Sources"].isExpanded()

--- a/app/tests/unit/test_keyboard_navigation.py
+++ b/app/tests/unit/test_keyboard_navigation.py
@@ -84,7 +84,7 @@ class TestTabOrder:
 
         palette = ComponentPalette()
         qtbot.addWidget(palette)
-        # QListWidget default or set by MainWindow
+        # QTreeWidget default or set by MainWindow
         policy = palette.focusPolicy()
         # Should accept some form of focus
         assert policy != Qt.FocusPolicy.NoFocus

--- a/app/tests/unit/test_path_finding.py
+++ b/app/tests/unit/test_path_finding.py
@@ -346,3 +346,164 @@ class TestWireDataRoutingFailed:
         )
         wire.routing_failed = True
         assert wire.routing_failed is True
+
+
+# ===========================================================================
+# 12. Diagonal / 45-degree wire routing
+# ===========================================================================
+
+
+@pytest.fixture
+def diagonal_pathfinder():
+    """Yield an IDA* pathfinder with diagonal routing enabled."""
+    return IDAStarPathfinder(grid_size=GRID, allow_diagonal=True)
+
+
+class TestDiagonalRouting:
+    def test_default_is_orthogonal(self):
+        """Default pathfinder should use orthogonal-only movement."""
+        pf = IDAStarPathfinder(grid_size=GRID)
+        assert pf.allow_diagonal is False
+
+    def test_diagonal_flag_accepted(self):
+        """Pathfinder should accept and store the allow_diagonal flag."""
+        pf = IDAStarPathfinder(grid_size=GRID, allow_diagonal=True)
+        assert pf.allow_diagonal is True
+
+    def test_diagonal_path_has_diagonal_segments(self, diagonal_pathfinder):
+        """Diagonal routing should produce segments that move both x and y."""
+        start, end = _grid(0, 0), _grid(5, 5)
+        waypoints, _, _, routing_failed = diagonal_pathfinder.find_path(start, end, set(), bounds=BOUNDS)
+        assert routing_failed is False
+        # With diagonal routing on a clear grid from (0,0) to (5,5),
+        # a straight diagonal is optimal — simplified to 2 points
+        grid_pts = _to_grid_tuples(waypoints)
+        assert grid_pts[0] == (0, 0)
+        assert grid_pts[-1] == (5, 5)
+        # The path should be shorter or equal to what orthogonal would give
+        assert len(waypoints) <= 3  # diagonal can do it in a straight line
+
+    def test_orthogonal_path_has_no_diagonal_segments(self, pathfinder):
+        """Orthogonal routing must never produce diagonal segments."""
+        start, end = _grid(0, 0), _grid(5, 5)
+        waypoints, _, _, _ = pathfinder.find_path(start, end, set(), bounds=BOUNDS)
+        for i in range(len(waypoints) - 1):
+            dx = waypoints[i + 1].x() - waypoints[i].x()
+            dy = waypoints[i + 1].y() - waypoints[i].y()
+            assert dx == 0 or dy == 0, f"Unexpected diagonal segment: ({dx}, {dy})"
+
+    def test_corner_cutting_prevented(self, diagonal_pathfinder):
+        """Diagonal moves should be blocked when adjacent cells are obstacles."""
+        # Place obstacles at (1,0) and (0,1) — diagonal move from (0,0) to (1,1)
+        # should be blocked because both adjacent cells are occupied
+        obstacles = {(1, 0), (0, 1)}
+        start, end = _grid(0, 0), _grid(1, 1)
+        waypoints, _, _, routing_failed = diagonal_pathfinder.find_path(start, end, obstacles, bounds=BOUNDS)
+        grid_pts = _to_grid_tuples(waypoints)
+        # Path must not cut through (1,0) or (0,1) diagonally
+        # It should route around (e.g., go to (-1,0) then up then right)
+        for pt in grid_pts:
+            assert pt not in obstacles
+
+    def test_diagonal_avoids_obstacles(self, diagonal_pathfinder):
+        """Diagonal routing should avoid obstacles just like orthogonal."""
+        obstacles = {(2, y) for y in range(-5, 6)}
+        start, end = _grid(0, 0), _grid(4, 0)
+        waypoints, _, _, routing_failed = diagonal_pathfinder.find_path(start, end, obstacles, bounds=BOUNDS)
+        assert routing_failed is False
+        grid_pts = _to_grid_tuples(waypoints)
+        assert grid_pts[0] == (0, 0)
+        assert grid_pts[-1] == (4, 0)
+        for pt in grid_pts:
+            assert pt not in obstacles
+
+
+class TestOctileHeuristic:
+    def test_manhattan_when_orthogonal(self, pathfinder):
+        """Orthogonal pathfinder should use Manhattan distance."""
+        assert pathfinder._heuristic((0, 0), (3, 4)) == 7
+
+    def test_octile_when_diagonal(self, diagonal_pathfinder):
+        """Diagonal pathfinder should use octile distance."""
+        # Octile: dx + dy + (√2 - 2) * min(dx, dy)
+        # For (0,0) to (3,4): dx=3, dy=4, min=3
+        # = 3 + 4 + (√2 - 2) * 3 = 7 + (1.4142.. - 2) * 3 = 7 - 1.7574.. ≈ 5.2426
+        import math
+
+        expected = 3 + 4 + (math.sqrt(2) - 2) * 3
+        result = diagonal_pathfinder._heuristic((0, 0), (3, 4))
+        assert abs(result - expected) < 1e-9
+
+    def test_octile_same_point(self, diagonal_pathfinder):
+        """Heuristic of same point should be zero regardless of mode."""
+        assert diagonal_pathfinder._heuristic((0, 0), (0, 0)) == 0
+
+    def test_octile_pure_diagonal(self, diagonal_pathfinder):
+        """Pure diagonal move: dx == dy, cost should be dx * √2."""
+        import math
+
+        # (0,0) to (3,3): dx=3, dy=3, min=3
+        # octile = 3 + 3 + (√2 - 2) * 3 = 6 + 3√2 - 6 = 3√2
+        expected = 3 * math.sqrt(2)
+        result = diagonal_pathfinder._heuristic((0, 0), (3, 3))
+        assert abs(result - expected) < 1e-9
+
+
+class TestRoutingModeConstants:
+    def test_orthogonal_dirs_count(self):
+        """ORTHOGONAL_DIRS should have exactly 4 directions."""
+        from GUI.path_finding import WeightedPathfinder
+
+        assert len(WeightedPathfinder.ORTHOGONAL_DIRS) == 4
+
+    def test_diagonal_dirs_count(self):
+        """DIAGONAL_DIRS should have exactly 8 directions."""
+        from GUI.path_finding import WeightedPathfinder
+
+        assert len(WeightedPathfinder.DIAGONAL_DIRS) == 8
+
+    def test_sqrt2_constant(self):
+        """SQRT2 constant should equal math.sqrt(2)."""
+        import math
+
+        from GUI.path_finding import WeightedPathfinder
+
+        assert abs(WeightedPathfinder.SQRT2 - math.sqrt(2)) < 1e-15
+
+
+class TestThemeManagerRoutingMode:
+    def test_default_routing_mode(self):
+        """Default routing mode should be 'orthogonal'."""
+        from GUI.styles.theme_manager import ThemeManager
+
+        tm = ThemeManager()
+        assert tm.routing_mode == "orthogonal"
+
+    def test_set_routing_mode_diagonal(self):
+        """Setting routing mode to 'diagonal' should work."""
+        from GUI.styles.theme_manager import ThemeManager
+
+        tm = ThemeManager()
+        old = tm.routing_mode
+        try:
+            tm.set_routing_mode("diagonal")
+            assert tm.routing_mode == "diagonal"
+        finally:
+            tm.set_routing_mode(old)
+
+    def test_set_invalid_routing_mode_ignored(self):
+        """Setting an invalid routing mode should be silently ignored."""
+        from GUI.styles.theme_manager import ThemeManager
+
+        tm = ThemeManager()
+        old = tm.routing_mode
+        tm.set_routing_mode("invalid_mode")
+        assert tm.routing_mode == old
+
+    def test_routing_modes_constant(self):
+        """ROUTING_MODES should contain both valid options."""
+        from GUI.styles.theme_manager import ROUTING_MODES
+
+        assert "orthogonal" in ROUTING_MODES
+        assert "diagonal" in ROUTING_MODES
+        assert len(ROUTING_MODES) == 2

--- a/app/tests/unit/test_preferences_dialog.py
+++ b/app/tests/unit/test_preferences_dialog.py
@@ -299,13 +299,16 @@ class TestAutosaveSpinboxState:
         assert not dlg.autosave_checkbox.isChecked()
         assert not dlg.autosave_spin.isEnabled()
 
-    def test_cancel_reverts_autosave_enabled(self, dialog, mock_main_window):
+    def test_cancel_reverts_autosave_enabled(self, qtbot, mock_main_window):
         """Cancel should revert auto-save enabled to the snapshot value."""
-        dialog.autosave_checkbox.setChecked(False)
-        dialog._on_cancel()
+        # Ensure autosave is enabled before opening dialog so snapshot captures True
         settings = QSettings("SDSMT", "SDM Spice")
+        settings.setValue("autosave/enabled", True)
+        dlg = PreferencesDialog(mock_main_window, parent=None)
+        qtbot.addWidget(dlg)
+        dlg.autosave_checkbox.setChecked(False)
+        dlg._on_cancel()
         enabled = settings.value("autosave/enabled")
-        # Snapshot was True (default), so it should revert to True
         assert enabled is True or enabled == "true"
         mock_main_window._start_autosave_timer.assert_called()
 

--- a/app/tests/unit/test_qtbot_widget_interactions.py
+++ b/app/tests/unit/test_qtbot_widget_interactions.py
@@ -123,15 +123,21 @@ class TestComponentPaletteInteractions:
     def test_search_for_op_amp(self, palette):
         """Searching 'op' shows Op-Amp."""
         palette.search_input.setText("op")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = [
+            item.text(0)
+            for item in palette.get_all_component_items()
+            if not item.isHidden() and not item.parent().isHidden()
+        ]
         assert "Op-Amp" in visible
 
     def test_search_for_diode(self, palette):
         """Searching 'diode' shows Diode, LED, and Zener Diode."""
         palette.search_input.setText("diode")
-        lw = palette.list_widget
-        visible = [lw.item(i).text() for i in range(lw.count()) if not lw.item(i).isHidden()]
+        visible = [
+            item.text(0)
+            for item in palette.get_all_component_items()
+            if not item.isHidden() and not item.parent().isHidden()
+        ]
         assert "Diode" in visible
         assert "Zener Diode" in visible
 
@@ -139,9 +145,12 @@ class TestComponentPaletteInteractions:
         """Clearing search shows all items again."""
         palette.search_input.setText("xyz_no_match")
         palette.search_input.clear()
-        lw = palette.list_widget
-        visible = sum(1 for i in range(lw.count()) if not lw.item(i).isHidden())
-        assert visible == lw.count()
+        visible = [
+            item.text(0)
+            for item in palette.get_all_component_items()
+            if not item.isHidden() and not item.parent().isHidden()
+        ]
+        assert len(visible) == len(palette.get_all_component_items())
 
 
 # ===========================================================================

--- a/app/tests/unit/test_undo_redo.py
+++ b/app/tests/unit/test_undo_redo.py
@@ -12,6 +12,7 @@ from controllers.commands import (
     FlipComponentCommand,
     MoveComponentCommand,
     PasteCommand,
+    RerouteWireCommand,
     RotateComponentCommand,
 )
 from controllers.undo_manager import UndoManager
@@ -415,3 +416,121 @@ class TestCircuitControllerIntegration:
 
         assert not controller.can_undo()
         assert not controller.can_redo()
+
+
+class TestRerouteWireCommand:
+    """Test reroute wire command with undo."""
+
+    def _setup_circuit_with_wire(self):
+        """Helper to create a circuit with two components and one wire with waypoints."""
+        model = CircuitModel()
+        controller = CircuitController(model)
+        r1 = controller.add_component("Resistor", (0, 0))
+        r2 = controller.add_component("Resistor", (100, 0))
+        controller.add_wire(r1.component_id, 0, r2.component_id, 0)
+        # Simulate existing waypoints on the wire
+        model.wires[0].waypoints = [(0.0, 0.0), (50.0, 0.0), (100.0, 0.0)]
+        return model, controller
+
+    def test_execute_clears_waypoints(self):
+        """Reroute command clears waypoints to trigger fresh pathfinding."""
+        model, controller = self._setup_circuit_with_wire()
+        assert model.wires[0].waypoints == [(0.0, 0.0), (50.0, 0.0), (100.0, 0.0)]
+
+        cmd = RerouteWireCommand(controller, 0)
+        cmd.execute()
+
+        # Waypoints cleared (canvas handler would run pathfinding)
+        assert model.wires[0].waypoints == []
+
+    def test_undo_restores_old_waypoints(self):
+        """Undo restores the waypoints that existed before reroute."""
+        model, controller = self._setup_circuit_with_wire()
+        original_waypoints = [(0.0, 0.0), (50.0, 0.0), (100.0, 0.0)]
+
+        cmd = RerouteWireCommand(controller, 0)
+        cmd.execute()
+
+        # Undo should restore original waypoints
+        cmd.undo()
+        assert model.wires[0].waypoints == original_waypoints
+
+    def test_redo_clears_waypoints_again(self):
+        """Redo after undo clears waypoints again."""
+        model, controller = self._setup_circuit_with_wire()
+
+        cmd = RerouteWireCommand(controller, 0)
+        cmd.execute()
+        cmd.undo()
+        assert model.wires[0].waypoints == [(0.0, 0.0), (50.0, 0.0), (100.0, 0.0)]
+
+        cmd.execute()
+        assert model.wires[0].waypoints == []
+
+    def test_description(self):
+        """Command has correct description."""
+        model, controller = self._setup_circuit_with_wire()
+        cmd = RerouteWireCommand(controller, 0)
+        assert cmd.get_description() == "Reroute wire"
+
+    def test_invalid_wire_index_no_op(self):
+        """Reroute with invalid index does nothing."""
+        model = CircuitModel()
+        controller = CircuitController(model)
+
+        cmd = RerouteWireCommand(controller, 99)
+        cmd.execute()  # Should not raise
+        cmd.undo()  # Should not raise
+
+    def test_reroute_preserves_other_wire_data(self):
+        """Reroute only affects waypoints, not connection endpoints."""
+        model, controller = self._setup_circuit_with_wire()
+        wire = model.wires[0]
+        start_comp = wire.start_component_id
+        start_term = wire.start_terminal
+        end_comp = wire.end_component_id
+        end_term = wire.end_terminal
+
+        cmd = RerouteWireCommand(controller, 0)
+        cmd.execute()
+
+        assert wire.start_component_id == start_comp
+        assert wire.start_terminal == start_term
+        assert wire.end_component_id == end_comp
+        assert wire.end_terminal == end_term
+
+    def test_reroute_via_controller_is_undoable(self):
+        """Reroute executed through controller can be undone with controller.undo()."""
+        model, controller = self._setup_circuit_with_wire()
+        original_waypoints = [(0.0, 0.0), (50.0, 0.0), (100.0, 0.0)]
+
+        cmd = RerouteWireCommand(controller, 0)
+        controller.execute_command(cmd)
+
+        assert controller.can_undo()
+
+        controller.undo()
+        assert model.wires[0].waypoints == original_waypoints
+
+    def test_compound_reroute_multiple_wires(self):
+        """Rerouting multiple wires as a compound command is undoable as one step."""
+        model = CircuitModel()
+        controller = CircuitController(model)
+        r1 = controller.add_component("Resistor", (0, 0))
+        r2 = controller.add_component("Resistor", (100, 0))
+        r3 = controller.add_component("Resistor", (200, 0))
+        controller.add_wire(r1.component_id, 0, r2.component_id, 0)
+        controller.add_wire(r2.component_id, 1, r3.component_id, 0)
+        model.wires[0].waypoints = [(0.0, 0.0), (100.0, 0.0)]
+        model.wires[1].waypoints = [(100.0, 0.0), (200.0, 0.0)]
+
+        commands = [RerouteWireCommand(controller, 0), RerouteWireCommand(controller, 1)]
+        compound = CompoundCommand(commands, "Reroute 2 wires")
+        controller.execute_command(compound)
+
+        assert model.wires[0].waypoints == []
+        assert model.wires[1].waypoints == []
+
+        controller.undo()
+        assert model.wires[0].waypoints == [(0.0, 0.0), (100.0, 0.0)]
+        assert model.wires[1].waypoints == [(100.0, 0.0), (200.0, 0.0)]

--- a/app/tests/unit/test_undo_redo.py
+++ b/app/tests/unit/test_undo_redo.py
@@ -13,6 +13,7 @@ from controllers.commands import (
     MoveComponentCommand,
     PasteCommand,
     RotateComponentCommand,
+    ToggleWireLockCommand,
 )
 from controllers.undo_manager import UndoManager
 from models.circuit import CircuitModel
@@ -415,3 +416,90 @@ class TestCircuitControllerIntegration:
 
         assert not controller.can_undo()
         assert not controller.can_redo()
+
+
+class TestToggleWireLockCommand:
+    """Test wire lock/unlock command with undo."""
+
+    def _setup_circuit_with_wire(self):
+        """Helper to create a circuit with two components and one wire."""
+        model = CircuitModel()
+        controller = CircuitController(model)
+        r1 = controller.add_component("Resistor", (0, 0))
+        r2 = controller.add_component("Resistor", (100, 0))
+        controller.add_wire(r1.component_id, 0, r2.component_id, 0)
+        return model, controller
+
+    def test_lock_wire(self):
+        """Locking a wire sets locked=True."""
+        model, controller = self._setup_circuit_with_wire()
+        assert not model.wires[0].locked
+
+        cmd = ToggleWireLockCommand(controller, 0, True)
+        cmd.execute()
+        assert model.wires[0].locked
+
+    def test_unlock_wire(self):
+        """Unlocking a wire sets locked=False."""
+        model, controller = self._setup_circuit_with_wire()
+        model.wires[0].locked = True
+
+        cmd = ToggleWireLockCommand(controller, 0, False)
+        cmd.execute()
+        assert not model.wires[0].locked
+
+    def test_undo_lock(self):
+        """Undo restores previous locked state."""
+        model, controller = self._setup_circuit_with_wire()
+
+        cmd = ToggleWireLockCommand(controller, 0, True)
+        cmd.execute()
+        assert model.wires[0].locked
+
+        cmd.undo()
+        assert not model.wires[0].locked
+
+    def test_undo_unlock(self):
+        """Undo of unlock re-locks the wire."""
+        model, controller = self._setup_circuit_with_wire()
+        model.wires[0].locked = True
+
+        cmd = ToggleWireLockCommand(controller, 0, False)
+        cmd.execute()
+        assert not model.wires[0].locked
+
+        cmd.undo()
+        assert model.wires[0].locked
+
+    def test_description_lock(self):
+        """Lock command has correct description."""
+        model, controller = self._setup_circuit_with_wire()
+        cmd = ToggleWireLockCommand(controller, 0, True)
+        assert cmd.get_description() == "Lock wire"
+
+    def test_description_unlock(self):
+        """Unlock command has correct description."""
+        model, controller = self._setup_circuit_with_wire()
+        cmd = ToggleWireLockCommand(controller, 0, False)
+        assert cmd.get_description() == "Unlock wire"
+
+    def test_invalid_wire_index_no_op(self):
+        """Toggle on invalid wire index does nothing."""
+        model = CircuitModel()
+        controller = CircuitController(model)
+        cmd = ToggleWireLockCommand(controller, 99, True)
+        cmd.execute()  # Should not raise
+        cmd.undo()  # Should not raise
+
+    def test_lock_via_controller_undoable(self):
+        """Lock executed through controller is undoable."""
+        model, controller = self._setup_circuit_with_wire()
+
+        cmd = ToggleWireLockCommand(controller, 0, True)
+        controller.execute_command(cmd)
+
+        assert model.wires[0].locked
+        assert controller.can_undo()
+
+        controller.undo()
+        assert not model.wires[0].locked

--- a/app/tests/unit/test_wire_reroute_after_delete.py
+++ b/app/tests/unit/test_wire_reroute_after_delete.py
@@ -28,6 +28,7 @@ class TestRerouteWiresNearComponents:
         wire = MagicMock()
         wire.start_comp = start_comp
         wire.end_comp = end_comp
+        wire.model.locked = False
         return wire
 
     def test_reroutes_wire_sharing_start_component(self):

--- a/app/tests/unit/test_wire_reroute_dedup.py
+++ b/app/tests/unit/test_wire_reroute_dedup.py
@@ -149,6 +149,7 @@ class TestCoSelectedRerouteDedup:
         wire = Mock()
         wire.start_comp = comp_a
         wire.end_comp = comp_b
+        wire.model.locked = False
 
         canvas.wires = [wire]
 
@@ -176,6 +177,7 @@ class TestCoSelectedRerouteDedup:
         wire = Mock()
         wire.start_comp = comp_a
         wire.end_comp = comp_b
+        wire.model.locked = False
 
         canvas.wires = [wire]
 
@@ -203,6 +205,7 @@ class TestCoSelectedRerouteDedup:
         wire = Mock()
         wire.start_comp = comp_a
         wire.end_comp = comp_b
+        wire.model.locked = False
 
         canvas.wires = [wire]
 


### PR DESCRIPTION
## Summary - **Root cause**:  called  and  without first syncing / from the controller model to the graphics item model. The two are separate  objects (the graphics item copy is created via  in ), so toggling flip on the controller model had no effect on what  read. - **Fix 1** (): propagate  and  to  in  before calling . - **Fix 2** ():  overrides the base class without applying the flip scale transform; add the same  block that the base class uses. - **Tests**: three model-layer regression tests added — one that demonstrates the pre-fix bug (terminals unchanged without sync), two that verify the corrected sync for  and . ## Test plan - [ ] Run  — all tests pass - [ ] Human test: place a Diode, press F → symbol should mirror horizontally; press Shift+F → symbol should mirror vertically - [ ] Human test: place a Ground, press F → should mirror horizontally (previously no visual change) - [ ] Human test: undo flip (Ctrl+Z) → symbol returns to original orientation Closes #113 🤖 Generated with [Claude Code](https://claude.com/claude-code)