### PR TITLE
Centralize QSettings in SettingsService (#598)

### DIFF
--- a/app/GUI/circuitikz_options_dialog.py
+++ b/app/GUI/circuitikz_options_dialog.py
@@ -1,6 +1,6 @@
 """Dialog for configuring CircuiTikZ export options."""
 
-from PyQt6.QtCore import QSettings
+from controllers.settings_service import settings
 from PyQt6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -113,37 +113,34 @@ class CircuiTikZOptionsDialog(QDialog):
         }
 
     def _save_settings(self):
-        settings = QSettings("SDSMT", "SDM Spice")
         opts = self.get_options()
-        settings.setValue(f"{SETTINGS_PREFIX}style", opts["style"])
-        settings.setValue(f"{SETTINGS_PREFIX}scale", opts["scale"])
-        settings.setValue(f"{SETTINGS_PREFIX}include_ids", opts["include_ids"])
-        settings.setValue(f"{SETTINGS_PREFIX}include_values", opts["include_values"])
-        settings.setValue(f"{SETTINGS_PREFIX}include_net_labels", opts["include_net_labels"])
-        settings.setValue(f"{SETTINGS_PREFIX}standalone", opts["standalone"])
+        settings.set(f"{SETTINGS_PREFIX}style", opts["style"])
+        settings.set(f"{SETTINGS_PREFIX}scale", opts["scale"])
+        settings.set(f"{SETTINGS_PREFIX}include_ids", opts["include_ids"])
+        settings.set(f"{SETTINGS_PREFIX}include_values", opts["include_values"])
+        settings.set(f"{SETTINGS_PREFIX}include_net_labels", opts["include_net_labels"])
+        settings.set(f"{SETTINGS_PREFIX}standalone", opts["standalone"])
 
     def _restore_settings(self):
-        settings = QSettings("SDSMT", "SDM Spice")
-
-        style = settings.value(f"{SETTINGS_PREFIX}style", "american")
+        style = settings.get_str(f"{SETTINGS_PREFIX}style", "american")
         self.style_combo.setCurrentIndex(1 if style == "european" else 0)
 
-        scale = settings.value(f"{SETTINGS_PREFIX}scale")
+        scale = settings.get(f"{SETTINGS_PREFIX}scale")
         if scale is not None:
             self.scale_spin.setValue(float(scale))
 
-        include_ids = settings.value(f"{SETTINGS_PREFIX}include_ids")
+        include_ids = settings.get(f"{SETTINGS_PREFIX}include_ids")
         if include_ids is not None:
-            self.include_ids_cb.setChecked(include_ids == "true" or include_ids is True)
+            self.include_ids_cb.setChecked(settings.get_bool(f"{SETTINGS_PREFIX}include_ids"))
 
-        include_values = settings.value(f"{SETTINGS_PREFIX}include_values")
+        include_values = settings.get(f"{SETTINGS_PREFIX}include_values")
         if include_values is not None:
-            self.include_values_cb.setChecked(include_values == "true" or include_values is True)
+            self.include_values_cb.setChecked(settings.get_bool(f"{SETTINGS_PREFIX}include_values"))
 
-        include_net_labels = settings.value(f"{SETTINGS_PREFIX}include_net_labels")
+        include_net_labels = settings.get(f"{SETTINGS_PREFIX}include_net_labels")
         if include_net_labels is not None:
-            self.include_net_labels_cb.setChecked(include_net_labels == "true" or include_net_labels is True)
+            self.include_net_labels_cb.setChecked(settings.get_bool(f"{SETTINGS_PREFIX}include_net_labels"))
 
-        standalone = settings.value(f"{SETTINGS_PREFIX}standalone")
+        standalone = settings.get(f"{SETTINGS_PREFIX}standalone")
         if standalone is not None:
-            self.standalone_cb.setChecked(standalone == "true" or standalone is True)
+            self.standalone_cb.setChecked(settings.get_bool(f"{SETTINGS_PREFIX}standalone"))

--- a/app/GUI/component_palette.py
+++ b/app/GUI/component_palette.py
@@ -1,5 +1,6 @@
+from controllers.settings_service import settings as app_settings
 from models.component import COMPONENT_CATEGORIES
-from PyQt6.QtCore import QMimeData, QSettings, QSize, Qt, pyqtSignal
+from PyQt6.QtCore import QMimeData, QSize, Qt, pyqtSignal
 from PyQt6.QtGui import QBrush, QDrag, QFont, QIcon, QPainter, QPen, QPixmap
 from PyQt6.QtWidgets import QLineEdit, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 
@@ -273,19 +274,18 @@ class ComponentPalette(QWidget):
                 self._used_in_file_item.setExpanded(True)
 
     def _load_expanded_state(self) -> dict[str, bool]:
-        """Load category expanded/collapsed state from QSettings."""
-        settings = QSettings("SDSMT", "SDM Spice")
+        """Load category expanded/collapsed state from settings."""
         state = {}
         for category_name in COMPONENT_CATEGORIES:
-            val = settings.value(f"palette/expanded/{category_name}")
+            val = app_settings.get(f"palette/expanded/{category_name}")
             if val is not None:
-                state[category_name] = val == "true" or val is True
+                state[category_name] = app_settings.get_bool(f"palette/expanded/{category_name}")
             else:
                 state[category_name] = True  # default expanded
         return state
 
     def _save_expanded_state(self, _item=None):
-        """Save category expanded/collapsed state to QSettings."""
+        """Save category expanded/collapsed state to settings."""
         # Don't save while searching (search auto-expands categories)
         if self.search_input.text():
             return
@@ -293,9 +293,8 @@ class ComponentPalette(QWidget):
         # prefs when recommendations auto-collapse categories
         if self._recommended_item is not None:
             return
-        settings = QSettings("SDSMT", "SDM Spice")
         for category_name, category_item in self._category_items.items():
