### PR TITLE
Route simulation result parsing through controller layer

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -1517,7 +1517,7 @@ class CircuitCanvasView(QGraphicsView):
 
         # Draw OP voltage annotations (distinct style)
         if show_op:
-            from simulation.result_parser import format_si
+            from utils.format_utils import format_si
 
             op_pen = theme_manager.pen("op_voltage")
             op_brush = theme_manager.brush("op_annotation_bg")
@@ -1684,7 +1684,7 @@ class CircuitCanvasView(QGraphicsView):
     def _probe_node(self, node):
         """Create a probe result for a node."""
         from PyQt6.QtCore import QPointF
-        from simulation.result_parser import format_si
+        from utils.format_utils import format_si
 
         label = node.get_label()
         if label not in self.node_voltages:
@@ -1708,7 +1708,7 @@ class CircuitCanvasView(QGraphicsView):
     def _probe_component(self, comp_item):
         """Create a probe result for a component."""
         from PyQt6.QtCore import QPointF
-        from simulation.result_parser import format_si
+        from utils.format_utils import format_si
 
         comp_id = comp_item.component_id
         comp_ref = comp_id.lower()

--- a/app/GUI/main_window_simulation.py
+++ b/app/GUI/main_window_simulation.py
@@ -223,7 +223,7 @@ class SimulationMixin:
 
     def _display_measurement_results(self, measurements):
         """Display .meas measurement results."""
-        from simulation.result_parser import format_si
+        from utils.format_utils import format_si
 
         self.results_text.append("\nMEASUREMENTS:")
         self.results_text.append("-" * 40)
@@ -319,17 +319,13 @@ class SimulationMixin:
             self._last_results = tran_data
             self.results_text.append("\nTRANSIENT ANALYSIS RESULTS:")
 
-            from simulation import ResultParser
-
-            table_string = ResultParser.format_results_as_table(tran_data)
+            table_string = self.sim_ctrl.format_results_table(tran_data)
             self.results_text.append(table_string)
 
             # Power summary for resistors
-            from simulation.power_metrics import compute_transient_power_metrics, format_power_summary
-
-            power_metrics = compute_transient_power_metrics(tran_data, self.model.components)
+            power_metrics, power_summary = self.sim_ctrl.compute_power_metrics(tran_data, self.model.components)
             if power_metrics:
-                self.results_text.append(format_power_summary(power_metrics))
+                self.results_text.append(power_summary)
 
             self.results_text.append("\n" + "-" * 40)
             self.results_text.append("Waveform plot has also been generated in a new window.")
@@ -351,14 +347,14 @@ class SimulationMixin:
                 else:
                     self._waveform_dialog.close()
                     self._waveform_dialog.deleteLater()
-                    self._waveform_dialog = WaveformDialog(tran_data, self)
+                    self._waveform_dialog = WaveformDialog(tran_data, self, sim_ctrl=self.sim_ctrl)
                     self._waveform_dialog.show()
             else:
                 # Clean up previous waveform dialog
                 if self._waveform_dialog is not None:
                     self._waveform_dialog.close()
                     self._waveform_dialog.deleteLater()
-                self._waveform_dialog = WaveformDialog(tran_data, self)
+                self._waveform_dialog = WaveformDialog(tran_data, self, sim_ctrl=self.sim_ctrl)
                 self._waveform_dialog.show()
         else:
             self.results_text.append("\nNo transient data found in output.")
@@ -428,7 +424,7 @@ class SimulationMixin:
 
     def _display_tf_results(self, result):
         """Display Transfer Function (.tf) results."""
-        from simulation.result_parser import format_si
+        from utils.format_utils import format_si
 
         tf_data = result.data if result.data else None
         if tf_data:
@@ -455,7 +451,7 @@ class SimulationMixin:
 
     def _display_pz_results(self, result):
         """Display Pole-Zero analysis results."""
-        from simulation.result_parser import format_si
+        from utils.format_utils import format_si
 
         pz_data = result.data if result.data else None
         if pz_data:
@@ -590,18 +586,16 @@ class SimulationMixin:
 
             if ok_count > 0:
                 self.results_text.append("\nResults opened in a new window.")
