### PR TITLE
Fix FileController load methods silently dropping annotations and recommended_components

### DIFF
--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -137,6 +137,7 @@ class FileController:
         self.model.analysis_type = new_model.analysis_type
         self.model.analysis_params = new_model.analysis_params
         self.model.annotations = new_model.annotations
+        self.model.recommended_components = new_model.recommended_components
 
         self.current_file = filepath
         self._save_session()
@@ -162,6 +163,7 @@ class FileController:
         self.model.analysis_type = new_model.analysis_type
         self.model.analysis_params = new_model.analysis_params
         self.model.annotations = new_model.annotations
+        self.model.recommended_components = new_model.recommended_components
 
         if self.circuit_ctrl:
             self.circuit_ctrl._notify("model_loaded", None)
@@ -300,6 +302,8 @@ class FileController:
             self.model.component_counter = new_model.component_counter
             self.model.analysis_type = new_model.analysis_type
             self.model.analysis_params = new_model.analysis_params
+            self.model.annotations = new_model.annotations
+            self.model.recommended_components = new_model.recommended_components
 
             if source_path:
                 self.current_file = Path(source_path)

--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -444,6 +444,88 @@ class TestRecentFiles:
         assert "file/recent_files" in calls
 
 
+class TestAnnotationsAndRecommendedComponents:
+    """Issue #498: FileController load methods silently drop annotations and recommended_components."""
+
+    def _build_circuit_with_extras(self):
+        """Build a circuit with annotations and recommended_components."""
+        from models.annotation import AnnotationData
+
+        model = _build_simple_circuit()
+        model.annotations = [
+            AnnotationData(text="Test note", x=50.0, y=50.0, font_size=12, bold=True, color="#FF0000"),
+        ]
+        model.recommended_components = ["Resistor", "Capacitor", "Op-Amp"]
+        return model
+
+    def test_load_circuit_preserves_annotations(self, tmp_path):
+        model = self._build_circuit_with_extras()
+        ctrl = FileController(model)
+        filepath = tmp_path / "test.json"
+        ctrl.save_circuit(filepath)
+
+        ctrl2 = FileController()
+        ctrl2.load_circuit(filepath)
+        assert len(ctrl2.model.annotations) == 1
+        assert ctrl2.model.annotations[0].text == "Test note"
+        assert ctrl2.model.annotations[0].bold is True
+
+    def test_load_circuit_preserves_recommended_components(self, tmp_path):
+        model = self._build_circuit_with_extras()
+        ctrl = FileController(model)
+        filepath = tmp_path / "test.json"
+        ctrl.save_circuit(filepath)
+
+        ctrl2 = FileController()
+        ctrl2.load_circuit(filepath)
+        assert ctrl2.model.recommended_components == ["Resistor", "Capacitor", "Op-Amp"]
+
+    def test_load_from_dict_preserves_recommended_components(self):
+        model = self._build_circuit_with_extras()
+        data = model.to_dict()
+
+        ctrl = FileController()
+        ctrl.load_from_dict(data)
+        assert ctrl.model.recommended_components == ["Resistor", "Capacitor", "Op-Amp"]
+        assert len(ctrl.model.annotations) == 1
+
+    def test_autosave_preserves_annotations_and_recommended(self, tmp_path):
+        model = self._build_circuit_with_extras()
+        autosave_file = str(tmp_path / ".autosave_recovery.json")
+        ctrl = FileController(model, autosave_file=autosave_file)
+        ctrl.auto_save()
+
+        ctrl2 = FileController(autosave_file=autosave_file)
+        ctrl2.load_auto_save()
+        assert len(ctrl2.model.annotations) == 1
+        assert ctrl2.model.annotations[0].text == "Test note"
+        assert ctrl2.model.recommended_components == ["Resistor", "Capacitor", "Op-Amp"]
+
+    def test_round_trip_full_model(self, tmp_path):
+        """Save and load a model with all fields — nothing should be lost."""
+        from models.annotation import AnnotationData
+
+        model = _build_simple_circuit()
+        model.annotations = [
+            AnnotationData(text="A", x=10, y=20),
+            AnnotationData(text="B", x=30, y=40, bold=True),
+        ]
+        model.recommended_components = ["Inductor"]
+        model.analysis_type = "AC Sweep"
+        model.analysis_params = {"fstart": "1", "fstop": "1Meg"}
+
+        ctrl = FileController(model)
+        filepath = tmp_path / "full.json"
+        ctrl.save_circuit(filepath)
+
+        ctrl2 = FileController()
+        ctrl2.load_circuit(filepath)
+        assert len(ctrl2.model.annotations) == 2
+        assert ctrl2.model.annotations[1].bold is True
+        assert ctrl2.model.recommended_components == ["Inductor"]
+        assert ctrl2.model.analysis_type == "AC Sweep"
+
+
 class TestQtDependencies:
     def test_qsettings_imported_for_recent_files(self):
         """FileController now uses QSettings for recent files (Issue #101)."""


### PR DESCRIPTION
load_auto_save() now restores annotations and recommended_components. load_circuit() and load_from_dict() now restore recommended_components (annotations were already restored). Adds 5 round-trip tests covering all three load methods. Closes #498