### PR TITLE
Move pathfinding algorithm from GUI to algorithms package (#587)

### DIFF
--- a/app/GUI/__init__.py
+++ b/app/GUI/__init__.py
@@ -1,10 +1,11 @@
+from algorithms.path_finding import IDAStarPathfinder, get_component_obstacles, get_wire_obstacles
+
 from .analysis_dialog import AnalysisDialog
 from .circuit_canvas import CircuitCanvas, CircuitCanvasView
 from .circuit_node import Node
 from .component_item import ComponentGraphicsItem
 from .component_palette import ComponentPalette
 from .main_window import MainWindow
-from .path_finding import IDAStarPathfinder, get_component_obstacles, get_wire_obstacles
 
 # Re-export from centralized styles module
 from .styles import COMPONENTS, DEFAULT_COMPONENT_COUNTER, GRID_SIZE, theme_manager

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -172,7 +172,7 @@ class WireGraphicsItem(QGraphicsPathItem):
     def update_position(self):
         """Update wire path using selected algorithm"""
         # Lazy import for faster startup - only loaded when wires are created
-        from .path_finding import IDAStarPathfinder, get_component_obstacles
+        from algorithms.path_finding import IDAStarPathfinder, get_component_obstacles
 
         # Get old bounding rect for invalidation
         old_rect = self.boundingRect()
@@ -180,8 +180,8 @@ class WireGraphicsItem(QGraphicsPathItem):
         # Prepare for update by invalidating current bounds
         self.prepareGeometryChange()
 
-        start = self.start_comp.get_terminal_pos(self.start_term)
-        end = self.end_comp.get_terminal_pos(self.end_term)
+        start_qpt = self.start_comp.get_terminal_pos(self.start_term)
+        end_qpt = self.end_comp.get_terminal_pos(self.end_term)
 
         # Get obstacles from canvas
         if self.canvas:
@@ -213,28 +213,38 @@ class WireGraphicsItem(QGraphicsPathItem):
             all_wires = self.canvas.wires if hasattr(self.canvas, "wires") else []
             existing_wires = [w for w in all_wires if w.algorithm == self.algorithm]
 
+            # Adapt Qt objects for the Qt-free pathfinding module
+            adapted_components = {cid: _ComponentAdapter(c) for cid, c in self.canvas.components.items()}
+            adapted_wires = [_WireAdapter(w) for w in existing_wires]
+
             obstacles = get_component_obstacles(
-                self.canvas.components,
+                adapted_components,
                 GRID_SIZE,
                 terminal_clearance_only=terminal_clearance,
                 active_terminals=active_terminals,
-                existing_wires=existing_wires,
+                existing_wires=adapted_wires,
                 current_node=self.node,
             )
 
+            # Convert QPointF positions to tuples for the pathfinder
+            start_tuple = (start_qpt.x(), start_qpt.y())
+            end_tuple = (end_qpt.x(), end_qpt.y())
+
             allow_diagonal = theme_manager.routing_mode == "diagonal"
             pathfinder = IDAStarPathfinder(GRID_SIZE, allow_diagonal=allow_diagonal)
-            result = pathfinder.find_path(start, end, obstacles, algorithm=self.algorithm)
+            result = pathfinder.find_path(start_tuple, end_tuple, obstacles, algorithm=self.algorithm)
 
             # Unpack result (waypoints, runtime, iterations, routing_failed)
-            self.waypoints, runtime, iterations, routing_failed = result
+            tuple_waypoints, runtime, iterations, routing_failed = result
+
+            # Convert tuple waypoints back to QPointF for Qt drawing
+            self.waypoints = [QPointF(wp[0], wp[1]) for wp in tuple_waypoints]
 
             # Store in model
             self.model.runtime = runtime
             self.model.iterations = iterations
             self.model.routing_failed = routing_failed
-            # Convert QPointF waypoints to tuples for model storage
-            self.model.waypoints = [(wp.x(), wp.y()) for wp in self.waypoints]
+            self.model.waypoints = list(tuple_waypoints)
 
             if routing_failed:
                 logger.warning(
@@ -248,11 +258,11 @@ class WireGraphicsItem(QGraphicsPathItem):
                 self._notify_routing_failed()
         else:
             # Fallback to direct line
-            self.waypoints = [start, end]
+            self.waypoints = [start_qpt, end_qpt]
             self.model.runtime = 0.0
             self.model.iterations = 0
             self.model.routing_failed = False
-            self.model.waypoints = [(start.x(), start.y()), (end.x(), end.y())]
+            self.model.waypoints = [(start_qpt.x(), start_qpt.y()), (end_qpt.x(), end_qpt.y())]
 
         # Create path from waypoints
         path = QPainterPath()
@@ -467,6 +477,50 @@ class WireGraphicsItem(QGraphicsPathItem):
         )
 
         return wire
+
+
+# ---------------------------------------------------------------------------
+# Adapters: convert Qt objects to tuple-based interface for pathfinding
+# ---------------------------------------------------------------------------
+
+
+class _ComponentAdapter:
+    """Wraps a ComponentGraphicsItem so position methods return (x, y) tuples."""
+
+    __slots__ = ("_comp",)
+
+    def __init__(self, comp):
+        self._comp = comp
+
+    def __getattr__(self, name):
+        return getattr(self._comp, name)
+
+    def pos(self):
+        p = self._comp.pos()
+        return (p.x(), p.y())
+
+    def get_terminal_pos(self, index):
+        p = self._comp.get_terminal_pos(index)
+        return (p.x(), p.y())
+
+
+class _WireAdapter:
+    """Wraps a WireGraphicsItem so waypoints are plain (x, y) tuples."""
+
+    __slots__ = ("_wire",)
+
+    def __init__(self, wire):
+        self._wire = wire
+
+    def __getattr__(self, name):
+        return getattr(self._wire, name)
+
+    @property
+    def waypoints(self):
+        wps = self._wire.waypoints
+        if wps:
+            return [(p.x(), p.y()) if isinstance(p, QPointF) else (p[0], p[1]) for p in wps]
+        return wps
 
 
 # Backward compatibility alias

--- a/app/algorithms/__init__.py
+++ b/app/algorithms/__init__.py
@@ -1,0 +1,17 @@
+from .path_finding import (
+    IDAStarPathfinder,
+    WeightedPathfinder,
+    get_component_obstacles,
+    get_wire_obstacles,
+    polygon_to_grid_filled,
+    polygon_to_grid_frame,
+)
+
+__all__ = [
+    "IDAStarPathfinder",
+    "WeightedPathfinder",
+    "get_component_obstacles",
+    "get_wire_obstacles",
+    "polygon_to_grid_filled",
+    "polygon_to_grid_frame",
+]

--- a/app/algorithms/path_finding.py
+++ b/app/algorithms/path_finding.py
@@ -2,14 +2,15 @@
 pathfinding.py
 
 IDA* pathfinding for grid-aligned wire routing in circuit schematics.
+
+All positions are represented as plain (x, y) tuples — no Qt dependency.
+Callers using QPointF should convert before calling and after receiving results.
 """
 
 import math
 import time
 from abc import ABC, abstractmethod
 from typing import Set, Tuple
-
-from PyQt6.QtCore import QPointF
 
 
 class WeightedPathfinder(ABC):
@@ -73,8 +74,8 @@ class WeightedPathfinder(ABC):
         Find path from start_pos to end_pos avoiding obstacles.
 
         Args:
-            start_pos: QPointF - starting position
-            end_pos: QPointF - ending position
+            start_pos: (x, y) tuple - starting position in scene coordinates
+            end_pos: (x, y) tuple - ending position in scene coordinates
             obstacles: set of (grid_x, grid_y) tuples representing blocked cells
             bounds: tuple (min_x, min_y, width, height) for valid routing area
             algorithm: str - algorithm identifier (e.g., 'astar', 'dijkstra')
@@ -83,7 +84,7 @@ class WeightedPathfinder(ABC):
 
         Returns:
             tuple: (waypoints, runtime, iterations)
-                - waypoints: list of QPointF representing the path
+                - waypoints: list of (x, y) tuples representing the path
                 - runtime: float, time taken in seconds
                 - iterations: int, number of algorithm iterations
         """
@@ -123,21 +124,21 @@ class WeightedPathfinder(ABC):
             grid_coord: (x, y) tuple in grid space
 
         Returns:
-            QPointF in scene coordinates
+            (x, y) tuple in scene coordinates
         """
-        return QPointF(grid_coord[0] * self.grid_size, grid_coord[1] * self.grid_size)
+        return (grid_coord[0] * self.grid_size, grid_coord[1] * self.grid_size)
 
     def _pos_to_grid(self, pos) -> Tuple[int, int]:
         """
         Convert scene position to grid coordinates.
 
         Args:
-            pos: QPointF in scene coordinates
+            pos: (x, y) tuple in scene coordinates
 
         Returns:
             (x, y) tuple in grid space
         """
-        return (round(pos.x() / self.grid_size), round(pos.y() / self.grid_size))
+        return (round(pos[0] / self.grid_size), round(pos[1] / self.grid_size))
 
     def _heuristic(self, a, b):
         """
@@ -183,10 +184,10 @@ class WeightedPathfinder(ABC):
         Remove unnecessary waypoints (collinear points).
 
         Args:
-            waypoints: list of QPointF
+            waypoints: list of (x, y) tuples
 
         Returns:
-            list of QPointF with collinear points removed
+            list of (x, y) tuples with collinear points removed
         """
         if len(waypoints) <= 2:
             return waypoints
@@ -199,10 +200,10 @@ class WeightedPathfinder(ABC):
             next_point = waypoints[i + 1]
 
             # Check if current point is on the same line as prev and next
-            dx1 = current.x() - prev.x()
-            dy1 = current.y() - prev.y()
-            dx2 = next_point.x() - current.x()
-            dy2 = next_point.y() - current.y()
+            dx1 = current[0] - prev[0]
+            dy1 = current[1] - prev[1]
+            dx2 = next_point[0] - current[0]
+            dy2 = next_point[1] - current[1]
 
             # If not collinear (direction changes), keep the waypoint
             if not self._same_direction(dx1, dy1, dx2, dy2):
@@ -286,7 +287,7 @@ class IDAStarPathfinder(WeightedPathfinder):
 
         Returns:
             tuple: (waypoints, routing_failed)
-                - waypoints: list of QPointF representing the path
+                - waypoints: list of (x, y) tuples representing the path
                 - routing_failed: True if no valid path was found
         """
         start_grid = self._pos_to_grid(start_pos)
@@ -379,7 +380,7 @@ class IDAStarPathfinder(WeightedPathfinder):
             new_direction = (dx, dy)
 
             neighbor_pos = self._grid_to_pos(neighbor)
-            if not (min_x <= neighbor_pos.x() <= max_x and min_y <= neighbor_pos.y() <= max_y):
+            if not (min_x <= neighbor_pos[0] <= max_x and min_y <= neighbor_pos[1] <= max_y):
                 continue
 
             if neighbor in obstacles:
@@ -444,7 +445,7 @@ def polygon_to_grid_filled(
 
     Args:
         polygon_points: List of (x, y) tuples in local coordinates
-        position: Component position (QPointF)
+        position: Component position as (x, y) tuple
         rotation_angle: Rotation in degrees
         grid_size: Grid cell size
         inset: Inset distance in grid cells (for non-connected components)
@@ -484,8 +485,8 @@ def polygon_to_grid_filled(
         rotated_y = x * sin_a + y * cos_a
 
         # Translate to world position
-        world_x = position.x() + rotated_x
-        world_y = position.y() + rotated_y
+        world_x = position[0] + rotated_x
+        world_y = position[1] + rotated_y
 
         world_points.append((world_x, world_y))
 
@@ -580,7 +581,7 @@ def polygon_to_grid_frame(
 
     Args:
         polygon_points: List of (x, y) tuples in local coordinates
-        position: Component position (QPointF)
+        position: Component position as (x, y) tuple
         rotation_angle: Rotation in degrees
         grid_size: Grid cell size
         inset: Inset distance in grid cells (for non-connected components)
@@ -622,8 +623,8 @@ def polygon_to_grid_frame(
         rotated_y = x * sin_a + y * cos_a
 
         # Translate to world position
-        world_x = position.x() + rotated_x
-        world_y = position.y() + rotated_y
+        world_x = position[0] + rotated_x
+        world_y = position[1] + rotated_y
 
         world_points.append((world_x, world_y))
 
@@ -669,7 +670,8 @@ def get_wire_obstacles(wires, current_node, grid_size=20):
     Wires from the same node are not obstacles (allows bundling).
 
     Args:
-        wires: list of WireItem objects (all wires in the circuit)
+        wires: list of wire-like objects with .node and .waypoints attributes.
+            Each waypoint must be an (x, y) tuple.
         current_node: Node object that the current wire belongs to (or None)
         grid_size: size of grid cells
 
@@ -695,10 +697,10 @@ def get_wire_obstacles(wires, current_node, grid_size=20):
                 p2 = wire.waypoints[i + 1]
 
                 # Convert waypoints to grid coordinates
-                x1 = round(p1.x() / grid_size)
-                y1 = round(p1.y() / grid_size)
-                x2 = round(p2.x() / grid_size)
-                y2 = round(p2.y() / grid_size)
+                x1 = round(p1[0] / grid_size)
+                y1 = round(p1[1] / grid_size)
+                x2 = round(p2[0] / grid_size)
+                y2 = round(p2[1] / grid_size)
 
                 # Use Bresenham's algorithm to rasterize the line segment
                 dx = abs(x2 - x1)
@@ -737,26 +739,28 @@ def get_component_obstacles(
     """
     Get set of grid cells blocked by components and wires from other nodes.
 
+    Components must expose the following interface (duck-typed):
+        - component_id: str
+        - terminals: sequence (len used)
+        - rotation_angle: float
+        - pos() -> (x, y) tuple
+        - get_terminal_pos(index) -> (x, y) tuple
+        - get_obstacle_shape() -> list[(x, y)] (optional)
+
     Args:
-        components: dict of ComponentGraphicsItem objects
+        components: dict mapping component_id to component objects
         grid_size: size of grid cells
         padding: extra grid cells around each component (negative values shrink boundary inward)
         exclude_ids: set of component IDs to exclude from obstacles (optional) - DEPRECATED
         terminal_clearance_only: set of component IDs where only terminal areas should be cleared (not entire body)
         active_terminals: list of (component_id, terminal_index) tuples that must be cleared for pathfinding
-        existing_wires: list of WireItem objects (for wire-to-wire obstacle detection)
+        existing_wires: list of wire-like objects (for wire-to-wire obstacle detection)
         current_node: Node object that current wire belongs to (for same-net detection)
 
     Returns:
         set of (grid_x, grid_y) tuples
     """
     obstacles = set()
-
-    # if exclude_ids is None:
-    #     exclude_ids = set()
-
-    # if terminal_clearance_only is None:
-    #     terminal_clearance_only = set()
 
     if active_terminals is None:
         active_terminals = []
@@ -772,8 +776,8 @@ def get_component_obstacles(
         for i in range(len(comp.terminals)):
             term_pos = comp.get_terminal_pos(i)
             term_grid = (
-                round(term_pos.x() / grid_size),
-                round(term_pos.y() / grid_size),
+                round(term_pos[0] / grid_size),
+                round(term_pos[1] / grid_size),
             )
             terminal_key = (comp.component_id, i)
             is_active = terminal_key in active_terminals_set
@@ -822,8 +826,8 @@ def get_component_obstacles(
         for i in range(len(comp.terminals)):
             term_pos = comp.get_terminal_pos(i)
             # Use same conversion as pathfinding uses
-            term_grid_x = round(term_pos.x() / grid_size)
-            term_grid_y = round(term_pos.y() / grid_size)
+            term_grid_x = round(term_pos[0] / grid_size)
+            term_grid_y = round(term_pos[1] / grid_size)
 
             terminal_key = (comp.component_id, i)
             is_active_terminal = terminal_key in active_terminals_set

--- a/app/tests/unit/test_path_finding.py
+++ b/app/tests/unit/test_path_finding.py
@@ -1,8 +1,7 @@
 """Tests for path_finding.py — IDA* wire routing algorithm."""
 
 import pytest
-from GUI.path_finding import IDAStarPathfinder
-from PyQt6.QtCore import QPointF
+from algorithms.path_finding import IDAStarPathfinder
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -27,13 +26,13 @@ BOUNDS = (-200, -200, 400, 400)
 
 
 def _grid(gx, gy):
-    """Shorthand: grid coords -> QPointF in scene coordinates."""
-    return QPointF(gx * GRID, gy * GRID)
+    """Shorthand: grid coords -> (x, y) tuple in scene coordinates."""
+    return (gx * GRID, gy * GRID)
 
 
 def _to_grid_tuples(waypoints):
-    """Convert list of QPointF waypoints to list of (gx, gy) grid tuples."""
-    return [(round(p.x() / GRID), round(p.y() / GRID)) for p in waypoints]
+    """Convert list of (x, y) waypoints to list of (gx, gy) grid tuples."""
+    return [(round(p[0] / GRID), round(p[1] / GRID)) for p in waypoints]
 
 
 # ===========================================================================
@@ -43,13 +42,13 @@ def _to_grid_tuples(waypoints):
 
 class TestGridConversion:
     def test_pos_to_grid(self, pathfinder):
-        assert pathfinder._pos_to_grid(QPointF(0, 0)) == (0, 0)
-        assert pathfinder._pos_to_grid(QPointF(40, 60)) == (2, 3)
+        assert pathfinder._pos_to_grid((0, 0)) == (0, 0)
+        assert pathfinder._pos_to_grid((40, 60)) == (2, 3)
 
     def test_grid_to_pos(self, pathfinder):
         pos = pathfinder._grid_to_pos((2, 3))
-        assert pos.x() == 40
-        assert pos.y() == 60
+        assert pos[0] == 40
+        assert pos[1] == 60
 
     def test_round_trip(self, pathfinder):
         for gx, gy in [(0, 0), (5, -3), (-10, 7)]:
@@ -60,8 +59,8 @@ class TestGridConversion:
 
     def test_pos_to_grid_rounds(self, pathfinder):
         """Positions that aren't exactly on grid should round to nearest cell."""
-        assert pathfinder._pos_to_grid(QPointF(11, 29)) == (1, 1)
-        assert pathfinder._pos_to_grid(QPointF(9, 31)) == (0, 2)
+        assert pathfinder._pos_to_grid((11, 29)) == (1, 1)
+        assert pathfinder._pos_to_grid((9, 31)) == (0, 2)
 
 
 # ===========================================================================
@@ -208,8 +207,8 @@ class TestOrthogonalPaths:
         start, end = _grid(0, 0), _grid(3, 4)
         waypoints, _, _, _ = pathfinder.find_path(start, end, set(), bounds=BOUNDS)
         for i in range(len(waypoints) - 1):
-            dx = waypoints[i + 1].x() - waypoints[i].x()
-            dy = waypoints[i + 1].y() - waypoints[i].y()
+            dx = waypoints[i + 1][0] - waypoints[i][0]
+            dy = waypoints[i + 1][1] - waypoints[i][1]
             # At least one of dx/dy must be zero (no diagonal movement)
             assert dx == 0 or dy == 0, f"Diagonal segment: ({dx}, {dy})"
 
@@ -388,8 +387,8 @@ class TestDiagonalRouting:
         start, end = _grid(0, 0), _grid(5, 5)
         waypoints, _, _, _ = pathfinder.find_path(start, end, set(), bounds=BOUNDS)
         for i in range(len(waypoints) - 1):
-            dx = waypoints[i + 1].x() - waypoints[i].x()
-            dy = waypoints[i + 1].y() - waypoints[i].y()
+            dx = waypoints[i + 1][0] - waypoints[i][0]
+            dy = waypoints[i + 1][1] - waypoints[i][1]
             assert dx == 0 or dy == 0, f"Unexpected diagonal segment: ({dx}, {dy})"
 
     def test_corner_cutting_prevented(self, diagonal_pathfinder):
@@ -452,13 +451,13 @@ class TestOctileHeuristic:
 class TestRoutingModeConstants:
     def test_orthogonal_dirs_count(self):
         """ORTHOGONAL_DIRS should have exactly 4 directions."""
-        from GUI.path_finding import WeightedPathfinder
+        from algorithms.path_finding import WeightedPathfinder
 
         assert len(WeightedPathfinder.ORTHOGONAL_DIRS) == 4
 
     def test_diagonal_dirs_count(self):
         """DIAGONAL_DIRS should have exactly 8 directions."""
-        from GUI.path_finding import WeightedPathfinder
+        from algorithms.path_finding import WeightedPathfinder
 
         assert len(WeightedPathfinder.DIAGONAL_DIRS) == 8
 
@@ -466,7 +465,7 @@ class TestRoutingModeConstants:
         """SQRT2 constant should equal math.sqrt(2)."""
         import math
 
-        from GUI.path_finding import WeightedPathfinder
+        from algorithms.path_finding import WeightedPathfinder
 
         assert abs(WeightedPathfinder.SQRT2 - math.sqrt(2)) < 1e-15
 


### PR DESCRIPTION
## Summary - Relocated  (846 lines) from  to a new  package, fixing the layer boundary violation where a pure algorithm was misplaced in the GUI layer - Replaced the single  import with plain  tuples throughout the module — the algorithms package now has zero Qt dependencies - Added thin  and  classes in  to convert between QPointF and tuples at the GUI boundary - Updated all imports in , , and  Closes #587 ## Test plan - [x] All 48 pathfinding tests pass with tuple-based API - [x] Full test suite (3060 tests) passes - [x] Linting passes (ruff, isort, black) - [ ] CI passes 🤖 Generated with [Claude Code](https://claude.com/claude-code)