### PR TITLE
fix: suppress wire preview tearing during group drag (#442)

### DIFF
--- a/app/GUI/analysis_dialog.py
+++ b/app/GUI/analysis_dialog.py
@@ -452,7 +452,11 @@ class AnalysisDialog(QDialog):
         """Save current parameters as a named preset."""
         params = self.get_parameters()
         if params is None:
-            QMessageBox.warning(self, "Invalid Parameters", "Please enter valid parameters before saving a preset.")
+            QMessageBox.warning(
+                self,
+                "Invalid Parameters",
+                "Please enter valid parameters before saving a preset.",
+            )
             return
 
         # Remove analysis_type key from params (stored separately)

--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -370,7 +370,9 @@ class ComponentGraphicsItem(QGraphicsItem):
             # Show straight-line preview for connected wires during drag
             # (full pathfinding runs after drag ends via debounced timer)
             self.update()
-            if self.scene():
+            # Skip wire preview for followers during group drag to avoid
+            # tearing artifacts from rapid forced scene repaints (#442).
+            if self.scene() and not self._group_moving:
                 views = self.scene().views()
                 if views:
                     canvas = views[0]

--- a/app/GUI/main_window_simulation.py
+++ b/app/GUI/main_window_simulation.py
@@ -779,7 +779,10 @@ class SimulationMixin:
         from simulation.markdown_exporter import write_markdown
 
         filename, _ = QFileDialog.getSaveFileName(
-            self, "Export Results to Markdown", "", "Markdown Files (*.md);;All Files (*)"
+            self,
+            "Export Results to Markdown",
+            "",
+            "Markdown Files (*.md);;All Files (*)",
         )
         if filename:
             try:

--- a/app/GUI/meas_dialog.py
+++ b/app/GUI/meas_dialog.py
@@ -317,7 +317,12 @@ class MeasurementEntryDialog(QDialog):
                 params["targ_edge"] = self.targ_edge_combo.currentText()
 
         directive = build_directive(self._domain, name, meas_type, params)
-        return {"name": name, "meas_type": meas_type, "params": params, "directive": directive}
+        return {
+            "name": name,
+            "meas_type": meas_type,
+            "params": params,
+            "directive": directive,
+        }
 
     def _load_initial(self, data):
         """Pre-populate form from a data dict."""

--- a/app/GUI/monte_carlo_results_dialog.py
+++ b/app/GUI/monte_carlo_results_dialog.py
@@ -256,7 +256,12 @@ class MonteCarloResultsDialog(QDialog):
             ax.text(0.5, 0.5, "No data", ha="center", va="center", transform=ax.transAxes)
             self._summary.setPlainText("No metric data available.")
         else:
-            ax.hist(values, bins=min(30, max(5, len(values) // 3)), edgecolor="black", alpha=0.7)
+            ax.hist(
+                values,
+                bins=min(30, max(5, len(values) // 3)),
+                edgecolor="black",
+                alpha=0.7,
+            )
             ax.set_xlabel(metric)
             ax.set_ylabel("Count")
             ax.set_title(f"Distribution — {metric}")

--- a/app/GUI/netlist_preview.py
+++ b/app/GUI/netlist_preview.py
@@ -31,7 +31,12 @@ class SpiceHighlighter(QSyntaxHighlighter):
         control_fmt = QTextCharFormat()
         control_fmt.setForeground(QColor("#9C27B0"))
         control_fmt.setFontWeight(QFont.Weight.Bold)
-        self._rules.append((re.compile(r"^(run|quit|print|set|let|wrdata|setplot)\b.*$", re.IGNORECASE), control_fmt))
+        self._rules.append(
+            (
+                re.compile(r"^(run|quit|print|set|let|wrdata|setplot)\b.*$", re.IGNORECASE),
+                control_fmt,
+            )
+        )
 
     def highlightBlock(self, text):
         """Apply syntax highlighting rules to a single line of text."""

--- a/app/GUI/parameter_sweep_plot_dialog.py
+++ b/app/GUI/parameter_sweep_plot_dialog.py
@@ -85,7 +85,14 @@ class ParameterSweepPlotDialog(QDialog):
                 all_nodes.update(r.data.keys())
 
         if not all_nodes:
-            ax.text(0.5, 0.5, "No data available", ha="center", va="center", transform=ax.transAxes)
+            ax.text(
+                0.5,
+                0.5,
+                "No data available",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+            )
             return
 
         cmap = plt.get_cmap("tab10")
@@ -131,7 +138,14 @@ class ParameterSweepPlotDialog(QDialog):
 
             for node in nodes:
                 values = [pt[node] for pt in r.data]
-                ax.plot(times, values, color=color, label=f"{node} ({component_id}={label})", alpha=0.8, linewidth=1)
+                ax.plot(
+                    times,
+                    values,
+                    color=color,
+                    label=f"{node} ({component_id}={label})",
+                    alpha=0.8,
+                    linewidth=1,
+                )
 
         ax.set_xlabel("Time (s)")
         ax.set_ylabel("Voltage (V)")
@@ -165,10 +179,20 @@ class ParameterSweepPlotDialog(QDialog):
             color = cmap(i / max(n - 1, 1))
 
             for node, mag_vals in sorted(magnitude.items()):
-                ax_mag.semilogx(freqs, mag_vals, color=color, label=f"{node} ({component_id}={label})", alpha=0.8)
+                ax_mag.semilogx(
+                    freqs,
+                    mag_vals,
+                    color=color,
+                    label=f"{node} ({component_id}={label})",
+                    alpha=0.8,
+                )
                 if node in phase:
                     ax_phase.semilogx(
-                        freqs, phase[node], color=color, label=f"{node} ({component_id}={label})", alpha=0.8
+                        freqs,
+                        phase[node],
+                        color=color,
+                        label=f"{node} ({component_id}={label})",
+                        alpha=0.8,
                     )
 
         ax_mag.set_ylabel("Magnitude")
@@ -213,7 +237,13 @@ class ParameterSweepPlotDialog(QDialog):
             for col_idx in range(2, len(headers)):
                 col_label = headers[col_idx]
                 values = [row[col_idx] for row in rows]
-                ax.plot(sweep_vals, values, color=color, label=f"{col_label} ({component_id}={label})", alpha=0.8)
+                ax.plot(
+                    sweep_vals,
+                    values,
+                    color=color,
+                    label=f"{col_label} ({component_id}={label})",
+                    alpha=0.8,
+                )
 
         ax.set_xlabel(x_label)
         ax.set_ylabel("Voltage (V)")

--- a/app/GUI/path_finding.py
+++ b/app/GUI/path_finding.py
@@ -23,7 +23,16 @@ class WeightedPathfinder(ABC):
     # 4-direction orthogonal moves
     ORTHOGONAL_DIRS = [(0, 1), (0, -1), (1, 0), (-1, 0)]
     # 8-direction moves (orthogonal + diagonal)
-    DIAGONAL_DIRS = [(0, 1), (0, -1), (1, 0), (-1, 0), (1, 1), (1, -1), (-1, 1), (-1, -1)]
+    DIAGONAL_DIRS = [
+        (0, 1),
+        (0, -1),
+        (1, 0),
+        (-1, 0),
+        (1, 1),
+        (1, -1),
+        (-1, 1),
+        (-1, -1),
+    ]
     SQRT2 = math.sqrt(2)
 
     def __init__(self, grid_size=20, allow_diagonal=False):

--- a/app/GUI/results_plot_dialog.py
+++ b/app/GUI/results_plot_dialog.py
@@ -467,7 +467,12 @@ class ACSweepPlotDialog(QDialog):
         ref_level = markers["ref_level_db"]
         if ref_level is not None:
             artist = self._ax_mag.axhline(
-                y=ref_level, color="#CC0066", linestyle="--", linewidth=1, alpha=0.7, label="-3dB level"
+                y=ref_level,
+                color="#CC0066",
+                linestyle="--",
+                linewidth=1,
+                alpha=0.7,
+                label="-3dB level",
             )
             self._marker_artists.append(artist)
 

--- a/app/GUI/rubric_editor_dialog.py
+++ b/app/GUI/rubric_editor_dialog.py
@@ -482,7 +482,11 @@ class RubricEditorDialog(QDialog):
         """Save the rubric to a .spice-rubric file."""
         errors = self._validate()
         if errors:
-            QMessageBox.warning(self, "Validation Errors", "Please fix errors before saving:\n\n" + "\n".join(errors))
+            QMessageBox.warning(
+                self,
+                "Validation Errors",
+                "Please fix errors before saving:\n\n" + "\n".join(errors),
+            )
             return
 
         filename, _ = QFileDialog.getSaveFileName(
@@ -570,7 +574,9 @@ class RubricEditorDialog(QDialog):
         errors = self._validate()
         if errors:
             QMessageBox.warning(
-                self, "Validation Errors", "Please fix errors before proceeding:\n\n" + "\n".join(errors)
+                self,
+                "Validation Errors",
+                "Please fix errors before proceeding:\n\n" + "\n".join(errors),
             )
             return
 

--- a/app/GUI/styles/dark_theme.py
+++ b/app/GUI/styles/dark_theme.py
@@ -117,7 +117,11 @@ class DarkTheme(BaseTheme):
             # Probe pens
             "probe_voltage": {"color": "probe_voltage", "width": 1.5},
             "probe_current": {"color": "probe_current", "width": 1.5},
-            "probe_highlight": {"color": "probe_highlight", "width": 2.0, "style": "dash"},
+            "probe_highlight": {
+                "color": "probe_highlight",
+                "width": 2.0,
+                "style": "dash",
+            },
         }
 
     def _define_brushes(self):

--- a/app/GUI/styles/light_theme.py
+++ b/app/GUI/styles/light_theme.py
@@ -114,7 +114,11 @@ class LightTheme(BaseTheme):
             # Probe pens
             "probe_voltage": {"color": "probe_voltage", "width": 1.5},
             "probe_current": {"color": "probe_current", "width": 1.5},
-            "probe_highlight": {"color": "probe_highlight", "width": 2.0, "style": "dash"},
+            "probe_highlight": {
+                "color": "probe_highlight",
+                "width": 2.0,
+                "style": "dash",
+            },
         }
 
     def _define_brushes(self):

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -380,7 +380,10 @@ class WireGraphicsItem(QGraphicsPathItem):
         """Called by WaypointHandle on mouse release to persist changes."""
         # Sync to model
         self.model.waypoints = [
-            (wp.x() if isinstance(wp, QPointF) else wp[0], wp.y() if isinstance(wp, QPointF) else wp[1])
+            (
+                wp.x() if isinstance(wp, QPointF) else wp[0],
+                wp.y() if isinstance(wp, QPointF) else wp[1],
+            )
             for wp in self.waypoints
         ]
         self.model.locked = True

--- a/app/cli.py
+++ b/app/cli.py
@@ -474,7 +474,12 @@ def diff_circuits(model_a: CircuitModel, model_b: CircuitModel) -> dict:
 
     # --- Wires ---
     def wire_key(w):
-        return (w.start_component_id, w.start_terminal, w.end_component_id, w.end_terminal)
+        return (
+            w.start_component_id,
+            w.start_terminal,
+            w.end_component_id,
+            w.end_terminal,
+        )
 
     wires_a = {wire_key(w) for w in model_a.wires}
     wires_b = {wire_key(w) for w in model_b.wires}
@@ -492,9 +497,15 @@ def diff_circuits(model_a: CircuitModel, model_b: CircuitModel) -> dict:
     # --- Analysis ---
     analysis_diff = {}
     if model_a.analysis_type != model_b.analysis_type:
-        analysis_diff["type"] = {"from": model_a.analysis_type, "to": model_b.analysis_type}
+        analysis_diff["type"] = {
+            "from": model_a.analysis_type,
+            "to": model_b.analysis_type,
+        }
     if model_a.analysis_params != model_b.analysis_params:
-        analysis_diff["params"] = {"from": model_a.analysis_params, "to": model_b.analysis_params}
+        analysis_diff["params"] = {
+            "from": model_a.analysis_params,
+            "to": model_b.analysis_params,
+        }
     diff["analysis"] = analysis_diff
 
     return diff
@@ -640,11 +651,23 @@ def build_parser() -> argparse.ArgumentParser:
     # simulate
     sim_parser = subparsers.add_parser("simulate", help="Run simulation and output results")
     sim_parser.add_argument("circuit", help="Path to circuit JSON file (use '-' for stdin)")
-    sim_parser.add_argument("--format", choices=["json", "csv"], default="json", help="Output format (default: json)")
+    sim_parser.add_argument(
+        "--format",
+        choices=["json", "csv"],
+        default="json",
+        help="Output format (default: json)",
+    )
     sim_parser.add_argument("--output", "-o", help="Write results to file instead of stdout")
     sim_parser.add_argument(
         "--analysis",
-        choices=["DC Operating Point", "DC Sweep", "AC Sweep", "Transient", "Temperature Sweep", "Noise"],
+        choices=[
+            "DC Operating Point",
+            "DC Sweep",
+            "AC Sweep",
+            "Transient",
+            "Temperature Sweep",
+            "Noise",
+        ],
         help="Override the analysis type configured in the circuit file",
     )
 
@@ -656,7 +679,11 @@ def build_parser() -> argparse.ArgumentParser:
     exp_parser = subparsers.add_parser("export", help="Export circuit in specified format")
     exp_parser.add_argument("circuit", help="Path to circuit JSON file (use '-' for stdin)")
     exp_parser.add_argument(
-        "--format", "-f", choices=["cir", "json"], default="cir", help="Export format (default: cir)"
+        "--format",
+        "-f",
+        choices=["cir", "json"],
+        default="cir",
+        help="Export format (default: cir)",
     )
     exp_parser.add_argument("--output", "-o", help="Write output to file instead of stdout")
 
@@ -664,12 +691,22 @@ def build_parser() -> argparse.ArgumentParser:
     batch_parser = subparsers.add_parser("batch", help="Run simulations on multiple circuit files")
     batch_parser.add_argument("path", help="Directory or glob pattern matching circuit JSON files")
     batch_parser.add_argument(
-        "--format", choices=["json", "csv"], default="json", help="Output format for per-file results (default: json)"
+        "--format",
+        choices=["json", "csv"],
+        default="json",
+        help="Output format for per-file results (default: json)",
     )
     batch_parser.add_argument("--output-dir", help="Write per-file results to this directory")
     batch_parser.add_argument(
         "--analysis",
-        choices=["DC Operating Point", "DC Sweep", "AC Sweep", "Transient", "Temperature Sweep", "Noise"],
+        choices=[
+            "DC Operating Point",
+            "DC Sweep",
+            "AC Sweep",
+            "Transient",
+            "Temperature Sweep",
+            "Noise",
+        ],
         help="Override the analysis type for all circuits",
     )
     batch_parser.add_argument("--fail-fast", action="store_true", help="Stop on first error")
@@ -681,21 +718,33 @@ def build_parser() -> argparse.ArgumentParser:
     # import
     import_parser = subparsers.add_parser("import", help="Import a SPICE netlist to circuit JSON")
     import_parser.add_argument("netlist", help="Path to SPICE netlist file (.cir, .spice, .sp)")
-    import_parser.add_argument("--output", "-o", help="Output JSON file path (default: same name with .json extension)")
+    import_parser.add_argument(
+        "--output",
+        "-o",
+        help="Output JSON file path (default: same name with .json extension)",
+    )
 
     # diff
     diff_parser = subparsers.add_parser("diff", help="Compare two circuit files and report differences")
     diff_parser.add_argument("circuit_a", help="Path to reference circuit JSON file")
     diff_parser.add_argument("circuit_b", help="Path to circuit JSON file to compare")
     diff_parser.add_argument(
-        "--format", "-f", choices=["text", "json"], default="text", help="Output format (default: text)"
+        "--format",
+        "-f",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
     )
 
     # stats
     stats_parser = subparsers.add_parser("stats", help="Display circuit complexity statistics")
     stats_parser.add_argument("circuit", help="Path to circuit JSON file")
     stats_parser.add_argument(
-        "--format", "-f", choices=["text", "json"], default="text", help="Output format (default: text)"
+        "--format",
+        "-f",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
     )
 
     return parser

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -508,7 +508,11 @@ class SimulationController:
                 success, output_file, stdout, stderr = self.runner.run_simulation(netlist)
                 if not success:
                     step_results.append(
-                        SimulationResult(success=False, error=stderr or "Simulation failed", netlist=netlist)
+                        SimulationResult(
+                            success=False,
+                            error=stderr or "Simulation failed",
+                            netlist=netlist,
+                        )
                     )
                     errors.append(f"Run {i + 1}: {stderr or 'failed'}")
                     continue

--- a/app/grading/grader.py
+++ b/app/grading/grader.py
@@ -99,7 +99,10 @@ class CircuitGrader:
         return handler(self, check, student, reference)
 
     def _check_component_exists(
-        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+        self,
+        check: RubricCheck,
+        student: CircuitModel,
+        reference: Optional[CircuitModel],
     ) -> CheckGradeResult:
         component_id = check.params.get("component_id", "")
         component_type = check.params.get("component_type", "")
@@ -124,7 +127,10 @@ class CircuitGrader:
         )
 
     def _check_component_value(
-        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+        self,
+        check: RubricCheck,
+        student: CircuitModel,
+        reference: Optional[CircuitModel],
     ) -> CheckGradeResult:
         component_id = check.params.get("component_id", "")
         expected_value = check.params.get("expected_value", "")
@@ -141,7 +147,10 @@ class CircuitGrader:
         )
 
     def _check_component_count(
-        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+        self,
+        check: RubricCheck,
+        student: CircuitModel,
+        reference: Optional[CircuitModel],
     ) -> CheckGradeResult:
         component_type = check.params.get("component_type", "")
         expected_count = check.params.get("expected_count", 0)
@@ -158,7 +167,10 @@ class CircuitGrader:
         )
 
     def _check_topology(
-        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+        self,
+        check: RubricCheck,
+        student: CircuitModel,
+        reference: Optional[CircuitModel],
     ) -> CheckGradeResult:
         component_a = check.params.get("component_a", "")
         component_b = check.params.get("component_b", "")
@@ -176,7 +188,10 @@ class CircuitGrader:
         )
 
     def _check_ground(
-        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+        self,
+        check: RubricCheck,
+        student: CircuitModel,
+        reference: Optional[CircuitModel],
     ) -> CheckGradeResult:
         has_ground = any(n.is_ground for n in student.nodes)
         component_id = check.params.get("component_id", "")
@@ -202,7 +217,10 @@ class CircuitGrader:
         )
 
     def _check_analysis_type(
-        self, check: RubricCheck, student: CircuitModel, reference: Optional[CircuitModel]
+        self,
+        check: RubricCheck,
+        student: CircuitModel,
+        reference: Optional[CircuitModel],
     ) -> CheckGradeResult:
         expected_type = check.params.get("expected_type", "")
         cr = self._comparer.check_analysis_type(student, expected_type)