-            settings.setValue(f"palette/expanded/{category_name}", category_item.isExpanded())
+            app_settings.set(f"palette/expanded/{category_name}", category_item.isExpanded())
 
     def update_used_in_file(self, component_types: list[str]) -> None:
         """Show a 'Used in File' section at the top of the palette.

--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -4,7 +4,7 @@ import json
 import logging
 from pathlib import Path
 
-from PyQt6.QtCore import QSettings
+from controllers.settings_service import settings as app_settings
 from PyQt6.QtGui import QAction
 from PyQt6.QtWidgets import QFileDialog, QMessageBox
 
@@ -16,8 +16,7 @@ class FileOperationsMixin:
 
     def _apply_default_zoom(self):
         """Apply the user's preferred default zoom level to the canvas."""
-        settings = QSettings("SDSMT", "SDM Spice")
-        zoom_percent = int(settings.value("view/default_zoom", 100))
+        zoom_percent = app_settings.get_int("view/default_zoom", 100)
         self.canvas.set_default_zoom(zoom_percent)
 
     def _on_new(self):

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -1,58 +1,55 @@
 """Settings persistence, autosave, crash recovery, and window lifecycle for MainWindow."""
 
-from PyQt6.QtCore import QSettings
+from controllers.settings_service import settings
 from PyQt6.QtWidgets import QMessageBox
 
 from .styles import theme_manager
 
 
 class SettingsMixin:
-    """Mixin providing QSettings persistence, autosave, and closeEvent."""
+    """Mixin providing settings persistence, autosave, and closeEvent."""
 
     def _save_settings(self):
-        """Save user preferences via QSettings"""
-        settings = QSettings("SDSMT", "SDM Spice")
-        settings.setValue("window/geometry", self.saveGeometry())
-        settings.setValue("window/state", self.saveState())
-        settings.setValue("splitter/sizes", self.center_splitter.sizes())
-        settings.setValue("analysis/type", self.model.analysis_type)
-        settings.setValue("view/show_labels", self.canvas.show_component_labels)
-        settings.setValue("view/show_values", self.canvas.show_component_values)
-        settings.setValue("view/show_nodes", self.canvas.show_node_labels)
+        """Save user preferences via the centralized settings service."""
+        settings.set("window/geometry", self.saveGeometry())
+        settings.set("window/state", self.saveState())
+        settings.set("splitter/sizes", self.center_splitter.sizes())
+        settings.set("analysis/type", self.model.analysis_type)
+        settings.set("view/show_labels", self.canvas.show_component_labels)
+        settings.set("view/show_values", self.canvas.show_component_values)
+        settings.set("view/show_nodes", self.canvas.show_node_labels)
         # Preserve auto-save defaults if not yet set
-        if settings.value("autosave/interval") is None:
-            settings.setValue("autosave/interval", 60)
-        if settings.value("autosave/enabled") is None:
-            settings.setValue("autosave/enabled", True)
-        settings.setValue("view/show_statistics", self.statistics_panel.isVisible())
+        if settings.get("autosave/interval") is None:
+            settings.set("autosave/interval", 60)
+        if settings.get("autosave/enabled") is None:
+            settings.set("autosave/enabled", True)
+        settings.set("view/show_statistics", self.statistics_panel.isVisible())
         # Preserve default zoom if not yet set
-        if settings.value("view/default_zoom") is None:
-            settings.setValue("view/default_zoom", 100)
-        settings.setValue("view/theme_key", theme_manager.get_theme_key())
-        settings.setValue("view/theme", theme_manager.current_theme.name)
-        settings.setValue("view/symbol_style", theme_manager.symbol_style)
-        settings.setValue("view/color_mode", theme_manager.color_mode)
-        settings.setValue("view/wire_thickness", theme_manager.wire_thickness)
-        settings.setValue("view/show_junction_dots", theme_manager.show_junction_dots)
-        settings.setValue("view/routing_mode", theme_manager.routing_mode)
+        if settings.get("view/default_zoom") is None:
+            settings.set("view/default_zoom", 100)
+        settings.set("view/theme_key", theme_manager.get_theme_key())
+        settings.set("view/theme", theme_manager.current_theme.name)
+        settings.set("view/symbol_style", theme_manager.symbol_style)
+        settings.set("view/color_mode", theme_manager.color_mode)
+        settings.set("view/wire_thickness", theme_manager.wire_thickness)
+        settings.set("view/show_junction_dots", theme_manager.show_junction_dots)
+        settings.set("view/routing_mode", theme_manager.routing_mode)
 
     def _restore_settings(self):
-        """Restore user preferences from QSettings"""
-        settings = QSettings("SDSMT", "SDM Spice")
-
-        geometry = settings.value("window/geometry")
+        """Restore user preferences from the centralized settings service."""
+        geometry = settings.get("window/geometry")
         if geometry:
             self.restoreGeometry(geometry)
 
-        state = settings.value("window/state")
+        state = settings.get("window/state")
         if state:
             self.restoreState(state)
 
-        splitter_sizes = settings.value("splitter/sizes")
+        splitter_sizes = settings.get("splitter/sizes")
         if splitter_sizes:
             self.center_splitter.setSizes([int(s) for s in splitter_sizes])
 
-        analysis_type = settings.value("analysis/type")
+        analysis_type = settings.get("analysis/type")
         if analysis_type:
             # Don't restore "Parameter Sweep" — it requires component selection
             if analysis_type == "Parameter Sweep":
@@ -60,35 +57,35 @@ class SettingsMixin:
             self.simulation_ctrl.set_analysis(analysis_type, self.model.analysis_params)
             self._sync_analysis_menu()
 
-        show_labels = settings.value("view/show_labels")
+        show_labels = settings.get("view/show_labels")
         if show_labels is not None:
-            checked = show_labels == "true" or show_labels is True
+            checked = settings.get_bool("view/show_labels")
             self.canvas.show_component_labels = checked
             self.show_labels_action.setChecked(checked)
 
-        show_values = settings.value("view/show_values")
+        show_values = settings.get("view/show_values")
         if show_values is not None:
-            checked = show_values == "true" or show_values is True
+            checked = settings.get_bool("view/show_values")
             self.canvas.show_component_values = checked
             self.show_values_action.setChecked(checked)
 
-        show_nodes = settings.value("view/show_nodes")
+        show_nodes = settings.get("view/show_nodes")
         if show_nodes is not None:
-            checked = show_nodes == "true" or show_nodes is True
+            checked = settings.get_bool("view/show_nodes")
             self.canvas.show_node_labels = checked
             self.show_nodes_action.setChecked(checked)
 
