### PR TITLE
Drag-and-drop file import on circuit canvas (#398)

### DIFF
--- a/app/GUI/drag_drop_router.py
+++ b/app/GUI/drag_drop_router.py
@@ -1,0 +1,26 @@
+"""Route dropped files to the correct import handler based on extension.
+
+Pure-Python module (no Qt) so the routing logic is testable without a display.
+"""
+
+# Map file extensions to the FileController method name that handles them.
+EXTENSION_ROUTES = {
+    ".json": "load_circuit",
+    ".asc": "import_asc",
+    ".cir": "import_netlist",
+    ".spice": "import_netlist",
+    ".sp": "import_netlist",
+    ".net": "import_netlist",
+}
+
+
+def route_dropped_file(extension):
+    """Return the handler name for *extension*, or None if unsupported.
+
+    Args:
+        extension: file extension including the dot, e.g. ".json"
+
+    Returns:
+        str | None: handler name like "load_circuit", or None
+    """
+    return EXTENSION_ROUTES.get(extension.lower())

--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -11,6 +11,7 @@ MainWindow is composed from focused mixin modules:
 """
 
 import logging
+from pathlib import Path
 
 from controllers.circuit_controller import CircuitController
 from controllers.file_controller import FileController
@@ -100,6 +101,9 @@ class MainWindow(
         self._restore_settings()
         self._check_auto_save_recovery()
         self._load_last_session()
+
+        # Enable drag-and-drop of circuit files onto the window
+        self.setAcceptDrops(True)
 
         # Auto-save timer
         self._autosave_timer = QTimer(self)
@@ -363,3 +367,87 @@ class MainWindow(
             self.netlist_preview.set_netlist(netlist)
         except (ValueError, KeyError, TypeError) as e:
             self.netlist_preview.set_error(str(e))
+
+    # Drag-and-drop file import
+
+    def dragEnterEvent(self, event):
+        """Accept file drops onto the main window."""
+        if event is None:
+            return
+        mime = event.mimeData()
+        if mime and mime.hasUrls():
+            event.acceptProposedAction()
+
+    def dropEvent(self, event):
+        """Handle file drops — route by extension to the correct importer."""
+        if event is None:
+            return
+        mime = event.mimeData()
+        if not mime or not mime.hasUrls():
+            return
+
+        urls = mime.urls()
+        if not urls:
+            return
+
+        filepath = urls[0].toLocalFile()
+        if not filepath:
+            return
+
+        self._import_dropped_file(filepath)
+        event.acceptProposedAction()
+
+    def _import_dropped_file(self, filepath):
+        """Route a dropped file to the correct import handler by extension."""
+        from .drag_drop_router import route_dropped_file
+
+        ext = Path(filepath).suffix.lower()
+        handler_name = route_dropped_file(ext)
+
+        if handler_name is None:
+            QMessageBox.warning(
+                self,
+                "Unsupported File",
+                f"Cannot import '{Path(filepath).name}'.\n\nSupported formats: .json, .asc, .cir, .spice, .sp, .net",
+            )
+            return
+
+        # Prompt if current circuit has unsaved changes
+        if self._dirty or len(self.canvas.components) > 0:
+            reply = QMessageBox.question(
+                self,
+                "Import File",
+                f"Import '{Path(filepath).name}'?\nCurrent circuit will be replaced.",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            )
+            if reply == QMessageBox.StandardButton.No:
+                return
+
+        try:
+            if handler_name == "load_circuit":
+                self.file_ctrl.load_circuit(filepath)
+                self.setWindowTitle(f"Circuit Design GUI - {filepath}")
+                self._sync_analysis_menu()
+                self._apply_default_zoom()
+            elif handler_name == "import_netlist":
+                self.file_ctrl.import_netlist(filepath)
+                self.setWindowTitle(f"Circuit Design GUI - {Path(filepath).name} (imported)")
+                self._sync_analysis_menu()
+                self._set_dirty(True)
+            elif handler_name == "import_asc":
+                warnings = self.file_ctrl.import_asc(filepath)
+                self.setWindowTitle(f"Circuit Design GUI - {Path(filepath).name} (imported)")
+                self._sync_analysis_menu()
+                self._set_dirty(True)
+                if warnings:
+                    QMessageBox.information(
+                        self,
+                        "Import Warnings",
+                        "Warnings:\n" + "\n".join(f"  - {w}" for w in warnings),
+                    )
+
+            statusBar = self.statusBar()
+            if statusBar:
+                statusBar.showMessage(f"Imported {Path(filepath).name}", 3000)
+        except (OSError, ValueError) as e:
+            QMessageBox.critical(self, "Import Error", f"Failed to import file:\n{e}")

--- a/app/tests/unit/test_drag_drop.py
+++ b/app/tests/unit/test_drag_drop.py
@@ -1,0 +1,63 @@
+"""Tests for drag-and-drop file import routing logic."""
+
+import pytest
+from GUI.drag_drop_router import EXTENSION_ROUTES, route_dropped_file
+
+
+class TestRouteDroppedFile:
+    """Extension routing returns the correct handler name."""
+
+    def test_json_routes_to_load_circuit(self):
+        assert route_dropped_file(".json") == "load_circuit"
+
+    def test_asc_routes_to_import_asc(self):
+        assert route_dropped_file(".asc") == "import_asc"
+
+    def test_cir_routes_to_import_netlist(self):
+        assert route_dropped_file(".cir") == "import_netlist"
+
+    def test_spice_routes_to_import_netlist(self):
+        assert route_dropped_file(".spice") == "import_netlist"
+
+    def test_sp_routes_to_import_netlist(self):
+        assert route_dropped_file(".sp") == "import_netlist"
+
+    def test_net_routes_to_import_netlist(self):
+        assert route_dropped_file(".net") == "import_netlist"
+
+    def test_unsupported_extension_returns_none(self):
+        assert route_dropped_file(".pdf") is None
+        assert route_dropped_file(".txt") is None
+        assert route_dropped_file(".png") is None
+
+    def test_case_insensitive(self):
+        assert route_dropped_file(".JSON") == "load_circuit"
+        assert route_dropped_file(".ASC") == "import_asc"
+        assert route_dropped_file(".CIR") == "import_netlist"
+
+    def test_empty_extension_returns_none(self):
+        assert route_dropped_file("") is None
+
+
+class TestExtensionRoutes:
+    """The EXTENSION_ROUTES mapping is complete."""
+
+    def test_all_netlist_extensions_present(self):
+        for ext in (".cir", ".spice", ".sp", ".net"):
+            assert ext in EXTENSION_ROUTES
+
+    def test_json_present(self):
+        assert ".json" in EXTENSION_ROUTES
+
+    def test_asc_present(self):
+        assert ".asc" in EXTENSION_ROUTES
+
+
+class TestNoQtDependencies:
+    def test_no_pyqt_imports(self):
+        import GUI.drag_drop_router as mod
+
+        source = open(mod.__file__).read()
+        assert "PyQt" not in source
+        assert "QtCore" not in source
+        assert "QtWidgets" not in source


### PR DESCRIPTION
Adds drag-and-drop file import with extension routing (.json/.asc/.cir/.spice/.sp/.net). Pure-Python router module with tests. Closes #398