--- a/app/grading/rubric_generator.py
+++ b/app/grading/rubric_generator.py
@@ -105,7 +105,11 @@ def generate_rubric_from_circuit(
                 check_id=f"topo_{pair[0]}_{pair[1]}",
                 check_type="topology",
                 points=0,
-                params={"component_a": pair[0], "component_b": pair[1], "shared_node": True},
+                params={
+                    "component_a": pair[0],
+                    "component_b": pair[1],
+                    "shared_node": True,
+                },
                 feedback_pass=f"{pair[0]} and {pair[1]} are connected.",
                 feedback_fail=f"{pair[0]} and {pair[1]} should be connected but are not.",
             )

--- a/app/scripting/__init__.py
+++ b/app/scripting/__init__.py
@@ -28,4 +28,10 @@ from controllers.simulation_controller import SimulationResult
 from scripting.circuit import Circuit
 from scripting.jupyter import circuit_to_svg, plot_result, register_jupyter_formatters
 
-__all__ = ["Circuit", "SimulationResult", "circuit_to_svg", "plot_result", "register_jupyter_formatters"]
+__all__ = [
+    "Circuit",
+    "SimulationResult",
+    "circuit_to_svg",
+    "plot_result",
+    "register_jupyter_formatters",
+]

--- a/app/scripting/jupyter.py
+++ b/app/scripting/jupyter.py
@@ -163,7 +163,12 @@ def _empty_svg(width: int, height: int) -> str:
         "text",
         x=str(width // 2),
         y=str(height // 2),
-        **{"text-anchor": "middle", "fill": "#999", "font-family": "sans-serif", "font-size": "14"},
+        **{
+            "text-anchor": "middle",
+            "fill": "#999",
+            "font-family": "sans-serif",
+            "font-size": "14",
+        },
     )
     text.text = "(empty circuit)"
     return ET.tostring(svg, encoding="unicode")

--- a/app/simulation/asc_parser.py
+++ b/app/simulation/asc_parser.py
@@ -176,7 +176,12 @@ def parse_asc(text):
             parts = stripped.split()
             if len(parts) >= 5:
                 try:
-                    x1, y1, x2, y2 = int(parts[1]), int(parts[2]), int(parts[3]), int(parts[4])
+                    x1, y1, x2, y2 = (
+                        int(parts[1]),
+                        int(parts[2]),
+                        int(parts[3]),
+                        int(parts[4]),
+                    )
                     wires.append((x1, y1, x2, y2))
                 except ValueError:
                     pass

--- a/app/simulation/circuitikz_parser.py
+++ b/app/simulation/circuitikz_parser.py
@@ -145,7 +145,13 @@ def import_circuitikz(text):
 
     # Parse bipoles: \draw (x1,y1) to[opts] (x2,y2);
     for m in _RE_DRAW_TO.finditer(body):
-        x1, y1, opts, x2, y2 = m.group(1), m.group(2), m.group(3), m.group(4), m.group(5)
+        x1, y1, opts, x2, y2 = (
+            m.group(1),
+            m.group(2),
+            m.group(3),
+            m.group(4),
+            m.group(5),
+        )
         bipoles.append(
             {
                 "x1": float(x1),

--- a/app/simulation/result_parser.py
+++ b/app/simulation/result_parser.py
@@ -75,7 +75,9 @@ class ResultParser:
 
                 # Branch current patterns: i(device) = current or @device[current]
                 i_match = re.search(
-                    r"(?:i\((\w+)\)|@(\w+)\[current\])\s*[=:]\s*([-+]?[\d.]+e?[-+]?\d*)", line, re.IGNORECASE
+                    r"(?:i\((\w+)\)|@(\w+)\[current\])\s*[=:]\s*([-+]?[\d.]+e?[-+]?\d*)",
+                    line,
+                    re.IGNORECASE,
                 )
                 if i_match:
                     device = i_match.group(1) or i_match.group(2)
@@ -222,7 +224,11 @@ class ResultParser:
         """
         try:
             lines = output.split("\n")
-            noise_data = {"frequencies": [], "onoise_spectrum": [], "inoise_spectrum": []}
+            noise_data = {
+                "frequencies": [],
+                "onoise_spectrum": [],
+                "inoise_spectrum": [],
+            }
 
             header_found = False
             headers = []

--- a/app/tests/unit/test_annotation_undo.py
+++ b/app/tests/unit/test_annotation_undo.py
@@ -8,11 +8,7 @@ through the CircuitController rather than directly on the canvas.
 import inspect
 
 from controllers.circuit_controller import CircuitController
-from controllers.commands import (
-    AddAnnotationCommand,
-    DeleteAnnotationCommand,
-    EditAnnotationCommand,
-)
+from controllers.commands import AddAnnotationCommand, DeleteAnnotationCommand, EditAnnotationCommand
 from models.annotation import AnnotationData
 from models.circuit import CircuitModel
 

--- a/app/tests/unit/test_annotations.py
+++ b/app/tests/unit/test_annotations.py
@@ -43,7 +43,14 @@ class TestAnnotationData:
         assert d["color"] == "#FFFFFF"
 
     def test_from_dict(self):
-        d = {"text": "Loaded", "x": 10.0, "y": 20.0, "font_size": 12, "bold": True, "color": "#00FF00"}
+        d = {
+            "text": "Loaded",
+            "x": 10.0,
+            "y": 20.0,
+            "font_size": 12,
+            "bold": True,
+            "color": "#00FF00",
+        }
         ann = AnnotationData.from_dict(d)
         assert ann.text == "Loaded"
         assert ann.x == 10.0

--- a/app/tests/unit/test_auto_save.py
+++ b/app/tests/unit/test_auto_save.py
@@ -32,9 +32,24 @@ def _build_simple_circuit():
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.component_counter = {"V": 1, "R": 1, "GND": 1}
     model.rebuild_nodes()

--- a/app/tests/unit/test_batch_grading.py
+++ b/app/tests/unit/test_batch_grading.py
@@ -40,10 +40,30 @@ def _build_circuit(r_value="1k", c_value="100n"):
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="C1", end_terminal=0),
-        WireData(start_component_id="C1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="C1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="C1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.component_counter = {"V": 1, "R": 1, "C": 1, "GND": 1}
     model.analysis_type = "AC Sweep"
@@ -68,7 +88,11 @@ def _build_rubric():
                 check_id="r1_value",
                 check_type="component_value",
                 points=25,
-                params={"component_id": "R1", "expected_value": "1k", "tolerance_pct": 10},
+                params={
+                    "component_id": "R1",
+                    "expected_value": "1k",
+                    "tolerance_pct": 10,
+                },
                 feedback_pass="R1 value OK",
                 feedback_fail="R1 value wrong",
             ),

--- a/app/tests/unit/test_cli.py
+++ b/app/tests/unit/test_cli.py
@@ -33,10 +33,34 @@ def voltage_divider(tmp_path):
     """Create a valid voltage divider circuit file."""
     circuit = {
         "components": [
-            {"type": "Voltage Source", "id": "V1", "value": "5V", "pos": {"x": 0, "y": 0}, "rotation": 0},
-            {"type": "Resistor", "id": "R1", "value": "1k", "pos": {"x": 200, "y": 0}, "rotation": 0},
-            {"type": "Resistor", "id": "R2", "value": "1k", "pos": {"x": 300, "y": 0}, "rotation": 0},
-            {"type": "Ground", "id": "GND1", "value": "0V", "pos": {"x": 350, "y": 150}, "rotation": 0},
+            {
+                "type": "Voltage Source",
+                "id": "V1",
+                "value": "5V",
+                "pos": {"x": 0, "y": 0},
+                "rotation": 0,
+            },
+            {
+                "type": "Resistor",
+                "id": "R1",
+                "value": "1k",
+                "pos": {"x": 200, "y": 0},
+                "rotation": 0,
+            },
+            {
+                "type": "Resistor",
+                "id": "R2",
+                "value": "1k",
+                "pos": {"x": 300, "y": 0},
+                "rotation": 0,
+            },
+            {
+                "type": "Ground",
+                "id": "GND1",
+                "value": "0V",
+                "pos": {"x": 350, "y": 150},
+                "rotation": 0,
+            },
         ],
         "wires": [
             {"start_comp": "V1", "start_term": 0, "end_comp": "R1", "end_term": 0},
@@ -225,14 +249,42 @@ class TestBatchCommand:
         """Create a directory with multiple circuit files."""
         base = {
             "components": [
-                {"type": "Voltage Source", "id": "V1", "value": "5V", "pos": {"x": 0, "y": 0}, "rotation": 0},
-                {"type": "Resistor", "id": "R1", "value": "1k", "pos": {"x": 200, "y": 0}, "rotation": 0},
-                {"type": "Ground", "id": "GND1", "value": "0V", "pos": {"x": 0, "y": 200}, "rotation": 0},
+                {
+                    "type": "Voltage Source",
+                    "id": "V1",
+                    "value": "5V",
+                    "pos": {"x": 0, "y": 0},
+                    "rotation": 0,
+                },
+                {
+                    "type": "Resistor",
+                    "id": "R1",
+                    "value": "1k",
+                    "pos": {"x": 200, "y": 0},
+                    "rotation": 0,
+                },
+                {
+                    "type": "Ground",
+                    "id": "GND1",
+                    "value": "0V",
+                    "pos": {"x": 0, "y": 200},
+                    "rotation": 0,
+                },
             ],
             "wires": [
                 {"start_comp": "V1", "start_term": 0, "end_comp": "R1", "end_term": 0},
-                {"start_comp": "R1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
-                {"start_comp": "V1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+                {
+                    "start_comp": "R1",
+                    "start_term": 1,
+                    "end_comp": "GND1",
+                    "end_term": 0,
+                },
+                {
+                    "start_comp": "V1",
+                    "start_term": 1,
+                    "end_comp": "GND1",
+                    "end_term": 0,
+                },
             ],
             "counters": {"R": 1, "V": 1, "GND": 1},
         }
@@ -256,14 +308,42 @@ class TestBatchCommand:
         # Valid circuit
         valid = {
             "components": [
-                {"type": "Voltage Source", "id": "V1", "value": "5V", "pos": {"x": 0, "y": 0}, "rotation": 0},
-                {"type": "Resistor", "id": "R1", "value": "1k", "pos": {"x": 200, "y": 0}, "rotation": 0},
-                {"type": "Ground", "id": "GND1", "value": "0V", "pos": {"x": 0, "y": 200}, "rotation": 0},
+                {
+                    "type": "Voltage Source",
+                    "id": "V1",
+                    "value": "5V",
+                    "pos": {"x": 0, "y": 0},
+                    "rotation": 0,
+                },
+                {
+                    "type": "Resistor",
+                    "id": "R1",
+                    "value": "1k",
+                    "pos": {"x": 200, "y": 0},
+                    "rotation": 0,
+                },
+                {
+                    "type": "Ground",
+                    "id": "GND1",
+                    "value": "0V",
+                    "pos": {"x": 0, "y": 200},
+                    "rotation": 0,
+                },
             ],
             "wires": [
                 {"start_comp": "V1", "start_term": 0, "end_comp": "R1", "end_term": 0},
-                {"start_comp": "R1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
-                {"start_comp": "V1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+                {
+                    "start_comp": "R1",
+                    "start_term": 1,
+                    "end_comp": "GND1",
+                    "end_term": 0,
+                },
+                {
+                    "start_comp": "V1",
+                    "start_term": 1,
+                    "end_comp": "GND1",
+                    "end_term": 0,
+                },
             ],
             "counters": {"R": 1, "V": 1, "GND": 1},
         }
@@ -490,14 +570,42 @@ class TestDiffCommand:
     def base_circuit_data(self):
         return {
             "components": [
-                {"type": "Voltage Source", "id": "V1", "value": "5V", "pos": {"x": 0, "y": 0}, "rotation": 0},
-                {"type": "Resistor", "id": "R1", "value": "1k", "pos": {"x": 200, "y": 0}, "rotation": 0},
-                {"type": "Ground", "id": "GND1", "value": "0V", "pos": {"x": 0, "y": 200}, "rotation": 0},
+                {
+                    "type": "Voltage Source",
+                    "id": "V1",
+                    "value": "5V",
+                    "pos": {"x": 0, "y": 0},
+                    "rotation": 0,
+                },
+                {
+                    "type": "Resistor",
+                    "id": "R1",
+                    "value": "1k",
+                    "pos": {"x": 200, "y": 0},
+                    "rotation": 0,
+                },
+                {
+                    "type": "Ground",
+                    "id": "GND1",
+                    "value": "0V",
+                    "pos": {"x": 0, "y": 200},
+                    "rotation": 0,
+                },
             ],
             "wires": [
                 {"start_comp": "V1", "start_term": 0, "end_comp": "R1", "end_term": 0},
-                {"start_comp": "R1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
-                {"start_comp": "V1", "start_term": 1, "end_comp": "GND1", "end_term": 0},
+                {
+                    "start_comp": "R1",
+                    "start_term": 1,
+                    "end_comp": "GND1",
+                    "end_term": 0,
+                },
+                {
+                    "start_comp": "V1",
+                    "start_term": 1,
+                    "end_comp": "GND1",
+                    "end_term": 0,
+                },
             ],
             "counters": {"R": 1, "V": 1, "GND": 1},
         }
@@ -526,7 +634,13 @@ class TestDiffCommand:
     def circuit_b_component_added(self, tmp_path, base_circuit_data):
         data = json.loads(json.dumps(base_circuit_data))
         data["components"].append(
-            {"type": "Resistor", "id": "R2", "value": "4.7k", "pos": {"x": 300, "y": 0}, "rotation": 0}
+            {
+                "type": "Resistor",
+                "id": "R2",
+                "value": "4.7k",
+                "pos": {"x": 300, "y": 0},
+                "rotation": 0,
+            }
         )
         data["counters"]["R"] = 2
         filepath = tmp_path / "circuit_b_added.json"
@@ -547,7 +661,11 @@ class TestDiffCommand:
     def circuit_b_analysis_changed(self, tmp_path, base_circuit_data):
         data = json.loads(json.dumps(base_circuit_data))
         data["analysis_type"] = "AC Sweep"
-        data["analysis_params"] = {"start_freq": "1", "stop_freq": "1MEG", "points": "100"}
+        data["analysis_params"] = {
+            "start_freq": "1",
+            "stop_freq": "1MEG",
+            "points": "100",
+        }
         filepath = tmp_path / "circuit_b_analysis.json"
         filepath.write_text(json.dumps(data))
         return str(filepath)
@@ -605,7 +723,10 @@ class TestDiffCommand:
         model_a = load_circuit(circuit_a)
         model_b = load_circuit(circuit_b_analysis_changed)
         diff = diff_circuits(model_a, model_b)
-        assert diff["analysis"]["type"] == {"from": "DC Operating Point", "to": "AC Sweep"}
+        assert diff["analysis"]["type"] == {
+            "from": "DC Operating Point",
+            "to": "AC Sweep",
+        }
         assert "params" in diff["analysis"]
 
     def test_text_format(self, circuit_a, circuit_b_value_changed, capsys):

--- a/app/tests/unit/test_cross_platform.py
+++ b/app/tests/unit/test_cross_platform.py
@@ -32,7 +32,10 @@ class TestNgspiceRunnerPlatformDetection:
         with (
             patch("shutil.which", return_value=None),
             patch("platform.system", return_value="Linux"),
-            patch("os.path.exists", side_effect=lambda p: (checked_paths.append(p), False)[1]),
+            patch(
+                "os.path.exists",
+                side_effect=lambda p: (checked_paths.append(p), False)[1],
+            ),
         ):
             runner.find_ngspice()
         assert "/usr/bin/ngspice" in checked_paths
@@ -44,7 +47,10 @@ class TestNgspiceRunnerPlatformDetection:
         with (
             patch("shutil.which", return_value=None),
             patch("platform.system", return_value="Darwin"),
-            patch("os.path.exists", side_effect=lambda p: (checked_paths.append(p), False)[1]),
+            patch(
+                "os.path.exists",
+                side_effect=lambda p: (checked_paths.append(p), False)[1],
+            ),
         ):
             runner.find_ngspice()
         assert "/usr/local/bin/ngspice" in checked_paths
@@ -56,7 +62,10 @@ class TestNgspiceRunnerPlatformDetection:
         with (
             patch("shutil.which", return_value=None),
             patch("platform.system", return_value="Windows"),
-            patch("os.path.exists", side_effect=lambda p: (checked_paths.append(p), False)[1]),
+            patch(
+                "os.path.exists",
+                side_effect=lambda p: (checked_paths.append(p), False)[1],
+            ),
         ):
             runner.find_ngspice()
         assert any("ngspice" in p.lower() for p in checked_paths)

--- a/app/tests/unit/test_data_roundtrips_and_undo.py
+++ b/app/tests/unit/test_data_roundtrips_and_undo.py
@@ -198,7 +198,12 @@ class TestSerializationRoundTrips:
         """Analysis type and params survive circuit round-trip."""
         model = CircuitModel()
         model.analysis_type = "AC Sweep"
-        model.analysis_params = {"variation": "dec", "points": "10", "fstart": "1", "fstop": "1e6"}
+        model.analysis_params = {
+            "variation": "dec",
+            "points": "10",
+            "fstart": "1",
+            "fstop": "1e6",
+        }
 
         data = model.to_dict()
         restored = CircuitModel.from_dict(data)

--- a/app/tests/unit/test_grading_panel.py
+++ b/app/tests/unit/test_grading_panel.py
@@ -41,10 +41,30 @@ def _build_rc_filter(r_value="1k", c_value="100n"):
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="C1", end_terminal=0),
-        WireData(start_component_id="C1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="C1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="C1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.component_counter = {"V": 1, "R": 1, "C": 1, "GND": 1}
     model.analysis_type = "AC Sweep"
@@ -69,7 +89,11 @@ def _build_rubric():
                 check_id="r1_value",
                 check_type="component_value",
                 points=25,
-                params={"component_id": "R1", "expected_value": "1k", "tolerance_pct": 10},
+                params={
+                    "component_id": "R1",
+                    "expected_value": "1k",
+                    "tolerance_pct": 10,
+                },
                 feedback_pass="R1 value OK",
                 feedback_fail="R1 value wrong",
             ),

--- a/app/tests/unit/test_initial_conditions.py
+++ b/app/tests/unit/test_initial_conditions.py
@@ -49,7 +49,13 @@ class TestICSerializer:
         assert comp.initial_condition is None
 
     def test_from_dict_with_ic(self):
-        d = {"type": "Capacitor", "id": "C1", "value": "1u", "pos": {"x": 0, "y": 0}, "initial_condition": "5"}
+        d = {
+            "type": "Capacitor",
+            "id": "C1",
+            "value": "1u",
+            "pos": {"x": 0, "y": 0},
+            "initial_condition": "5",
+        }
         comp = ComponentData.from_dict(d)
         assert comp.initial_condition == "5"
 

--- a/app/tests/unit/test_main_window_refactor.py
+++ b/app/tests/unit/test_main_window_refactor.py
@@ -118,7 +118,11 @@ class TestMainWindowHasAllExpectedMethods:
     def test_menu_methods(self):
         from GUI.main_window import MainWindow
 
-        for method in ["create_menu_bar", "_open_keybindings_dialog", "_apply_keybindings"]:
+        for method in [
+            "create_menu_bar",
+            "_open_keybindings_dialog",
+            "_apply_keybindings",
+        ]:
             assert hasattr(MainWindow, method), f"Missing: {method}"
 
     def test_file_operation_methods(self):

--- a/app/tests/unit/test_markdown_exporter.py
+++ b/app/tests/unit/test_markdown_exporter.py
@@ -75,18 +75,30 @@ class TestExportDcSweepResults:
 
 class TestExportAcResults:
     def test_contains_frequency_header(self):
-        data = {"frequencies": [100.0], "magnitude": {"out": [1.0]}, "phase": {"out": [45.0]}}
+        data = {
+            "frequencies": [100.0],
+            "magnitude": {"out": [1.0]},
+            "phase": {"out": [45.0]},
+        }
         md = export_ac_results(data)
         assert "Frequency (Hz)" in md
 
     def test_contains_mag_and_phase(self):
-        data = {"frequencies": [100.0], "magnitude": {"out": [1.0]}, "phase": {"out": [45.0]}}
+        data = {
+            "frequencies": [100.0],
+            "magnitude": {"out": [1.0]},
+            "phase": {"out": [45.0]},
+        }
         md = export_ac_results(data)
         assert "|V(out)|" in md
         assert "phase(V(out))" in md
 
     def test_data_values(self):
-        data = {"frequencies": [1000.0], "magnitude": {"out": [0.707]}, "phase": {"out": [-45.0]}}
+        data = {
+            "frequencies": [1000.0],
+            "magnitude": {"out": [0.707]},
+            "phase": {"out": [-45.0]},
+        }
         md = export_ac_results(data)
         assert "1000" in md
         assert "0.707" in md
@@ -113,20 +125,32 @@ class TestExportTransientResults:
 
 class TestExportNoiseResults:
     def test_contains_headers(self):
-        data = {"frequencies": [100.0], "onoise_spectrum": [1e-6], "inoise_spectrum": [2e-6]}
+        data = {
+            "frequencies": [100.0],
+            "onoise_spectrum": [1e-6],
+            "inoise_spectrum": [2e-6],
+        }
         md = export_noise_results(data)
         assert "Frequency (Hz)" in md
         assert "Output Noise" in md
         assert "Input Noise" in md
 
     def test_data_values(self):
-        data = {"frequencies": [1000.0], "onoise_spectrum": [1.5e-6], "inoise_spectrum": []}
+        data = {
+            "frequencies": [1000.0],
+            "onoise_spectrum": [1.5e-6],
+            "inoise_spectrum": [],
+        }
         md = export_noise_results(data)
         assert "1000" in md
         assert "1.5e-06" in md
 
     def test_omits_empty_columns(self):
-        data = {"frequencies": [100.0], "onoise_spectrum": [1e-6], "inoise_spectrum": []}
+        data = {
+            "frequencies": [100.0],
+            "onoise_spectrum": [1e-6],
+            "inoise_spectrum": [],
+        }
         md = export_noise_results(data)
         assert "Output Noise" in md
         assert "Input Noise" not in md

--- a/app/tests/unit/test_meas_dialog.py
+++ b/app/tests/unit/test_meas_dialog.py
@@ -16,7 +16,12 @@ class TestBuildDirective:
         assert d == ".meas tran avg_out AVG v(out)"
 
     def test_rms_with_range(self):
-        d = build_directive("tran", "rms_out", "RMS", {"variable": "v(out)", "from_val": "1m", "to_val": "10m"})
+        d = build_directive(
+            "tran",
+            "rms_out",
+            "RMS",
+            {"variable": "v(out)", "from_val": "1m", "to_val": "10m"},
+        )
         assert d == ".meas tran rms_out RMS v(out) FROM=1m TO=10m"
 
     def test_min_no_range(self):
@@ -32,7 +37,12 @@ class TestBuildDirective:
         assert d == ".meas tran swing PP v(out)"
 
     def test_integ(self):
-        d = build_directive("tran", "charge", "INTEG", {"variable": "i(R1)", "from_val": "0", "to_val": "5m"})
+        d = build_directive(
+            "tran",
+            "charge",
+            "INTEG",
+            {"variable": "i(R1)", "from_val": "0", "to_val": "5m"},
+        )
         assert d == ".meas tran charge INTEG i(R1) FROM=0 TO=5m"
 
     def test_find_at(self):
@@ -44,13 +54,21 @@ class TestBuildDirective:
             "tran",
             "crossing",
             "FIND_WHEN",
-            {"variable": "v(out)", "when_var": "v(in)", "when_val": "0.5", "cross": "RISE=1"},
+            {
+                "variable": "v(out)",
+                "when_var": "v(in)",
+                "when_val": "0.5",
+                "cross": "RISE=1",
+            },
         )
         assert d == ".meas tran crossing FIND v(out) WHEN v(in)=0.5 RISE=1"
 
     def test_find_when_no_cross(self):
         d = build_directive(
-            "tran", "thresh", "FIND_WHEN", {"variable": "v(out)", "when_var": "v(in)", "when_val": "2.5", "cross": ""}
+            "tran",
+            "thresh",
+            "FIND_WHEN",
+            {"variable": "v(out)", "when_var": "v(in)", "when_val": "2.5", "cross": ""},
         )
         assert d == ".meas tran thresh FIND v(out) WHEN v(in)=2.5"
 
@@ -288,13 +306,23 @@ class TestAnalysisDialogMeasIntegration:
         assert "No measurements" in dialog.meas_label.text()
 
         dialog._measurements = [
-            {"name": "m1", "meas_type": "AVG", "params": {}, "directive": ".meas tran m1 AVG v(out)"},
+            {
+                "name": "m1",
+                "meas_type": "AVG",
+                "params": {},
+                "directive": ".meas tran m1 AVG v(out)",
+            },
         ]
         dialog._update_meas_label()
         assert "1 measurement" in dialog.meas_label.text()
 
         dialog._measurements.append(
-            {"name": "m2", "meas_type": "MAX", "params": {}, "directive": ".meas tran m2 MAX v(out)"},
+            {
+                "name": "m2",
+                "meas_type": "MAX",
+                "params": {},
+                "directive": ".meas tran m2 MAX v(out)",
+            },
         )
         dialog._update_meas_label()
         assert "2 measurements" in dialog.meas_label.text()

--- a/app/tests/unit/test_meas_directive.py
+++ b/app/tests/unit/test_meas_directive.py
@@ -29,9 +29,24 @@ def _build_transient_circuit():
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.analysis_type = "Transient"
     model.analysis_params = {"step": "1u", "duration": "10m"}

--- a/app/tests/unit/test_monte_carlo.py
+++ b/app/tests/unit/test_monte_carlo.py
@@ -160,9 +160,24 @@ def _build_simple_circuit():
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.analysis_type = "DC Operating Point"
     model.rebuild_nodes()
@@ -176,7 +191,12 @@ class TestMonteCarloController:
         mock_runner = MagicMock()
         mock_runner.find_ngspice.return_value = "/usr/bin/ngspice"
         mock_runner.output_dir = "/tmp/sim_output"
-        mock_runner.run_simulation.return_value = (True, "/tmp/output.txt", "stdout", "")
+        mock_runner.run_simulation.return_value = (
+            True,
+            "/tmp/output.txt",
+            "stdout",
+            "",
+        )
         mock_runner.read_output.return_value = (
             "Node                      Voltage\n"
             "----                      -------\n"

--- a/app/tests/unit/test_multiselect_tearing.py
+++ b/app/tests/unit/test_multiselect_tearing.py
@@ -1,0 +1,105 @@
+"""Tests for issue #442 — Ctrl+click multi-select tearing during group drag.
+
+Verifies that wire drag-preview updates are suppressed for follower
+components during group movement to prevent visual tearing artifacts.
+"""
+
+import inspect
+
+from GUI.component_item import ComponentGraphicsItem, Resistor
+from GUI.styles import GRID_SIZE
+from PyQt6.QtCore import QPointF
+from PyQt6.QtWidgets import QGraphicsScene
+
+
+def _add_resistor(scene, comp_id, x, y):
+    """Add a resistor to the scene at position (x, y), bypassing snap."""
+    comp = Resistor(comp_id)
+    scene.addItem(comp)
+    comp.setFlag(ComponentGraphicsItem.GraphicsItemFlag.ItemSendsGeometryChanges, False)
+    comp.setPos(x, y)
+    comp.setFlag(ComponentGraphicsItem.GraphicsItemFlag.ItemSendsGeometryChanges, True)
+    return comp
+
+
+class TestWirePreviewSuppression:
+    """Verify that followers skip wire preview during group drag (#442)."""
+
+    def test_group_moving_guard_in_position_has_changed(self):
+        """ItemPositionHasChanged handler must check _group_moving before wire preview."""
+        source = inspect.getsource(ComponentGraphicsItem.itemChange)
+        # The handler should contain both the enum and the guard
+        assert "ItemPositionHasChanged" in source
+        assert "not self._group_moving" in source
+
+    def test_show_drag_preview_only_called_when_not_group_moving(self):
+        """show_drag_preview should only appear inside the not _group_moving block."""
+        source = inspect.getsource(ComponentGraphicsItem.itemChange)
+        lines = source.split("\n")
+        # Find the line with _group_moving guard and the line with show_drag_preview
+        guard_line = None
+        preview_line = None
+        for i, line in enumerate(lines):
+            if "not self._group_moving" in line:
+                guard_line = i
+            if "show_drag_preview" in line:
+                preview_line = i
+        assert guard_line is not None, "_group_moving guard not found"
+        assert preview_line is not None, "show_drag_preview not found"
+        # The preview call must come AFTER the guard
+        assert preview_line > guard_line
+
+    def test_follower_group_moving_flag_during_setpos(self):
+        """Follower's _group_moving should be True when leader moves it."""
+        scene = QGraphicsScene()
+        leader = _add_resistor(scene, "R1", 100, 0)
+        follower = _add_resistor(scene, "R2", 200, 0)
+
+        leader.setSelected(True)
+        follower.setSelected(True)
+
+        # Track _group_moving state during follower's itemChange
+        captured_states = []
+        orig_itemChange = ComponentGraphicsItem.itemChange
+
+        def tracking_itemChange(self_item, change, value):
+            if self_item is follower:
+                captured_states.append(self_item._group_moving)
+            return orig_itemChange(self_item, change, value)
+
+        ComponentGraphicsItem.itemChange = tracking_itemChange
+        try:
+            # Move leader, which should move follower with _group_moving=True
+            leader.setPos(QPointF(100 + GRID_SIZE, 0))
+        finally:
+            ComponentGraphicsItem.itemChange = orig_itemChange
+
+        # At least one callback should have seen _group_moving=True
+        assert any(captured_states), "follower was never called during group drag"
+        assert any(s is True for s in captured_states), "follower's _group_moving was never True during group drag"
+
+    def test_leader_group_moving_stays_false(self):
+        """Leader's _group_moving should remain False during its own movement."""
+        scene = QGraphicsScene()
+        leader = _add_resistor(scene, "R1", 100, 0)
+        follower = _add_resistor(scene, "R2", 200, 0)
+
+        leader.setSelected(True)
+        follower.setSelected(True)
+
+        leader_states = []
+        orig_itemChange = ComponentGraphicsItem.itemChange
+
+        def tracking_itemChange(self_item, change, value):
+            if self_item is leader:
+                leader_states.append(self_item._group_moving)
+            return orig_itemChange(self_item, change, value)
+
+        ComponentGraphicsItem.itemChange = tracking_itemChange
+        try:
+            leader.setPos(QPointF(100 + GRID_SIZE, 0))
+        finally:
+            ComponentGraphicsItem.itemChange = orig_itemChange
+
+        # Leader should never have _group_moving=True
+        assert all(s is False for s in leader_states), "leader's _group_moving was True during its own drag"

--- a/app/tests/unit/test_netlist_snapshots.py
+++ b/app/tests/unit/test_netlist_snapshots.py
@@ -354,7 +354,14 @@ class TestAnalysisDirectives:
         w2 = WireData("R1", 1, "GND1", 0)
         w3 = WireData("V1", 1, "GND1", 0)
         return _model_with_circuit(
-            v1, r1, gnd, w1, w2, w3, analysis_type=analysis_type, analysis_params=analysis_params
+            v1,
+            r1,
+            gnd,
+            w1,
+            w2,
+            w3,
+            analysis_type=analysis_type,
+            analysis_params=analysis_params,
         )
 
     def test_dc_operating_point(self):
@@ -368,7 +375,10 @@ class TestAnalysisDirectives:
         assert ".dc V1 0 10 0.1" in netlist
 
     def test_ac_sweep(self):
-        model = self._basic_circuit("AC Sweep", {"sweep_type": "dec", "points": "10", "fStart": "1", "fStop": "1MEG"})
+        model = self._basic_circuit(
+            "AC Sweep",
+            {"sweep_type": "dec", "points": "10", "fStart": "1", "fStop": "1MEG"},
+        )
         netlist = _generate_from_model(model)
         assert ".ac dec 10 1 1MEG" in netlist
 

--- a/app/tests/unit/test_parameter_sweep.py
+++ b/app/tests/unit/test_parameter_sweep.py
@@ -31,9 +31,24 @@ def _build_simple_circuit():
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.analysis_type = "DC Operating Point"
     model.rebuild_nodes()
@@ -152,7 +167,12 @@ class TestParameterSweepExecution:
         mock_runner = MagicMock()
         mock_runner.find_ngspice.return_value = "/usr/bin/ngspice"
         mock_runner.output_dir = "/tmp/sim_output"
-        mock_runner.run_simulation.return_value = (True, "/tmp/output.txt", "stdout", "")
+        mock_runner.run_simulation.return_value = (
+            True,
+            "/tmp/output.txt",
+            "stdout",
+            "",
+        )
         mock_runner.read_output.return_value = (
             "Node                      Voltage\n"
             "----                      -------\n"

--- a/app/tests/unit/test_qtbot_widget_interactions.py
+++ b/app/tests/unit/test_qtbot_widget_interactions.py
@@ -36,7 +36,14 @@ class TestAnalysisDialogInteractions:
 
     @pytest.mark.parametrize(
         "analysis_type",
-        ["DC Operating Point", "DC Sweep", "AC Sweep", "Transient", "Temperature Sweep", "Noise"],
+        [
+            "DC Operating Point",
+            "DC Sweep",
+            "AC Sweep",
+            "Transient",
+            "Temperature Sweep",
+            "Noise",
+        ],
     )
     def test_each_analysis_type_opens(self, qtbot, analysis_type):
         """Every analysis type dialog opens without error."""
@@ -79,7 +86,14 @@ class TestAnalysisDialogInteractions:
         """Noise analysis has all 6 parameter fields."""
         dialog = AnalysisDialog(analysis_type="Noise")
         qtbot.addWidget(dialog)
-        expected_keys = {"output_node", "source", "fStart", "fStop", "points", "sweepType"}
+        expected_keys = {
+            "output_node",
+            "source",
+            "fStart",
+            "fStop",
+            "points",
+            "sweepType",
+        }
         assert set(dialog.field_widgets.keys()) == expected_keys
 
     def test_temp_sweep_command_generation(self, qtbot):
@@ -364,7 +378,18 @@ class TestComponentTerminalGeometry:
 
     @pytest.mark.parametrize(
         "comp_type",
-        ["Op-Amp", "VCVS", "CCVS", "VCCS", "CCCS", "BJT NPN", "BJT PNP", "MOSFET NMOS", "MOSFET PMOS", "VC Switch"],
+        [
+            "Op-Amp",
+            "VCVS",
+            "CCVS",
+            "VCCS",
+            "CCCS",
+            "BJT NPN",
+            "BJT PNP",
+            "MOSFET NMOS",
+            "MOSFET PMOS",
+            "VC Switch",
+        ],
     )
     def test_multi_terminal_component_geometry(self, comp_type):
         """Multi-terminal components have correct terminal count and non-overlapping positions."""

--- a/app/tests/unit/test_results_plot_dialog.py
+++ b/app/tests/unit/test_results_plot_dialog.py
@@ -209,7 +209,10 @@ class TestSavePlot:
         ax.set_title("Test")
 
         out = tmp_path / "plot.png"
-        with patch("GUI.results_plot_dialog.QFileDialog.getSaveFileName", return_value=(str(out), "")):
+        with patch(
+            "GUI.results_plot_dialog.QFileDialog.getSaveFileName",
+            return_value=(str(out), ""),
+        ):
             result = save_plot(fig)
 
         assert result == str(out)
@@ -222,7 +225,10 @@ class TestSavePlot:
         ax.plot([0, 1], [0, 1])
 
         out = tmp_path / "plot.svg"
-        with patch("GUI.results_plot_dialog.QFileDialog.getSaveFileName", return_value=(str(out), "")):
+        with patch(
+            "GUI.results_plot_dialog.QFileDialog.getSaveFileName",
+            return_value=(str(out), ""),
+        ):
             result = save_plot(fig)
 
         assert result == str(out)

--- a/app/tests/unit/test_rubric_generator.py
+++ b/app/tests/unit/test_rubric_generator.py
@@ -38,10 +38,30 @@ def _build_rc_filter():
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="C1", end_terminal=0),
-        WireData(start_component_id="C1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="C1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="C1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.component_counter = {"V": 1, "R": 1, "C": 1, "GND": 1}
     model.analysis_type = "AC Sweep"
@@ -220,14 +240,30 @@ class TestTopologyChecks:
         """Multiple wires between the same pair should produce only one check."""
         model = CircuitModel()
         model.components["R1"] = ComponentData(
-            component_id="R1", component_type="Resistor", value="1k", position=(0.0, 0.0)
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(0.0, 0.0),
         )
         model.components["R2"] = ComponentData(
-            component_id="R2", component_type="Resistor", value="2k", position=(100.0, 0.0)
+            component_id="R2",
+            component_type="Resistor",
+            value="2k",
+            position=(100.0, 0.0),
         )
         model.wires = [
-            WireData(start_component_id="R1", start_terminal=0, end_component_id="R2", end_terminal=0),
-            WireData(start_component_id="R2", start_terminal=1, end_component_id="R1", end_terminal=1),
+            WireData(
+                start_component_id="R1",
+                start_terminal=0,
+                end_component_id="R2",
+                end_terminal=0,
+            ),
+            WireData(
+                start_component_id="R2",
+                start_terminal=1,
+                end_component_id="R1",
+                end_terminal=1,
+            ),
         ]
         model.rebuild_nodes()
         rubric = generate_rubric_from_circuit(model)
@@ -316,7 +352,10 @@ class TestPointDistribution:
     def test_remainder_distributed_to_first_checks(self):
         model = CircuitModel()
         model.components["R1"] = ComponentData(
-            component_id="R1", component_type="Resistor", value="1k", position=(0.0, 0.0)
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(0.0, 0.0),
         )
         model.rebuild_nodes()
         # 2 checks (exists + value), 7 points -> 3 + 4, remainder 1 to first

--- a/app/tests/unit/test_rubric_grader.py
+++ b/app/tests/unit/test_rubric_grader.py
@@ -40,10 +40,30 @@ def _build_rc_filter(r_value="1k", c_value="100n", analysis="AC Sweep"):
         position=(0.0, 100.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="C1", end_terminal=0),
-        WireData(start_component_id="C1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="C1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="C1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.component_counter = {"V": 1, "R": 1, "C": 1, "GND": 1}
     model.analysis_type = analysis
@@ -77,7 +97,11 @@ def _build_rc_rubric():
                 check_id="r1_value",
                 check_type="component_value",
                 points=20,
-                params={"component_id": "R1", "expected_value": "1k", "tolerance_pct": 10},
+                params={
+                    "component_id": "R1",
+                    "expected_value": "1k",
+                    "tolerance_pct": 10,
+                },
                 feedback_pass="R1 value correct",
                 feedback_fail="R1 value should be approximately 1k",
             ),
@@ -331,22 +355,49 @@ class TestCircuitGraderTopology:
         """R1 and C1 not connected should fail topology check."""
         model = CircuitModel()
         model.components["V1"] = ComponentData(
-            component_id="V1", component_type="Voltage Source", value="5V", position=(0.0, 0.0)
+            component_id="V1",
+            component_type="Voltage Source",
+            value="5V",
+            position=(0.0, 0.0),
         )
         model.components["R1"] = ComponentData(
-            component_id="R1", component_type="Resistor", value="1k", position=(100.0, 0.0)
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(100.0, 0.0),
         )
         model.components["C1"] = ComponentData(
-            component_id="C1", component_type="Capacitor", value="100n", position=(200.0, 0.0)
+            component_id="C1",
+            component_type="Capacitor",
+            value="100n",
+            position=(200.0, 0.0),
         )
         model.components["GND1"] = ComponentData(
-            component_id="GND1", component_type="Ground", value="0V", position=(0.0, 100.0)
+            component_id="GND1",
+            component_type="Ground",
+            value="0V",
+            position=(0.0, 100.0),
         )
         # Wire V1-R1 and C1-GND but NOT R1-C1
         model.wires = [
-            WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-            WireData(start_component_id="C1", start_terminal=1, end_component_id="GND1", end_terminal=0),
-            WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+            WireData(
+                start_component_id="V1",
+                start_terminal=1,
+                end_component_id="R1",
+                end_terminal=0,
+            ),
+            WireData(
+                start_component_id="C1",
+                start_terminal=1,
+                end_component_id="GND1",
+                end_terminal=0,
+            ),
+            WireData(
+                start_component_id="V1",
+                start_terminal=0,
+                end_component_id="GND1",
+                end_terminal=0,
+            ),
         ]
         model.analysis_type = "AC Sweep"
         model.rebuild_nodes()
@@ -363,7 +414,10 @@ class TestCircuitGraderGround:
     def test_missing_ground_fails(self):
         model = CircuitModel()
         model.components["R1"] = ComponentData(
-            component_id="R1", component_type="Resistor", value="1k", position=(0.0, 0.0)
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(0.0, 0.0),
         )
         model.rebuild_nodes()
 

--- a/app/tests/unit/test_sensitivity_analysis.py
+++ b/app/tests/unit/test_sensitivity_analysis.py
@@ -35,10 +35,30 @@ def _build_divider_model(analysis_type="Sensitivity", analysis_params=None):
         position=(0.0, 200.0),
     )
     model.wires = [
-        WireData(start_component_id="V1", start_terminal=1, end_component_id="R1", end_terminal=0),
-        WireData(start_component_id="R1", start_terminal=1, end_component_id="R2", end_terminal=0),
-        WireData(start_component_id="R2", start_terminal=1, end_component_id="GND1", end_terminal=0),
-        WireData(start_component_id="V1", start_terminal=0, end_component_id="GND1", end_terminal=0),
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="R2",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R2",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
     ]
     model.analysis_type = analysis_type
     model.analysis_params = analysis_params or {"output_node": "2"}

--- a/app/tests/unit/test_simulation_presets.py
+++ b/app/tests/unit/test_simulation_presets.py
@@ -67,7 +67,11 @@ class TestUserPresets:
 
     def test_cannot_overwrite_builtin(self, mgr):
         with pytest.raises(ValueError, match="built-in"):
-            mgr.save_preset("Quick Transient", "Transient", {"duration": 1, "step": 0.001, "startTime": 0})
+            mgr.save_preset(
+                "Quick Transient",
+                "Transient",
+                {"duration": 1, "step": 0.001, "startTime": 0},
+            )
 
     def test_delete_user_preset(self, mgr):
         mgr.save_preset("Temp", "DC Sweep", {"source": "V1", "min": 0, "max": 5, "step": 0.1})
@@ -103,7 +107,11 @@ class TestPresetPersistence:
 
     def test_file_format_is_json(self, preset_file):
         mgr = PresetManager(preset_file)
-        mgr.save_preset("Test", "AC Sweep", {"fStart": 10, "fStop": 1000, "points": 50, "sweepType": "dec"})
+        mgr.save_preset(
+            "Test",
+            "AC Sweep",
+            {"fStart": 10, "fStop": 1000, "points": 50, "sweepType": "dec"},
+        )
         data = json.loads(preset_file.read_text())
         assert "presets" in data
         assert len(data["presets"]) == 1

--- a/app/tests/unit/test_template_manager.py
+++ b/app/tests/unit/test_template_manager.py
@@ -166,8 +166,18 @@ class TestLoadTemplate:
             "name": "Test",
             "category": "Test",
             "components": [
-                {"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}},
-                {"id": "R2", "type": "Resistor", "value": "2k", "pos": {"x": 100, "y": 0}},
+                {
+                    "id": "R1",
+                    "type": "Resistor",
+                    "value": "1k",
+                    "pos": {"x": 0, "y": 0},
+                },
+                {
+                    "id": "R2",
+                    "type": "Resistor",
+                    "value": "2k",
+                    "pos": {"x": 100, "y": 0},
+                },
             ],
             "wires": [],
             "counters": {"R": 2},
@@ -189,9 +199,24 @@ class TestLoadTemplate:
             "name": "Test",
             "category": "Test",
             "components": [
-                {"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}},
-                {"id": "R3", "type": "Resistor", "value": "2k", "pos": {"x": 100, "y": 0}},
-                {"id": "V1", "type": "VoltageSource", "value": "5V", "pos": {"x": 200, "y": 0}},
+                {
+                    "id": "R1",
+                    "type": "Resistor",
+                    "value": "1k",
+                    "pos": {"x": 0, "y": 0},
+                },
+                {
+                    "id": "R3",
+                    "type": "Resistor",
+                    "value": "2k",
+                    "pos": {"x": 100, "y": 0},
+                },
+                {
+                    "id": "V1",
+                    "type": "VoltageSource",
+                    "value": "5V",
+                    "pos": {"x": 200, "y": 0},
+                },
             ],
             "wires": [],
             "counters": {"R": 999, "V": 999},

--- a/app/tests/unit/test_undo_redo.py
+++ b/app/tests/unit/test_undo_redo.py
@@ -612,7 +612,10 @@ class TestRerouteWireCommand:
         model.wires[0].waypoints = [(0.0, 0.0), (100.0, 0.0)]
         model.wires[1].waypoints = [(100.0, 0.0), (200.0, 0.0)]
 
-        commands = [RerouteWireCommand(controller, 0), RerouteWireCommand(controller, 1)]
+        commands = [
+            RerouteWireCommand(controller, 0),
+            RerouteWireCommand(controller, 1),
+        ]
         compound = CompoundCommand(commands, "Reroute 2 wires")
         controller.execute_command(compound)
 


### PR DESCRIPTION
## Summary - Skip  for follower components during group drag by checking  flag in  handler - The rapid forced scene repaints from each follower's wire preview updates caused visual tearing artifacts (ghost text left behind) - Only the leader component now triggers wire preview during drag; full pathfinding runs after drag ends via debounced timer ## Test plan - [x] 4 new tests in  (structural + behavioral) - [x] Full test suite (2723 tests) passes - [x] ruff check, isort, black all pass Closes #442 🤖 Generated with [Claude Code](https://claude.com/claude-code)