### PR TITLE
Add score distribution histogram to batch grading (#379)

### DIFF
--- a/app/GUI/batch_grading_dialog.py
+++ b/app/GUI/batch_grading_dialog.py
@@ -81,6 +81,11 @@ class BatchGradingDialog(QDialog):
         self.export_btn.setEnabled(False)
         self.export_btn.clicked.connect(self._on_export)
         btn_layout.addWidget(self.export_btn)
+
+        self.save_histogram_btn = QPushButton("Save Histogram")
+        self.save_histogram_btn.setEnabled(False)
+        self.save_histogram_btn.clicked.connect(self._on_save_histogram)
+        btn_layout.addWidget(self.save_histogram_btn)
         layout.addLayout(btn_layout)
 
         # Progress bar
@@ -99,6 +104,9 @@ class BatchGradingDialog(QDialog):
         results_layout.addWidget(self.results_label)
         self.results_group.setVisible(False)
         layout.addWidget(self.results_group)
+
+        # Histogram placeholder (populated after grading)
+        self._histogram_canvas = None
 
     def _on_browse_folder(self):
         folder = QFileDialog.getExistingDirectory(self, "Select Student Submissions Folder")
@@ -155,6 +163,7 @@ class BatchGradingDialog(QDialog):
         self._display_results(self._batch_result)
         self.grade_btn.setEnabled(True)
         self.export_btn.setEnabled(True)
+        self.save_histogram_btn.setEnabled(bool(self._batch_result.results))
         self.progress_label.setText("Grading complete")
 
     def _display_results(self, result: BatchGradingResult):
@@ -184,6 +193,56 @@ class BatchGradingDialog(QDialog):
                 lines.append(f"  ... and {len(result.errors) - 5} more")
 
         self.results_label.setText("\n".join(lines))
+
+        # Show histogram if there are results
+        if result.results:
+            self._show_histogram(result)
+
+    def _show_histogram(self, result: BatchGradingResult):
+        """Embed a matplotlib histogram in the results group."""
+        try:
+            from grading.histogram import create_histogram_figure
+            from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+        except ImportError:
+            logger.warning("matplotlib not available for histogram")
+            return
+
+        # Remove previous histogram canvas if re-grading
+        if self._histogram_canvas is not None:
+            self.results_group.layout().removeWidget(self._histogram_canvas)
+            self._histogram_canvas.deleteLater()
+            self._histogram_canvas = None
+
+        fig = create_histogram_figure(result)
+        canvas = FigureCanvas(fig)
+        canvas.setMinimumHeight(250)
+        self.results_group.layout().addWidget(canvas)
+        self._histogram_canvas = canvas
+
+        # Resize dialog to fit histogram
+        self.setMinimumWidth(600)
+
+    def _on_save_histogram(self):
+        """Save the histogram as a PNG file."""
+        if self._batch_result is None or not self._batch_result.results:
+            return
+
+        filename, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save Histogram",
+            "",
+            "PNG Images (*.png);;All Files (*)",
+        )
+        if not filename:
+            return
+
+        try:
+            from grading.histogram import save_histogram_png
+
+            save_histogram_png(self._batch_result, filename)
+            QMessageBox.information(self, "Saved", f"Histogram saved to {filename}")
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to save histogram:\n{e}")
 
     def _on_export(self):
         if self._batch_result is None:

--- a/app/grading/histogram.py
+++ b/app/grading/histogram.py
@@ -1,0 +1,93 @@
+"""Score distribution histogram generation for batch grading results.
+
+Pure Python module — no Qt dependencies. Matplotlib is used only for
+figure creation and is imported lazily.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from grading.batch_grader import BatchGradingResult
+
+
+def compute_score_bins(result: BatchGradingResult, num_bins: int = 10) -> tuple[list[str], list[int]]:
+    """Compute score distribution bins from batch grading results.
+
+    Args:
+        result: Batch grading result containing individual GradingResults.
+        num_bins: Number of equal-width bins (default 10 for 10% intervals).
+
+    Returns:
+        Tuple of (bin_labels, counts) where bin_labels are strings like
+        "0-10%" and counts are the number of students in each bin.
+    """
+    bin_width = 100.0 / num_bins
+    counts = [0] * num_bins
+    labels = []
+
+    for i in range(num_bins):
+        lo = int(i * bin_width)
+        hi = int((i + 1) * bin_width)
+        labels.append(f"{lo}-{hi}%")
+
+    for gr in result.results:
+        pct = gr.percentage
+        # Clamp to [0, 100]
+        pct = max(0.0, min(100.0, pct))
+        idx = int(pct / bin_width)
+        # 100% goes into the last bin
+        if idx >= num_bins:
+            idx = num_bins - 1
+        counts[idx] += 1
+
+    return labels, counts
+
+
+def create_histogram_figure(result: BatchGradingResult, num_bins: int = 10):
+    """Create a matplotlib Figure showing the score distribution histogram.
+
+    Args:
+        result: Batch grading result.
+        num_bins: Number of bins.
+
+    Returns:
+        matplotlib.figure.Figure with the histogram plotted.
+    """
+    import matplotlib
+    import matplotlib.figure as mpl_figure
+
+    labels, counts = compute_score_bins(result, num_bins)
+
+    fig = mpl_figure.Figure(figsize=(6, 3), dpi=100)
+    ax = fig.add_subplot(111)
+
+    x_positions = range(len(labels))
+    ax.bar(x_positions, counts, color="#4CAF50", edgecolor="#388E3C", width=0.8)
+
+    ax.set_xticks(list(x_positions))
+    ax.set_xticklabels(labels, rotation=45, ha="right", fontsize=8)
+    ax.set_xlabel("Score Range")
+    ax.set_ylabel("Number of Students")
+    ax.set_title("Score Distribution")
+
+    # Integer y-axis ticks
+    max_count = max(counts) if counts else 1
+    ax.set_ylim(0, max_count + 1)
+    ax.yaxis.set_major_locator(matplotlib.ticker.MaxNLocator(integer=True))
+
+    fig.tight_layout()
+    return fig
+
+
+def save_histogram_png(result: BatchGradingResult, filepath: str, num_bins: int = 10) -> None:
+    """Save score distribution histogram as a PNG image.
+
+    Args:
+        result: Batch grading result.
+        filepath: Output PNG file path.
+        num_bins: Number of bins.
+    """
+    fig = create_histogram_figure(result, num_bins)
+    fig.savefig(filepath, dpi=150, bbox_inches="tight")

--- a/app/tests/unit/test_score_histogram.py
+++ b/app/tests/unit/test_score_histogram.py
@@ -1,0 +1,230 @@
+"""Tests for score distribution histogram generation.
+
+Covers:
+- compute_score_bins bin calculation logic
+- create_histogram_figure produces a matplotlib Figure
+- save_histogram_png writes a file
+- BatchGradingDialog histogram integration (structural)
+"""
+
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from grading.histogram import compute_score_bins
+
+# ---------------------------------------------------------------------------
+# Lightweight stand-in so we don't need to import the full grading chain
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeGradingResult:
+    percentage: float = 0.0
+
+
+@dataclass
+class _FakeBatchResult:
+    results: list = field(default_factory=list)
+    total_students: int = 0
+    successful: int = 0
+    failed: int = 0
+    rubric_title: str = "Test"
+
+    @property
+    def mean_score(self):
+        if not self.results:
+            return 0.0
+        return sum(r.percentage for r in self.results) / len(self.results)
+
+
+# ---------------------------------------------------------------------------
+# compute_score_bins
+# ---------------------------------------------------------------------------
+
+
+class TestComputeScoreBins:
+    """Tests for the pure-Python bin computation."""
+
+    def test_empty_results(self):
+        result = _FakeBatchResult()
+        labels, counts = compute_score_bins(result)
+        assert len(labels) == 10
+        assert all(c == 0 for c in counts)
+
+    def test_all_perfect_scores(self):
+        result = _FakeBatchResult(results=[_FakeGradingResult(100.0) for _ in range(5)])
+        labels, counts = compute_score_bins(result)
+        # 100% should go into the last bin (90-100%)
+        assert counts[-1] == 5
+        assert sum(counts) == 5
+
+    def test_all_zero_scores(self):
+        result = _FakeBatchResult(results=[_FakeGradingResult(0.0) for _ in range(3)])
+        labels, counts = compute_score_bins(result)
+        assert counts[0] == 3
+        assert sum(counts) == 3
+
+    def test_spread_across_bins(self):
+        scores = [5, 15, 25, 35, 45, 55, 65, 75, 85, 95]
+        result = _FakeBatchResult(results=[_FakeGradingResult(s) for s in scores])
+        labels, counts = compute_score_bins(result)
+        # Each bin should have exactly 1 student
+        assert counts == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+
+    def test_boundary_values(self):
+        """Test bin boundaries: 10 goes into 10-20%, 20 into 20-30%, etc."""
+        result = _FakeBatchResult(
+            results=[
+                _FakeGradingResult(0.0),
+                _FakeGradingResult(10.0),
+                _FakeGradingResult(50.0),
+                _FakeGradingResult(90.0),
+                _FakeGradingResult(100.0),
+            ]
+        )
+        labels, counts = compute_score_bins(result)
+        assert counts[0] == 1  # 0%
+        assert counts[1] == 1  # 10%
+        assert counts[5] == 1  # 50%
+        assert counts[9] == 2  # 90% and 100%
+
+    def test_custom_num_bins(self):
+        result = _FakeBatchResult(results=[_FakeGradingResult(50.0)])
+        labels, counts = compute_score_bins(result, num_bins=5)
+        assert len(labels) == 5
+        assert len(counts) == 5
+        # 50% in 5 bins of 20% each -> bin 2 (40-60%)
+        assert counts[2] == 1
+
+    def test_label_format(self):
+        result = _FakeBatchResult()
+        labels, _ = compute_score_bins(result)
+        assert labels[0] == "0-10%"
+        assert labels[4] == "40-50%"
+        assert labels[9] == "90-100%"
+
+    def test_clamps_negative_scores(self):
+        result = _FakeBatchResult(results=[_FakeGradingResult(-5.0)])
+        labels, counts = compute_score_bins(result)
+        assert counts[0] == 1
+
+    def test_clamps_over_100(self):
+        result = _FakeBatchResult(results=[_FakeGradingResult(110.0)])
+        labels, counts = compute_score_bins(result)
+        assert counts[9] == 1
+
+    def test_realistic_class_distribution(self):
+        """Simulate a typical class with various scores."""
+        scores = [42, 55, 67, 72, 75, 78, 80, 82, 85, 88, 90, 91, 95, 98, 100]
+        result = _FakeBatchResult(results=[_FakeGradingResult(s) for s in scores])
+        labels, counts = compute_score_bins(result)
+        assert sum(counts) == 15
+        # Check some bins
+        assert counts[4] == 1  # 42
+        assert counts[5] == 1  # 55
+        assert counts[9] == 5  # 90, 91, 95, 98, 100
+
+
+# ---------------------------------------------------------------------------
+# create_histogram_figure (requires matplotlib)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateHistogramFigure:
+    """Tests for matplotlib figure generation."""
+
+    def test_returns_figure(self):
+        try:
+            from grading.histogram import create_histogram_figure
+        except ImportError:
+            pytest.skip("matplotlib not available")
+
+        result = _FakeBatchResult(results=[_FakeGradingResult(s) for s in [50, 60, 70, 80, 90]])
+        fig = create_histogram_figure(result)
+        assert fig is not None
+        # Should have one axes
+        assert len(fig.axes) == 1
+
+    def test_figure_has_correct_title(self):
+        try:
+            from grading.histogram import create_histogram_figure
+        except ImportError:
+            pytest.skip("matplotlib not available")
+
+        result = _FakeBatchResult(results=[_FakeGradingResult(75.0)])
+        fig = create_histogram_figure(result)
+        ax = fig.axes[0]
+        assert ax.get_title() == "Score Distribution"
+
+    def test_figure_bar_count_matches_bins(self):
+        try:
+            from grading.histogram import create_histogram_figure
+        except ImportError:
+            pytest.skip("matplotlib not available")
+
+        result = _FakeBatchResult(results=[_FakeGradingResult(50.0)])
+        fig = create_histogram_figure(result, num_bins=10)
+        ax = fig.axes[0]
+        # Should have 10 bar patches
+        assert len(ax.patches) == 10
+
+
+# ---------------------------------------------------------------------------
+# save_histogram_png
+# ---------------------------------------------------------------------------
+
+
+class TestSaveHistogramPng:
+    """Tests for saving histogram to PNG file."""
+
+    def test_saves_file(self):
+        try:
+            from grading.histogram import save_histogram_png
+        except ImportError:
+            pytest.skip("matplotlib not available")
+
+        result = _FakeBatchResult(results=[_FakeGradingResult(s) for s in [50, 60, 70]])
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            filepath = Path(f.name)
+        try:
+            save_histogram_png(result, str(filepath))
+            assert filepath.exists()
+            assert filepath.stat().st_size > 0
+        finally:
+            filepath.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# BatchGradingDialog integration (structural)
+# ---------------------------------------------------------------------------
+
+
+class TestBatchGradingDialogHistogram:
+    """Structural tests for histogram integration in the dialog."""
+
+    def test_dialog_has_histogram_canvas_attr(self):
+        """Verify the dialog stores a histogram canvas reference."""
+        source = Path(__file__).parents[2] / "GUI" / "batch_grading_dialog.py"
+        text = source.read_text()
+        assert "_histogram_canvas" in text
+
+    def test_dialog_has_show_histogram_method(self):
+        source = Path(__file__).parents[2] / "GUI" / "batch_grading_dialog.py"
+        text = source.read_text()
+        assert "def _show_histogram" in text
+
+    def test_dialog_has_save_histogram_button(self):
+        source = Path(__file__).parents[2] / "GUI" / "batch_grading_dialog.py"
+        text = source.read_text()
+        assert "save_histogram_btn" in text
+        assert "Save Histogram" in text
+
+    def test_display_results_calls_show_histogram(self):
+        source = Path(__file__).parents[2] / "GUI" / "batch_grading_dialog.py"
+        text = source.read_text()
+        assert "_show_histogram" in text


### PR DESCRIPTION
## Summary - Score distribution histogram using matplotlib embedded in BatchGradingDialog - compute_score_bins for flexible binning, create_histogram_figure for visualization - Save Histogram button to export as PNG - Displayed automatically after batch grading completes ## Test plan - [x] 18 unit tests covering bin computation, figure creation, PNG export, and dialog integration - [ ] Manual: run batch grading and verify histogram appears with correct distribution Closes #379 Generated with [Claude Code](https://claude.com/claude-code)