-        show_stats = settings.value("view/show_statistics")
+        show_stats = settings.get("view/show_statistics")
         if show_stats is not None:
-            checked = show_stats == "true" or show_stats is True
+            checked = settings.get_bool("view/show_statistics")
             self.statistics_panel.setVisible(checked)
             self.show_statistics_action.setChecked(checked)
 
-        default_zoom = settings.value("view/default_zoom")
+        default_zoom = settings.get("view/default_zoom")
         if default_zoom is not None:
             self.canvas.set_default_zoom(int(default_zoom))
 
-        saved_theme_key = settings.value("view/theme_key")
+        saved_theme_key = settings.get("view/theme_key")
         if saved_theme_key and saved_theme_key != "light":
             theme_manager.set_theme_by_key(saved_theme_key)
             self._apply_theme()
@@ -96,28 +93,27 @@ class SettingsMixin:
                 self._refresh_theme_menu()
         else:
             # Legacy fallback: check old theme name
-            saved_theme = settings.value("view/theme")
+            saved_theme = settings.get("view/theme")
             if saved_theme == "Dark Theme":
                 self._set_theme("dark")
 
-        saved_symbol_style = settings.value("view/symbol_style")
+        saved_symbol_style = settings.get("view/symbol_style")
         if saved_symbol_style in ("ieee", "iec"):
             self._set_symbol_style(saved_symbol_style)
 
-        saved_color_mode = settings.value("view/color_mode")
+        saved_color_mode = settings.get("view/color_mode")
         if saved_color_mode in ("color", "monochrome"):
             self._set_color_mode(saved_color_mode)
 
-        saved_wire_thickness = settings.value("view/wire_thickness")
+        saved_wire_thickness = settings.get("view/wire_thickness")
         if saved_wire_thickness in ("thin", "normal", "thick"):
             self._set_wire_thickness(saved_wire_thickness)
 
-        saved_junction_dots = settings.value("view/show_junction_dots")
+        saved_junction_dots = settings.get("view/show_junction_dots")
         if saved_junction_dots is not None:
-            show = saved_junction_dots == "true" or saved_junction_dots is True
-            self._set_show_junction_dots(show)
+            self._set_show_junction_dots(settings.get_bool("view/show_junction_dots"))
 
-        saved_routing_mode = settings.value("view/routing_mode")
+        saved_routing_mode = settings.get("view/routing_mode")
         if saved_routing_mode in ("orthogonal", "diagonal"):
             self._set_routing_mode(saved_routing_mode)
 
@@ -129,10 +125,9 @@ class SettingsMixin:
 
     def _start_autosave_timer(self):
         """Start or restart the auto-save timer using the configured interval."""
-        settings = QSettings("SDSMT", "SDM Spice")
-        interval = int(settings.value("autosave/interval", 60))
-        enabled = settings.value("autosave/enabled", True)
-        if enabled == "false" or enabled is False:
+        interval = settings.get_int("autosave/interval", 60)
+        enabled = settings.get_bool("autosave/enabled", True)
+        if not enabled:
             self._autosave_timer.stop()
             return
         self._autosave_timer.start(interval * 1000)

--- a/app/GUI/preferences_dialog.py
+++ b/app/GUI/preferences_dialog.py
@@ -1,6 +1,6 @@
 """Unified Preferences dialog for application settings."""
 
-from PyQt6.QtCore import QSettings
+from controllers.settings_service import settings
 from PyQt6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -63,10 +63,9 @@ class PreferencesDialog(QDialog):
         self._snap_color_mode = theme_manager.color_mode
         self._snap_wire_thickness = theme_manager.wire_thickness
         self._snap_show_junction_dots = theme_manager.show_junction_dots
-        settings = QSettings("SDSMT", "SDM Spice")
-        self._snap_autosave_enabled = settings.value("autosave/enabled", True)
-        self._snap_autosave_interval = int(settings.value("autosave/interval", 60))
-        self._snap_default_zoom = int(settings.value("view/default_zoom", 100))
+        self._snap_autosave_enabled = settings.get("autosave/enabled", True)
+        self._snap_autosave_interval = settings.get_int("autosave/interval", 60)
+        self._snap_default_zoom = settings.get_int("view/default_zoom", 100)
 
     def _revert_settings(self):
         """Restore appearance and autosave to snapshot values."""
@@ -76,10 +75,9 @@ class PreferencesDialog(QDialog):
         self.main_window._set_color_mode(self._snap_color_mode)
         self.main_window._set_wire_thickness(self._snap_wire_thickness)
         self.main_window._set_show_junction_dots(self._snap_show_junction_dots)
-        settings = QSettings("SDSMT", "SDM Spice")
-        settings.setValue("autosave/enabled", self._snap_autosave_enabled)
-        settings.setValue("autosave/interval", self._snap_autosave_interval)
-        settings.setValue("view/default_zoom", self._snap_default_zoom)
+        settings.set("autosave/enabled", self._snap_autosave_enabled)
+        settings.set("autosave/interval", self._snap_autosave_interval)
+        settings.set("view/default_zoom", self._snap_default_zoom)
         self.main_window._start_autosave_timer()
 
     # ---- UI construction --------------------------------------------------
@@ -383,19 +381,18 @@ class PreferencesDialog(QDialog):
 
     def _on_ok(self):
         """Persist all settings and close."""
-        settings = QSettings("SDSMT", "SDM Spice")
-        settings.setValue("autosave/enabled", self.autosave_checkbox.isChecked())
-        settings.setValue("autosave/interval", self.autosave_spin.value())
+        settings.set("autosave/enabled", self.autosave_checkbox.isChecked())
+        settings.set("autosave/interval", self.autosave_spin.value())
         zoom_index = self.default_zoom_combo.currentIndex()
-        settings.setValue("view/default_zoom", _ZOOM_ITEMS[zoom_index][1])
+        settings.set("view/default_zoom", _ZOOM_ITEMS[zoom_index][1])
         self.main_window._start_autosave_timer()
         # Persist theme key
