### PR TITLE
Decouple scene items from widget hierarchy (#593)

### DIFF
--- a/app/GUI/annotation_item.py
+++ b/app/GUI/annotation_item.py
@@ -15,6 +15,7 @@ class AnnotationItem(QGraphicsTextItem):
 
     def __init__(self, text="Annotation", x=0.0, y=0.0, font_size=10, bold=False, color=""):
         super().__init__(text)
+        self.canvas = None  # Injected by CircuitCanvasView after creation
         self.setPos(x, y)
         # Resolve empty color to theme-appropriate default
         if not color:
@@ -38,11 +39,9 @@ class AnnotationItem(QGraphicsTextItem):
 
     def mouseDoubleClickEvent(self, event):
         """Open a dialog to edit the annotation text (via canvas for undo support)."""
-        if self.scene() and self.scene().views():
-            canvas = self.scene().views()[0]
-            if hasattr(canvas, "_edit_annotation"):
-                canvas._edit_annotation(self)
-                return
+        if self.canvas and hasattr(self.canvas, "_edit_annotation"):
+            self.canvas._edit_annotation(self)
+            return
         # Fallback: direct edit without undo
         text, ok = QInputDialog.getText(None, "Edit Annotation", "Text:", text=self.toPlainText())
         if ok and text:

--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -46,6 +46,7 @@ class CircuitCanvasView(QGraphicsView):
     canvasClicked = pyqtSignal()
     zoomChanged = pyqtSignal(float)  # current zoom level (1.0 = 100%)
     probeRequested = pyqtSignal(str, str)  # (signal_name, probe_type: "node"|"component")
+    statusMessage = pyqtSignal(str, int)  # (message, timeout_ms) — relay for scene items
 
     def __init__(self, controller=None):
         super().__init__()
@@ -191,6 +192,7 @@ class CircuitCanvasView(QGraphicsView):
     def _handle_component_added(self, component_data) -> None:
         """Create graphics item when component added to model"""
         comp = ComponentGraphicsItem.from_dict(component_data.to_dict())
+        comp.canvas = self
         self.scene.addItem(comp)
         self.components[component_data.component_id] = comp
 
@@ -343,6 +345,20 @@ class CircuitCanvasView(QGraphicsView):
             model_wire = self.controller.model.wires[wire_index]
             model_wire.waypoints = [(wp.x(), wp.y()) for wp in wire.waypoints]
 
+    # ===================================================================
+    # Scene item callbacks (avoid hierarchy climbing in items)
+    # ===================================================================
+
+    def on_routing_failed(self, message: str) -> None:
+        """Relay a routing-failure message from a wire item to the UI."""
+        self.statusMessage.emit(message, 5000)
+
+    def on_wire_waypoints_changed(self, wire_item) -> None:
+        """Handle manual waypoint adjustment from a wire item."""
+        if self.controller and wire_item in self.wires:
+            idx = self.wires.index(wire_item)
+            self.controller.update_wire_waypoints(idx, wire_item.model.waypoints)
+
     def _handle_annotation_added(self, annotation_data) -> None:
         """Create AnnotationItem when annotation added to model."""
         ann = AnnotationItem(
@@ -353,6 +369,7 @@ class CircuitCanvasView(QGraphicsView):
             bold=annotation_data.bold,
             color=annotation_data.color,
         )
+        ann.canvas = self
         self.scene.addItem(ann)
         self.annotations.append(ann)
         self.scene.update()
@@ -1441,6 +1458,7 @@ class CircuitCanvasView(QGraphicsView):
             comp_item.setPos(old_x + dx, old_y + dy)
             comp_item.model.position = (old_x + dx, old_y + dy)
 
+            comp_item.canvas = self
             self.scene.addItem(comp_item)
             self.components[new_id] = comp_item
 
@@ -2332,6 +2350,7 @@ class CircuitCanvasView(QGraphicsView):
 
         for comp_data in data["components"]:
             comp = ComponentGraphicsItem.from_dict(comp_data)
+            comp.canvas = self
             self.scene.addItem(comp)
             self.components[comp.component_id] = comp
 
@@ -2351,6 +2370,7 @@ class CircuitCanvasView(QGraphicsView):
         # Load annotations
         for ann_data in data.get("annotations", []):
             ann = AnnotationItem.from_dict(ann_data)
+            ann.canvas = self
             self.scene.addItem(ann)
             self.annotations.append(ann)
 

--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -38,6 +38,8 @@ class ComponentGraphicsItem(QGraphicsItem):
                 position=(0.0, 0.0),
             )
 