-                self._show_plot_dialog(MonteCarloResultsDialog(mc_data, self))
+                self._show_plot_dialog(MonteCarloResultsDialog(mc_data, self, sim_ctrl=self.sim_ctrl))
         else:
             self.results_text.append("\nNo Monte Carlo data.")
         self.canvas.clear_op_results()
 
     def _calculate_power(self, node_voltages):
         """Calculate and display power dissipation for all components."""
-        from simulation.power_calculator import calculate_power, total_power
-
         components = list(self.circuit_ctrl.model.components.values())
         nodes = self.circuit_ctrl.model.nodes
-        power_data = calculate_power(components, nodes, node_voltages)
+        power_data, tp = self.sim_ctrl.compute_power(components, nodes, node_voltages)
 
         if power_data:
             # Build voltage-across data for properties panel
@@ -620,7 +614,6 @@ class SimulationMixin:
                 if l0 and l1 and l0 in node_voltages and l1 in node_voltages:
                     voltage_data[cid] = node_voltages[l0] - node_voltages[l1]
 
-            tp = total_power(power_data)
             self.properties_panel.set_simulation_results(power_data, voltage_data, tp)
 
             # Show summary in results text
@@ -669,7 +662,10 @@ class SimulationMixin:
                 self._plot_dialog.activateWindow()
                 return
 
-        self._show_plot_dialog(dialog_class(data, self))
+        if dialog_class is ACSweepPlotDialog:
+            self._show_plot_dialog(dialog_class(data, self, sim_ctrl=self.sim_ctrl))
+        else:
+            self._show_plot_dialog(dialog_class(data, self))
 
     def export_results_csv(self):
         """Export the last simulation results to a CSV file"""

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -310,7 +310,7 @@ class ViewOperationsMixin:
             return
         # Open or raise the waveform dialog
         if self._waveform_dialog is None or not self._waveform_dialog.isVisible():
-            self._waveform_dialog = WaveformDialog(tran_data, self)
+            self._waveform_dialog = WaveformDialog(tran_data, self, sim_ctrl=self.sim_ctrl)
             self._waveform_dialog.show()
         self._waveform_dialog.raise_()
         self._waveform_dialog.activateWindow()
@@ -333,7 +333,7 @@ class ViewOperationsMixin:
         if not ac_data:
             return
         if self._plot_dialog is None or not self._plot_dialog.isVisible():
-            self._show_plot_dialog(ACSweepPlotDialog(ac_data, self))
+            self._show_plot_dialog(ACSweepPlotDialog(ac_data, self, sim_ctrl=self.sim_ctrl))
         self._plot_dialog.raise_()
         self._plot_dialog.activateWindow()
         self.statusBar().showMessage(f"Opened AC sweep plot for {signal_name}.", 2000)

--- a/app/GUI/monte_carlo_results_dialog.py
+++ b/app/GUI/monte_carlo_results_dialog.py
@@ -8,7 +8,6 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from PyQt6.QtWidgets import QComboBox, QDialog, QHBoxLayout, QLabel, QTextEdit, QVBoxLayout
-from simulation.monte_carlo import compute_mc_statistics
 
 from .styles import theme_manager
 
@@ -45,11 +44,12 @@ class MonteCarloResultsDialog(QDialog):
 
     analysis_type = "Monte Carlo"
 
-    def __init__(self, mc_data, parent=None):
+    def __init__(self, mc_data, parent=None, sim_ctrl=None):
         super().__init__(parent)
         self.setWindowTitle("Monte Carlo Results")
         self.setMinimumSize(1000, 700)
 
+        self._sim_ctrl = sim_ctrl
         self._mc_data = mc_data
         self._base_type = mc_data.get("base_analysis_type", "")
 
@@ -267,7 +267,12 @@ class MonteCarloResultsDialog(QDialog):
             ax.set_title(f"Distribution — {metric}")
             ax.grid(True, alpha=0.3)
 
