### PR TITLE
fix: route copy/paste through controller to sync with model (closes #443, #444, #445, #446)

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -42,17 +42,32 @@ class FileOperationsMixin:
         """Copy selected components to internal clipboard."""
         ids = self.canvas.get_selected_component_ids()
         if ids:
-            self.canvas.copy_selected_components(ids)
+            self.circuit_ctrl.copy_components(ids)
+            n = len(ids)
+            statusBar = self.statusBar()
+            if statusBar:
+                statusBar.showMessage(f"Copied {n} component{'s' if n != 1 else ''}", 2000)
 
     def cut_selected(self):
         """Cut selected components to internal clipboard."""
         ids = self.canvas.get_selected_component_ids()
         if ids:
-            self.canvas.cut_selected_components(ids)
+            self.circuit_ctrl.cut_components(ids)
 
     def paste_components(self):
         """Paste components from internal clipboard."""
-        self.canvas.paste_components()
+        new_comps, new_wires = self.circuit_ctrl.paste_components()
+        if new_comps:
+            # Select newly pasted items on the canvas
+            self.canvas.scene.clearSelection()
+            for comp_data in new_comps:
+                comp_item = self.canvas.components.get(comp_data.component_id)
+                if comp_item is not None:
+                    comp_item.setSelected(True)
+            n = len(new_comps)
+            statusBar = self.statusBar()
+            if statusBar:
+                statusBar.showMessage(f"Pasted {n} component{'s' if n != 1 else ''}", 2000)
 
     def copy_circuit_json(self):
         """Copy the entire circuit to system clipboard as JSON."""

--- a/app/tests/unit/test_copy_paste.py
+++ b/app/tests/unit/test_copy_paste.py
@@ -182,6 +182,27 @@ class TestPasteComponents:
         assert len(ctrl.model.components) == 4
         assert len(ctrl.model.wires) == 2
 
+    def test_paste_then_delete(self, controller):
+        """Pasted components must be deletable (regression: #443)."""
+        controller.add_component("Resistor", (0.0, 0.0))
+        controller.copy_components(["R1"])
+        new_comps, _ = controller.paste_components()
+        pasted_id = new_comps[0].component_id
+        assert pasted_id in controller.model.components
+        controller.remove_component(pasted_id)
+        assert pasted_id not in controller.model.components
+
+    def test_paste_ids_never_collide(self, controller):
+        """Multiple pastes must produce unique IDs (regression: #443)."""
+        controller.add_component("Resistor", (0.0, 0.0))
+        controller.copy_components(["R1"])
+        all_ids = {"R1"}
+        for _ in range(5):
+            new_comps, _ = controller.paste_components()
+            new_id = new_comps[0].component_id
+            assert new_id not in all_ids, f"Duplicate ID: {new_id}"
+            all_ids.add(new_id)
+
 
 class TestCutComponents:
     def test_cut_copies_and_deletes(self, controller, events):


### PR DESCRIPTION
## Summary
- **Root cause**: `copy_selected()`, `cut_selected()`, and `paste_components()` in `MainWindow` called canvas methods directly, bypassing `CircuitController`. Pasted components existed only as graphics items — absent from `CircuitModel` — causing duplicate IDs, undeletable components, and broken wire handling.
- **Fix**: Route all three operations through `circuit_ctrl` so the model stays in sync and observer events fire correctly.
- Added two regression tests: `test_paste_then_delete` and `test_paste_ids_never_collide`.

## Test plan
- [x] Existing 25 copy/paste controller tests pass (unchanged behavior)
- [x] New `test_paste_then_delete` — pasted component can be removed from model
- [x] New `test_paste_ids_never_collide` — 5 successive pastes produce unique IDs
- [x] Pre-commit hooks pass (black, isort, ruff)

Closes #443, closes #444, closes #445, closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)