### PR TITLE
Recent exports quick-access menu with re-export (#401)

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -630,3 +630,141 @@ class FileOperationsMixin:
             self.file_ctrl.current_file = None
         except (OSError, ValueError) as e:
             QMessageBox.critical(self, "Error", f"Failed to load example: {e}")
+
+    # ------------------------------------------------------------------
+    # Recent exports tracking and re-export
+    # ------------------------------------------------------------------
+
+    def _track_export(self, path, fmt, export_function):
+        """Record a completed export for the Recent Exports menu."""
+        from .recent_exports import add_recent_export
+
+        add_recent_export(path, fmt, export_function)
+
+    def _populate_recent_exports_menu(self):
+        """Rebuild the Recent Exports submenu from QSettings."""
+        from .recent_exports import get_recent_exports
+
+        menu = self._recent_exports_menu
+        menu.clear()
+        entries = get_recent_exports()
+
+        if not entries:
+            empty = menu.addAction("(no recent exports)")
+            empty.setEnabled(False)
+            return
+
+        for entry in entries:
+            label = f"[{entry['format']}] {Path(entry['path']).name}"
+            action = menu.addAction(label)
+            path = entry["path"]
+            func_name = entry["export_function"]
+            action.triggered.connect(lambda checked=False, p=path, f=func_name: self._re_export_to(p, f))
+
+    def _on_re_export_last(self):
+        """Re-export using the most recent export settings."""
+        from .recent_exports import get_recent_exports
+
+        entries = get_recent_exports()
+        if not entries:
+            QMessageBox.information(self, "Re-export", "No recent exports to repeat.")
+            return
+
+        last = entries[0]
+        self._re_export_to(last["path"], last["export_function"])
+
+    def _re_export_to(self, path, export_function):
+        """Repeat an export operation to the given path."""
+        import os
+
+        try:
+            if export_function == "export_netlist":
+                netlist = self.simulation_ctrl.generate_netlist()
+                with open(path, "w") as f:
+                    f.write(netlist)
+            elif export_function == "export_image":
+                self.canvas.export_image(path, include_grid=False)
+            elif export_function == "export_bom_csv":
+                from simulation.bom_exporter import export_bom_csv, write_bom_csv
+
+                circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+                content = export_bom_csv(self.model.components, circuit_name=circuit_name)
+                write_bom_csv(content, path)
+            elif export_function == "export_bom_excel":
+                from simulation.bom_exporter import export_bom_excel
+
+                circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+                export_bom_excel(self.model.components, path, circuit_name=circuit_name)
+            elif export_function == "export_results_csv":
+                self._re_export_results_csv(path)
+            elif export_function == "export_results_excel":
+                self._re_export_results_excel(path)
+            elif export_function == "export_circuitikz":
+                from simulation.circuitikz_exporter import generate
+
+                content = generate(
+                    self.model.components,
+                    self.model.wires,
+                    self.model.nodes,
+                    self.model.terminal_to_node,
+                )
+                with open(path, "w") as f:
+                    f.write(content)
+            elif export_function == "export_asc":
+                from simulation.asc_exporter import export_asc, write_asc
+
+                content = export_asc(self.model)
+                write_asc(content, path)
+            elif export_function == "export_results_markdown":
+                md = self._get_markdown_content()
+                if md:
+                    from simulation.markdown_exporter import write_markdown
+
+                    write_markdown(md, path)
+            else:
+                QMessageBox.warning(self, "Re-export", f"Unknown export type: {export_function}")
+                return
+
+            statusBar = self.statusBar()
+            if statusBar:
+                statusBar.showMessage(f"Re-exported to {Path(path).name}", 3000)
+        except Exception as e:
+            QMessageBox.critical(self, "Re-export Error", f"Failed to re-export:\n{e}")
+
+    def _re_export_results_csv(self, path):
+        """Re-export simulation results to CSV at the given path."""
+        if self._last_results is None:
+            return
+        import os
+
+        from simulation.csv_exporter import (
+            export_ac_results,
+            export_dc_sweep_results,
+            export_noise_results,
+            export_op_results,
+            export_transient_results,
+            write_csv,
+        )
+
+        circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+        dispatch = {
+            "DC Operating Point": export_op_results,
+            "DC Sweep": export_dc_sweep_results,
+            "AC Sweep": export_ac_results,
+            "Transient": export_transient_results,
+            "Noise": export_noise_results,
+        }
+        func = dispatch.get(self._last_results_type)
+        if func:
+            write_csv(func(self._last_results, circuit_name), path)
+
+    def _re_export_results_excel(self, path):
+        """Re-export simulation results to Excel at the given path."""
+        if self._last_results is None:
+            return
+        import os
+
+        from simulation.excel_exporter import export_to_excel
+
+        circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+        export_to_excel(self._last_results, self._last_results_type, path, circuit_name)

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -1,7 +1,7 @@
 """Menu bar construction and keybinding management for MainWindow."""
 
-from PyQt6.QtGui import QAction, QActionGroup
-from PyQt6.QtWidgets import QDialog
+from PyQt6.QtGui import QAction, QActionGroup, QKeySequence
+from PyQt6.QtWidgets import QDialog, QMenu
 
 
 class MenuBarMixin:
@@ -106,6 +106,16 @@ class MenuBarMixin:
         generate_report_action.setToolTip("Generate a comprehensive PDF report with schematic, netlist, and results")
         generate_report_action.triggered.connect(self._on_generate_report)
         file_menu.addAction(generate_report_action)
+
+        re_export_action = QAction("Re-export &Last", self)
+        re_export_action.setShortcut(QKeySequence("Ctrl+Shift+E"))
+        re_export_action.setToolTip("Repeat the most recent export operation")
+        re_export_action.triggered.connect(self._on_re_export_last)
+        file_menu.addAction(re_export_action)
+
+        self._recent_exports_menu = QMenu("Recent E&xports", self)
+        file_menu.addMenu(self._recent_exports_menu)
+        self._recent_exports_menu.aboutToShow.connect(self._populate_recent_exports_menu)
 
         file_menu.addSeparator()
 

--- a/app/GUI/recent_exports.py
+++ b/app/GUI/recent_exports.py
@@ -1,0 +1,75 @@
+"""Track recent export operations for quick re-export.
+
+Stores up to MAX_RECENT_EXPORTS entries in QSettings.  Each entry is a dict
+with keys: path, format, export_function, timestamp.
+"""
+
+import json
+import os
+from datetime import datetime
+
+from PyQt6.QtCore import QSettings
+
+MAX_RECENT_EXPORTS = 5
+SETTINGS_KEY = "export/recent_exports"
+
+
+def get_recent_exports():
+    """Return list of recent export dicts (most recent first).
+
+    Each dict has keys: path, format, export_function, timestamp.
+    Non-existent paths are filtered out.
+    """
+    settings = QSettings("SDSMT", "SDM Spice")
+    raw = settings.value(SETTINGS_KEY, "[]")
+
+    try:
+        entries = json.loads(raw) if isinstance(raw, str) else []
+    except (json.JSONDecodeError, TypeError):
+        entries = []
+
+    if not isinstance(entries, list):
+        entries = []
+
+    # Filter out files that no longer exist
+    existing = [e for e in entries if isinstance(e, dict) and os.path.exists(e.get("path", ""))]
+    if len(existing) != len(entries):
+        settings.setValue(SETTINGS_KEY, json.dumps(existing))
+
+    return existing
+
+
+def add_recent_export(path, fmt, export_function):
+    """Record an export operation.
+
+    Args:
+        path: file path that was exported to
+        fmt: human-readable format name (e.g. "CSV", "Excel", "Image")
+        export_function: callable name to repeat the export (e.g. "export_results_csv")
+    """
+    entry = {
+        "path": str(path),
+        "format": fmt,
+        "export_function": export_function,
+        "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    }
+
+    entries = get_recent_exports()
+
+    # Remove duplicate path
+    entries = [e for e in entries if e.get("path") != entry["path"]]
+
+    # Prepend
+    entries.insert(0, entry)
+
+    # Cap
+    entries = entries[:MAX_RECENT_EXPORTS]
+
+    settings = QSettings("SDSMT", "SDM Spice")
+    settings.setValue(SETTINGS_KEY, json.dumps(entries))
+
+
+def clear_recent_exports():
+    """Clear all recent export entries."""
+    settings = QSettings("SDSMT", "SDM Spice")
+    settings.setValue(SETTINGS_KEY, "[]")

--- a/app/tests/unit/test_recent_exports.py
+++ b/app/tests/unit/test_recent_exports.py
@@ -1,0 +1,104 @@
+"""Tests for recent exports tracking and recall logic."""
+
+import json
+import os
+import tempfile
+
+import pytest
+from GUI.recent_exports import (
+    MAX_RECENT_EXPORTS,
+    SETTINGS_KEY,
+    add_recent_export,
+    clear_recent_exports,
+    get_recent_exports,
+)
+from PyQt6.QtCore import QSettings
+
+
+@pytest.fixture(autouse=True)
+def _clean_settings():
+    """Clear recent exports before and after each test."""
+    settings = QSettings("SDSMT", "SDM Spice")
+    settings.setValue(SETTINGS_KEY, "[]")
+    yield
+    settings.setValue(SETTINGS_KEY, "[]")
+
+
+class TestGetRecentExports:
+    def test_empty_by_default(self):
+        assert get_recent_exports() == []
+
+    def test_returns_list(self):
+        result = get_recent_exports()
+        assert isinstance(result, list)
+
+
+class TestAddRecentExport:
+    def test_add_one_export(self, tmp_path):
+        path = tmp_path / "test.csv"
+        path.touch()
+        add_recent_export(str(path), "CSV", "export_results_csv")
+        exports = get_recent_exports()
+        assert len(exports) == 1
+        assert exports[0]["path"] == str(path)
+        assert exports[0]["format"] == "CSV"
+        assert exports[0]["export_function"] == "export_results_csv"
+
+    def test_most_recent_first(self, tmp_path):
+        p1 = tmp_path / "first.csv"
+        p2 = tmp_path / "second.csv"
+        p1.touch()
+        p2.touch()
+        add_recent_export(str(p1), "CSV", "export_results_csv")
+        add_recent_export(str(p2), "Excel", "export_results_excel")
+        exports = get_recent_exports()
+        assert exports[0]["path"] == str(p2)
+        assert exports[1]["path"] == str(p1)
+
+    def test_duplicate_path_moves_to_front(self, tmp_path):
+        p1 = tmp_path / "file.csv"
+        p2 = tmp_path / "other.xlsx"
+        p1.touch()
+        p2.touch()
+        add_recent_export(str(p1), "CSV", "export_results_csv")
+        add_recent_export(str(p2), "Excel", "export_results_excel")
+        add_recent_export(str(p1), "CSV", "export_results_csv")
+        exports = get_recent_exports()
+        assert len(exports) == 2
+        assert exports[0]["path"] == str(p1)
+
+    def test_max_limit_enforced(self, tmp_path):
+        for i in range(MAX_RECENT_EXPORTS + 3):
+            p = tmp_path / f"file{i}.csv"
+            p.touch()
+            add_recent_export(str(p), "CSV", "export_results_csv")
+        exports = get_recent_exports()
+        assert len(exports) == MAX_RECENT_EXPORTS
+
+    def test_has_timestamp(self, tmp_path):
+        p = tmp_path / "test.csv"
+        p.touch()
+        add_recent_export(str(p), "CSV", "export_results_csv")
+        exports = get_recent_exports()
+        assert "timestamp" in exports[0]
+
+
+class TestClearRecentExports:
+    def test_clear(self, tmp_path):
+        p = tmp_path / "test.csv"
+        p.touch()
+        add_recent_export(str(p), "CSV", "export_results_csv")
+        assert len(get_recent_exports()) == 1
+        clear_recent_exports()
+        assert len(get_recent_exports()) == 0
+
+
+class TestFiltersMissing:
+    def test_filters_nonexistent_paths(self, tmp_path):
+        p = tmp_path / "exists.csv"
+        p.touch()
+        add_recent_export(str(p), "CSV", "export_results_csv")
+        add_recent_export("/nonexistent/path.csv", "CSV", "export_results_csv")
+        exports = get_recent_exports()
+        # Only the existing file should remain
+        assert all(os.path.exists(e["path"]) for e in exports)


### PR DESCRIPTION
Tracks last 5 exports in QSettings with Recent Exports submenu and Re-export Last (Ctrl+Shift+E). Supports all export types. Closes #401