### PR TITLE
feat: Draggable waypoint handles for manual wire reshaping (#262)

### DIFF
--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -7,11 +7,58 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from models.wire import WireData
 from PyQt6.QtCore import QPointF, Qt
 from PyQt6.QtGui import QBrush, QPainterPath, QPainterPathStroker, QPen
-from PyQt6.QtWidgets import QGraphicsPathItem
+from PyQt6.QtWidgets import QGraphicsEllipseItem, QGraphicsPathItem
 
 from .styles import GRID_SIZE, WIRE_CLICK_WIDTH, theme_manager
 
+# Radius of the draggable waypoint handles (in scene units)
+_HANDLE_RADIUS = 5
+
 logger = logging.getLogger(__name__)
+
+
+class WaypointHandle(QGraphicsEllipseItem):
+    """Small draggable circle displayed at a wire waypoint.
+
+    When the user drags a handle the parent wire's waypoints list is
+    updated in real time and the wire path is redrawn.  On release the
+    model is synced and the wire is marked locked so auto-rerouting
+    won't overwrite the manual adjustment.
+    """
+
+    def __init__(self, wire: "WireGraphicsItem", index: int, pos: QPointF):
+        r = _HANDLE_RADIUS
+        super().__init__(-r, -r, 2 * r, 2 * r)
+        self._wire = wire
+        self._index = index
+        self.setPos(pos)
+        self.setBrush(QBrush(theme_manager.color("wire_selected")))
+        self.setPen(QPen(Qt.GlobalColor.white, 1))
+        self.setZValue(200)  # Above everything
+        self.setFlag(QGraphicsEllipseItem.GraphicsItemFlag.ItemIsMovable, True)
+        self.setFlag(QGraphicsEllipseItem.GraphicsItemFlag.ItemSendsGeometryChanges, True)
+        self.setCursor(Qt.CursorShape.SizeAllCursor)
+
+    def itemChange(self, change, value):
+        if change == QGraphicsEllipseItem.GraphicsItemChange.ItemPositionHasChanged:
+            new_pos = value
+            # Snap to grid
+            snapped = QPointF(
+                round(new_pos.x() / GRID_SIZE) * GRID_SIZE,
+                round(new_pos.y() / GRID_SIZE) * GRID_SIZE,
+            )
+            self._wire._move_waypoint(self._index, snapped)
+        return super().itemChange(change, value)
+
+    def mouseReleaseEvent(self, event):
+        super().mouseReleaseEvent(event)
+        # Snap position visually after drag
+        snapped = QPointF(
+            round(self.pos().x() / GRID_SIZE) * GRID_SIZE,
+            round(self.pos().y() / GRID_SIZE) * GRID_SIZE,
+        )
+        self.setPos(snapped)
+        self._wire._finish_waypoint_drag()
 
 
 class WireGraphicsItem(QGraphicsPathItem):
@@ -64,8 +111,11 @@ class WireGraphicsItem(QGraphicsPathItem):
 
         self.waypoints = []  # List of QPointF waypoints (computed during routing)
 
+        self._waypoint_handles: list[WaypointHandle] = []
+
         self.setPen(QPen(self.layer_color, theme_manager.wire_thickness_px))
         self.setFlag(QGraphicsPathItem.GraphicsItemFlag.ItemIsSelectable)
+        self.setFlag(QGraphicsPathItem.GraphicsItemFlag.ItemSendsGeometryChanges)
         self.setZValue(1)  # Render wires above components (z=0)
 
         if self.model.waypoints:
@@ -284,6 +334,75 @@ class WireGraphicsItem(QGraphicsPathItem):
         stroker.setCapStyle(Qt.PenCapStyle.RoundCap)
         stroker.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
         return stroker.createStroke(self.path())
+
+    # --- Waypoint handle management ---
+
+    def itemChange(self, change, value):
+        """Show / hide waypoint handles when selection state changes."""
+        if change == QGraphicsPathItem.GraphicsItemChange.ItemSelectedHasChanged:
+            if value:
+                self._show_handles()
+            else:
+                self._hide_handles()
+        return super().itemChange(change, value)
+
+    def _show_handles(self):
+        """Create draggable handles at each interior waypoint."""
+        self._hide_handles()
+        if len(self.waypoints) < 3:
+            return  # Only start/end — nothing to drag
+        scene = self.scene()
+        if scene is None:
+            return
+        for i, wp in enumerate(self.waypoints):
+            if i == 0 or i == len(self.waypoints) - 1:
+                continue  # Skip terminal endpoints
+            pt = wp if isinstance(wp, QPointF) else QPointF(wp[0], wp[1])
+            handle = WaypointHandle(self, i, pt)
+            scene.addItem(handle)
+            self._waypoint_handles.append(handle)
+
+    def _hide_handles(self):
+        """Remove all waypoint handles from the scene."""
+        scene = self.scene()
+        for handle in self._waypoint_handles:
+            if scene:
+                scene.removeItem(handle)
+        self._waypoint_handles.clear()
+
+    def _move_waypoint(self, index: int, new_pos: QPointF):
+        """Called by WaypointHandle during drag to update the wire path."""
+        if 0 < index < len(self.waypoints):
+            self.waypoints[index] = new_pos
+            self._rebuild_path_from_waypoints()
+
+    def _finish_waypoint_drag(self):
+        """Called by WaypointHandle on mouse release to persist changes."""
+        # Sync to model
+        self.model.waypoints = [
+            (wp.x() if isinstance(wp, QPointF) else wp[0], wp.y() if isinstance(wp, QPointF) else wp[1])
+            for wp in self.waypoints
+        ]
+        self.model.locked = True
+        # Notify controller if available
+        if self.canvas and hasattr(self.canvas, "controller") and self.canvas.controller:
+            self.canvas.controller._notify("wire_routed", self.model)
+
+    def _rebuild_path_from_waypoints(self):
+        """Rebuild the QPainterPath from the current waypoints list."""
+        old_rect = self.boundingRect()
+        self.prepareGeometryChange()
+        path = QPainterPath()
+        if self.waypoints:
+            first = self.waypoints[0]
+            path.moveTo(first if isinstance(first, QPointF) else QPointF(first[0], first[1]))
+            for wp in self.waypoints[1:]:
+                path.lineTo(wp if isinstance(wp, QPointF) else QPointF(wp[0], wp[1]))
+        self.setPath(path)
+        if self.scene():
+            self.scene().update(old_rect)
+            self.scene().update(self.boundingRect())
+        self.update()
 
     def get_terminals(self):
         """Get both terminal identifiers for this wire"""

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -4,8 +4,22 @@ Shared test fixtures for the Spice-GUI test suite.
 All fixtures build pure-Python model objects (no Qt dependencies).
 """
 
+import os
 import sys
 from pathlib import Path
+
+# Prevent matplotlib.use("QtAgg") from failing in headless environments.
+if os.environ.get("QT_QPA_PLATFORM") == "offscreen":
+    import matplotlib
+
+    _orig_mpl_use = matplotlib.use
+
+    def _safe_mpl_use(backend, **kwargs):
+        if backend == "QtAgg":
+            return
+        return _orig_mpl_use(backend, **kwargs)
+
+    matplotlib.use = _safe_mpl_use
 
 # Ensure app/ is on sys.path so bare imports (models, simulation, GUI, controllers)
 # work when running individual test files (e.g., python -m pytest app/tests/unit/test_foo.py).

--- a/app/tests/unit/test_waypoint_editing.py
+++ b/app/tests/unit/test_waypoint_editing.py
@@ -1,0 +1,209 @@
+"""
+Unit tests for manual waypoint editing (#262).
+
+Tests that draggable handles appear at wire waypoints when the wire is
+selected, that dragging a handle updates the wire path, and that the
+model is synced and locked after editing.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from models.wire import WireData
+from PyQt6.QtCore import QPointF
+
+
+@pytest.fixture
+def mock_canvas():
+    """Create a minimal canvas mock."""
+    canvas = MagicMock()
+    canvas.wires = []
+    canvas.components = {}
+    canvas.controller = MagicMock()
+    return canvas
+
+
+@pytest.fixture
+def wire_with_waypoints(mock_canvas):
+    """Create a WireGraphicsItem with pre-set waypoints (no pathfinding)."""
+    from GUI.wire_item import WireGraphicsItem
+
+    model = WireData(
+        start_component_id="R1",
+        start_terminal=0,
+        end_component_id="R2",
+        end_terminal=1,
+        waypoints=[(0, 0), (50, 0), (50, 50), (100, 50)],
+    )
+
+    start_comp = MagicMock()
+    start_comp.component_id = "R1"
+    start_comp.get_terminal_pos.return_value = QPointF(0, 0)
+
+    end_comp = MagicMock()
+    end_comp.component_id = "R2"
+    end_comp.get_terminal_pos.return_value = QPointF(100, 50)
+
+    wire = WireGraphicsItem(
+        start_comp=start_comp,
+        start_term=0,
+        end_comp=end_comp,
+        end_term=1,
+        canvas=mock_canvas,
+        model=model,
+    )
+    return wire
+
+
+class TestWaypointHandleCreation:
+    """Test that waypoint handles are created on selection."""
+
+    def test_handles_list_initially_empty(self, wire_with_waypoints):
+        assert wire_with_waypoints._waypoint_handles == []
+
+    def test_show_handles_creates_interior_handles(self, wire_with_waypoints, qtbot):
+        from PyQt6.QtWidgets import QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(wire_with_waypoints)
+        # 4 waypoints, interior = index 1 and 2
+        wire_with_waypoints._show_handles()
+        assert len(wire_with_waypoints._waypoint_handles) == 2
+
+    def test_hide_handles_removes_all(self, wire_with_waypoints, qtbot):
+        from PyQt6.QtWidgets import QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(wire_with_waypoints)
+        wire_with_waypoints._show_handles()
+        assert len(wire_with_waypoints._waypoint_handles) == 2
+        wire_with_waypoints._hide_handles()
+        assert len(wire_with_waypoints._waypoint_handles) == 0
+
+    def test_no_handles_for_two_point_wire(self, mock_canvas, qtbot):
+        from GUI.wire_item import WireGraphicsItem
+
+        model = WireData(
+            start_component_id="R1",
+            start_terminal=0,
+            end_component_id="R2",
+            end_terminal=1,
+            waypoints=[(0, 0), (100, 0)],
+        )
+        start_comp = MagicMock()
+        start_comp.component_id = "R1"
+        start_comp.get_terminal_pos.return_value = QPointF(0, 0)
+        end_comp = MagicMock()
+        end_comp.component_id = "R2"
+        end_comp.get_terminal_pos.return_value = QPointF(100, 0)
+
+        wire = WireGraphicsItem(
+            start_comp=start_comp,
+            start_term=0,
+            end_comp=end_comp,
+            end_term=1,
+            canvas=mock_canvas,
+            model=model,
+        )
+        from PyQt6.QtWidgets import QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(wire)
+        wire._show_handles()
+        assert len(wire._waypoint_handles) == 0
+
+    def test_handles_positioned_at_waypoints(self, wire_with_waypoints, qtbot):
+        from PyQt6.QtWidgets import QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(wire_with_waypoints)
+        wire_with_waypoints._show_handles()
+        handle1, handle2 = wire_with_waypoints._waypoint_handles
+        assert handle1.pos() == QPointF(50, 0)
+        assert handle2.pos() == QPointF(50, 50)
+
+
+class TestWaypointDragging:
+    """Test that dragging a handle updates the wire path."""
+
+    def test_move_waypoint_updates_wire(self, wire_with_waypoints, qtbot):
+        new_pos = QPointF(60, 10)
+        wire_with_waypoints._move_waypoint(1, new_pos)
+        assert wire_with_waypoints.waypoints[1] == new_pos
+
+    def test_move_waypoint_ignores_endpoints(self, wire_with_waypoints, qtbot):
+        original_start = wire_with_waypoints.waypoints[0]
+        wire_with_waypoints._move_waypoint(0, QPointF(999, 999))
+        assert wire_with_waypoints.waypoints[0] == original_start
+
+    def test_finish_drag_syncs_model(self, wire_with_waypoints, qtbot):
+        wire_with_waypoints._move_waypoint(1, QPointF(60, 10))
+        wire_with_waypoints._finish_waypoint_drag()
+        model_wps = wire_with_waypoints.model.waypoints
+        assert (60.0, 10.0) in model_wps
+
+    def test_finish_drag_locks_wire(self, wire_with_waypoints, qtbot):
+        assert not wire_with_waypoints.model.locked
+        wire_with_waypoints._move_waypoint(1, QPointF(60, 10))
+        wire_with_waypoints._finish_waypoint_drag()
+        assert wire_with_waypoints.model.locked
+
+    def test_finish_drag_notifies_controller(self, wire_with_waypoints, qtbot):
+        wire_with_waypoints._move_waypoint(1, QPointF(60, 10))
+        wire_with_waypoints._finish_waypoint_drag()
+        wire_with_waypoints.canvas.controller._notify.assert_called_once_with("wire_routed", wire_with_waypoints.model)
+
+    def test_path_rebuilt_after_move(self, wire_with_waypoints, qtbot):
+        old_path = wire_with_waypoints.path()
+        old_element_count = old_path.elementCount()
+        wire_with_waypoints._move_waypoint(1, QPointF(60, 10))
+        new_path = wire_with_waypoints.path()
+        # Path should still have same number of elements (segments)
+        assert new_path.elementCount() == old_element_count
+
+
+class TestWaypointHandleProperties:
+    """Test WaypointHandle properties and behavior."""
+
+    def test_handle_is_movable(self, wire_with_waypoints, qtbot):
+        from PyQt6.QtWidgets import QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(wire_with_waypoints)
+        wire_with_waypoints._show_handles()
+        handle = wire_with_waypoints._waypoint_handles[0]
+        flags = handle.flags()
+        from PyQt6.QtWidgets import QGraphicsItem
+
+        assert flags & QGraphicsItem.GraphicsItemFlag.ItemIsMovable
+
+    def test_handle_z_value_above_wire(self, wire_with_waypoints, qtbot):
+        from PyQt6.QtWidgets import QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(wire_with_waypoints)
+        wire_with_waypoints._show_handles()
+        handle = wire_with_waypoints._waypoint_handles[0]
+        assert handle.zValue() > wire_with_waypoints.zValue()
+
+
+class TestSelectionToggle:
+    """Test that selection toggles handles via itemChange."""
+
+    def test_selection_shows_handles(self, wire_with_waypoints, qtbot):
+        from PyQt6.QtWidgets import QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(wire_with_waypoints)
+        wire_with_waypoints.setSelected(True)
+        assert len(wire_with_waypoints._waypoint_handles) == 2
+
+    def test_deselection_hides_handles(self, wire_with_waypoints, qtbot):
+        from PyQt6.QtWidgets import QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(wire_with_waypoints)
+        wire_with_waypoints.setSelected(True)
+        assert len(wire_with_waypoints._waypoint_handles) == 2
+        wire_with_waypoints.setSelected(False)
+        assert len(wire_with_waypoints._waypoint_handles) == 0


### PR DESCRIPTION
## Summary - Adds draggable **WaypointHandle** circles at interior wire waypoints when a wire is selected - Dragging a handle updates the wire path in real time with grid snapping - On mouse release, model waypoints are synced and the wire is auto-locked to prevent rerouting - Controller notified via  event for dirty flag tracking ## Test plan - [x] 15 new tests covering handle creation, dragging, model sync, selection toggle - [x] ruff check --fix app/ pass cleanly - [x] Full test suite passes (2710 tests) - [ ] Manual: select a routed wire, verify blue handles appear at bend points - [ ] Manual: drag a handle, verify wire reshapes in real time - [ ] Manual: after drag, verify wire shows locked (dotted) style Closes #262