### PR TITLE
Fix OP parser losing valid data on single line failure

### DIFF
--- a/app/simulation/result_parser.py
+++ b/app/simulation/result_parser.py
@@ -61,69 +61,76 @@ class ResultParser:
         node_voltages = {}
         branch_currents = {}
 
-        try:
-            lines = output.split("\n")
+        lines = output.split("\n")
 
-            for i, line in enumerate(lines):
-                # Pattern 1: v(nodename) = voltage
-                match = re.search(r"v\((\w+)\)\s*[=:]\s*([-+]?[\d.]+e?[-+]?\d*)", line, re.IGNORECASE)
-                if match:
+        for i, line in enumerate(lines):
+            # Pattern 1: v(nodename) = voltage
+            match = re.search(r"v\((\w+)\)\s*[=:]\s*([-+]?[\d.]+e?[-+]?\d*)", line, re.IGNORECASE)
+            if match:
+                try:
                     node_name = match.group(1)
                     voltage = float(match.group(2))
                     node_voltages[node_name] = voltage
-                    continue
+                except (ValueError, IndexError):
+                    logger.debug("Skipping unparseable OP voltage line: %s", line)
+                continue
 
-                # Branch current patterns: i(device) = current or @device[current]
-                i_match = re.search(
-                    r"(?:i\((\w+)\)|@(\w+)\[current\])\s*[=:]\s*([-+]?[\d.]+e?[-+]?\d*)",
-                    line,
-                    re.IGNORECASE,
-                )
-                if i_match:
+            # Branch current patterns: i(device) = current or @device[current]
+            i_match = re.search(
+                r"(?:i\((\w+)\)|@(\w+)\[current\])\s*[=:]\s*([-+]?[\d.]+e?[-+]?\d*)",
+                line,
+                re.IGNORECASE,
+            )
+            if i_match:
+                try:
                     device = i_match.group(1) or i_match.group(2)
                     current = float(i_match.group(3))
                     branch_currents[device.lower()] = current
-                    continue
+                except (ValueError, IndexError):
+                    logger.debug("Skipping unparseable OP current line: %s", line)
+                continue
 
-                # Pattern 2: Node/Voltage table
-                if "node" in line.lower() and "voltage" in line.lower():
-                    for j in range(i + 1, min(i + 50, len(lines))):
-                        result_line = lines[j].strip()
-                        if not result_line or result_line.startswith("-"):
+            # Pattern 2: Node/Voltage table
+            if "node" in line.lower() and "voltage" in line.lower():
+                for j in range(i + 1, min(i + 50, len(lines))):
+                    result_line = lines[j].strip()
+                    if not result_line or result_line.startswith("-"):
+                        continue
+                    if result_line.startswith("*") or result_line.lower().startswith("source"):
+                        break
+
+                    parts = result_line.split()
+                    if len(parts) >= 2:
+                        try:
+                            node_name = parts[0].replace("v(", "").replace(")", "")
+                            voltage = float(parts[1])
+                            node_voltages[node_name] = voltage
+                        except (ValueError, IndexError):
                             continue
-                        if result_line.startswith("*") or result_line.lower().startswith("source"):
-                            break
 
-                        parts = result_line.split()
-                        if len(parts) >= 2:
-                            try:
-                                node_name = parts[0].replace("v(", "").replace(")", "")
-                                voltage = float(parts[1])
-                                node_voltages[node_name] = voltage
-                            except (ValueError, IndexError):
-                                continue
-
-            # Pattern 3: ngspice print output format
-            for line in lines:
-                # Voltages: " V(5)   1.000000e-06 "
-                match = re.match(r"^\s*V\((\w+)\)\s+([-+]?[\d.]+e?[-+]?\d*)\s*", line, re.IGNORECASE)
-                if match:
+        # Pattern 3: ngspice print output format
+        for line in lines:
+            # Voltages: " V(5)   1.000000e-06 "
+            match = re.match(r"^\s*V\((\w+)\)\s+([-+]?[\d.]+e?[-+]?\d*)\s*", line, re.IGNORECASE)
+            if match:
+                try:
                     node_name = match.group(1)
                     voltage = float(match.group(2))
                     node_voltages[node_name] = voltage