-        settings.setValue("view/theme_key", theme_manager.get_theme_key())
-        settings.setValue("view/theme", theme_manager.current_theme.name)
-        settings.setValue("view/symbol_style", theme_manager.symbol_style)
-        settings.setValue("view/color_mode", theme_manager.color_mode)
-        settings.setValue("view/wire_thickness", theme_manager.wire_thickness)
-        settings.setValue("view/show_junction_dots", theme_manager.show_junction_dots)
+        settings.set("view/theme_key", theme_manager.get_theme_key())
+        settings.set("view/theme", theme_manager.current_theme.name)
+        settings.set("view/symbol_style", theme_manager.symbol_style)
+        settings.set("view/color_mode", theme_manager.color_mode)
+        settings.set("view/wire_thickness", theme_manager.wire_thickness)
+        settings.set("view/show_junction_dots", theme_manager.show_junction_dots)
         self._accepted = True
         self.close()
 

--- a/app/GUI/recent_exports.py
+++ b/app/GUI/recent_exports.py
@@ -1,14 +1,14 @@
 """Track recent export operations for quick re-export.
 
-Stores up to MAX_RECENT_EXPORTS entries in QSettings.  Each entry is a dict
-with keys: path, format, export_function, timestamp.
+Stores up to MAX_RECENT_EXPORTS entries via the centralized settings
+service.  Each entry is a dict with keys: path, format, export_function,
+timestamp.
 """
 
-import json
 import os
 from datetime import datetime
 
-from PyQt6.QtCore import QSettings
+from controllers.settings_service import settings
 
 MAX_RECENT_EXPORTS = 5
 SETTINGS_KEY = "export/recent_exports"
@@ -20,13 +20,7 @@ def get_recent_exports():
     Each dict has keys: path, format, export_function, timestamp.
     Non-existent paths are filtered out.
     """
-    settings = QSettings("SDSMT", "SDM Spice")
-    raw = settings.value(SETTINGS_KEY, "[]")
-
-    try:
-        entries = json.loads(raw) if isinstance(raw, str) else []
-    except (json.JSONDecodeError, TypeError):
-        entries = []
+    entries = settings.get_json(SETTINGS_KEY, [])
 
     if not isinstance(entries, list):
         entries = []
@@ -34,7 +28,7 @@ def get_recent_exports():
     # Filter out files that no longer exist
     existing = [e for e in entries if isinstance(e, dict) and os.path.exists(e.get("path", ""))]
     if len(existing) != len(entries):
-        settings.setValue(SETTINGS_KEY, json.dumps(existing))
+        settings.set_json(SETTINGS_KEY, existing)
 
     return existing
 
@@ -65,11 +59,9 @@ def add_recent_export(path, fmt, export_function):
     # Cap
     entries = entries[:MAX_RECENT_EXPORTS]
 
-    settings = QSettings("SDSMT", "SDM Spice")
-    settings.setValue(SETTINGS_KEY, json.dumps(entries))
+    settings.set_json(SETTINGS_KEY, entries)
 
 
 def clear_recent_exports():
     """Clear all recent export entries."""
-    settings = QSettings("SDSMT", "SDM Spice")
-    settings.setValue(SETTINGS_KEY, "[]")
+    settings.set_json(SETTINGS_KEY, [])

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -2,7 +2,7 @@
 FileController - Handles circuit file I/O and session persistence.
 
 File dialog interaction is the responsibility of the view layer.
-Recent files tracking uses QSettings for cross-session persistence.
+Recent files tracking uses the centralized settings service for cross-session persistence.
 """
 
 import json
@@ -10,8 +10,8 @@ import os
 from pathlib import Path
 from typing import List, Optional
 
+from controllers.settings_service import settings
 from models.circuit import CircuitModel
-from PyQt6.QtCore import QSettings
 
 SESSION_FILE = "last_session.txt"
 AUTOSAVE_FILE = ".autosave_recovery.json"
@@ -219,24 +219,19 @@ class FileController:
 
     def get_recent_files(self) -> List[str]:
         """
-        Get list of recently opened files from QSettings.
+        Get list of recently opened files.
 
         Returns:
             List of file paths (most recent first), with non-existent files removed.
         """
-        settings = QSettings("SDSMT", "SDM Spice")
-        recent = settings.value("file/recent_files", [])
-
-        # Ensure it's a list
-        if not isinstance(recent, list):
-            recent = []
+        recent = settings.get_list("file/recent_files")
 
         # Filter out files that no longer exist
         existing = [f for f in recent if os.path.exists(f)]
 
         # Update settings if we removed any
         if len(existing) != len(recent):
-            settings.setValue("file/recent_files", existing)
+            settings.set("file/recent_files", existing)
 
         return existing
 
@@ -261,13 +256,11 @@ class FileController:
         recent = recent[:MAX_RECENT_FILES]
 
         # Save to settings
-        settings = QSettings("SDSMT", "SDM Spice")
-        settings.setValue("file/recent_files", recent)
+        settings.set("file/recent_files", recent)
 
     def clear_recent_files(self) -> None:
         """Clear the recent files list."""
-        settings = QSettings("SDSMT", "SDM Spice")
-        settings.setValue("file/recent_files", [])
+        settings.set("file/recent_files", [])
 
     # ------------------------------------------------------------------
     # Auto-save and crash recovery

