### PR TITLE
Move validate_circuit_data to models, fix grading dependency

### DIFF
--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -18,41 +18,7 @@ AUTOSAVE_FILE = ".autosave_recovery.json"
 MAX_RECENT_FILES = 10
 
 
-def validate_circuit_data(data) -> None:
-    """
-    Validate JSON structure before loading.
-
-    Raises ValueError with a descriptive message if anything is wrong.
-    This is the same validation that was previously in CircuitCanvas._validate_circuit_data.
-    """
-    if not isinstance(data, dict):
-        raise ValueError("File does not contain a valid circuit object.")
-
-    if "components" not in data or not isinstance(data["components"], list):
-        raise ValueError("Missing or invalid 'components' list.")
-    if "wires" not in data or not isinstance(data["wires"], list):
-        raise ValueError("Missing or invalid 'wires' list.")
-
-    comp_ids = set()
-    for i, comp in enumerate(data["components"]):
-        for key in ("id", "type", "value", "pos"):
-            if key not in comp:
-                raise ValueError(f"Component #{i + 1} is missing required field '{key}'.")
-        pos = comp["pos"]
-        if not isinstance(pos, dict) or "x" not in pos or "y" not in pos:
-            raise ValueError(f"Component '{comp.get('id', i)}' has invalid position data.")
-        if not isinstance(pos["x"], (int, float)) or not isinstance(pos["y"], (int, float)):
-            raise ValueError(f"Component '{comp['id']}' position values must be numeric.")
-        comp_ids.add(comp["id"])
-
-    for i, wire in enumerate(data["wires"]):
-        for key in ("start_comp", "end_comp", "start_term", "end_term"):
-            if key not in wire:
-                raise ValueError(f"Wire #{i + 1} is missing required field '{key}'.")
-        if wire["start_comp"] not in comp_ids:
-            raise ValueError(f"Wire #{i + 1} references unknown component '{wire['start_comp']}'.")
-        if wire["end_comp"] not in comp_ids:
-            raise ValueError(f"Wire #{i + 1} references unknown component '{wire['end_comp']}'.")
+from models.circuit_validator import validate_circuit_data  # noqa: F401 — re-exported for compatibility
 
 
 class FileController:

--- a/app/grading/batch_grader.py
+++ b/app/grading/batch_grader.py
@@ -13,10 +13,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Optional
 
-from controllers.file_controller import validate_circuit_data
 from grading.grader import CircuitGrader, GradingResult
 from grading.rubric import Rubric
 from models.circuit import CircuitModel
+from models.circuit_validator import validate_circuit_data
 
 logger = logging.getLogger(__name__)
 

--- a/app/models/circuit_validator.py
+++ b/app/models/circuit_validator.py
@@ -1,0 +1,41 @@
+"""Validate circuit JSON data structures.
+
+Pure-Python validation with no controller or Qt dependencies.
+This module is the canonical location for ``validate_circuit_data``.
+"""
+
+
+def validate_circuit_data(data) -> None:
+    """
+    Validate JSON structure before loading.
+
+    Raises ValueError with a descriptive message if anything is wrong.
+    """
+    if not isinstance(data, dict):
+        raise ValueError("File does not contain a valid circuit object.")
+
+    if "components" not in data or not isinstance(data["components"], list):
+        raise ValueError("Missing or invalid 'components' list.")
+    if "wires" not in data or not isinstance(data["wires"], list):
+        raise ValueError("Missing or invalid 'wires' list.")
+
+    comp_ids = set()
+    for i, comp in enumerate(data["components"]):
+        for key in ("id", "type", "value", "pos"):
+            if key not in comp:
+                raise ValueError(f"Component #{i + 1} is missing required field '{key}'.")
+        pos = comp["pos"]
+        if not isinstance(pos, dict) or "x" not in pos or "y" not in pos:
+            raise ValueError(f"Component '{comp.get('id', i)}' has invalid position data.")
+        if not isinstance(pos["x"], (int, float)) or not isinstance(pos["y"], (int, float)):
+            raise ValueError(f"Component '{comp['id']}' position values must be numeric.")
+        comp_ids.add(comp["id"])
+
+    for i, wire in enumerate(data["wires"]):
+        for key in ("start_comp", "end_comp", "start_term", "end_term"):
+            if key not in wire:
+                raise ValueError(f"Wire #{i + 1} is missing required field '{key}'.")
+        if wire["start_comp"] not in comp_ids:
+            raise ValueError(f"Wire #{i + 1} references unknown component '{wire['start_comp']}'.")
+        if wire["end_comp"] not in comp_ids:
+            raise ValueError(f"Wire #{i + 1} references unknown component '{wire['end_comp']}'.")


### PR DESCRIPTION
## Summary - Extracted validate_circuit_data from controllers/file_controller.py into models/circuit_validator.py - Updated grading/batch_grader.py to import from models instead of controllers, eliminating the backwards dependency - Controllers re-export the function for backward compatibility ## Test plan - [ ] Verify batch grading still works - [ ] Verify file loading validation still works - [ ] CI passes all checks Closes #588 Generated with Claude Code