-            stats = compute_mc_statistics(values)
+            if self._sim_ctrl is not None:
+                stats = self._sim_ctrl.compute_mc_statistics(values)
+            else:
+                from controllers.simulation_controller import SimulationController
+
+                stats = SimulationController.compute_mc_statistics(values)
             lines = [
                 f"Metric: {metric}",
                 f"Runs:   {stats['count']}",

--- a/app/GUI/results_plot_dialog.py
+++ b/app/GUI/results_plot_dialog.py
@@ -261,11 +261,12 @@ class ACSweepPlotDialog(QDialog):
 
     analysis_type = "AC Sweep"
 
-    def __init__(self, data, parent=None, label=None):
+    def __init__(self, data, parent=None, label=None, sim_ctrl=None):
         super().__init__(parent)
         self.setWindowTitle("AC Sweep Results — Bode Plot")
         self.setMinimumSize(900, 600)
 
+        self._sim_ctrl = sim_ctrl
         self._datasets = []
         self._lines = {}
         self._legend_line_map = {}
@@ -436,7 +437,7 @@ class ACSweepPlotDialog(QDialog):
 
     def _draw_markers(self):
         """Compute and draw frequency response markers for the first signal."""
-        from simulation.freq_markers import compute_markers, format_frequency
+        from utils.format_utils import format_frequency
 
         self._clear_marker_artists()
 
@@ -457,7 +458,12 @@ class ACSweepPlotDialog(QDialog):
         mag_vals = magnitude[first_signal]
         phase_vals = phase.get(first_signal)
 
-        markers = compute_markers(frequencies, mag_vals, phase_vals)
+        if self._sim_ctrl is not None:
+            markers = self._sim_ctrl.compute_frequency_markers(frequencies, mag_vals, phase_vals)
+        else:
+            from simulation.freq_markers import compute_markers
+
+            markers = compute_markers(frequencies, mag_vals, phase_vals)
 
         if markers["peak_gain_db"] is None:
             self._marker_summary.setPlainText("No markers computed (insufficient data).")

--- a/app/GUI/waveform_dialog.py
+++ b/app/GUI/waveform_dialog.py
@@ -1,6 +1,7 @@
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+from controllers.simulation_controller import SimulationController
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from PyQt6.QtGui import QColor
@@ -23,7 +24,6 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from simulation.fft_analysis import analyze_signal_spectrum
 
 from .format_utils import format_value, parse_value
 from .measurement_cursors import CursorReadoutPanel, MeasurementCursors
@@ -68,9 +68,10 @@ class MplCanvas(FigureCanvas):
 class WaveformDialog(QDialog):
     analysis_type = "Transient"
 
-    def __init__(self, data, parent=None):
+    def __init__(self, data, parent=None, sim_ctrl=None):
         super().__init__(parent)
 
+        self._sim_ctrl = sim_ctrl
         self.setWindowTitle("Transient Analysis Waveforms")
         self.setMinimumSize(1200, 700)
 
@@ -607,7 +608,7 @@ class WaveformDialog(QDialog):
             return
 
         # Show FFT dialog with signal selection
-        dialog = FFTAnalysisDialog(time, self.full_data, signal_names, self)
+        dialog = FFTAnalysisDialog(time, self.full_data, signal_names, self, sim_ctrl=self._sim_ctrl)
         dialog.exec()
 
     def closeEvent(self, event):
@@ -627,11 +628,12 @@ class FFTAnalysisDialog(QDialog):
     - Fundamental frequency and THD display
     """
 
-    def __init__(self, time: np.ndarray, data: list, signal_names: list, parent=None):
+    def __init__(self, time: np.ndarray, data: list, signal_names: list, parent=None, sim_ctrl=None):
         super().__init__(parent)
         self.setWindowTitle("Spectrum Analysis")
         self.setMinimumSize(1000, 700)
 
+        self._sim_ctrl = sim_ctrl
         self.time = time
         self.data = data
         self.signal_names = signal_names
@@ -717,7 +719,10 @@ class FFTAnalysisDialog(QDialog):
         signal = np.array([row.get(signal_name, 0) for row in self.data])
 
         try:
-            self._fft_result = analyze_signal_spectrum(self.time, signal, signal_name, window_type)
+            if self._sim_ctrl is not None:
+                self._fft_result = self._sim_ctrl.compute_signal_fft(self.time, signal, signal_name, window_type)
+            else:
+                self._fft_result = SimulationController.compute_signal_fft(self.time, signal, signal_name, window_type)
             self._replot()
         except Exception as e:
             QMessageBox.critical(self, "FFT Error", f"Failed to compute FFT: {e}")

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -556,6 +556,67 @@ class SimulationController:
             warnings=validation.warnings,
         )
 
+    # --- Result analysis helpers ---
+
+    @staticmethod
+    def format_results_table(tran_data: dict) -> str:
+        """Format transient data as a text table."""
+        from simulation import ResultParser
+
+        return ResultParser.format_results_as_table(tran_data)
+
+    @staticmethod
+    def compute_power_metrics(tran_data: dict, components: dict) -> tuple:
+        """Compute transient power metrics for resistors.
+
+        Returns:
+            (power_metrics, summary_text) where *power_metrics* is a list of
+            per-component metrics and *summary_text* is a pre-formatted string.
+            If no metrics are available, returns ``([], "")``.
+        """
+        from simulation.power_metrics import compute_transient_power_metrics, format_power_summary
+
+        metrics = compute_transient_power_metrics(tran_data, components)
+        if metrics:
+            return metrics, format_power_summary(metrics)
+        return [], ""
+
+    @staticmethod
+    def compute_power(components, nodes, node_voltages) -> tuple:
+        """Calculate power dissipation for all components.
+
+        Returns:
+            (power_data, total) — *power_data* is a dict mapping component ID
+            to power value; *total* is the summed total power.
+        """
+        from simulation.power_calculator import calculate_power, total_power
+
+        power_data = calculate_power(components, nodes, node_voltages)
+        if power_data:
+            return power_data, total_power(power_data)
+        return {}, 0.0
+
+    @staticmethod
+    def compute_frequency_markers(frequencies, magnitude, phase=None) -> dict:
+        """Compute frequency response markers from AC sweep data."""
+        from simulation.freq_markers import compute_markers
+
+        return compute_markers(frequencies, magnitude, phase)
+
+    @staticmethod
+    def compute_signal_fft(time, signal, signal_name, window_type="hamming"):
+        """Compute FFT spectrum for a transient signal."""
+        from simulation.fft_analysis import analyze_signal_spectrum
+
+        return analyze_signal_spectrum(time, signal, signal_name, window_type)
+
+    @staticmethod
+    def compute_mc_statistics(values) -> dict:
+        """Compute Monte Carlo statistics for a set of values."""
+        from simulation.monte_carlo import compute_mc_statistics
+
+        return compute_mc_statistics(values)
+
     @staticmethod
     def _format_sweep_value(value: float) -> str:
         """Format a float as a SPICE-compatible value string.

--- a/app/simulation/freq_markers.py
+++ b/app/simulation/freq_markers.py
@@ -118,15 +118,4 @@ def _empty_markers():
     }
 
 