--- a/app/controllers/settings_service.py
+++ b/app/controllers/settings_service.py
@@ -1,0 +1,87 @@
+"""Centralized application settings persistence.
+
+All QSettings access goes through this module, ensuring a single point
+of contact for the platform's persistence layer.  GUI dialogs, mixins,
+and controllers should import ``settings`` from this module rather than
+constructing ``QSettings`` directly.
+"""
+
+import json
+from typing import Any, List
+
+from PyQt6.QtCore import QSettings
+
+_ORG = "SDSMT"
+_APP = "SDM Spice"
+
+
+class SettingsService:
+    """Thin wrapper around QSettings providing a single access point.
+
+    Typed helpers (``get_bool``, ``get_int``, etc.) handle the
+    string-coercion quirks of ``QSettings`` so callers don't have to.
+    """
+
+    def __init__(self) -> None:
+        self._qs = QSettings(_ORG, _APP)
+
+    # -- generic -------------------------------------------------------
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Read a setting value (raw)."""
+        return self._qs.value(key, default)
+
+    def set(self, key: str, value: Any) -> None:
+        """Write a setting value."""
+        self._qs.setValue(key, value)
+
+    # -- typed helpers --------------------------------------------------
+
+    def get_bool(self, key: str, default: bool = False) -> bool:
+        """Read a boolean setting (handles QSettings string coercion)."""
+        val = self._qs.value(key)
+        if val is None:
+            return default
+        if isinstance(val, bool):
+            return val
+        return str(val).lower() == "true"
+
+    def get_int(self, key: str, default: int = 0) -> int:
+        """Read an integer setting."""
+        val = self._qs.value(key, default)
+        return int(val) if val is not None else default
+
+    def get_float(self, key: str, default: float = 0.0) -> float:
+        """Read a float setting."""
+        val = self._qs.value(key, default)
+        return float(val) if val is not None else default
+
+    def get_str(self, key: str, default: str = "") -> str:
+        """Read a string setting."""
+        val = self._qs.value(key, default)
+        return str(val) if val is not None else default
+
+    def get_json(self, key: str, default: Any = None) -> Any:
+        """Read a JSON-encoded setting."""
+        raw = self._qs.value(key)
+        if raw is None:
+            return default if default is not None else []
+        try:
+            return json.loads(raw) if isinstance(raw, str) else (default if default is not None else [])
+        except (json.JSONDecodeError, TypeError):
+            return default if default is not None else []
+
+    def set_json(self, key: str, value: Any) -> None:
+        """Write a value as JSON string."""
+        self._qs.setValue(key, json.dumps(value))
+
+    def get_list(self, key: str) -> List[str]:
+        """Read a list setting (QSettings may return a single string or a list)."""
+        val = self._qs.value(key, [])
+        if not isinstance(val, list):
+            return []
+        return val
+
+
+# Module-level singleton — importable as ``from controllers.settings_service import settings``
+settings = SettingsService()

--- a/app/tests/unit/test_component_palette.py
+++ b/app/tests/unit/test_component_palette.py
@@ -7,22 +7,22 @@ recommended components, and used-in-file auto-detection.
 """
 
 import pytest
+from controllers.settings_service import settings as app_settings
 from GUI.component_palette import _RECOMMENDED_CATEGORY, _USED_IN_FILE_CATEGORY, ComponentPalette
 from GUI.styles import COMPONENTS
 from models.component import COMPONENT_CATEGORIES
-from PyQt6.QtCore import QSettings, Qt
+from PyQt6.QtCore import Qt
 
 
 @pytest.fixture(autouse=True)
 def _clear_palette_settings():
-    """Clear palette QSettings before each test to avoid cross-test contamination."""
-    settings = QSettings("SDSMT", "SDM Spice")
+    """Clear palette settings before each test to avoid cross-test contamination."""
     for category_name in COMPONENT_CATEGORIES:
-        settings.remove(f"palette/expanded/{category_name}")
+        app_settings.set(f"palette/expanded/{category_name}", None)
     yield
     # Cleanup after test too
     for category_name in COMPONENT_CATEGORIES:
-        settings.remove(f"palette/expanded/{category_name}")
+        app_settings.set(f"palette/expanded/{category_name}", None)
 
 
 @pytest.fixture
@@ -200,9 +200,8 @@ class TestComponentPaletteSettingsPersistence:
 
     def test_new_palette_loads_saved_state(self, qtbot):
         # Save collapsed state
-        settings = QSettings("SDSMT", "SDM Spice")
-        settings.setValue("palette/expanded/Passive", False)
-        settings.setValue("palette/expanded/Sources", True)
+        app_settings.set("palette/expanded/Passive", False)
+        app_settings.set("palette/expanded/Sources", True)
         # Create new palette instance
         p2 = ComponentPalette()
         qtbot.addWidget(p2)

--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -294,38 +294,34 @@ class TestValidateCircuitData:
 class TestRecentFiles:
     """Test recent files functionality (Issue #101)."""
 
-    @patch("controllers.file_controller.QSettings")
-    def test_get_recent_files_returns_empty_list_initially(self, mock_qsettings):
+    @patch("controllers.file_controller.settings")
+    def test_get_recent_files_returns_empty_list_initially(self, mock_settings):
         """get_recent_files should return empty list when no recent files."""
-        mock_settings_instance = MagicMock()
-        mock_settings_instance.value.return_value = []
-        mock_qsettings.return_value = mock_settings_instance
+        mock_settings.get_list.return_value = []
 
         ctrl = FileController()
         recent = ctrl.get_recent_files()
         assert recent == []
 
-    @patch("controllers.file_controller.QSettings")
-    def test_add_recent_file_adds_to_list(self, mock_qsettings, tmp_path):
+    @patch("controllers.file_controller.settings")
+    def test_add_recent_file_adds_to_list(self, mock_settings, tmp_path):
         """add_recent_file should add file to recent list."""
-        mock_settings_instance = MagicMock()
-        mock_settings_instance.value.return_value = []
-        mock_qsettings.return_value = mock_settings_instance
+        mock_settings.get_list.return_value = []
 
         ctrl = FileController()
         filepath = tmp_path / "test.json"
         filepath.touch()  # Create file
         ctrl.add_recent_file(filepath)
 
-        # Check that setValue was called with the file path
-        mock_settings_instance.setValue.assert_called()
-        call_args = mock_settings_instance.setValue.call_args
+        # Check that set was called with the file path
+        mock_settings.set.assert_called()
+        call_args = mock_settings.set.call_args
         assert call_args[0][0] == "file/recent_files"
         assert str(filepath.absolute()) in call_args[0][1]
 
     @patch("controllers.file_controller.os.path.exists")
-    @patch("controllers.file_controller.QSettings")
-    def test_add_recent_file_moves_to_front_if_exists(self, mock_qsettings, mock_exists, tmp_path):
+    @patch("controllers.file_controller.settings")
+    def test_add_recent_file_moves_to_front_if_exists(self, mock_settings, mock_exists, tmp_path):
         """add_recent_file should move existing file to front."""
         file1 = str((tmp_path / "file1.json").absolute())
         file2 = str((tmp_path / "file2.json").absolute())
