### PR TITLE
Add hover visual feedback to canvas components and wires (#515)

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -53,9 +53,12 @@ class ComponentGraphicsItem(QGraphicsItem):
         self._position_update_timer = None
         self._pending_position = None
 
+        self._hovered = False
+
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable)
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable)
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemSendsGeometryChanges)
+        self.setAcceptHoverEvents(True)
 
         # Create terminals
         self.update_terminals()
@@ -182,6 +185,18 @@ class ComponentGraphicsItem(QGraphicsItem):
             compound = CompoundCommand(move_commands, f"Move {len(move_commands)} components")
             controller.undo_manager._undo_stack.append(compound)
             controller.undo_manager._redo_stack.clear()
+
+    def hoverEnterEvent(self, event):
+        """Show visual feedback when the mouse enters the component."""
+        self._hovered = True
+        self.update()
+        super().hoverEnterEvent(event)
+
+    def hoverLeaveEvent(self, event):
+        """Remove visual feedback when the mouse leaves the component."""
+        self._hovered = False
+        self.update()
+        super().hoverLeaveEvent(event)
 
     def hoverMoveEvent(self, event):
         """Update cursor based on whether hovering over terminal"""
@@ -355,6 +370,10 @@ class ComponentGraphicsItem(QGraphicsItem):
         # Highlight if selected
         if self.isSelected():
             painter.setPen(theme_manager.pen("component_selected"))
+            painter.drawRect(QRectF(-40, -20, 80, 40))
+        elif self._hovered:
+            hover_pen = QPen(color.lighter(130), 1.5, Qt.PenStyle.DashLine)
+            painter.setPen(hover_pen)
             painter.drawRect(QRectF(-40, -20, 80, 40))
 
         # Draw locked indicator (dimmed border with lock icon)

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -113,9 +113,12 @@ class WireGraphicsItem(QGraphicsPathItem):
 
         self._waypoint_handles: list[WaypointHandle] = []
 
+        self._hovered = False
+
         self.setPen(QPen(self.layer_color, theme_manager.wire_thickness_px))
         self.setFlag(QGraphicsPathItem.GraphicsItemFlag.ItemIsSelectable)
         self.setFlag(QGraphicsPathItem.GraphicsItemFlag.ItemSendsGeometryChanges)
+        self.setAcceptHoverEvents(True)
         self.setZValue(1)  # Render wires above components (z=0)
 
         if self.model.waypoints:
@@ -287,6 +290,18 @@ class WireGraphicsItem(QGraphicsPathItem):
             if status:
                 status.showMessage("Wire routing failed — move components to create space", 5000)
 
+    def hoverEnterEvent(self, event):
+        """Highlight wire on hover."""
+        self._hovered = True
+        self.update()
+        super().hoverEnterEvent(event)
+
+    def hoverLeaveEvent(self, event):
+        """Remove highlight when hover ends."""
+        self._hovered = False
+        self.update()
+        super().hoverLeaveEvent(event)
+
     def paint(self, painter, option=None, widget=None):
         """Override paint to show selection highlight, layer color, and junction dots."""
         if painter is None:
@@ -297,6 +312,9 @@ class WireGraphicsItem(QGraphicsPathItem):
         # Draw wire with appropriate style
         if self.isSelected():
             painter.setPen(theme_manager.pen("wire_selected"))
+        elif self._hovered:
+            hover_color = self.layer_color.lighter(150)
+            painter.setPen(QPen(hover_color, width + 1))
         elif self.model.routing_failed:
             pen = QPen(Qt.GlobalColor.red, width, Qt.PenStyle.DashLine)
             painter.setPen(pen)

--- a/app/tests/unit/test_canvas_hover_feedback.py
+++ b/app/tests/unit/test_canvas_hover_feedback.py
@@ -1,0 +1,107 @@
+"""
+Unit tests for canvas hover visual feedback (issue #515).
+
+Verifies that components and wires show visual feedback on hover.
+"""
+
+import pytest
+from GUI.component_item import ComponentGraphicsItem
+from GUI.wire_item import WireGraphicsItem
+from models.component import ComponentData
+from models.wire import WireData
+from PyQt6.QtCore import QPointF
+
+
+class TestComponentHoverFeedback:
+    """Test ComponentGraphicsItem hover visual feedback."""
+
+    def test_component_accepts_hover_events(self):
+        comp = ComponentGraphicsItem("R1", "Resistor")
+        assert comp.acceptHoverEvents()
+
+    def test_component_starts_not_hovered(self):
+        comp = ComponentGraphicsItem("R1", "Resistor")
+        assert comp._hovered is False
+
+    def test_hover_enter_sets_hovered(self, qtbot):
+        from PyQt6.QtWidgets import QGraphicsScene, QGraphicsView
+
+        scene = QGraphicsScene()
+        view = QGraphicsView(scene)
+        qtbot.addWidget(view)
+
+        comp = ComponentGraphicsItem("R1", "Resistor")
+        scene.addItem(comp)
+
+        # Simulate hover
+        comp._hovered = True
+        comp.update()
+        assert comp._hovered is True
+
+    def test_hover_leave_clears_hovered(self, qtbot):
+        from PyQt6.QtWidgets import QGraphicsScene, QGraphicsView
+
+        scene = QGraphicsScene()
+        view = QGraphicsView(scene)
+        qtbot.addWidget(view)
+
+        comp = ComponentGraphicsItem("R1", "Resistor")
+        scene.addItem(comp)
+
+        comp._hovered = True
+        comp._hovered = False
+        comp.update()
+        assert comp._hovered is False
+
+
+class TestWireHoverFeedback:
+    """Test WireGraphicsItem hover visual feedback."""
+
+    @pytest.fixture
+    def wire_setup(self, qtbot):
+        from PyQt6.QtWidgets import QGraphicsScene, QGraphicsView
+
+        scene = QGraphicsScene()
+        view = QGraphicsView(scene)
+        qtbot.addWidget(view)
+
+        comp1 = ComponentGraphicsItem("R1", "Resistor")
+        comp1.setPos(0, 0)
+        scene.addItem(comp1)
+
+        comp2 = ComponentGraphicsItem("R2", "Resistor")
+        comp2.setPos(200, 0)
+        scene.addItem(comp2)
+
+        model = WireData(
+            start_component_id="R1",
+            start_terminal=0,
+            end_component_id="R2",
+            end_terminal=0,
+            waypoints=[(0, 0), (200, 0)],
+        )
+        wire = WireGraphicsItem(comp1, 0, comp2, 0, model=model)
+        scene.addItem(wire)
+
+        return wire, scene
+
+    def test_wire_accepts_hover_events(self, wire_setup):
+        wire, _ = wire_setup
+        assert wire.acceptHoverEvents()
+
+    def test_wire_starts_not_hovered(self, wire_setup):
+        wire, _ = wire_setup
+        assert wire._hovered is False
+
+    def test_wire_hover_enter_sets_flag(self, wire_setup):
+        wire, _ = wire_setup
+        wire._hovered = True
+        wire.update()
+        assert wire._hovered is True
+
+    def test_wire_hover_leave_clears_flag(self, wire_setup):
+        wire, _ = wire_setup
+        wire._hovered = True
+        wire._hovered = False
+        wire.update()
+        assert wire._hovered is False


### PR DESCRIPTION
## Summary
- Add hover highlight effects to components and wires on the circuit canvas
- Components get a subtle glow, wires change color on hover

Closes #515

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>