-def format_frequency(freq_hz):
-    """Format a frequency value with appropriate SI prefix."""
-    if freq_hz is None:
-        return "N/A"
-    if freq_hz >= 1e9:
-        return f"{freq_hz / 1e9:.2f} GHz"
-    elif freq_hz >= 1e6:
-        return f"{freq_hz / 1e6:.2f} MHz"
-    elif freq_hz >= 1e3:
-        return f"{freq_hz / 1e3:.2f} kHz"
-    else:
-        return f"{freq_hz:.2f} Hz"
+from utils.format_utils import format_frequency  # noqa: F401 — re-exported for compatibility

--- a/app/simulation/result_parser.py
+++ b/app/simulation/result_parser.py
@@ -8,43 +8,9 @@ import logging
 import math
 import re
 
+from utils.format_utils import format_si  # noqa: F401 — canonical location; re-exported for compatibility
+
 logger = logging.getLogger(__name__)
-
-# SI prefix table for engineering notation
-_SI_PREFIXES = [
-    (1e-15, "f"),
-    (1e-12, "p"),
-    (1e-9, "n"),
-    (1e-6, "\u00b5"),
-    (1e-3, "m"),
-    (1e0, ""),
-    (1e3, "k"),
-    (1e6, "M"),
-    (1e9, "G"),
-]
-
-
-def format_si(value, unit=""):
-    """Format a value with SI prefix.
-
-    Examples:
-        format_si(0.0033, "V") -> "3.30 mV"
-        format_si(1500, "Hz") -> "1.50 kHz"
-        format_si(0, "V") -> "0.00 V"
-    """
-    if value == 0 or not math.isfinite(value):
-        return f"0.00 {unit}" if unit else "0.00"
-
-    abs_val = abs(value)
-    for threshold, prefix in _SI_PREFIXES:
-        if abs_val < threshold * 1000:
-            scaled = value / threshold
-            return f"{scaled:.2f} {prefix}{unit}" if unit else f"{scaled:.2f} {prefix}"
-
-    # Larger than 1G — use the largest prefix
-    threshold, prefix = _SI_PREFIXES[-1]
-    scaled = value / threshold
-    return f"{scaled:.2f} {prefix}{unit}" if unit else f"{scaled:.2f} {prefix}"
 
 
 class ResultParser:

--- a/app/utils/format_utils.py
+++ b/app/utils/format_utils.py
@@ -7,6 +7,7 @@ This module lives in the shared ``utils`` package so that both the simulation
 layer and the GUI layer can use it without creating a backwards dependency.
 """
 
+import math
 import re
 
 # Dictionary of SI prefixes and their multipliers
@@ -153,3 +154,54 @@ def validate_component_value(value: str, component_type: str) -> tuple[bool, str
         return False, f"{component_type} value must be positive (got {value})."
 
     return True, ""
+
+
+# SI prefix table used by format_si (threshold-based, ascending order)
+_SI_PREFIXES = [
+    (1e-15, "f"),
+    (1e-12, "p"),
+    (1e-9, "n"),
+    (1e-6, "\u00b5"),
+    (1e-3, "m"),
+    (1e0, ""),
+    (1e3, "k"),
+    (1e6, "M"),
+    (1e9, "G"),
+]
+
+
+def format_si(value, unit=""):
+    """Format a value with SI prefix.
+
+    Examples:
+        format_si(0.0033, "V") -> "3.30 mV"
+        format_si(1500, "Hz") -> "1.50 kHz"
+        format_si(0, "V") -> "0.00 V"
+    """
+    if value == 0 or not math.isfinite(value):
+        return f"0.00 {unit}" if unit else "0.00"
+
+    abs_val = abs(value)
+    for threshold, prefix in _SI_PREFIXES:
+        if abs_val < threshold * 1000:
+            scaled = value / threshold
+            return f"{scaled:.2f} {prefix}{unit}" if unit else f"{scaled:.2f} {prefix}"
+
+    # Larger than 1G — use the largest prefix
+    threshold, prefix = _SI_PREFIXES[-1]
+    scaled = value / threshold
+    return f"{scaled:.2f} {prefix}{unit}" if unit else f"{scaled:.2f} {prefix}"
+
+
+def format_frequency(freq_hz):
+    """Format a frequency value with appropriate SI prefix."""
+    if freq_hz is None:
+        return "N/A"
+    if freq_hz >= 1e9:
+        return f"{freq_hz / 1e9:.2f} GHz"
+    elif freq_hz >= 1e6:
+        return f"{freq_hz / 1e6:.2f} MHz"
+    elif freq_hz >= 1e3:
+        return f"{freq_hz / 1e3:.2f} kHz"
+    else:
+        return f"{freq_hz:.2f} Hz"


### PR DESCRIPTION
## Summary - Moved format_si and format_frequency to utils/format_utils.py as shared formatting utilities - Added result analysis methods to SimulationController (format_results_table, compute_power_metrics, compute_power, compute_frequency_markers, compute_signal_fft, compute_mc_statistics) - Updated GUI files to import formatting from utils and route analysis through the controller - Simulation modules re-export moved functions for backward compatibility ## Test plan - [ ] Verify simulation results display correctly (OP, transient, AC, DC sweep) - [ ] Verify frequency markers on Bode plots - [ ] Verify FFT analysis dialog - [ ] Verify Monte Carlo statistics display - [ ] Verify power dissipation display - [ ] CI passes all checks Closes #569 Generated with Claude Code