@@ -333,22 +329,20 @@ class TestRecentFiles:
         # Mock: all files exist
         mock_exists.return_value = True
 
-        mock_settings_instance = MagicMock()
-        mock_settings_instance.value.return_value = [file2, file1]
-        mock_qsettings.return_value = mock_settings_instance
+        mock_settings.get_list.return_value = [file2, file1]
 
         ctrl = FileController()
         ctrl.add_recent_file(Path(file1))
 
         # file1 should now be at the front
-        call_args = mock_settings_instance.setValue.call_args
+        call_args = mock_settings.set.call_args
         saved_list = call_args[0][1]
         assert saved_list[0] == file1
         assert saved_list[1] == file2
 
     @patch("controllers.file_controller.os.path.exists")
-    @patch("controllers.file_controller.QSettings")
-    def test_add_recent_file_maintains_max_limit(self, mock_qsettings, mock_exists, tmp_path):
+    @patch("controllers.file_controller.settings")
+    def test_add_recent_file_maintains_max_limit(self, mock_settings, mock_exists, tmp_path):
         """add_recent_file should keep only MAX_RECENT_FILES (10) files."""
         # Create 11 file paths
         existing_files = [str((tmp_path / f"file{i}.json").absolute()) for i in range(10)]
@@ -357,22 +351,20 @@ class TestRecentFiles:
         # Mock: all files exist
         mock_exists.return_value = True
 
-        mock_settings_instance = MagicMock()
-        mock_settings_instance.value.return_value = existing_files
-        mock_qsettings.return_value = mock_settings_instance
+        mock_settings.get_list.return_value = existing_files
 
         ctrl = FileController()
         ctrl.add_recent_file(new_file)
 
         # Should have exactly 10 files
-        call_args = mock_settings_instance.setValue.call_args
+        call_args = mock_settings.set.call_args
         saved_list = call_args[0][1]
         assert len(saved_list) == 10
         assert saved_list[0] == str(new_file.absolute())
 
-    @patch("controllers.file_controller.QSettings")
+    @patch("controllers.file_controller.settings")
     @patch("controllers.file_controller.os.path.exists")
-    def test_get_recent_files_filters_missing_files(self, mock_exists, mock_qsettings, tmp_path):
+    def test_get_recent_files_filters_missing_files(self, mock_exists, mock_settings, tmp_path):
         """get_recent_files should filter out files that no longer exist."""
         file1 = str((tmp_path / "exists.json").absolute())
         file2 = str((tmp_path / "missing.json").absolute())
@@ -380,9 +372,7 @@ class TestRecentFiles:
         # Mock: file1 exists, file2 doesn't
         mock_exists.side_effect = lambda f: f == file1
 
-        mock_settings_instance = MagicMock()
-        mock_settings_instance.value.return_value = [file1, file2]
-        mock_qsettings.return_value = mock_settings_instance
+        mock_settings.get_list.return_value = [file1, file2]
 
         ctrl = FileController()
         recent = ctrl.get_recent_files()
@@ -391,46 +381,39 @@ class TestRecentFiles:
         assert recent == [file1]
 
         # Should update settings to remove missing file
-        assert mock_settings_instance.setValue.called
+        assert mock_settings.set.called
 
-    @patch("controllers.file_controller.QSettings")
-    def test_clear_recent_files(self, mock_qsettings):
+    @patch("controllers.file_controller.settings")
+    def test_clear_recent_files(self, mock_settings):
         """clear_recent_files should empty the list."""
-        mock_settings_instance = MagicMock()
-        mock_qsettings.return_value = mock_settings_instance
-
         ctrl = FileController()
         ctrl.clear_recent_files()
 
         # Should save empty list
-        mock_settings_instance.setValue.assert_called_with("file/recent_files", [])
+        mock_settings.set.assert_called_with("file/recent_files", [])
 
-    @patch("controllers.file_controller.QSettings")
-    def test_save_circuit_updates_recent_files(self, mock_qsettings, tmp_path):
+    @patch("controllers.file_controller.settings")
+    def test_save_circuit_updates_recent_files(self, mock_settings, tmp_path):
         """save_circuit should add file to recent files list."""
-        mock_settings_instance = MagicMock()
-        mock_settings_instance.value.return_value = []
-        mock_qsettings.return_value = mock_settings_instance
+        mock_settings.get_list.return_value = []
 
         model = _build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
 
-        # Should have called setValue to add to recent files
-        calls = [call[0][0] for call in mock_settings_instance.setValue.call_args_list]
+        # Should have called set to add to recent files
+        calls = [call[0][0] for call in mock_settings.set.call_args_list]
         assert "file/recent_files" in calls
 
-    @patch("controllers.file_controller.QSettings")
-    def test_load_circuit_updates_recent_files(self, mock_qsettings, tmp_path):
+    @patch("controllers.file_controller.settings")
+    def test_load_circuit_updates_recent_files(self, mock_settings, tmp_path):
         """load_circuit should add file to recent files list."""
         # First save a circuit
         model = _build_simple_circuit()
         filepath = tmp_path / "test.json"
 
-        mock_settings_instance = MagicMock()
-        mock_settings_instance.value.return_value = []
-        mock_qsettings.return_value = mock_settings_instance
+        mock_settings.get_list.return_value = []
 
         ctrl = FileController(model)
         ctrl.save_circuit(filepath)
@@ -439,8 +422,8 @@ class TestRecentFiles:
         ctrl2 = FileController()
         ctrl2.load_circuit(filepath)
 
-        # Should have called setValue to add to recent files
-        calls = [call[0][0] for call in mock_settings_instance.setValue.call_args_list]
+        # Should have called set to add to recent files
+        calls = [call[0][0] for call in mock_settings.set.call_args_list]
         assert "file/recent_files" in calls
 
 
@@ -602,12 +585,13 @@ class TestAnnotationsAndRecommendedComponents:
 
 
 class TestQtDependencies:
-    def test_qsettings_imported_for_recent_files(self):
-        """FileController now uses QSettings for recent files (Issue #101)."""
+    def test_settings_service_used_for_recent_files(self):
+        """FileController uses centralized SettingsService for persistence (#598)."""
         import controllers.file_controller as mod
 
         source = open(mod.__file__).read()
