### PR TITLE
Fix CircuiTikZ round-trip conflating CCVS with VCVS and CCCS with VCCS

### DIFF
--- a/app/simulation/circuitikz_exporter.py
+++ b/app/simulation/circuitikz_exporter.py
@@ -224,7 +224,12 @@ def _emit_bipole(lines, comp, tikz_name, transform, include_ids, include_values)
             opts.append(f"a={{{_escape_latex(comp.value)}}}")
         opt_str = ", ".join([tikz_name] + opts)
 
-        lines.append(f"  \\draw {_coord(*out_start)} to[{opt_str}] {_coord(*out_end)};")
+        # Append a type comment so the parser can distinguish CCVS from VCVS
+        # (both share the same CircuiTikZ component name).
+        type_comment = ""
+        if comp.component_type in ("CCVS", "CCCS"):
+            type_comment = f" % spice: {comp.component_type}"
+        lines.append(f"  \\draw {_coord(*out_start)} to[{opt_str}] {_coord(*out_end)};{type_comment}")
         lines.append(f"  \\draw[dashed] {_coord(*ctrl_start)} to[short] {_coord(*ctrl_end)};")
         return
 

--- a/app/simulation/circuitikz_parser.py
+++ b/app/simulation/circuitikz_parser.py
@@ -50,7 +50,7 @@ _TIKZ_TO_TRIPOLE = {
 # Regex patterns
 _RE_COORD = r"\(\s*([\d.eE+-]+)\s*,\s*([\d.eE+-]+)\s*\)"
 _RE_DRAW_TO = re.compile(
-    r"\\draw\s+" + _RE_COORD + r"\s+to\s*\[([^\]]*)\]\s*" + _RE_COORD + r"\s*;",
+    r"\\draw\s+" + _RE_COORD + r"\s+to\s*\[([^\]]*)\]\s*" + _RE_COORD + r"\s*;([^\n]*)",
     re.DOTALL,
 )
 _RE_NODE_COMPONENT = re.compile(
@@ -143,15 +143,21 @@ def import_circuitikz(text):
     grounds = []
     wires = []
 
-    # Parse bipoles: \draw (x1,y1) to[opts] (x2,y2);
+    # Parse bipoles: \draw (x1,y1) to[opts] (x2,y2); [% spice: <type>]
     for m in _RE_DRAW_TO.finditer(body):
-        x1, y1, opts, x2, y2 = (
+        x1, y1, opts, x2, y2, trailing = (
             m.group(1),
             m.group(2),
             m.group(3),
             m.group(4),
             m.group(5),
+            m.group(6),
         )
+        # Check for a % spice: <type> override (disambiguates CCVS/CCCS)
+        spice_type = None
+        type_m = re.search(r"%\s*spice:\s*(\S+)", trailing)
+        if type_m:
+            spice_type = type_m.group(1)
         bipoles.append(
             {
                 "x1": float(x1),
@@ -159,6 +165,7 @@ def import_circuitikz(text):
                 "opts": opts,
                 "x2": float(x2),
                 "y2": float(y2),
+                "spice_type": spice_type,
             }
         )
 
@@ -231,6 +238,11 @@ def import_circuitikz(text):
         if comp_type is None:
             warnings.append(f"Unsupported CircuiTikZ component: {comp_name}")
             continue
+
+        # Override type when a % spice: <type> comment is present
+        # (distinguishes CCVS from VCVS, CCCS from VCCS)
+        if bp.get("spice_type") and bp["spice_type"] in ("CCVS", "CCCS"):
+            comp_type = bp["spice_type"]
 
         comp_id = _parse_label(bp["opts"])
         value = _parse_value(bp["opts"])

--- a/app/tests/unit/test_circuitikz_parser.py
+++ b/app/tests/unit/test_circuitikz_parser.py
@@ -158,6 +158,80 @@ class TestValueExtraction:
         assert model.components["R1"].value != ""
 
 
+class TestControlledSourceDisambiguation:
+    """Issue #520: CircuiTikZ round-trip conflates CCVS with VCVS and CCCS with VCCS."""
+
+    def test_ccvs_preserved_via_spice_comment(self):
+        tex = r"""
+\begin{circuitikz}
+  \draw (1.5, 0.5) to[american controlled voltage source, l=$H1$, a={1k}] (1.5, -0.5); % spice: CCVS
+\end{circuitikz}
+"""
+        model, _ = import_circuitikz(tex)
+        assert model.components["H1"].component_type == "CCVS"
+
+    def test_cccs_preserved_via_spice_comment(self):
+        tex = r"""
+\begin{circuitikz}
+  \draw (1.5, 0.5) to[american controlled current source, l=$F1$, a={1}] (1.5, -0.5); % spice: CCCS
+\end{circuitikz}
+"""
+        model, _ = import_circuitikz(tex)
+        assert model.components["F1"].component_type == "CCCS"
+
+    def test_vcvs_default_without_comment(self):
+        tex = r"""
+\begin{circuitikz}
+  \draw (1.5, 0.5) to[american controlled voltage source, l=$E1$, a={10}] (1.5, -0.5);
+\end{circuitikz}
+"""
+        model, _ = import_circuitikz(tex)
+        assert model.components["E1"].component_type == "VCVS"
+
+    def test_vccs_default_without_comment(self):
+        tex = r"""
+\begin{circuitikz}
+  \draw (1.5, 0.5) to[american controlled current source, l=$G1$, a={1m}] (1.5, -0.5);
+\end{circuitikz}
+"""
+        model, _ = import_circuitikz(tex)
+        assert model.components["G1"].component_type == "VCCS"
+
+    def test_full_round_trip_ccvs(self):
+        """Export a CCVS and reimport — must come back as CCVS, not VCVS."""
+        from models.circuit import CircuitModel
+        from models.component import ComponentData
+        from simulation.circuitikz_exporter import generate
+
+        ccvs = ComponentData("H1", "CCVS", "1k", position=(100, 100))
+        model = CircuitModel()
+        model.add_component(ccvs)
+        model.rebuild_nodes()
+
+        tex = generate(model.components, model.wires, model.nodes, model.terminal_to_node)
+        reimported, warnings = import_circuitikz(tex)
+
+        assert len(warnings) == 0
+        assert reimported.components["H1"].component_type == "CCVS"
+
+    def test_full_round_trip_cccs(self):
+        """Export a CCCS and reimport — must come back as CCCS, not VCCS."""
+        from models.circuit import CircuitModel
+        from models.component import ComponentData
+        from simulation.circuitikz_exporter import generate
+
+        cccs = ComponentData("F1", "CCCS", "1", position=(100, 100))
+        model = CircuitModel()
+        model.add_component(cccs)
+        model.rebuild_nodes()
+
+        tex = generate(model.components, model.wires, model.nodes, model.terminal_to_node)
+        reimported, warnings = import_circuitikz(tex)
+
+        assert len(warnings) == 0
+        assert reimported.components["F1"].component_type == "CCCS"
+
+
 class TestWarnings:
     def test_unsupported_component_warning(self):
         tex = r"""


### PR DESCRIPTION
Emit a spice type comment on the draw line for current-controlled sources (which share CircuiTikZ names with voltage-controlled ones). The parser checks for this comment and overrides the component type so CCVS and CCCS survive export-reimport. Adds 6 tests. Closes #520