-                    continue
-                # Currents: " I(v1)   -2.100000e-03 "
-                i_match = re.match(r"^\s*I\((\w+)\)\s+([-+]?[\d.]+e?[-+]?\d*)\s*", line, re.IGNORECASE)
-                if i_match:
+                except (ValueError, IndexError):
+                    logger.debug("Skipping unparseable OP print line: %s", line)
+                continue
+            # Currents: " I(v1)   -2.100000e-03 "
+            i_match = re.match(r"^\s*I\((\w+)\)\s+([-+]?[\d.]+e?[-+]?\d*)\s*", line, re.IGNORECASE)
+            if i_match:
+                try:
                     device = i_match.group(1)
                     current = float(i_match.group(2))
                     branch_currents[device.lower()] = current
+                except (ValueError, IndexError):
+                    logger.debug("Skipping unparseable OP print line: %s", line)
 
-            return {"node_voltages": node_voltages, "branch_currents": branch_currents}
-
-        except (ValueError, IndexError, AttributeError) as e:
-            logger.error("Error parsing OP results: %s", e, exc_info=True)
-            return {"node_voltages": {}, "branch_currents": {}}
+        return {"node_voltages": node_voltages, "branch_currents": branch_currents}
 
     @staticmethod
     def parse_dc_results(output):

--- a/app/tests/unit/test_result_parser.py
+++ b/app/tests/unit/test_result_parser.py
@@ -48,6 +48,29 @@ class TestParseOpResults:
         assert result["node_voltages"] == {}
         assert result["branch_currents"] == {}
 
+    def test_bad_line_does_not_discard_valid_data(self):
+        """A single unparseable line must not lose previously parsed results (#529)."""
+        output = "v(nodeA) = 5.00000\nv(bad) = NOT_A_NUMBER\nv(nodeB) = 2.50000\n"
+        result = ResultParser.parse_op_results(output)
+        assert result["node_voltages"]["nodeA"] == pytest.approx(5.0)
+        assert result["node_voltages"]["nodeB"] == pytest.approx(2.5)
+        assert "bad" not in result["node_voltages"]
+
+    def test_bad_current_line_preserves_other_data(self):
+        """An unparseable branch current should not discard voltages (#529)."""
+        output = "v(nodeA) = 3.30000\ni(v1) = GARBAGE\n  V(nodeB)   1.000000e+00\n"
+        result = ResultParser.parse_op_results(output)
+        assert result["node_voltages"]["nodeA"] == pytest.approx(3.3)
+        assert result["node_voltages"]["nodeB"] == pytest.approx(1.0)
+
+    def test_mixed_good_and_bad_print_format(self):
+        """Pattern 3 bad lines should be skipped, not abort (#529)."""
+        output = "  V(nodeA)   5.000000e+00\n  V(nodeB)   CORRUPT_VALUE\n  V(nodeC)   2.500000e+00\n"
+        result = ResultParser.parse_op_results(output)
+        assert result["node_voltages"]["nodeA"] == pytest.approx(5.0)
+        assert result["node_voltages"]["nodeC"] == pytest.approx(2.5)
+        assert "nodeB" not in result["node_voltages"]
+
 
 # ── parse_dc_results ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary - Replaced the outer  in  with per-line  blocks so that a single unparseable line (e.g., ) is skipped instead of discarding all previously parsed voltages and currents. - Added 3 regression tests verifying that valid data survives alongside bad lines in all three parsing patterns. ## Test plan - [ ] Verify new tests , , and  pass - [ ] Verify existing OP parser tests still pass - [ ] CI green Closes #529 🤖 Generated with [Claude Code](https://claude.com/claude-code)