### PR TITLE
feat: Click-to-place waypoints during wire drawing (#263)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -1,6 +1,6 @@
 import logging
 
-from PyQt6.QtCore import QPoint, QRect, QRectF, Qt, QTimer, pyqtSignal
+from PyQt6.QtCore import QPoint, QPointF, QRect, QRectF, Qt, QTimer, pyqtSignal
 from PyQt6.QtGui import QAction, QBrush, QPainter, QPen
 from PyQt6.QtWidgets import (
     QGraphicsLineItem,
@@ -104,6 +104,8 @@ class CircuitCanvasView(QGraphicsView):
         self.wire_start_comp = None
         self.wire_start_term = None
         self.temp_wire_line = None  # Temporary line while drawing wire
+        self._wire_waypoints: list[QPointF] = []  # In-progress waypoints (click-to-place)
+        self._wire_waypoint_markers: list = []  # Visual markers for placed waypoints
 
         # Rubber band selection
         self._rubber_band = None
@@ -707,12 +709,23 @@ class CircuitCanvasView(QGraphicsView):
 
                         if can_connect:
                             if self.controller:
+                                # Build manual waypoints if the user clicked intermediate points
+                                manual_wps = None
+                                if self._wire_waypoints:
+                                    start_pos = self.wire_start_comp.get_terminal_pos(self.wire_start_term)
+                                    end_pos = clicked_component.get_terminal_pos(target_term)
+                                    manual_wps = (
+                                        [(start_pos.x(), start_pos.y())]
+                                        + [(wp.x(), wp.y()) for wp in self._wire_waypoints]
+                                        + [(end_pos.x(), end_pos.y())]
+                                    )
                                 # Controller creates wire, observer creates graphics item
                                 self.controller.add_wire(
                                     self.wire_start_comp.component_id,
                                     self.wire_start_term,
                                     clicked_component.component_id,
                                     target_term,
+                                    waypoints=manual_wps,
                                 )
                                 self.wireAdded.emit(
                                     self.wire_start_comp.component_id,
@@ -742,9 +755,16 @@ class CircuitCanvasView(QGraphicsView):
                     # Wire completed, allow normal behavior to continue
                     # Don't accept - let event propagate for other handling
 
-            # If we're in wire drawing mode but clicked elsewhere, cancel it
+            # If we're in wire drawing mode but clicked elsewhere, place a waypoint
             elif self.wire_start_comp is not None:
-                self.cancel_wire_drawing()
+                snapped = QPointF(
+                    round(scene_pos.x() / GRID_SIZE) * GRID_SIZE,
+                    round(scene_pos.y() / GRID_SIZE) * GRID_SIZE,
+                )
+                self._wire_waypoints.append(snapped)
+                self._add_waypoint_marker(snapped)
+                event.accept()
+                return
 
             # If we didn't click a terminal, check if we clicked an empty area
             else:
@@ -771,11 +791,14 @@ class CircuitCanvasView(QGraphicsView):
             return
 
         if self.wire_start_comp is not None and self.temp_wire_line is not None:
-            # Update temporary wire to follow mouse
+            # Update temporary wire to follow mouse from last waypoint (or start terminal)
             pos = event.position().toPoint()
             scene_pos = self.mapToScene(pos)
-            start_pos = self.wire_start_comp.get_terminal_pos(self.wire_start_term)
-            self.temp_wire_line.setLine(start_pos.x(), start_pos.y(), scene_pos.x(), scene_pos.y())
+            if self._wire_waypoints:
+                anchor = self._wire_waypoints[-1]
+            else:
+                anchor = self.wire_start_comp.get_terminal_pos(self.wire_start_term)
+            self.temp_wire_line.setLine(anchor.x(), anchor.y(), scene_pos.x(), scene_pos.y())
             self.temp_wire_line.update()
             event.accept()
             return
@@ -816,6 +839,27 @@ class CircuitCanvasView(QGraphicsView):
             self.temp_wire_line = None
         self.wire_start_comp = None
         self.wire_start_term = None
+        self._wire_waypoints.clear()
+        self._remove_waypoint_markers()
+
+    def _add_waypoint_marker(self, pos: QPointF):
+        """Draw a small dot at a placed waypoint during wire drawing."""
+        from PyQt6.QtWidgets import QGraphicsEllipseItem
+
+        r = 4
+        marker = QGraphicsEllipseItem(-r, -r, 2 * r, 2 * r)
+        marker.setPos(pos)
+        marker.setBrush(QBrush(theme_manager.color("wire_preview")))
+        marker.setPen(QPen(Qt.PenStyle.NoPen))
+        marker.setZValue(101)
+        self.scene.addItem(marker)
+        self._wire_waypoint_markers.append(marker)
+
+    def _remove_waypoint_markers(self):
+        """Remove all placed-waypoint visual markers."""
+        for marker in self._wire_waypoint_markers:
+            self.scene.removeItem(marker)
+        self._wire_waypoint_markers.clear()
 
     def focusOutEvent(self, event):
         """Cancel wire drawing when the canvas loses focus (e.g. modal dialog opens)."""

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -4,8 +4,22 @@ Shared test fixtures for the Spice-GUI test suite.
 All fixtures build pure-Python model objects (no Qt dependencies).
 """
 
+import os
 import sys
 from pathlib import Path
+
+# Prevent matplotlib.use("QtAgg") from failing in headless environments.
+if os.environ.get("QT_QPA_PLATFORM") == "offscreen":
+    import matplotlib
+
+    _orig_mpl_use = matplotlib.use
+
+    def _safe_mpl_use(backend, **kwargs):
+        if backend == "QtAgg":
+            return
+        return _orig_mpl_use(backend, **kwargs)
+
+    matplotlib.use = _safe_mpl_use
 
 # Ensure app/ is on sys.path so bare imports (models, simulation, GUI, controllers)
 # work when running individual test files (e.g., python -m pytest app/tests/unit/test_foo.py).

--- a/app/tests/unit/test_click_waypoints.py
+++ b/app/tests/unit/test_click_waypoints.py
@@ -1,0 +1,137 @@
+"""
+Unit tests for click-to-place waypoints during wire drawing (#263).
+
+Tests that clicking in empty space during wire drawing adds waypoints,
+that the preview line anchors from the last waypoint, and that waypoints
+are passed to the controller on wire completion.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt6.QtCore import QPointF
+
+
+@pytest.fixture
+def canvas(qtbot):
+    """Create a CircuitCanvasView inside a QApplication context."""
+    from GUI.circuit_canvas import CircuitCanvasView
+
+    c = CircuitCanvasView()
+    qtbot.addWidget(c)
+    return c
+
+
+class TestWireWaypointState:
+    """Test that the canvas tracks in-progress waypoints."""
+
+    def test_initial_waypoints_empty(self, canvas):
+        assert canvas._wire_waypoints == []
+
+    def test_initial_markers_empty(self, canvas):
+        assert canvas._wire_waypoint_markers == []
+
+
+class TestCancelClearsWaypoints:
+    """Test that cancel_wire_drawing clears waypoints and markers."""
+
+    def test_cancel_clears_waypoints(self, canvas):
+        canvas._wire_waypoints.append(QPointF(50, 50))
+        canvas.cancel_wire_drawing()
+        assert canvas._wire_waypoints == []
+
+    def test_cancel_clears_markers(self, canvas):
+        canvas._add_waypoint_marker(QPointF(50, 50))
+        assert len(canvas._wire_waypoint_markers) == 1
+        canvas.cancel_wire_drawing()
+        assert canvas._wire_waypoint_markers == []
+
+    def test_cancel_clears_temp_line(self, canvas):
+        from PyQt6.QtWidgets import QGraphicsLineItem
+
+        line = QGraphicsLineItem(0, 0, 100, 100)
+        canvas.scene.addItem(line)
+        canvas.temp_wire_line = line
+        canvas.cancel_wire_drawing()
+        assert canvas.temp_wire_line is None
+
+    def test_cancel_resets_start_comp(self, canvas):
+        canvas.wire_start_comp = MagicMock()
+        canvas.cancel_wire_drawing()
+        assert canvas.wire_start_comp is None
+
+
+class TestWaypointMarkers:
+    """Test visual waypoint marker management."""
+
+    def test_add_marker_creates_item(self, canvas):
+        canvas._add_waypoint_marker(QPointF(100, 100))
+        assert len(canvas._wire_waypoint_markers) == 1
+
+    def test_add_multiple_markers(self, canvas):
+        canvas._add_waypoint_marker(QPointF(50, 50))
+        canvas._add_waypoint_marker(QPointF(100, 100))
+        assert len(canvas._wire_waypoint_markers) == 2
+
+    def test_remove_markers_clears_list(self, canvas):
+        canvas._add_waypoint_marker(QPointF(50, 50))
+        canvas._remove_waypoint_markers()
+        assert len(canvas._wire_waypoint_markers) == 0
+
+    def test_marker_z_value_above_preview(self, canvas):
+        canvas._add_waypoint_marker(QPointF(50, 50))
+        marker = canvas._wire_waypoint_markers[0]
+        assert marker.zValue() > 100  # Preview line is at z=100
+
+    def test_marker_positioned_correctly(self, canvas):
+        pos = QPointF(75, 25)
+        canvas._add_waypoint_marker(pos)
+        marker = canvas._wire_waypoint_markers[0]
+        assert marker.pos() == pos
+
+
+class TestWaypointPassthrough:
+    """Test that manually placed waypoints are passed to the controller."""
+
+    def test_empty_waypoints(self, canvas):
+        """When no waypoints are placed, list is empty."""
+        assert canvas._wire_waypoints == []
+
+    def test_waypoints_list_builds_correctly(self, canvas):
+        """Test the waypoint list construction logic."""
+        canvas._wire_waypoints = [QPointF(50, 0), QPointF(50, 100)]
+        start_pos = QPointF(0, 0)
+        end_pos = QPointF(100, 100)
+        manual_wps = (
+            [(start_pos.x(), start_pos.y())]
+            + [(wp.x(), wp.y()) for wp in canvas._wire_waypoints]
+            + [(end_pos.x(), end_pos.y())]
+        )
+        assert manual_wps == [(0, 0), (50, 0), (50, 100), (100, 100)]
+
+    def test_waypoints_include_start_and_end(self, canvas):
+        """Waypoint list should start at terminal and end at terminal."""
+        canvas._wire_waypoints = [QPointF(50, 50)]
+        start_pos = QPointF(0, 0)
+        end_pos = QPointF(100, 100)
+        manual_wps = (
+            [(start_pos.x(), start_pos.y())]
+            + [(wp.x(), wp.y()) for wp in canvas._wire_waypoints]
+            + [(end_pos.x(), end_pos.y())]
+        )
+        assert len(manual_wps) == 3
+        assert manual_wps[0] == (0, 0)
+        assert manual_wps[1] == (50, 50)
+        assert manual_wps[2] == (100, 100)
+
+    def test_single_waypoint_produces_three_points(self, canvas):
+        """One click waypoint + start + end = 3 points total."""
+        canvas._wire_waypoints = [QPointF(50, 0)]
+        start_pos = QPointF(0, 0)
+        end_pos = QPointF(100, 0)
+        manual_wps = (
+            [(start_pos.x(), start_pos.y())]
+            + [(wp.x(), wp.y()) for wp in canvas._wire_waypoints]
+            + [(end_pos.x(), end_pos.y())]
+        )
+        assert len(manual_wps) == 3


### PR DESCRIPTION
## Summary - During wire drawing, clicking empty canvas space places a bend point (waypoint) instead of canceling - Visual dot markers show placed waypoints during the drawing process - Preview line anchors from the last placed waypoint for accurate visual feedback - On wire completion, manual waypoints are passed to the controller and stored in WireData (bypassing auto-routing) - Escape key and focus-out still cancel wire drawing and clear all waypoints ## Test plan - [x] 15 new tests covering state tracking, cancel cleanup, markers, and waypoint list construction - [x] make format and make lint pass cleanly - [x] Full test suite passes (2710 tests) - [ ] Manual: start drawing a wire, click empty space to add bend points - [ ] Manual: verify dots appear at placed waypoints - [ ] Manual: complete wire at destination terminal, verify wire follows placed path Closes #263