### PR TITLE
Fix CSV gradebook export assuming identical check_results (#534)

### DIFF
--- a/app/grading/grade_exporter.py
+++ b/app/grading/grade_exporter.py
@@ -30,9 +30,17 @@ def export_gradebook_csv(result: BatchGradingResult, filepath: str) -> None:
             writer.writerow(["No results to export"])
         return
 
-    # Build header from first result's check IDs
-    first = result.results[0]
-    check_headers = [f"{cr.check_id} ({cr.points_possible}pts)" for cr in first.check_results]
+    # Collect all unique check IDs across all results (preserving first-seen order)
+    check_columns: list[tuple[str, int]] = []  # (check_id, points_possible)
+    seen_ids: set[str] = set()
+    for gr in result.results:
+        for cr in gr.check_results:
+            if cr.check_id not in seen_ids:
+                seen_ids.add(cr.check_id)
+                check_columns.append((cr.check_id, cr.points_possible))
+
+    check_headers = [f"{cid} ({pts}pts)" for cid, pts in check_columns]
+    check_ids = [cid for cid, _ in check_columns]
 
     header = ["Student File", "Total Score", "Percentage"] + check_headers
 
@@ -46,8 +54,9 @@ def export_gradebook_csv(result: BatchGradingResult, filepath: str) -> None:
                 f"{gr.earned_points}/{gr.total_points}",
                 f"{gr.percentage:.1f}%",
             ]
-            for cr in gr.check_results:
-                row.append(cr.points_earned)
+            scores_by_id = {cr.check_id: cr.points_earned for cr in gr.check_results}
+            for cid in check_ids:
+                row.append(scores_by_id.get(cid, ""))
             writer.writerow(row)
 
         # Summary row

--- a/app/tests/unit/test_batch_grading.py
+++ b/app/tests/unit/test_batch_grading.py
@@ -319,6 +319,66 @@ class TestGradeExporter:
         assert "r1_exists (25pts)" in header
         assert "r1_value (25pts)" in header
 
+    def test_csv_handles_differing_check_results(self, tmp_path):
+        """Regression test for #534: CSV export should not assume identical check_results."""
+        from grading.grader import CheckGradeResult, GradingResult
+
+        # Student A has checks [r1_exists, r1_value]
+        # Student B has only [r1_exists] (different checks)
+        gr_a = GradingResult(
+            student_file="alice.json",
+            rubric_title="Test",
+            total_points=50,
+            earned_points=50,
+            check_results=[
+                CheckGradeResult(
+                    check_id="r1_exists", passed=True, points_earned=25, points_possible=25, feedback="OK"
+                ),
+                CheckGradeResult(check_id="r1_value", passed=True, points_earned=25, points_possible=25, feedback="OK"),
+            ],
+        )
+        gr_b = GradingResult(
+            student_file="bob.json",
+            rubric_title="Test",
+            total_points=50,
+            earned_points=25,
+            check_results=[
+                CheckGradeResult(
+                    check_id="r1_exists", passed=True, points_earned=25, points_possible=25, feedback="OK"
+                ),
+            ],
+        )
+        result = BatchGradingResult(
+            rubric_title="Test",
+            total_students=2,
+            successful=2,
+            failed=0,
+            results=[gr_a, gr_b],
+        )
+
+        csv_path = tmp_path / "gradebook.csv"
+        export_gradebook_csv(result, str(csv_path))
+
+        with open(csv_path) as f:
+            reader = csv.reader(f)
+            header = next(reader)
+            row_a = next(reader)
+            row_b = next(reader)
+
+        # Both check columns should be in the header
+        assert "r1_exists (25pts)" in header
+        assert "r1_value (25pts)" in header
+
+        # Alice should have scores in both columns
+        r1_exists_idx = header.index("r1_exists (25pts)")
+        r1_value_idx = header.index("r1_value (25pts)")
+        assert row_a[r1_exists_idx] == "25"
+        assert row_a[r1_value_idx] == "25"
+
+        # Bob should have r1_exists but empty for r1_value
+        assert row_b[r1_exists_idx] == "25"
+        assert row_b[r1_value_idx] == ""
+
 
 class TestBatchGradingDialog:
     def test_dialog_creates(self, qtbot):


### PR DESCRIPTION
CSV header columns are now built from all unique check IDs across all student results instead of only the first. Each row uses a lookup dict to align scores correctly, with empty cells for missing checks. Added test with students having differing check_results. Closes #534