### PR TITLE
Move parse_value and SIMULATION_TIMEOUT to shared utils (#568)

### DIFF
--- a/app/GUI/format_utils.py
+++ b/app/GUI/format_utils.py
@@ -1,152 +1,25 @@
 """
 GUI/format_utils.py
 
-Provides utility functions for parsing and formatting numbers with SI unit prefixes.
+Re-exports from utils.format_utils for backward compatibility.
+
+The canonical definitions now live in ``utils.format_utils`` so that
+non-GUI layers (simulation, controllers) can use them without depending
+on the GUI package.
 """
 
-import re
-
-# Dictionary of SI prefixes and their multipliers
-# Includes common variations like 'u' for 'µ' and 'MEG' for 'M'
-SI_PREFIX_MULTIPLIERS = {
-    "f": 1e-15,  # Femto
-    "p": 1e-12,  # Pico
-    "n": 1e-9,  # Nano
-    "u": 1e-6,  # Micro
-    "µ": 1e-6,  # Micro
-    "m": 1e-3,  # Milli
-    "k": 1e3,  # Kilo
-    "M": 1e6,  # Mega
-    "MEG": 1e6,  # Mega (SPICE variant)
-    "G": 1e9,  # Giga
-    "T": 1e12,  # Tera
-}
-
-# For formatting, we iterate to find the best fit
-# We sort by value to handle this correctly.
-# Using a list of tuples: (multiplier, prefix)
-FORMATTING_PREFIXES = sorted(
-    [
-        (1e12, "T"),
-        (1e9, "G"),
-        (1e6, "M"),
-        (1e3, "k"),
-        (1, ""),
-        (1e-3, "m"),
-        (1e-6, "µ"),
-        (1e-9, "n"),
-        (1e-12, "p"),
-        (1e-15, "f"),
-    ],
-    key=lambda x: x[0],
-    reverse=True,
+from utils.format_utils import (
+    FORMATTING_PREFIXES,
+    SI_PREFIX_MULTIPLIERS,
+    format_value,
+    parse_value,
+    validate_component_value,
 )
 
-
-def parse_value(s: str) -> float:
-    """
-    Parses a string with an optional SI prefix into a float.
-    Examples: "10k" -> 10000.0, "25m" -> 0.025, "10u" -> 1e-5
-    """
-    if not isinstance(s, str):
-        return float(s)
-
-    s = s.strip()
-
-    # Check for SPICE 'MEG' variant first
-    if "MEG" in s.upper():
-        num_part = s[:-3]
-        multiplier = SI_PREFIX_MULTIPLIERS["MEG"]
-        try:
-            return float(num_part) * multiplier
-        except ValueError:
-            raise ValueError(f"Invalid number format: {s}")
-
-    # Use regex to separate the number from the potential prefix/unit
-    match = re.match(r"^(-?\d+\.?\d*e?[-+]?\d*)([a-zA-Zµ]*)", s)
-    if not match:
-        raise ValueError(f"Invalid number format: {s}")
-
-    num_str, unit_str = match.groups()
-
-    if not unit_str:
-        return float(num_str)
-
-    # Find the first character that is a known prefix
-    for i, char in enumerate(unit_str):
-        if char in SI_PREFIX_MULTIPLIERS:
-            multiplier = SI_PREFIX_MULTIPLIERS[char]
-            return float(num_str) * multiplier
-
-    # If no known prefix is found in the unit string, just return the number
-    return float(num_str)
-
-
-def format_value(value: float, unit: str = "") -> str:
-    """
-    Formats a float into a string with the most appropriate SI prefix.
-    Examples: 0.015 -> "15.00m", 15000 -> "15.00k"
-    """
-    if value == 0:
-        return f"0.00 {unit}"
-
-    abs_val = abs(value)
-
-    for mult, prefix in FORMATTING_PREFIXES:
-        if abs_val >= mult:
-            scaled_val = value / mult
-            # Format to 2 decimal places, but avoid trailing ".00" for integers
-            if scaled_val == int(scaled_val):
-                return f"{int(scaled_val)} {prefix}{unit}"
-            else:
-                return f"{scaled_val:.2f} {prefix}{unit}"
-
-    # If value is smaller than the smallest prefix, use scientific notation
-    return f"{value:.2e} {unit}"
-
-
-# Component types that require positive values
-_POSITIVE_ONLY_TYPES = {"Resistor", "Capacitor", "Inductor"}
-
-# Component types that don't need value validation
-_SKIP_VALIDATION_TYPES = {
-    "Ground",
-    "Op-Amp",
-    "Waveform Source",
-    "BJT NPN",
-    "BJT PNP",
-    "MOSFET NMOS",
-    "MOSFET PMOS",
-    "VC Switch",
-    "Diode",
-    "LED",
-    "Zener Diode",
-}
-
-
-def validate_component_value(value: str, component_type: str) -> tuple[bool, str]:
-    """
-    Validate a component value string for the given component type.
-
-    Returns:
-        (is_valid, error_message) — error_message is empty when valid.
-    """
-    if component_type in _SKIP_VALIDATION_TYPES:
-        return True, ""
-
-    value = value.strip()
-    if not value:
-        return False, "Value cannot be empty."
-
-    try:
-        numeric = parse_value(value)
-    except (ValueError, TypeError):
-        return (
-            False,
-            f"Invalid value '{value}'. Use a number with optional suffix (e.g. 10k, 100n, 4.7M).",
-        )
-
-    if component_type in _POSITIVE_ONLY_TYPES and numeric <= 0:
-        return False, f"{component_type} value must be positive (got {value})."
-
-    return True, ""
+__all__ = [
+    "SI_PREFIX_MULTIPLIERS",
+    "FORMATTING_PREFIXES",
+    "parse_value",
+    "format_value",
+    "validate_component_value",
+]

--- a/app/GUI/styles/constants.py
+++ b/app/GUI/styles/constants.py
@@ -8,6 +8,7 @@ This file is the SINGLE SOURCE OF TRUTH for:
 """
 
 from models.component import COMPONENT_TYPES, SPICE_SYMBOLS, TERMINAL_COUNTS
+from utils.constants import SIMULATION_TIMEOUT  # noqa: F401  # re-exported
 
 # Grid settings
 GRID_SIZE = 10
@@ -26,8 +27,7 @@ DEFAULT_TERMINAL_PADDING = 15  # Gap between body edge and terminal (grid-aligne
 DEFAULT_WINDOW_SIZE = (1200, 800)
 DEFAULT_SPLITTER_SIZES = [500, 300]  # Canvas height : results height
 
-# Simulation settings
-SIMULATION_TIMEOUT = 60  # Seconds before ngspice is killed
+# Simulation settings — canonical value lives in utils.constants
 
 # Component drag settings
 WIRE_UPDATE_DELAY_MS = 50  # Delay before rerouting wires after drag

--- a/app/simulation/ngspice_runner.py
+++ b/app/simulation/ngspice_runner.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 from datetime import datetime
 
-from GUI.styles import SIMULATION_TIMEOUT
+from utils.constants import SIMULATION_TIMEOUT
 
 
 class NgspiceRunner:

--- a/app/simulation/power_calculator.py
+++ b/app/simulation/power_calculator.py
@@ -6,7 +6,7 @@ Calculates power dissipation for each component from DC operating point results.
 
 import logging
 
-from GUI.format_utils import parse_value
+from utils.format_utils import parse_value
 
 logger = logging.getLogger(__name__)
 

--- a/app/simulation/power_metrics.py
+++ b/app/simulation/power_metrics.py
@@ -6,7 +6,7 @@ Computes RMS voltage/current and average/peak power from transient simulation da
 
 import math
 
-from GUI.format_utils import parse_value
+from utils.format_utils import parse_value
 
 
 def compute_rms(values):

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,0 +1,7 @@
+"""
+Shared utilities for the Spice-GUI application.
+
+This package contains pure-Python helpers that may be used by any layer
+(models, controllers, simulation, GUI) without introducing cross-layer
+dependencies.
+"""

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -1,0 +1,12 @@
+"""
+utils/constants.py
+
+Application-wide constants that are independent of any specific layer.
+
+Constants that belong here are those needed by more than one layer
+(e.g. both simulation and GUI) and have no dependency on Qt or other
+layer-specific packages.
+"""
+
+# Simulation settings
+SIMULATION_TIMEOUT = 60  # Seconds before ngspice is killed

--- a/app/utils/format_utils.py
+++ b/app/utils/format_utils.py
@@ -1,0 +1,155 @@
+"""
+utils/format_utils.py
+
+Provides utility functions for parsing and formatting numbers with SI unit prefixes.
+
+This module lives in the shared ``utils`` package so that both the simulation
+layer and the GUI layer can use it without creating a backwards dependency.
+"""
+
+import re
+
+# Dictionary of SI prefixes and their multipliers
+# Includes common variations like 'u' for 'µ' and 'MEG' for 'M'
+SI_PREFIX_MULTIPLIERS = {
+    "f": 1e-15,  # Femto
+    "p": 1e-12,  # Pico
+    "n": 1e-9,  # Nano
+    "u": 1e-6,  # Micro
+    "µ": 1e-6,  # Micro
+    "m": 1e-3,  # Milli
+    "k": 1e3,  # Kilo
+    "M": 1e6,  # Mega
+    "MEG": 1e6,  # Mega (SPICE variant)
+    "G": 1e9,  # Giga
+    "T": 1e12,  # Tera
+}
+
+# For formatting, we iterate to find the best fit
+# We sort by value to handle this correctly.
+# Using a list of tuples: (multiplier, prefix)
+FORMATTING_PREFIXES = sorted(
+    [
+        (1e12, "T"),
+        (1e9, "G"),
+        (1e6, "M"),
+        (1e3, "k"),
+        (1, ""),
+        (1e-3, "m"),
+        (1e-6, "µ"),
+        (1e-9, "n"),
+        (1e-12, "p"),
+        (1e-15, "f"),
+    ],
+    key=lambda x: x[0],
+    reverse=True,
+)
+
+
+def parse_value(s: str) -> float:
+    """
+    Parses a string with an optional SI prefix into a float.
+    Examples: "10k" -> 10000.0, "25m" -> 0.025, "10u" -> 1e-5
+    """
+    if not isinstance(s, str):
+        return float(s)
+
+    s = s.strip()
+
+    # Check for SPICE 'MEG' variant first
+    if "MEG" in s.upper():
+        num_part = s[:-3]
+        multiplier = SI_PREFIX_MULTIPLIERS["MEG"]
+        try:
+            return float(num_part) * multiplier
+        except ValueError:
+            raise ValueError(f"Invalid number format: {s}")
+
+    # Use regex to separate the number from the potential prefix/unit
+    match = re.match(r"^(-?\d+\.?\d*e?[-+]?\d*)([a-zA-Zµ]*)", s)
+    if not match:
+        raise ValueError(f"Invalid number format: {s}")
+
+    num_str, unit_str = match.groups()
+
+    if not unit_str:
+        return float(num_str)
+
+    # Find the first character that is a known prefix
+    for i, char in enumerate(unit_str):
+        if char in SI_PREFIX_MULTIPLIERS:
+            multiplier = SI_PREFIX_MULTIPLIERS[char]
+            return float(num_str) * multiplier
+
+    # If no known prefix is found in the unit string, just return the number
+    return float(num_str)
+
+
+def format_value(value: float, unit: str = "") -> str:
+    """
+    Formats a float into a string with the most appropriate SI prefix.
+    Examples: 0.015 -> "15.00m", 15000 -> "15.00k"
+    """
+    if value == 0:
+        return f"0.00 {unit}"
+
+    abs_val = abs(value)
+
+    for mult, prefix in FORMATTING_PREFIXES:
+        if abs_val >= mult:
+            scaled_val = value / mult
+            # Format to 2 decimal places, but avoid trailing ".00" for integers
+            if scaled_val == int(scaled_val):
+                return f"{int(scaled_val)} {prefix}{unit}"
+            else:
+                return f"{scaled_val:.2f} {prefix}{unit}"
+
+    # If value is smaller than the smallest prefix, use scientific notation
+    return f"{value:.2e} {unit}"
+
+
+# Component types that require positive values
+_POSITIVE_ONLY_TYPES = {"Resistor", "Capacitor", "Inductor"}
+
+# Component types that don't need value validation
+_SKIP_VALIDATION_TYPES = {
+    "Ground",
+    "Op-Amp",
+    "Waveform Source",
+    "BJT NPN",
+    "BJT PNP",
+    "MOSFET NMOS",
+    "MOSFET PMOS",
+    "VC Switch",
+    "Diode",
+    "LED",
+    "Zener Diode",
+}
+
+
+def validate_component_value(value: str, component_type: str) -> tuple[bool, str]:
+    """
+    Validate a component value string for the given component type.
+
+    Returns:
+        (is_valid, error_message) — error_message is empty when valid.
+    """
+    if component_type in _SKIP_VALIDATION_TYPES:
+        return True, ""
+
+    value = value.strip()
+    if not value:
+        return False, "Value cannot be empty."
+
+    try:
+        numeric = parse_value(value)
+    except (ValueError, TypeError):
+        return (
+            False,
+            f"Invalid value '{value}'. Use a number with optional suffix (e.g. 10k, 100n, 4.7M).",
+        )
+
+    if component_type in _POSITIVE_ONLY_TYPES and numeric <= 0:
+        return False, f"{component_type} value must be positive (got {value})."
+
+    return True, ""


### PR DESCRIPTION
## Summary - Created  shared package with  and  - Moved , ,  from  to  - Moved  from  to  - Updated , , and  to import from  instead of  - GUI modules now re-export from  for backward compatibility Fixes #568 ## Test plan - [x] Verified simulation modules import successfully without loading any GUI modules - [x] Verified backward compatibility — GUI.format_utils and GUI.styles.SIMULATION_TIMEOUT still re-export correctly - [x] All linting and formatting checks pass - [ ] CI tests pass (requires PyQt6 system deps) 🤖 Generated with [Claude Code](https://claude.com/claude-code)