+        self.canvas = None  # Injected by CircuitCanvasView after creation
+
         self.terminals = []  # List[QPointF] - Qt rendering positions
         self.connections = []  # Store wire connections
         self.is_being_dragged = False
@@ -148,18 +150,13 @@ class ComponentGraphicsItem(QGraphicsItem):
         if not hasattr(self, "_drag_start_positions") or not self._drag_start_positions:
             return
 
-        if not self.scene() or not self.scene().views():
-            self._drag_start_positions = {}
-            return
-
-        canvas = self.scene().views()[0]
-        if not hasattr(canvas, "controller") or not canvas.controller:
+        if not self.canvas or not hasattr(self.canvas, "controller") or not self.canvas.controller:
             self._drag_start_positions = {}
             return
 
         from controllers.commands import CompoundCommand, MoveComponentCommand
 
-        controller = canvas.controller
+        controller = self.canvas.controller
         move_commands = []
 
         for comp_id, old_pos in self._drag_start_positions.items():
@@ -260,14 +257,11 @@ class ComponentGraphicsItem(QGraphicsItem):
 
             self.value = new_value
             self.update()
-            _scene = self.scene()
-            if _scene is not None:
-                _scene.update()
+            if self.scene() is not None:
+                self.scene().update()
             # Sync to controller model so netlist generation sees the updated value
-            if _scene is not None and _scene.views():
-                canvas = _scene.views()[0]
-                if hasattr(canvas, "controller") and canvas.controller:
-                    canvas.controller.update_component_value(self.component_id, new_value)
+            if self.canvas and hasattr(self.canvas, "controller") and self.canvas.controller:
+                self.canvas.controller.update_component_value(self.component_id, new_value)
 
     # --- Geometry ---
 
@@ -396,10 +390,13 @@ class ComponentGraphicsItem(QGraphicsItem):
         painter.setBrush(QBrush(color.lighter(150)))
         self.draw_component_body(painter)
 
-        # Draw label (check canvas visibility settings)
-        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
-        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
-        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
+        # Draw label (check canvas visibility settings via injected reference)
+        show_label = (
+            self.canvas.show_component_labels if self.canvas and hasattr(self.canvas, "show_component_labels") else True
+        )
+        show_value = (
+            self.canvas.show_component_values if self.canvas and hasattr(self.canvas, "show_component_values") else True
+        )
 
         if show_label or show_value:
             painter.setPen(QPen(color))
@@ -450,14 +447,10 @@ class ComponentGraphicsItem(QGraphicsItem):
             self.update()
             # Skip wire preview for followers during group drag to avoid
             # tearing artifacts from rapid forced scene repaints (#442).
-            if self.scene() and not self._group_moving:
-                views = self.scene().views()
-                if views:
-                    canvas = views[0]
-                    if hasattr(canvas, "wires"):
-                        for wire in canvas.wires:
-                            if wire.start_comp is self or wire.end_comp is self:
-                                wire.show_drag_preview()
+            if not self._group_moving and self.canvas and hasattr(self.canvas, "wires"):
+                for wire in self.canvas.wires:
+                    if wire.start_comp is self or wire.end_comp is self:
+                        wire.show_drag_preview()
 
         return super().itemChange(change, value)
 