-        # QSettings should be imported
-        assert "QSettings" in source
+        # Should use centralized settings service, not QSettings directly
+        assert "settings_service" in source
+        assert "QSettings" not in source
         # But no QtWidgets (stays out of view layer)
         assert "QtWidgets" not in source

--- a/app/tests/unit/test_preferences_dialog.py
+++ b/app/tests/unit/test_preferences_dialog.py
@@ -3,9 +3,9 @@
 from unittest.mock import MagicMock
 
 import pytest
+from controllers.settings_service import settings as app_settings
 from GUI.preferences_dialog import PreferencesDialog
 from GUI.styles import LightTheme, theme_manager
-from PyQt6.QtCore import QSettings
 from PyQt6.QtWidgets import QCheckBox, QComboBox, QPushButton, QSpinBox, QTabWidget
 
 
@@ -16,10 +16,9 @@ def restore_theme():
     theme_manager.set_theme(LightTheme())
     theme_manager.set_wire_thickness("normal")
     theme_manager.set_show_junction_dots(True)
-    settings = QSettings("SDSMT", "SDM Spice")
-    settings.setValue("view/default_zoom", 100)
-    settings.setValue("autosave/enabled", True)
-    settings.setValue("autosave/interval", 60)
+    app_settings.set("view/default_zoom", 100)
+    app_settings.set("autosave/enabled", True)
+    app_settings.set("autosave/interval", 60)
 
 
 @pytest.fixture
@@ -145,9 +144,8 @@ class TestCancelRevert:
     def test_cancel_reverts_default_zoom(self, dialog, mock_main_window):
         dialog.default_zoom_combo.setCurrentIndex(0)  # 50%
         dialog._on_cancel()
-        settings = QSettings("SDSMT", "SDM Spice")
         # Should revert to original snapshot (100%)
-        assert int(settings.value("view/default_zoom", 100)) == 100
+        assert app_settings.get_int("view/default_zoom", 100) == 100
 
 
 class TestOkPersist:
@@ -159,22 +157,18 @@ class TestOkPersist:
 
         dialog._on_ok()
 
-        settings = QSettings("SDSMT", "SDM Spice")
-        assert settings.value("autosave/interval") == 120
-        enabled = settings.value("autosave/enabled")
-        assert enabled is True or enabled == "true"
+        assert app_settings.get_int("autosave/interval") == 120
+        assert app_settings.get_bool("autosave/enabled") is True
         mock_main_window._start_autosave_timer.assert_called()
 
     def test_ok_persists_theme_key(self, dialog, mock_main_window):
         dialog._on_ok()
-        settings = QSettings("SDSMT", "SDM Spice")
-        assert settings.value("view/theme_key") == "light"
+        assert app_settings.get_str("view/theme_key") == "light"
 
     def test_ok_persists_default_zoom(self, dialog, mock_main_window):
         dialog.default_zoom_combo.setCurrentIndex(3)  # 125%
         dialog._on_ok()
-        settings = QSettings("SDSMT", "SDM Spice")
-        assert int(settings.value("view/default_zoom")) == 125
+        assert app_settings.get_int("view/default_zoom") == 125
 
 
 class TestInitialValues:
@@ -254,17 +248,14 @@ class TestWireRenderingPreferences:
         # The mock main_window doesn't actually call theme_manager, so set it directly
         theme_manager.set_wire_thickness("thick")
         dialog._on_ok()
-        settings = QSettings("SDSMT", "SDM Spice")
-        assert settings.value("view/wire_thickness") == "thick"
+        assert app_settings.get_str("view/wire_thickness") == "thick"
 
     def test_ok_persists_junction_dots(self, dialog, mock_main_window):
         dialog.junction_dots_checkbox.setChecked(False)
         # The mock main_window doesn't actually call theme_manager, so set it directly
         theme_manager.set_show_junction_dots(False)
         dialog._on_ok()
-        settings = QSettings("SDSMT", "SDM Spice")
-        val = settings.value("view/show_junction_dots")
-        assert val is False or val == "false"
+        assert app_settings.get_bool("view/show_junction_dots") is False
 
 
 class TestAutosaveSpinboxState:
@@ -292,8 +283,7 @@ class TestAutosaveSpinboxState:
     def test_spinbox_initial_state_matches_checkbox(self, qtbot, mock_main_window):
         """Spinbox enabled state should match the checkbox on dialog open."""
         # Set autosave disabled before opening dialog
-        settings = QSettings("SDSMT", "SDM Spice")
-        settings.setValue("autosave/enabled", False)
+        app_settings.set("autosave/enabled", False)
         dlg = PreferencesDialog(mock_main_window, parent=None)
         qtbot.addWidget(dlg)
         assert not dlg.autosave_checkbox.isChecked()
@@ -302,14 +292,12 @@ class TestAutosaveSpinboxState:
     def test_cancel_reverts_autosave_enabled(self, qtbot, mock_main_window):
         """Cancel should revert auto-save enabled to the snapshot value."""
         # Ensure autosave is enabled before opening dialog so snapshot captures True
-        settings = QSettings("SDSMT", "SDM Spice")
-        settings.setValue("autosave/enabled", True)
+        app_settings.set("autosave/enabled", True)
         dlg = PreferencesDialog(mock_main_window, parent=None)
         qtbot.addWidget(dlg)
         dlg.autosave_checkbox.setChecked(False)
         dlg._on_cancel()
-        enabled = settings.value("autosave/enabled")
-        assert enabled is True or enabled == "true"
+        assert app_settings.get_bool("autosave/enabled") is True
         mock_main_window._start_autosave_timer.assert_called()
 
     def test_cancel_reverts_autosave_interval(self, dialog, mock_main_window):
@@ -317,8 +305,7 @@ class TestAutosaveSpinboxState:
         original = dialog.autosave_spin.value()
         dialog.autosave_spin.setValue(300)
         dialog._on_cancel()
-        settings = QSettings("SDSMT", "SDM Spice")
-        assert int(settings.value("autosave/interval", 60)) == original
+        assert app_settings.get_int("autosave/interval", 60) == original
 
 
 class TestThemeManagerWireProperties:

