### PR TITLE
Fix Waveform Source parameters lost in CircuiTikZ round-trip

### DIFF
--- a/app/simulation/circuitikz_parser.py
+++ b/app/simulation/circuitikz_parser.py
@@ -117,6 +117,33 @@ def _tikz_to_pixel(tx, ty, scale, offset_x=0.0, offset_y=0.0, max_ty=0.0):
     return (round(px, 1), round(py, 1))
 
 
+_WAVEFORM_PARAM_KEYS = {
+    "SIN": ("offset", "amplitude", "frequency", "delay", "theta", "phase"),
+    "PULSE": ("v1", "v2", "td", "tr", "tf", "pw", "per"),
+    "EXP": ("v1", "v2", "td1", "tau1", "td2", "tau2"),
+}
+
+
+def _parse_waveform_value(value_str):
+    """Parse a SPICE waveform value string into (waveform_type, params_for_type).
+
+    Accepts strings like ``SIN(0 5 1k 0 0 0)`` or ``PULSE(0 5 0 1n 1n 500u 1m)``.
+    Returns ``(None, None)`` when *value_str* is not a recognized waveform.
+    """
+    m = re.match(r"(SIN|PULSE|EXP)\s*\(([^)]*)\)", value_str.strip(), re.IGNORECASE)
+    if not m:
+        return None, None
+    wtype = m.group(1).upper()
+    tokens = m.group(2).split()
+    keys = _WAVEFORM_PARAM_KEYS.get(wtype)
+    if keys is None:
+        return None, None
+    params = {}
+    for i, key in enumerate(keys):
+        params[key] = tokens[i] if i < len(tokens) else "0"
+    return wtype, params
+
+
 def _extract_circuitikz_body(text):
     """Extract the content inside \\begin{circuitikz}...\\end{circuitikz}."""
     m = re.search(r"\\begin\{circuitikz\}(.*?)\\end\{circuitikz\}", text, re.DOTALL)
@@ -304,6 +331,14 @@ def import_circuitikz(text):
             value=value,
             position=pos,
         )
+
+        # Reconstruct structured waveform parameters from the value string
+        if comp_type == "Waveform Source" and value:
+            wtype, wparams = _parse_waveform_value(value)
+            if wtype and wparams:
+                comp.waveform_type = wtype
+                comp.waveform_params[wtype] = wparams
+
         model.add_component(comp)
 
         # Update counter

--- a/app/tests/unit/test_circuitikz_parser.py
+++ b/app/tests/unit/test_circuitikz_parser.py
@@ -297,6 +297,87 @@ class TestFourTerminalControlPair:
         assert len(terms) == 4
 
 
+class TestWaveformSourceRoundTrip:
+    """Issue #524: Waveform Source parameters lost in CircuiTikZ round-trip."""
+
+    def test_sin_waveform_params_restored(self):
+        tex = r"""
+\begin{circuitikz}
+  \draw (0, 1) to[sV, l=$VW1$, a={SIN(0 5 1k 0 0 0)}] (0, 0);
+\end{circuitikz}
+"""
+        model, _ = import_circuitikz(tex)
+        comp = model.components["VW1"]
+        assert comp.component_type == "Waveform Source"
+        assert comp.waveform_type == "SIN"
+        assert comp.waveform_params["SIN"]["offset"] == "0"
+        assert comp.waveform_params["SIN"]["amplitude"] == "5"
+        assert comp.waveform_params["SIN"]["frequency"] == "1k"
+
+    def test_pulse_waveform_params_restored(self):
+        tex = r"""
+\begin{circuitikz}
+  \draw (0, 1) to[sV, l=$VW1$, a={PULSE(0 5 0 1n 1n 500u 1m)}] (0, 0);
+\end{circuitikz}
+"""
+        model, _ = import_circuitikz(tex)
+        comp = model.components["VW1"]
+        assert comp.waveform_type == "PULSE"
+        assert comp.waveform_params["PULSE"]["v1"] == "0"
+        assert comp.waveform_params["PULSE"]["v2"] == "5"
+        assert comp.waveform_params["PULSE"]["per"] == "1m"
+
+    def test_exp_waveform_params_restored(self):
+        tex = r"""
+\begin{circuitikz}
+  \draw (0, 1) to[sV, l=$VW1$, a={EXP(0 5 0 1u 2u 2u)}] (0, 0);
+\end{circuitikz}
+"""
+        model, _ = import_circuitikz(tex)
+        comp = model.components["VW1"]
+        assert comp.waveform_type == "EXP"
+        assert comp.waveform_params["EXP"]["v1"] == "0"
+        assert comp.waveform_params["EXP"]["tau2"] == "2u"
+
+    def test_waveform_default_when_no_value(self):
+        tex = r"""
+\begin{circuitikz}
+  \draw (0, 1) to[sV, l=$VW1$] (0, 0);
+\end{circuitikz}
+"""
+        model, _ = import_circuitikz(tex)
+        comp = model.components["VW1"]
+        assert comp.component_type == "Waveform Source"
+        # Default waveform params should be initialized by ComponentData.__post_init__
+        assert comp.waveform_type == "SIN"
+        assert comp.waveform_params is not None
+
+    def test_full_round_trip_preserves_waveform(self):
+        """Export a waveform source and reimport — params must survive."""
+        from models.circuit import CircuitModel
+        from models.component import ComponentData
+        from simulation.circuitikz_exporter import generate
+
+        ws = ComponentData("VW1", "Waveform Source", "SIN(0 10 2k)", position=(100, 100))
+        ws.waveform_type = "SIN"
+        ws.waveform_params["SIN"]["offset"] = "0"
+        ws.waveform_params["SIN"]["amplitude"] = "10"
+        ws.waveform_params["SIN"]["frequency"] = "2k"
+
+        model = CircuitModel()
+        model.add_component(ws)
+        model.rebuild_nodes()
+
+        tex = generate(model.components, model.wires, model.nodes, model.terminal_to_node)
+        reimported, warnings = import_circuitikz(tex)
+
+        assert len(warnings) == 0
+        comp = reimported.components["VW1"]
+        assert comp.waveform_type == "SIN"
+        assert comp.waveform_params["SIN"]["amplitude"] == "10"
+        assert comp.waveform_params["SIN"]["frequency"] == "2k"
+
+
 class TestWarnings:
     def test_unsupported_component_warning(self):
         tex = r"""


### PR DESCRIPTION
Parse SIN, PULSE, and EXP waveform value strings during CircuiTikZ import to reconstruct waveform_type and waveform_params. Adds 5 round-trip tests. Closes #524