@@ -465,17 +458,12 @@ class ComponentGraphicsItem(QGraphicsItem):
         """Sync model position immediately, debounce wire rerouting (Phase 5)"""
         if self._position_update_timer:
             self._position_update_timer.stop()
-        # Get canvas controller
-        if not self.scene() or not self.scene().views():
-            return
-
-        canvas = self.scene().views()[0]
-        if not hasattr(canvas, "controller") or not canvas.controller:
+        if not self.canvas or not hasattr(self.canvas, "controller") or not self.canvas.controller:
             return
 
         # Sync model position immediately (lightweight attribute assignment)
         if self._pending_position:
-            comp = canvas.controller.model.components.get(self.component_id)
+            comp = self.canvas.controller.model.components.get(self.component_id)
             if comp:
                 comp.position = self._pending_position
 
@@ -492,15 +480,11 @@ class ComponentGraphicsItem(QGraphicsItem):
         if not self._pending_position:
             return
 
-        if not self.scene() or not self.scene().views():
-            return
-
-        canvas = self.scene().views()[0]
-        if not hasattr(canvas, "controller") or not canvas.controller:
+        if not self.canvas or not hasattr(self.canvas, "controller") or not self.canvas.controller:
             return
 
         # Notify controller - observer will update wires
-        canvas.controller.move_component(self.component_id, self._pending_position)
+        self.canvas.controller.move_component(self.component_id, self._pending_position)
         self._pending_position = None
 
     def get_terminal_pos(self, index):
@@ -636,9 +620,12 @@ class Ground(ComponentGraphicsItem):
         painter.setBrush(QBrush(color.lighter(150)))
         self.draw_component_body(painter)
 
-        canvas = self.scene().views()[0] if self.scene() and self.scene().views() else None
-        show_label = canvas.show_component_labels if canvas and hasattr(canvas, "show_component_labels") else True
-        show_value = canvas.show_component_values if canvas and hasattr(canvas, "show_component_values") else True
+        show_label = (
+            self.canvas.show_component_labels if self.canvas and hasattr(self.canvas, "show_component_labels") else True
+        )
+        show_value = (
+            self.canvas.show_component_values if self.canvas and hasattr(self.canvas, "show_component_values") else True
+        )
 
         if show_label or show_value:
             painter.setPen(QPen(color))