--- a/app/tests/unit/test_recent_exports.py
+++ b/app/tests/unit/test_recent_exports.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 
 import pytest
+from controllers.settings_service import settings as app_settings
 from GUI.recent_exports import (
     MAX_RECENT_EXPORTS,
     SETTINGS_KEY,
@@ -12,16 +13,14 @@ from GUI.recent_exports import (
     clear_recent_exports,
     get_recent_exports,
 )
-from PyQt6.QtCore import QSettings
 
 
 @pytest.fixture(autouse=True)
 def _clean_settings():
     """Clear recent exports before and after each test."""
-    settings = QSettings("SDSMT", "SDM Spice")
-    settings.setValue(SETTINGS_KEY, "[]")
+    app_settings.set_json(SETTINGS_KEY, [])
     yield
-    settings.setValue(SETTINGS_KEY, "[]")
+    app_settings.set_json(SETTINGS_KEY, [])
 
 
 class TestGetRecentExports:

--- a/app/tests/unit/test_settings_service.py
+++ b/app/tests/unit/test_settings_service.py
@@ -1,0 +1,126 @@
+"""Tests for centralized SettingsService (#598).
+
+Verifies that:
+- SettingsService provides typed accessors (get_bool, get_int, etc.)
+- All production code uses the centralized service instead of QSettings directly
+- JSON round-trip works correctly
+"""
+
+import json
+
+import pytest
+from controllers.settings_service import SettingsService, settings
+
+
+class TestSettingsServiceTypedHelpers:
+    """Test the typed helper methods handle QSettings string coercion."""
+
+    @pytest.fixture(autouse=True)
+    def _clean(self):
+        """Clear test keys before and after each test."""
+        for key in ("_test/bool", "_test/int", "_test/float", "_test/str", "_test/json", "_test/list"):
+            settings.set(key, None)
+        yield
+        for key in ("_test/bool", "_test/int", "_test/float", "_test/str", "_test/json", "_test/list"):
+            settings.set(key, None)
+
+    def test_get_bool_true(self):
+        settings.set("_test/bool", True)
+        assert settings.get_bool("_test/bool") is True
+
+    def test_get_bool_string_true(self):
+        settings.set("_test/bool", "true")
+        assert settings.get_bool("_test/bool") is True
+
+    def test_get_bool_false(self):
+        settings.set("_test/bool", False)
+        assert settings.get_bool("_test/bool") is False
+
+    def test_get_bool_string_false(self):
+        settings.set("_test/bool", "false")
+        assert settings.get_bool("_test/bool") is False
+
+    def test_get_bool_default(self):
+        assert settings.get_bool("_test/nonexistent", True) is True
+        assert settings.get_bool("_test/nonexistent", False) is False
+
+    def test_get_int(self):
+        settings.set("_test/int", 42)
+        assert settings.get_int("_test/int") == 42
+
+    def test_get_int_default(self):
+        assert settings.get_int("_test/nonexistent", 99) == 99
+
+    def test_get_float(self):
+        settings.set("_test/float", 3.14)
+        assert abs(settings.get_float("_test/float") - 3.14) < 0.01
+
+    def test_get_str(self):
+        settings.set("_test/str", "hello")
+        assert settings.get_str("_test/str") == "hello"
+
+    def test_get_str_default(self):
+        assert settings.get_str("_test/nonexistent", "default") == "default"
+
+    def test_json_round_trip(self):
+        data = [{"path": "/tmp/test.csv", "format": "CSV"}]
+        settings.set_json("_test/json", data)
+        result = settings.get_json("_test/json")
+        assert result == data
+
+    def test_get_json_default(self):
+        result = settings.get_json("_test/nonexistent", [])
+        assert result == []
+
+    def test_get_json_invalid(self):
+        settings.set("_test/json", "not-json{{{")
+        result = settings.get_json("_test/json", [])
+        assert result == []
+
+    def test_singleton_is_settings_service(self):
+        assert isinstance(settings, SettingsService)
+
+
+class TestNoDirectQSettingsInProduction:
+    """Verify production code no longer imports QSettings directly."""
+
+    _GUI_FILES = [
+        "GUI/main_window_settings.py",
+        "GUI/main_window_file_ops.py",
+        "GUI/preferences_dialog.py",
+        "GUI/component_palette.py",
+        "GUI/recent_exports.py",
+        "GUI/circuitikz_options_dialog.py",
+    ]
+
+    _CONTROLLER_FILES = [
+        "controllers/file_controller.py",
+    ]
+
+    @pytest.mark.parametrize("rel_path", _GUI_FILES + _CONTROLLER_FILES)
+    def test_no_direct_qsettings_import(self, rel_path):
+        """No production file should import QSettings directly."""
+        import importlib
+        import pathlib
+
+        base = pathlib.Path(__file__).resolve().parent.parent.parent / "app" / rel_path
+        if not base.exists():
+            # Resolve relative to app/ in case cwd differs
+            import os
+
+            base = pathlib.Path(os.getcwd()) / rel_path
+        source = base.read_text()
+        assert 'QSettings("SDSMT"' not in source, f"{rel_path} still creates QSettings directly"
+
+    @pytest.mark.parametrize("rel_path", _GUI_FILES + _CONTROLLER_FILES)
+    def test_uses_settings_service(self, rel_path):
+        """All production files should import from settings_service."""
+        import pathlib
+
+        base = pathlib.Path(__file__).resolve().parent.parent.parent / "app" / rel_path
+        if not base.exists():
+            import os
+
+            base = pathlib.Path(os.getcwd()) / rel_path
+        source = base.read_text()
+        assert "settings_service" in source, f"{rel_path} does not use settings_service"


### PR DESCRIPTION
## Summary - Introduce  with a  singleton that wraps QSettings - Typed helpers (, , , etc.) handle QSettings string coercion centrally - Replace all direct  construction in 7 production files with the shared service - Update 4 existing test files and add 28 new tests verifying the service and source-code compliance Closes #598 ## Test plan - [x] All 3115 tests pass (28 new tests added, zero regressions) - [x] Source-code grep tests verify no production file creates QSettings directly - [x] Pre-commit hooks pass (ruff, isort, black) 🤖 Generated with [Claude Code](https://claude.com/claude-code)