### PR TITLE
Add template preview dialog with metadata and circuit display (#374)

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -719,18 +719,33 @@ class FileOperationsMixin:
         self.templates_menu.addAction(browse_action)
 
     def _on_new_from_template(self):
-        """Open the template browser dialog."""
+        """Open the template browser dialog with preview."""
+        from controllers.template_controller import TemplateController
         from controllers.template_manager import TemplateManager
         from GUI.template_dialog import NewFromTemplateDialog
+        from GUI.template_preview_dialog import TemplatePreviewDialog
 
         if not hasattr(self, "_template_manager"):
             self._template_manager = TemplateManager()
 
         dialog = NewFromTemplateDialog(self._template_manager, self)
         if dialog.exec() == NewFromTemplateDialog.DialogCode.Accepted:
-            template = dialog.get_selected_template()
-            if template:
-                self._open_template(template.filepath)
+            template_info = dialog.get_selected_template()
+            if template_info is None:
+                return
+
+            # Load full template data for preview
+            try:
+                template_ctrl = TemplateController()
+                template_data = template_ctrl.load_template(template_info.filepath)
+            except (OSError, ValueError):
+                # If preview load fails, fall back to direct load
+                self._open_template(template_info.filepath)
+                return
+
+            preview = TemplatePreviewDialog(template_data, self)
+            if preview.exec() == TemplatePreviewDialog.DialogCode.Accepted:
+                self._open_template(template_info.filepath)
 
     def _open_template(self, filepath: Path):
         """Load a circuit template, replacing the current circuit."""

--- a/app/GUI/template_preview_dialog.py
+++ b/app/GUI/template_preview_dialog.py
@@ -1,0 +1,169 @@
+"""Preview dialog for assignment templates showing metadata and circuit summary."""
+
+from typing import Optional
+
+from models.template import TemplateData
+from PyQt6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QTextEdit,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+)
+
+
+class TemplatePreviewDialog(QDialog):
+    """Dialog to preview a template before loading it.
+
+    Shows metadata (title, author, description, tags, instructions)
+    and a read-only component/wire summary of the starter circuit.
+    """
+
+    def __init__(self, template_data: TemplateData, parent=None):
+        super().__init__(parent)
+        self._template = template_data
+        self._setup_ui()
+        self._populate(template_data)
+
+    def _setup_ui(self):
+        self.setWindowTitle("Template Preview")
+        self.setMinimumSize(600, 450)
+
+        layout = QVBoxLayout(self)
+
+        # --- Metadata section ---
+        meta_group = QGroupBox("Template Information")
+        meta_layout = QVBoxLayout(meta_group)
+
+        self.title_label = QLabel()
+        self.title_label.setStyleSheet("font-weight: bold; font-size: 16px;")
+        self.title_label.setWordWrap(True)
+        meta_layout.addWidget(self.title_label)
+
+        info_row = QHBoxLayout()
+        self.author_label = QLabel()
+        self.author_label.setStyleSheet("color: gray;")
+        info_row.addWidget(self.author_label)
+        self.date_label = QLabel()
+        self.date_label.setStyleSheet("color: gray;")
+        info_row.addWidget(self.date_label)
+        info_row.addStretch()
+        meta_layout.addLayout(info_row)
+
+        self.tags_label = QLabel()
+        self.tags_label.setWordWrap(True)
+        meta_layout.addWidget(self.tags_label)
+
+        self.description_label = QLabel()
+        self.description_label.setWordWrap(True)
+        meta_layout.addWidget(self.description_label)
+
+        layout.addWidget(meta_group)
+
+        # --- Instructions section ---
+        instructions_group = QGroupBox("Instructions")
+        instructions_layout = QVBoxLayout(instructions_group)
+
+        self.instructions_text = QTextEdit()
+        self.instructions_text.setReadOnly(True)
+        self.instructions_text.setMaximumHeight(120)
+        instructions_layout.addWidget(self.instructions_text)
+
+        layout.addWidget(instructions_group)
+
+        # --- Circuit preview section ---
+        circuit_group = QGroupBox("Starter Circuit Preview")
+        circuit_layout = QVBoxLayout(circuit_group)
+
+        self.circuit_tree = QTreeWidget()
+        self.circuit_tree.setHeaderLabels(["Item", "Details"])
+        self.circuit_tree.setMaximumHeight(180)
+        self.circuit_tree.setAlternatingRowColors(True)
+        circuit_layout.addWidget(self.circuit_tree)
+
+        self.circuit_summary = QLabel()
+        self.circuit_summary.setStyleSheet("color: gray; font-style: italic;")
+        circuit_layout.addWidget(self.circuit_summary)
+
+        layout.addWidget(circuit_group)
+
+        # --- Buttons ---
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons.button(QDialogButtonBox.StandardButton.Ok).setText("Load Template")
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _populate(self, template: TemplateData):
+        """Fill the dialog with template data."""
+        meta = template.metadata
+
+        # Metadata
+        self.title_label.setText(meta.title or "(Untitled)")
+        self.author_label.setText(f"Author: {meta.author}" if meta.author else "")
+        self.date_label.setText(f"Created: {meta.created}" if meta.created else "")
+        self.tags_label.setText(f"Tags: {', '.join(meta.tags)}" if meta.tags else "")
+        self.description_label.setText(meta.description or "(No description)")
+
+        # Instructions
+        if template.instructions:
+            self.instructions_text.setPlainText(template.instructions)
+        else:
+            self.instructions_text.setPlainText("(No instructions provided)")
+
+        # Circuit preview
+        self._populate_circuit_tree(template.starter_circuit)
+
+    def _populate_circuit_tree(self, circuit_data: Optional[dict]):
+        """Build a tree view of the circuit components and wires."""
+        self.circuit_tree.clear()
+
+        if circuit_data is None:
+            self.circuit_summary.setText("No starter circuit (empty canvas)")
+            return
+
+        components = circuit_data.get("components", [])
+        wires = circuit_data.get("wires", [])
+
+        # Components
+        if components:
+            comp_root = QTreeWidgetItem(self.circuit_tree, ["Components", f"({len(components)})"])
+            comp_root.setExpanded(True)
+            for comp in components:
+                comp_id = comp.get("component_id", "?")
+                comp_type = comp.get("component_type", "?")
+                value = comp.get("value", "")
+                QTreeWidgetItem(comp_root, [comp_id, f"{comp_type} — {value}"])
+
+        # Wires
+        if wires:
+            wire_root = QTreeWidgetItem(self.circuit_tree, ["Wires", f"({len(wires)})"])
+            for wire in wires:
+                start = f"{wire.get('start_component_id', '?')}:{wire.get('start_terminal', '?')}"
+                end = f"{wire.get('end_component_id', '?')}:{wire.get('end_terminal', '?')}"
+                QTreeWidgetItem(wire_root, [f"{start} → {end}", ""])
+
+        # Analysis info
+        analysis = circuit_data.get("analysis_type")
+        if analysis and analysis != "DC Operating Point":
+            QTreeWidgetItem(self.circuit_tree, ["Analysis Type", analysis])
+
+        # Summary
+        has_ref = self._template.reference_circuit is not None
+        parts = [
+            f"{len(components)} component(s)",
+            f"{len(wires)} wire(s)",
+        ]
+        if has_ref:
+            parts.append("reference circuit included")
+        self.circuit_summary.setText(", ".join(parts))
+
+        self.circuit_tree.resizeColumnToContents(0)
+
+    def get_template(self) -> TemplateData:
+        """Return the template data (for use after accept)."""
+        return self._template