--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -120,6 +120,7 @@ class MainWindow(
         self.canvas.canvasClicked.connect(self.on_canvas_clicked)
         self.canvas.selectionChanged.connect(self._on_selection_changed)
         self.canvas.probeRequested.connect(self._on_probe_requested)
+        self.canvas.statusMessage.connect(self._on_canvas_status_message)
         self.palette.componentDoubleClicked.connect(self.canvas.add_component_at_center)
         self.properties_panel.property_changed.connect(self.on_property_changed)
         self.circuit_ctrl.add_observer(self._on_dirty_change)
@@ -330,6 +331,12 @@ class MainWindow(
         """Handle click on an empty canvas area"""
         self.properties_stack.setCurrentIndex(0)
         self.properties_panel.show_no_selection()
+
+    def _on_canvas_status_message(self, message, timeout_ms):
+        """Relay status messages from canvas/scene items to the status bar."""
+        status = self.statusBar()
+        if status:
+            status.showMessage(message, timeout_ms)
 
     def on_property_changed(self, component_id, property_name, new_value):
         """Handle property changes from properties panel via controller."""

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -281,14 +281,9 @@ class WireGraphicsItem(QGraphicsPathItem):
         self.setPath(path)
 
     def _notify_routing_failed(self):
-        """Show status bar message when wire routing fails."""
-        if not self.canvas:
-            return
-        main_window = self.canvas.window() if hasattr(self.canvas, "window") else None
-        if main_window and hasattr(main_window, "statusBar"):
-            status = main_window.statusBar()
-            if status:
-                status.showMessage("Wire routing failed — move components to create space", 5000)
+        """Notify canvas that wire routing failed (canvas relays to UI)."""
+        if self.canvas and hasattr(self.canvas, "on_routing_failed"):
+            self.canvas.on_routing_failed("Wire routing failed — move components to create space")
 
     def hoverEnterEvent(self, event):
         """Highlight wire on hover."""
@@ -405,9 +400,9 @@ class WireGraphicsItem(QGraphicsPathItem):
             for wp in self.waypoints
         ]
         self.model.locked = True
-        # Notify controller if available
-        if self.canvas and hasattr(self.canvas, "controller") and self.canvas.controller:
-            self.canvas.controller._notify("wire_routed", self.model)
+        # Notify via canvas (avoids calling controller private methods)
+        if self.canvas and hasattr(self.canvas, "on_wire_waypoints_changed"):
+            self.canvas.on_wire_waypoints_changed(self)
 
     def _rebuild_path_from_waypoints(self):
         """Rebuild the QPainterPath from the current waypoints list."""

--- a/app/tests/unit/test_qtimer_reuse.py
+++ b/app/tests/unit/test_qtimer_reuse.py
@@ -24,13 +24,11 @@ class TestScheduleControllerUpdateTimerReuse:
     """_schedule_controller_update() should reuse the same QTimer."""
 
     def _make_comp_with_scene(self):
-        """Create a mock component with mocked scene and controller."""
+        """Create a mock component with mocked canvas and controller."""
         comp = _make_mock_comp()
         mock_canvas = MagicMock()
         mock_canvas.controller = MagicMock()
-        mock_scene = MagicMock()
-        mock_scene.views.return_value = [mock_canvas]
-        comp.scene.return_value = mock_scene
+        comp.canvas = mock_canvas
         return comp
 
     @patch("GUI.component_item.QTimer")
@@ -60,10 +58,10 @@ class TestScheduleControllerUpdateTimerReuse:
         assert mock_timer.start.call_count == 2
 
     @patch("GUI.component_item.QTimer")
-    def test_position_timer_no_scene_skips(self, MockQTimer):
-        """If no scene, should not create timer."""
+    def test_position_timer_no_canvas_skips(self, MockQTimer):
+        """If no canvas, should not create timer."""
         comp = _make_mock_comp()
-        comp.scene.return_value = None
+        comp.canvas = None
 
         comp._schedule_controller_update()
 

--- a/app/tests/unit/test_scene_item_decoupling.py
+++ b/app/tests/unit/test_scene_item_decoupling.py
@@ -1,0 +1,208 @@
+"""
+Tests for issue #593: Scene items use injected canvas reference instead of
+climbing the widget hierarchy via scene().views()[0].
+
+Verifies that:
+- ComponentGraphicsItem, AnnotationItem use self.canvas (not scene climbing)
+- WireGraphicsItem delegates routing-failed and waypoint changes to canvas
+- Canvas injects canvas references when creating items
+"""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from models.component import ComponentData
+
+
+class TestComponentItemCanvasInjection:
+    """Test that ComponentGraphicsItem uses injected canvas reference."""
+
+    def test_component_has_canvas_attribute(self):
+        from GUI.component_item import ComponentGraphicsItem
+
+        comp = ComponentGraphicsItem("R1", "Resistor")
+        assert hasattr(comp, "canvas")
+        assert comp.canvas is None
+
+    def test_canvas_set_externally(self):
+        from GUI.component_item import ComponentGraphicsItem
+
+        comp = ComponentGraphicsItem("R1", "Resistor")
+        mock_canvas = MagicMock()
+        comp.canvas = mock_canvas
+        assert comp.canvas is mock_canvas
+
+    def test_paint_reads_labels_from_canvas(self, qtbot):
+        from GUI.component_item import ComponentGraphicsItem
+
+        comp = ComponentGraphicsItem("R1", "Resistor")
+        mock_canvas = MagicMock()
+        mock_canvas.show_component_labels = False
+        mock_canvas.show_component_values = False
+        comp.canvas = mock_canvas
+
+        # Paint should not raise and should use canvas attributes
+        mock_painter = MagicMock()
+        mock_painter.pen.return_value = MagicMock()
+        comp.paint(mock_painter)
+        # If we got here without an error, the canvas reference worked
+
+    def test_schedule_controller_update_uses_canvas(self):
+        from GUI.component_item import ComponentGraphicsItem
+
+        comp = ComponentGraphicsItem("R1", "Resistor")
+        mock_canvas = MagicMock()
+        mock_controller = MagicMock()
+        mock_controller.model.components = {"R1": MagicMock()}
+        mock_canvas.controller = mock_controller
+        comp.canvas = mock_canvas
+
+        comp._pending_position = (100, 200)
+        comp._schedule_controller_update()
+
+        # Should have synced position via canvas.controller
+        mock_controller.model.components["R1"].__setattr__("position", (100, 200))
+
+    def test_no_hierarchy_climbing_in_source(self):
+        """Verify no scene().views()[0] patterns remain in component_item.py."""
+        import inspect
+
+        from GUI import component_item
+
+        source = inspect.getsource(component_item)
+        assert "scene().views()[0]" not in source
+
+
+class TestAnnotationItemCanvasInjection:
+    """Test that AnnotationItem uses injected canvas reference."""
+
+    def test_annotation_has_canvas_attribute(self):
+        from GUI.annotation_item import AnnotationItem
+
+        ann = AnnotationItem("Test")
+        assert hasattr(ann, "canvas")
+        assert ann.canvas is None
+
+    def test_double_click_delegates_to_canvas(self, qtbot):
+        from GUI.annotation_item import AnnotationItem
+
+        ann = AnnotationItem("Test")
+        mock_canvas = MagicMock()
+        mock_canvas._edit_annotation = MagicMock()
+        ann.canvas = mock_canvas
+
+        # Simulate double-click event
+        mock_event = MagicMock()
+        ann.mouseDoubleClickEvent(mock_event)
+
+        mock_canvas._edit_annotation.assert_called_once_with(ann)
+
+    def test_no_hierarchy_climbing_in_source(self):
+        """Verify no scene().views()[0] patterns remain in annotation_item.py."""
+        import inspect
+
+        from GUI import annotation_item
+
+        source = inspect.getsource(annotation_item)
+        assert "scene().views()[0]" not in source
+
+
+class TestWireItemDecoupling:
+    """Test that WireGraphicsItem doesn't climb to MainWindow."""
+
+    def test_routing_failed_calls_canvas(self, qtbot):
+        from GUI.wire_item import WireGraphicsItem
+        from models.wire import WireData
+
+        mock_canvas = MagicMock()
+        mock_start = MagicMock()
+        mock_start.component_id = "R1"
+        mock_end = MagicMock()
+        mock_end.component_id = "R2"
+
+        # Pre-create model with waypoints so __init__ skips pathfinding
+        model = WireData("R1", 0, "R2", 1)
+        model.waypoints = [(0.0, 0.0), (100.0, 100.0)]
+        wire = WireGraphicsItem(mock_start, 0, mock_end, 1, canvas=None, model=model)
+        wire.canvas = mock_canvas
+        wire._notify_routing_failed()
+
+        mock_canvas.on_routing_failed.assert_called_once()
+
+    def test_waypoint_drag_calls_canvas(self, qtbot):
+        from GUI.wire_item import WireGraphicsItem
+        from models.wire import WireData
+
+        mock_canvas = MagicMock()
+        mock_start = MagicMock()
+        mock_start.component_id = "R1"
+        mock_end = MagicMock()
+        mock_end.component_id = "R2"
+
+        # Pre-create model with waypoints so __init__ skips pathfinding
+        model = WireData("R1", 0, "R2", 1)
+        model.waypoints = [(0.0, 0.0), (50.0, 50.0), (100.0, 100.0)]
+        wire = WireGraphicsItem(mock_start, 0, mock_end, 1, canvas=None, model=model)
+        wire.canvas = mock_canvas
+        wire.waypoints = [(0, 0), (50, 50), (100, 100)]
+        wire._finish_waypoint_drag()
+
+        mock_canvas.on_wire_waypoints_changed.assert_called_once_with(wire)
+
+    def test_no_window_statusbar_access_in_source(self):
+        """Verify no window().statusBar() patterns remain in wire_item.py."""
+        import inspect
+
+        from GUI import wire_item
+
+        source = inspect.getsource(wire_item)
+        assert "window()" not in source
+        assert "statusBar()" not in source
+
+    def test_no_private_notify_in_source(self):
+        """Verify no controller._notify() calls remain in wire_item.py."""
+        import inspect
+
+        from GUI import wire_item
+
+        source = inspect.getsource(wire_item)
+        assert "controller._notify" not in source
+
+
+class TestCanvasInjectsReferences:
+    """Test that CircuitCanvasView injects canvas references when creating items."""
+
+    def test_handle_component_added_injects_canvas(self, qtbot):
+        from controllers.circuit_controller import CircuitController
+        from GUI.circuit_canvas import CircuitCanvasView
+        from models.circuit import CircuitModel
+
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        canvas = CircuitCanvasView(ctrl)
+        qtbot.addWidget(canvas)
+
+        comp_data = ctrl.add_component("Resistor", (100, 100))
+
+        # The observer should have created a graphics item with canvas reference
+        comp_item = canvas.components.get(comp_data.component_id)
+        assert comp_item is not None
+        assert comp_item.canvas is canvas
+
+    def test_canvas_status_message_signal_exists(self, qtbot):
+        from GUI.circuit_canvas import CircuitCanvasView
+
+        canvas = CircuitCanvasView()
+        qtbot.addWidget(canvas)
+        assert hasattr(canvas, "statusMessage")
+
+    def test_on_routing_failed_emits_signal(self, qtbot):
+        from GUI.circuit_canvas import CircuitCanvasView
+
+        canvas = CircuitCanvasView()
+        qtbot.addWidget(canvas)
+
+        with qtbot.waitSignal(canvas.statusMessage, timeout=1000) as blocker:
+            canvas.on_routing_failed("Test failure message")
+
+        assert blocker.args == ["Test failure message", 5000]

--- a/app/tests/unit/test_waypoint_editing.py
+++ b/app/tests/unit/test_waypoint_editing.py
@@ -148,10 +148,10 @@ class TestWaypointDragging:
         wire_with_waypoints._finish_waypoint_drag()
         assert wire_with_waypoints.model.locked
 
-    def test_finish_drag_notifies_controller(self, wire_with_waypoints, qtbot):
+    def test_finish_drag_notifies_canvas(self, wire_with_waypoints, qtbot):
         wire_with_waypoints._move_waypoint(1, QPointF(60, 10))
         wire_with_waypoints._finish_waypoint_drag()
-        wire_with_waypoints.canvas.controller._notify.assert_called_once_with("wire_routed", wire_with_waypoints.model)
+        wire_with_waypoints.canvas.on_wire_waypoints_changed.assert_called_once_with(wire_with_waypoints)
 
     def test_path_rebuilt_after_move(self, wire_with_waypoints, qtbot):
         old_path = wire_with_waypoints.path()


### PR DESCRIPTION
## Summary - Replace all  hierarchy climbing in , , and  with an explicit  reference injected at creation time - Add  signal on  so wire routing failures are relayed to the status bar without reaching into  internals - Route waypoint edits through  instead of calling  directly from wire items - Update existing tests (, ) to match new patterns; add 15 new tests in  Closes #593 ## Test plan - [x] All 3087 existing tests pass (no regressions) - [x] 15 new tests verify canvas injection, source code grep for removed anti-pattern, signal emission, and delegation calls - [x] Pre-commit hooks pass (ruff, isort, black) 🤖 Generated with [Claude Code](https://claude.com/claude-code)