### PR TITLE
Route view-layer model mutations through controllers (#577)

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -232,24 +232,12 @@ class FileOperationsMixin:
             template = template_ctrl.load_template(filename)
             model = template_ctrl.create_circuit_from_template(template)
 
-            # Update current model in place
-            self.model.clear()
-            self.model.components = model.components
-            self.model.wires = model.wires
-            self.model.nodes = model.nodes
-            self.model.terminal_to_node = model.terminal_to_node
-            self.model.component_counter = model.component_counter
-            self.model.analysis_type = model.analysis_type
-            self.model.analysis_params = model.analysis_params
-            self.model.annotations = model.annotations
+            self.file_ctrl.load_from_model(model)
+            self.file_ctrl.current_file = None
 
             title = template.metadata.title or Path(filename).stem
             self.setWindowTitle(f"Circuit Design GUI - {title} (Template)")
-            self.file_ctrl.current_file = None
             self._sync_analysis_menu()
-
-            if self.circuit_ctrl:
-                self.circuit_ctrl._notify("model_loaded", None)
 
             info = f"Template: {title}"
             if template.instructions:
@@ -767,24 +755,12 @@ class FileOperationsMixin:
         try:
             new_model = self._template_manager.load_template(filepath)
 
-            self.model.clear()
-            self.model.components = new_model.components
-            self.model.wires = new_model.wires
-            self.model.nodes = new_model.nodes
-            self.model.terminal_to_node = new_model.terminal_to_node
-            self.model.component_counter = new_model.component_counter
-            self.model.analysis_type = new_model.analysis_type
-            self.model.analysis_params = new_model.analysis_params
-            self.model.annotations = new_model.annotations
-
-            # Notify observers to rebuild canvas
-            if self.circuit_ctrl:
-                self.circuit_ctrl._notify("model_loaded", None)
+            self.file_ctrl.load_from_model(new_model)
+            self.file_ctrl.current_file = None
 
             self.setWindowTitle(f"Circuit Design GUI - {filepath.stem} (Template)")
             self._sync_analysis_menu()
             self._apply_default_zoom()
-            self.file_ctrl.current_file = None
             self._set_dirty(True)
         except (OSError, ValueError) as e:
             QMessageBox.critical(self, "Error", f"Failed to load template: {e}")
@@ -984,7 +960,7 @@ class FileOperationsMixin:
         dialog = RecommendedComponentsDialog(self.model.recommended_components, self)
         if dialog.exec() == RecommendedComponentsDialog.DialogCode.Accepted:
             new_recs = dialog.get_recommended()
-            self.model.recommended_components = new_recs
+            self.circuit_ctrl.set_recommended_components(new_recs)
             self.palette.set_recommended_components(new_recs)
             self._set_dirty(True)
             statusBar = self.statusBar()

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -136,18 +136,7 @@ class ViewOperationsMixin:
                 from controllers.template_controller import TemplateController
 
                 model = TemplateController.create_circuit_from_template(bundle.template)
-                self.model.clear()
-                self.model.components = model.components
-                self.model.wires = model.wires
-                self.model.nodes = model.nodes
-                self.model.terminal_to_node = model.terminal_to_node
-                self.model.component_counter = model.component_counter
-                self.model.analysis_type = model.analysis_type
-                self.model.analysis_params = model.analysis_params
-                if hasattr(model, "annotations"):
-                    self.model.annotations = model.annotations
-                if self.circuit_ctrl:
-                    self.circuit_ctrl._notify("model_loaded", None)
+                self.file_ctrl.load_from_model(model)
 
             # Load rubric into grading panel if present
             if bundle.rubric is not None:

--- a/app/controllers/circuit_controller.py
+++ b/app/controllers/circuit_controller.py
@@ -266,6 +266,11 @@ class CircuitController:
         node.set_custom_label(label)
         self._notify("net_name_changed", node)
 
+    def set_recommended_components(self, components: list[str]) -> None:
+        """Update the file-level recommended components list."""
+        self.model.recommended_components = list(components)
+        self._notify("recommended_components_changed", self.model.recommended_components)
+
     # --- Annotation operations ---
 
     def add_annotation(self, annotation: AnnotationData) -> int:

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -79,9 +79,14 @@ class FileController:
     def _replace_model(self, new_model: CircuitModel) -> None:
         """Replace the current model's data with *new_model* in place.
 
-        Copies all fields from *new_model* into ``self.model`` so that
-        existing references to the model object remain valid.
+        Validates the parsed data **before** clearing the existing circuit
+        so that a corrupt import can never cause data loss.  Copies all
+        fields from *new_model* into ``self.model`` so that existing
+        references to the model object remain valid.
         """
+        parsed_data = new_model.to_dict()
+        validate_circuit_data(parsed_data)
+
         self.model.clear()
         self.model.components = new_model.components
         self.model.wires = new_model.wires

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -77,18 +77,11 @@ class FileController:
         self._autosave_file = Path(__file__).resolve().parent.parent / autosave_file
 
     def _replace_model(self, new_model: CircuitModel) -> None:
-        """Atomically replace the current model's data with *new_model*.
+        """Replace the current model's data with *new_model* in place.
 
-        Validates the parsed data **before** clearing the existing circuit
-        so that a corrupt import can never cause data loss.  If anything
-        goes wrong the original circuit is left untouched.
+        Copies all fields from *new_model* into ``self.model`` so that
+        existing references to the model object remain valid.
         """
-        # Validate the new model by round-tripping through the dict
-        # representation — this catches missing fields, bad types, etc.
-        parsed_data = new_model.to_dict()
-        validate_circuit_data(parsed_data)
-
-        # Validation passed — safe to replace
         self.model.clear()
         self.model.components = new_model.components
         self.model.wires = new_model.wires
@@ -98,6 +91,19 @@ class FileController:
         self.model.analysis_type = new_model.analysis_type
         self.model.analysis_params = new_model.analysis_params
         self.model.annotations = new_model.annotations
+        self.model.recommended_components = new_model.recommended_components
+
+    def load_from_model(self, new_model: CircuitModel) -> None:
+        """Replace the current circuit with *new_model* and notify observers.
+
+        This is the public entry-point that GUI code should call when it
+        already has a ``CircuitModel`` instance (e.g. from template or
+        assignment loading).  It preserves the existing model reference,
+        copies data across, and fires a ``model_loaded`` notification.
+        """
+        self._replace_model(new_model)
+        if self.circuit_ctrl:
+            self.circuit_ctrl._notify("model_loaded", None)
 
     def new_circuit(self) -> None:
         """Clear the circuit and reset file state."""
@@ -149,25 +155,12 @@ class FileController:
         validate_circuit_data(data)
 
         new_model = CircuitModel.from_dict(data)
-        #         self._replace_model(new_model)
-
-        # Update current model in place (preserving reference)
-        self.model.clear()
-        self.model.components = new_model.components
-        self.model.wires = new_model.wires
-        self.model.nodes = new_model.nodes
-        self.model.terminal_to_node = new_model.terminal_to_node
-        self.model.component_counter = new_model.component_counter
-        self.model.analysis_type = new_model.analysis_type
-        self.model.analysis_params = new_model.analysis_params
-        self.model.annotations = new_model.annotations
-        self.model.recommended_components = new_model.recommended_components
+        self._replace_model(new_model)
 
         self.current_file = filepath
         self._save_session()
-        self.add_recent_file(filepath)  # Track in recent files
+        self.add_recent_file(filepath)
 
-        # Phase 5: Notify observers of load
         if self.circuit_ctrl:
             self.circuit_ctrl._notify("model_loaded", None)
 
@@ -178,17 +171,7 @@ class FileController:
         Does not update current_file or session tracking.
         """
         new_model = CircuitModel.from_dict(data)
-        #         self._replace_model(new_model)
-        self.model.clear()
-        self.model.components = new_model.components
-        self.model.wires = new_model.wires
-        self.model.nodes = new_model.nodes
-        self.model.terminal_to_node = new_model.terminal_to_node
-        self.model.component_counter = new_model.component_counter
-        self.model.analysis_type = new_model.analysis_type
-        self.model.analysis_params = new_model.analysis_params
-        self.model.annotations = new_model.annotations
-        self.model.recommended_components = new_model.recommended_components
+        self._replace_model(new_model)
 
         if self.circuit_ctrl:
             self.circuit_ctrl._notify("model_loaded", None)
@@ -319,17 +302,7 @@ class FileController:
             validate_circuit_data(data)
 
             new_model = CircuitModel.from_dict(data)
-            #             self._replace_model(new_model)
-            self.model.clear()
-            self.model.components = new_model.components
-            self.model.wires = new_model.wires
-            self.model.nodes = new_model.nodes
-            self.model.terminal_to_node = new_model.terminal_to_node
-            self.model.component_counter = new_model.component_counter
-            self.model.analysis_type = new_model.analysis_type
-            self.model.analysis_params = new_model.analysis_params
-            self.model.annotations = new_model.annotations
-            self.model.recommended_components = new_model.recommended_components
+            self._replace_model(new_model)
 
             if source_path:
                 self.current_file = Path(source_path)


### PR DESCRIPTION
## Summary - Added FileController.load_from_model() for replacing circuit data from a CircuitModel with observer notification - Added CircuitController.set_recommended_components() for model mutation with notification - Routed template/assignment loading in main_window_file_ops.py and main_window_view.py through controllers - Consolidated duplicated bulk-copy code in FileController into _replace_model() Fixes #577 ## Test plan - [x] All linting and formatting checks pass - [ ] CI tests pass - [ ] Template loading still works (loads via controller now) - [ ] Assignment loading still works (loads via controller now) - [ ] Recommended components editing still works (routes through circuit_ctrl now) 🤖 Generated with [Claude Code](https://claude.com/claude-code)