--- a/app/tests/unit/test_template_preview_dialog.py
+++ b/app/tests/unit/test_template_preview_dialog.py
@@ -1,0 +1,185 @@
+"""Tests for the template preview dialog."""
+
+import pytest
+from models.template import TemplateData, TemplateMetadata
+
+
+@pytest.fixture
+def sample_template():
+    """Create a sample template with metadata and circuit data."""
+    return TemplateData(
+        metadata=TemplateMetadata(
+            title="RC Low-Pass Filter",
+            description="Build an RC low-pass filter circuit",
+            author="Prof. Smith",
+            created="2026-01-15",
+            tags=["filters", "analog"],
+        ),
+        instructions="Connect R1 to C1 to form a voltage divider.",
+        starter_circuit={
+            "components": [
+                {
+                    "component_id": "R1",
+                    "component_type": "Resistor",
+                    "value": "1k",
+                    "position": [0, 0],
+                },
+                {
+                    "component_id": "C1",
+                    "component_type": "Capacitor",
+                    "value": "100n",
+                    "position": [100, 0],
+                },
+            ],
+            "wires": [
+                {
+                    "start_component_id": "R1",
+                    "start_terminal": 1,
+                    "end_component_id": "C1",
+                    "end_terminal": 0,
+                },
+            ],
+            "analysis_type": "AC Sweep",
+        },
+        reference_circuit={"components": [], "wires": []},
+    )
+
+
+@pytest.fixture
+def empty_template():
+    """Create a template with no starter circuit."""
+    return TemplateData(
+        metadata=TemplateMetadata(title="Empty Assignment"),
+        instructions="",
+        starter_circuit=None,
+    )
+
+
+@pytest.fixture
+def dialog(qtbot, sample_template):
+    """Create a TemplatePreviewDialog instance."""
+    from GUI.template_preview_dialog import TemplatePreviewDialog
+
+    dlg = TemplatePreviewDialog(sample_template)
+    qtbot.addWidget(dlg)
+    return dlg
+
+
+class TestTemplatePreviewDialog:
+    """Tests for TemplatePreviewDialog."""
+
+    def test_title_displayed(self, dialog, sample_template):
+        """Dialog displays the template title."""
+        assert dialog.title_label.text() == sample_template.metadata.title
+
+    def test_author_displayed(self, dialog):
+        """Dialog displays the author."""
+        assert "Prof. Smith" in dialog.author_label.text()
+
+    def test_date_displayed(self, dialog):
+        """Dialog displays the creation date."""
+        assert "2026-01-15" in dialog.date_label.text()
+
+    def test_tags_displayed(self, dialog):
+        """Dialog displays the tags."""
+        assert "filters" in dialog.tags_label.text()
+        assert "analog" in dialog.tags_label.text()
+
+    def test_description_displayed(self, dialog, sample_template):
+        """Dialog displays the description."""
+        assert dialog.description_label.text() == sample_template.metadata.description
+
+    def test_instructions_displayed(self, dialog, sample_template):
+        """Dialog displays the instructions."""
+        assert dialog.instructions_text.toPlainText() == sample_template.instructions
+
+    def test_circuit_tree_has_components(self, dialog):
+        """Circuit tree shows component nodes."""
+        tree = dialog.circuit_tree
+        # Root items: Components, Wires, possibly Analysis Type
+        assert tree.topLevelItemCount() >= 2
+        comp_root = tree.topLevelItem(0)
+        assert "Components" in comp_root.text(0)
+        assert comp_root.childCount() == 2
+
+    def test_circuit_tree_component_details(self, dialog):
+        """Component items show ID and type/value."""
+        tree = dialog.circuit_tree
+        comp_root = tree.topLevelItem(0)
+        first_comp = comp_root.child(0)
+        assert "R1" in first_comp.text(0)
+        assert "Resistor" in first_comp.text(1)
+
+    def test_circuit_tree_has_wires(self, dialog):
+        """Circuit tree shows wire nodes."""
+        tree = dialog.circuit_tree
+        wire_root = tree.topLevelItem(1)
+        assert "Wires" in wire_root.text(0)
+        assert wire_root.childCount() == 1
+
+    def test_analysis_type_shown(self, dialog):
+        """Non-default analysis type is shown in the tree."""
+        tree = dialog.circuit_tree
+        # Find the analysis type item
+        found = False
+        for i in range(tree.topLevelItemCount()):
+            item = tree.topLevelItem(i)
+            if "Analysis" in item.text(0):
+                assert "AC Sweep" in item.text(1)
+                found = True
+        assert found
+
+    def test_summary_label(self, dialog):
+        """Summary shows component and wire counts."""
+        assert "2 component(s)" in dialog.circuit_summary.text()
+        assert "1 wire(s)" in dialog.circuit_summary.text()
+        assert "reference circuit included" in dialog.circuit_summary.text()
+
+    def test_get_template_returns_data(self, dialog, sample_template):
+        """get_template returns the template data."""
+        assert dialog.get_template() is sample_template
+
+
+class TestTemplatePreviewEmpty:
+    """Tests for preview dialog with an empty template."""
+
+    def test_empty_circuit_message(self, qtbot, empty_template):
+        """Empty starter circuit shows appropriate message."""
+        from GUI.template_preview_dialog import TemplatePreviewDialog
+
+        dlg = TemplatePreviewDialog(empty_template)
+        qtbot.addWidget(dlg)
+        assert "empty" in dlg.circuit_summary.text().lower() or "No" in dlg.circuit_summary.text()
+
+    def test_no_instructions(self, qtbot, empty_template):
+        """Empty instructions shows placeholder."""
+        from GUI.template_preview_dialog import TemplatePreviewDialog
+
+        dlg = TemplatePreviewDialog(empty_template)
+        qtbot.addWidget(dlg)
+        assert dlg.instructions_text.toPlainText() != ""
+
+    def test_untitled_fallback(self, qtbot):
+        """Template with no title shows (Untitled)."""
+        from GUI.template_preview_dialog import TemplatePreviewDialog
+
+        tmpl = TemplateData(metadata=TemplateMetadata(title=""))
+        dlg = TemplatePreviewDialog(tmpl)
+        qtbot.addWidget(dlg)
+        assert "(Untitled)" in dlg.title_label.text()
+
+    def test_empty_author_hidden(self, qtbot, empty_template):
+        """Empty author field shows no author text."""
+        from GUI.template_preview_dialog import TemplatePreviewDialog
+
+        dlg = TemplatePreviewDialog(empty_template)
+        qtbot.addWidget(dlg)
+        assert dlg.author_label.text() == ""
+
+    def test_empty_tags_hidden(self, qtbot, empty_template):
+        """Empty tags field shows no tags text."""
+        from GUI.template_preview_dialog import TemplatePreviewDialog
+
+        dlg = TemplatePreviewDialog(empty_template)
+        qtbot.addWidget(dlg)
+        assert dlg.tags_label.text() == ""


### PR DESCRIPTION
## Summary - New TemplatePreviewDialog shows metadata (title, author, description, tags), instructions, and circuit preview tree before loading a template - Load and Cancel buttons let instructor verify they have the right template - Triggered from New from Template menu action ## Test plan - [x] 17 unit tests covering metadata display, circuit tree, summary labels, and empty template handling - [ ] Manual: use New from Template and verify preview dialog appears with correct info Closes #374 Generated with [Claude Code](https://claude.com/claude-code)