### PR TITLE
fix: add Ctrl+Y as alternative redo shortcut (closes #450)

### DIFF
--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -139,7 +139,7 @@ class MenuBarMixin:
         self.undo_action = undo_action  # Store reference to update enabled state
 
         redo_action = QAction("&Redo", self)
-        redo_action.setShortcut(kb.get("edit.redo"))
+        redo_action.setShortcuts([kb.get("edit.redo"), "Ctrl+Y"])
         redo_action.triggered.connect(self._on_redo)
         edit_menu.addAction(redo_action)
         self.redo_action = redo_action  # Store reference to update enabled state


### PR DESCRIPTION
## Summary
- Redo was only bound to `Ctrl+Shift+Z`. Users on Windows expect `Ctrl+Y`.
- Use `setShortcuts()` to bind both `Ctrl+Shift+Z` and `Ctrl+Y` to the redo action.

## Test plan
- [x] Pre-commit hooks pass
- [ ] Manual: open app, make a change, Ctrl+Z to undo, Ctrl+Y to redo — change re-applies

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)