### PR TITLE
Move connectivity analysis from GUI panel to utils (#591)

### DIFF
--- a/app/GUI/circuit_statistics_panel.py
+++ b/app/GUI/circuit_statistics_panel.py
@@ -5,6 +5,7 @@ from collections import Counter
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QFormLayout, QGroupBox, QLabel, QScrollArea, QTextEdit, QVBoxLayout, QWidget
+from utils.connectivity import find_floating_terminals
 
 from .styles import theme_manager
 
@@ -157,7 +158,7 @@ class CircuitStatisticsPanel(QWidget):
             self._components_form.addRow(f"{comp_type}:", label)
 
     def _update_connectivity(self):
-        floating = self._find_floating_terminals()
+        floating = find_floating_terminals(self.model.components, self.model.terminal_to_node)
         if not self.model.components:
             self._floating_label.setText("-")
             self._floating_label.setStyleSheet("")
@@ -171,18 +172,6 @@ class CircuitStatisticsPanel(QWidget):
             self._floating_label.setText("All connected")
             self._floating_label.setStyleSheet("QLabel { color: green; }")
             self._floating_label.setToolTip("")
-
-    def _find_floating_terminals(self):
-        """Return set of (component_id, terminal_index) that are not in any node."""
-        floating = set()
-        for comp in self.model.components.values():
-            if comp.component_type == "Ground":
-                continue
-            for tidx in range(comp.get_terminal_count()):
-                key = (comp.component_id, tidx)
-                if key not in self.model.terminal_to_node:
-                    floating.add(key)
-        return floating
 
     def _update_netlist_preview(self):
         if not self.model.components:

--- a/app/tests/unit/test_connectivity.py
+++ b/app/tests/unit/test_connectivity.py
@@ -1,0 +1,62 @@
+"""Tests for utils.connectivity – pure-function connectivity analysis."""
+
+from models.component import ComponentData
+from models.node import NodeData
+from utils.connectivity import find_floating_terminals
+
+
+def _comp(cid, ctype="Resistor"):
+    return ComponentData(component_id=cid, component_type=ctype, value="1k", position=(0, 0))
+
+
+class TestFindFloatingTerminals:
+    def test_empty_circuit(self):
+        assert find_floating_terminals({}, {}) == set()
+
+    def test_single_unconnected_resistor(self):
+        comps = {"R1": _comp("R1")}
+        floating = find_floating_terminals(comps, {})
+        assert floating == {("R1", 0), ("R1", 1)}
+
+    def test_fully_connected(self):
+        comps = {"R1": _comp("R1"), "V1": _comp("V1", "Voltage Source")}
+        node = NodeData()
+        ttn = {
+            ("R1", 0): node,
+            ("R1", 1): node,
+            ("V1", 0): node,
+            ("V1", 1): node,
+        }
+        floating = find_floating_terminals(comps, ttn)
+        assert floating == set()
+
+    def test_partially_connected(self):
+        comps = {"R1": _comp("R1")}
+        node = NodeData()
+        ttn = {("R1", 0): node}
+        floating = find_floating_terminals(comps, ttn)
+        assert floating == {("R1", 1)}
+
+    def test_ground_excluded(self):
+        comps = {"GND1": _comp("GND1", "Ground")}
+        floating = find_floating_terminals(comps, {})
+        assert floating == set()
+
+    def test_ground_mixed_with_other(self):
+        comps = {
+            "R1": _comp("R1"),
+            "GND1": _comp("GND1", "Ground"),
+        }
+        floating = find_floating_terminals(comps, {})
+        # Only R1 terminals should be floating, not ground
+        assert floating == {("R1", 0), ("R1", 1)}
+
+    def test_multiple_components(self):
+        comps = {
+            "R1": _comp("R1"),
+            "R2": _comp("R2"),
+        }
+        node = NodeData()
+        ttn = {("R1", 0): node, ("R2", 0): node}
+        floating = find_floating_terminals(comps, ttn)
+        assert floating == {("R1", 1), ("R2", 1)}

--- a/app/utils/connectivity.py
+++ b/app/utils/connectivity.py
@@ -1,0 +1,40 @@
+"""
+Pure-function circuit connectivity analysis.
+
+Detects floating (unconnected) terminals and other connectivity issues.
+No Qt or GUI dependency — operates on model data structures only.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.component import ComponentData
+    from models.node import NodeData
+
+
+def find_floating_terminals(
+    components: dict[str, ComponentData],
+    terminal_to_node: dict[tuple[str, int], NodeData],
+) -> set[tuple[str, int]]:
+    """Return the set of terminals that are not connected to any node.
+
+    Ground components are excluded since they implicitly connect to node 0.
+
+    Args:
+        components: Map of component_id → ComponentData.
+        terminal_to_node: Map of (component_id, terminal_index) → NodeData.
+
+    Returns:
+        Set of ``(component_id, terminal_index)`` tuples for unconnected terminals.
+    """
+    floating: set[tuple[str, int]] = set()
+    for comp in components.values():
+        if comp.component_type == "Ground":
+            continue
+        for tidx in range(comp.get_terminal_count()):
+            key = (comp.component_id, tidx)
+            if key not in terminal_to_node:
+                floating.add(key)
+    return floating


### PR DESCRIPTION
## Summary - Extracts find_floating_terminals() from CircuitStatisticsPanel into utils/connectivity.py as a pure function - The panel now delegates to the utility instead of containing analysis logic directly - Adds 7 focused unit tests for the extracted function in test_connectivity.py ## Test plan - [x] All 3108 tests pass locally (7 new + 3101 existing) - [x] Format and lint clean - [ ] Verify CI passes on all Python versions (3.11/3.12/3.13) Generated with Claude Code