### PR TITLE
Fix 4-terminal component control pair lost during CircuiTikZ reimport

### DIFF
--- a/app/simulation/circuitikz_exporter.py
+++ b/app/simulation/circuitikz_exporter.py
@@ -230,7 +230,9 @@ def _emit_bipole(lines, comp, tikz_name, transform, include_ids, include_values)
         if comp.component_type in ("CCVS", "CCCS"):
             type_comment = f" % spice: {comp.component_type}"
         lines.append(f"  \\draw {_coord(*out_start)} to[{opt_str}] {_coord(*out_end)};{type_comment}")
-        lines.append(f"  \\draw[dashed] {_coord(*ctrl_start)} to[short] {_coord(*ctrl_end)};")
+        lines.append(
+            f"  \\draw[dashed] {_coord(*ctrl_start)} to[short] {_coord(*ctrl_end)}; % ctrl: {comp.component_id}"
+        )
         return
 
     # Standard 2-terminal bipole

--- a/app/simulation/circuitikz_parser.py
+++ b/app/simulation/circuitikz_parser.py
@@ -62,6 +62,10 @@ _RE_NODE_GROUND = re.compile(
 _RE_DRAW_WIRE = re.compile(
     r"\\draw(?:\[dashed\])?\s+" + _RE_COORD + r"(?:\s*--\s*" + _RE_COORD + r")+\s*;",
 )
+# Matches dashed control-pair draws:  \draw[dashed] (x1,y1) to[short] (x2,y2); % ctrl: <id>
+_RE_DASHED_CTRL = re.compile(
+    r"\\draw\[dashed\]\s+" + _RE_COORD + r"\s+to\s*\[short\]\s*" + _RE_COORD + r"\s*;\s*%\s*ctrl:\s*(\S+)",
+)
 _RE_ALL_COORDS = re.compile(_RE_COORD)
 
 
@@ -189,6 +193,18 @@ def import_circuitikz(text):
         x, y = m.group(1), m.group(2)
         grounds.append({"x": float(x), "y": float(y)})
 
+    # Parse dashed control pairs: \draw[dashed] (x1,y1) to[short] (x2,y2); % ctrl: <id>
+    ctrl_pairs = {}  # comp_id -> (x1, y1, x2, y2) in TikZ coords
+    for m in _RE_DASHED_CTRL.finditer(body):
+        x1, y1, x2, y2, ctrl_id = (
+            float(m.group(1)),
+            float(m.group(2)),
+            float(m.group(3)),
+            float(m.group(4)),
+            m.group(5),
+        )
+        ctrl_pairs[ctrl_id] = (x1, y1, x2, y2)
+
     # Parse wires: \draw (x1,y1) -- (x2,y2) [-- ...];
     for m in _RE_DRAW_WIRE.finditer(body):
         segment_text = m.group(0)
@@ -213,6 +229,8 @@ def import_circuitikz(text):
         all_tikz_coords.append((g["x"], g["y"]))
     for w in wires:
         all_tikz_coords.extend(w)
+    for x1, y1, x2, y2 in ctrl_pairs.values():
+        all_tikz_coords.extend([(x1, y1), (x2, y2)])
 
     if not all_tikz_coords:
         return CircuitModel(), warnings
@@ -259,10 +277,26 @@ def import_circuitikz(text):
         if not value:
             value = DEFAULT_VALUES.get(comp_type, "")
 
-        # Position = midpoint between the two terminals
+        # Convert bipole endpoints to pixel coords
         p1 = to_pixel(bp["x1"], bp["y1"])
         p2 = to_pixel(bp["x2"], bp["y2"])
-        pos = (round((p1[0] + p2[0]) / 2, 1), round((p1[1] + p2[1]) / 2, 1))
+
+        # For 4-terminal devices the bipole draw represents the output pair
+        # (terminals 2,3) and a separate dashed draw holds the control pair
+        # (terminals 0,1).
+        from models.component import TERMINAL_COUNTS
+
+        is_four_terminal = TERMINAL_COUNTS.get(comp_type, 2) == 4
+        ctrl_pair = ctrl_pairs.get(comp_id) if is_four_terminal else None
+
+        if ctrl_pair is not None:
+            cp1 = to_pixel(ctrl_pair[0], ctrl_pair[1])
+            cp2 = to_pixel(ctrl_pair[2], ctrl_pair[3])
+            all_x = [p1[0], p2[0], cp1[0], cp2[0]]
+            all_y = [p1[1], p2[1], cp1[1], cp2[1]]
+            pos = (round(sum(all_x) / 4, 1), round(sum(all_y) / 4, 1))
+        else:
+            pos = (round((p1[0] + p2[0]) / 2, 1), round((p1[1] + p2[1]) / 2, 1))
 
         comp = ComponentData(
             component_id=comp_id,
@@ -284,8 +318,15 @@ def import_circuitikz(text):
                 counters[prefix] = num
 
         # Record terminal positions
-        terminal_positions[(comp_id, 0)] = p1
-        terminal_positions[(comp_id, 1)] = p2
+        if ctrl_pair is not None:
+            # 4-terminal: 0=ctrl+, 1=ctrl-, 2=out+, 3=out-
+            terminal_positions[(comp_id, 0)] = cp1
+            terminal_positions[(comp_id, 1)] = cp2
+            terminal_positions[(comp_id, 2)] = p1
+            terminal_positions[(comp_id, 3)] = p2
+        else:
+            terminal_positions[(comp_id, 0)] = p1
+            terminal_positions[(comp_id, 1)] = p2
 
     for tp in tripoles:
         opts = tp["opts"]

--- a/app/tests/unit/test_circuitikz_parser.py
+++ b/app/tests/unit/test_circuitikz_parser.py
@@ -232,6 +232,71 @@ class TestControlledSourceDisambiguation:
         assert reimported.components["F1"].component_type == "CCCS"
 
 
+class TestFourTerminalControlPair:
+    """Issue #523: 4-terminal component control pair lost during reimport."""
+
+    def test_vcvs_control_pair_imported(self):
+        tex = r"""
+\begin{circuitikz}
+  \draw (4.5, 0.5) to[american controlled voltage source, l=$E1$, a={10}] (4.5, -0.5);
+  \draw[dashed] (1.5, 0.5) to[short] (1.5, -0.5); % ctrl: E1
+\end{circuitikz}
+"""
+        model, warnings = import_circuitikz(tex)
+        assert "E1" in model.components
+        comp = model.components["E1"]
+        assert comp.component_type == "VCVS"
+        # 4-terminal component should have 4 terminal positions recorded
+        terms = comp.get_terminal_positions()
+        assert len(terms) == 4
+
+    def test_vccs_control_pair_imported(self):
+        tex = r"""
+\begin{circuitikz}
+  \draw (4.5, 0.5) to[american controlled current source, l=$G1$, a={1m}] (4.5, -0.5);
+  \draw[dashed] (1.5, 0.5) to[short] (1.5, -0.5); % ctrl: G1
+\end{circuitikz}
+"""
+        model, warnings = import_circuitikz(tex)
+        comp = model.components["G1"]
+        assert comp.component_type == "VCCS"
+        terms = comp.get_terminal_positions()
+        assert len(terms) == 4
+
+    def test_full_round_trip_four_terminal(self):
+        """Export a VCVS and reimport — all 4 terminal positions should survive."""
+        from models.circuit import CircuitModel
+        from models.component import ComponentData
+        from simulation.circuitikz_exporter import generate
+
+        vcvs = ComponentData("E1", "VCVS", "10", position=(100, 100))
+        model = CircuitModel()
+        model.add_component(vcvs)
+        model.rebuild_nodes()
+
+        tex = generate(model.components, model.wires, model.nodes, model.terminal_to_node)
+        reimported, warnings = import_circuitikz(tex)
+
+        assert len(warnings) == 0
+        comp = reimported.components["E1"]
+        assert comp.component_type == "VCVS"
+        terms = comp.get_terminal_positions()
+        assert len(terms) == 4
+
+    def test_vc_switch_control_pair_imported(self):
+        tex = r"""
+\begin{circuitikz}
+  \draw (4.5, 0.5) to[closing switch, l=$S1$, a={VT=2.5 RON=1 ROFF=1e6}] (4.5, -0.5);
+  \draw[dashed] (1.5, 0.5) to[short] (1.5, -0.5); % ctrl: S1
+\end{circuitikz}
+"""
+        model, warnings = import_circuitikz(tex)
+        comp = model.components["S1"]
+        assert comp.component_type == "VC Switch"
+        terms = comp.get_terminal_positions()
+        assert len(terms) == 4
+
+
 class TestWarnings:
     def test_unsupported_component_warning(self):
         tex = r"""


### PR DESCRIPTION
Tag dashed control-pair draws with a ctrl comment during export so the parser can associate them with the correct 4-terminal component on reimport. Records all four terminal positions instead of only the output pair. Adds 4 round-trip tests. Closes #523