### PR TITLE
Report misconfigured component_exists check with empty params (#536)

### DIFF
--- a/app/grading/grader.py
+++ b/app/grading/grader.py
@@ -107,16 +107,26 @@ class CircuitGrader:
         component_id = check.params.get("component_id", "")
         component_type = check.params.get("component_type", "")
 
+        if not component_id and not component_type:
+            return CheckGradeResult(
+                check_id=check.check_id,
+                passed=False,
+                points_earned=0,
+                points_possible=check.points,
+                feedback=(
+                    f"Misconfigured check '{check.check_id}': "
+                    "component_exists requires 'component_id' or 'component_type' in params"
+                ),
+            )
+
         if component_id:
             cr = self._comparer.check_component_exists(student, component_id, component_type)
             passed = cr.passed
-        elif component_type:
+        else:
             # Check by type count
             min_count = check.params.get("min_count", 1)
             count = sum(1 for c in student.components.values() if c.component_type == component_type)
             passed = count >= min_count
-        else:
-            passed = False
 
         return CheckGradeResult(
             check_id=check.check_id,

--- a/app/tests/unit/test_rubric_grader.py
+++ b/app/tests/unit/test_rubric_grader.py
@@ -525,6 +525,55 @@ class TestCircuitGraderExistsByType:
         assert result.check_results[0].passed is True
 
 
+class TestComponentExistsEmptyParams:
+    """Regression test for #536: component_exists should not silently fail with empty params."""
+
+    def test_empty_params_returns_misconfigured_feedback(self):
+        student = _build_rc_filter()
+        rubric = Rubric(
+            title="Empty Params Test",
+            total_points=10,
+            checks=[
+                RubricCheck(
+                    check_id="bad_check",
+                    check_type="component_exists",
+                    points=10,
+                    params={},
+                    feedback_pass="OK",
+                    feedback_fail="Missing",
+                )
+            ],
+        )
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        cr = result.check_results[0]
+        assert cr.passed is False
+        assert "Misconfigured" in cr.feedback
+        assert "component_id" in cr.feedback
+
+    def test_empty_string_params_returns_misconfigured_feedback(self):
+        student = _build_rc_filter()
+        rubric = Rubric(
+            title="Empty String Params Test",
+            total_points=10,
+            checks=[
+                RubricCheck(
+                    check_id="bad_check",
+                    check_type="component_exists",
+                    points=10,
+                    params={"component_id": "", "component_type": ""},
+                    feedback_pass="OK",
+                    feedback_fail="Missing",
+                )
+            ],
+        )
+        grader = CircuitGrader()
+        result = grader.grade(student, rubric)
+        cr = result.check_results[0]
+        assert cr.passed is False
+        assert "Misconfigured" in cr.feedback
+
+
 class TestGradingResult:
     def test_percentage_zero_total(self):
         result = GradingResult(


### PR DESCRIPTION
When both component_id and component_type are empty, the check now returns explicit Misconfigured check feedback instead of silently failing with the generic feedback_fail message. Added tests for both empty dict and empty string params. Closes #536