### PR TITLE
Move template CRUD out of NewFromTemplateDialog (#602)

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -715,7 +715,12 @@ class FileOperationsMixin:
         if not hasattr(self, "_template_manager"):
             self._template_manager = TemplateManager()
 
-        dialog = NewFromTemplateDialog(self._template_manager, self)
+        templates = self._template_manager.list_templates()
+        dialog = NewFromTemplateDialog(
+            templates,
+            delete_callback=self._template_manager.delete_template,
+            parent=self,
+        )
         if dialog.exec() == NewFromTemplateDialog.DialogCode.Accepted:
             template_info = dialog.get_selected_template()
             if template_info is None:

--- a/app/GUI/template_dialog.py
+++ b/app/GUI/template_dialog.py
@@ -1,8 +1,9 @@
 """Dialogs for circuit template save and load."""
 
-from typing import Optional
+from pathlib import Path
+from typing import Callable, Optional
 
-from controllers.template_manager import TemplateInfo, TemplateManager
+from controllers.template_manager import TemplateInfo
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
     QDialog,
@@ -21,11 +22,22 @@ from PyQt6.QtWidgets import (
 
 
 class NewFromTemplateDialog(QDialog):
-    """Dialog for creating a new circuit from a template."""
+    """Dialog for creating a new circuit from a template.
 
-    def __init__(self, template_manager: TemplateManager, parent=None):
+    This dialog is a pure view: it receives pre-fetched template data and
+    an optional *delete_callback* so that all CRUD operations stay in the
+    controller layer.
+    """
+
+    def __init__(
+        self,
+        templates: list[TemplateInfo],
+        delete_callback: Optional[Callable[[Path], bool]] = None,
+        parent=None,
+    ):
         super().__init__(parent)
-        self.template_manager = template_manager
+        self._templates = list(templates)
+        self._delete_callback = delete_callback
         self.selected_template: Optional[TemplateInfo] = None
         self._setup_ui()
         self._populate_templates()
@@ -82,12 +94,11 @@ class NewFromTemplateDialog(QDialog):
         layout.addLayout(right, stretch=1)
 
     def _populate_templates(self):
-        """Load and display all templates grouped by category."""
+        """Display templates grouped by category."""
         self.template_list.clear()
-        templates = self.template_manager.list_templates()
 
         current_category = None
-        for template in templates:
+        for template in self._templates:
             if template.category != current_category:
                 current_category = template.category
                 header = QListWidgetItem(f"--- {current_category} ---")
@@ -136,6 +147,8 @@ class NewFromTemplateDialog(QDialog):
     def _on_delete(self):
         if self.selected_template is None or self.selected_template.is_builtin:
             return
+        if self._delete_callback is None:
+            return
 
         reply = QMessageBox.question(
             self,
@@ -144,9 +157,11 @@ class NewFromTemplateDialog(QDialog):
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
         )
         if reply == QMessageBox.StandardButton.Yes:
-            self.template_manager.delete_template(self.selected_template.filepath)
-            self._populate_templates()
-            self._clear_details()
+            deleted = self._delete_callback(self.selected_template.filepath)
+            if deleted:
+                self._templates = [t for t in self._templates if t.filepath != self.selected_template.filepath]
+                self._populate_templates()
+                self._clear_details()
 
     def get_selected_template(self) -> Optional[TemplateInfo]:
         return self.selected_template

--- a/app/tests/unit/test_template_dialog.py
+++ b/app/tests/unit/test_template_dialog.py
@@ -1,0 +1,207 @@
+"""Tests for NewFromTemplateDialog after MVC refactor (#602).
+
+The dialog now receives a pre-fetched list of TemplateInfo objects and an
+optional delete callback, instead of directly holding a TemplateManager
+reference.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from controllers.template_manager import TemplateInfo
+
+
+def _make_templates():
+    """Return a small list of TemplateInfo objects for testing."""
+    return [
+        TemplateInfo(
+            name="Voltage Divider",
+            description="Basic voltage divider",
+            category="Passives",
+            filepath=Path("/builtin/voltage_divider.json"),
+            is_builtin=True,
+        ),
+        TemplateInfo(
+            name="RC Filter",
+            description="Simple RC low-pass filter",
+            category="Passives",
+            filepath=Path("/builtin/rc_filter.json"),
+            is_builtin=True,
+        ),
+        TemplateInfo(
+            name="My Custom",
+            description="User-created template",
+            category="User",
+            filepath=Path("/user/my_custom.json"),
+            is_builtin=False,
+        ),
+    ]
+
+
+@pytest.fixture
+def templates():
+    return _make_templates()
+
+
+@pytest.fixture
+def dialog(qtbot, templates):
+    from GUI.template_dialog import NewFromTemplateDialog
+
+    dlg = NewFromTemplateDialog(templates)
+    qtbot.addWidget(dlg)
+    return dlg
+
+
+class TestNewFromTemplateDialogConstruction:
+    """Dialog construction and template population."""
+
+    def test_no_template_manager_attribute(self, dialog):
+        """Dialog must not store a TemplateManager reference."""
+        assert not hasattr(dialog, "template_manager")
+
+    def test_stores_template_list(self, dialog, templates):
+        """Dialog stores a copy of the template list."""
+        assert dialog._templates == templates
+        # Must be a copy, not the same object
+        assert dialog._templates is not templates
+
+    def test_populates_list_widget(self, dialog):
+        """Template list widget has items for each template plus headers."""
+        # 2 category headers (Passives, User) + 3 template items = 5
+        assert dialog.template_list.count() == 5
+
+    def test_ok_button_disabled_initially(self, dialog):
+        """OK button is disabled until a template is selected."""
+        assert not dialog.ok_button.isEnabled()
+
+    def test_delete_button_disabled_initially(self, dialog):
+        """Delete button is disabled until a user template is selected."""
+        assert not dialog.delete_btn.isEnabled()
+
+    def test_empty_template_list(self, qtbot):
+        """Dialog handles an empty template list gracefully."""
+        from GUI.template_dialog import NewFromTemplateDialog
+
+        dlg = NewFromTemplateDialog([])
+        qtbot.addWidget(dlg)
+        assert dlg.template_list.count() == 0
+
+
+class TestNewFromTemplateDialogSelection:
+    """Template selection behaviour."""
+
+    def test_select_builtin_template(self, dialog):
+        """Selecting a built-in template enables OK but not delete."""
+        # Item at index 1 is the first template (index 0 is the category header)
+        dialog.template_list.setCurrentRow(1)
+        assert dialog.ok_button.isEnabled()
+        assert not dialog.delete_btn.isEnabled()
+
+    def test_select_user_template(self, dialog):
+        """Selecting a user template enables both OK and delete."""
+        # Category headers at 0, 3; user template at index 4
+        dialog.template_list.setCurrentRow(4)
+        assert dialog.ok_button.isEnabled()
+        assert dialog.delete_btn.isEnabled()
+
+    def test_get_selected_template(self, dialog, templates):
+        """get_selected_template returns the correct TemplateInfo."""
+        dialog.template_list.setCurrentRow(1)
+        selected = dialog.get_selected_template()
+        assert selected is not None
+        assert selected.name == "Voltage Divider"
+
+
+class TestNewFromTemplateDialogDelete:
+    """Delete callback integration."""
+
+    def test_delete_callback_called(self, qtbot, templates, monkeypatch):
+        """Clicking delete invokes the callback with the correct filepath."""
+        from GUI.template_dialog import NewFromTemplateDialog
+
+        callback = MagicMock(return_value=True)
+        dlg = NewFromTemplateDialog(templates, delete_callback=callback)
+        qtbot.addWidget(dlg)
+
+        # Select the user template (index 4)
+        dlg.template_list.setCurrentRow(4)
+
+        # Monkeypatch QMessageBox to auto-confirm
+        monkeypatch.setattr(
+            "GUI.template_dialog.QMessageBox.question",
+            lambda *a, **kw: QMessageBox.StandardButton.Yes,
+        )
+        from PyQt6.QtWidgets import QMessageBox
+
+        monkeypatch.setattr(
+            "GUI.template_dialog.QMessageBox.question",
+            lambda *a, **kw: QMessageBox.StandardButton.Yes,
+        )
+
+        dlg._on_delete()
+        callback.assert_called_once_with(Path("/user/my_custom.json"))
+
+    def test_delete_removes_from_list(self, qtbot, templates, monkeypatch):
+        """Successful delete removes the template from the list widget."""
+        from GUI.template_dialog import NewFromTemplateDialog
+        from PyQt6.QtWidgets import QMessageBox
+
+        callback = MagicMock(return_value=True)
+        dlg = NewFromTemplateDialog(templates, delete_callback=callback)
+        qtbot.addWidget(dlg)
+
+        dlg.template_list.setCurrentRow(4)
+        monkeypatch.setattr(
+            "GUI.template_dialog.QMessageBox.question",
+            lambda *a, **kw: QMessageBox.StandardButton.Yes,
+        )
+
+        count_before = dlg.template_list.count()
+        dlg._on_delete()
+        # Removed the template and its category header (User was the only one)
+        assert dlg.template_list.count() < count_before
+
+    def test_delete_callback_returning_false_keeps_list(self, qtbot, templates, monkeypatch):
+        """If the callback returns False, the list is unchanged."""
+        from GUI.template_dialog import NewFromTemplateDialog
+        from PyQt6.QtWidgets import QMessageBox
+
+        callback = MagicMock(return_value=False)
+        dlg = NewFromTemplateDialog(templates, delete_callback=callback)
+        qtbot.addWidget(dlg)
+
+        dlg.template_list.setCurrentRow(4)
+        monkeypatch.setattr(
+            "GUI.template_dialog.QMessageBox.question",
+            lambda *a, **kw: QMessageBox.StandardButton.Yes,
+        )
+
+        count_before = dlg.template_list.count()
+        dlg._on_delete()
+        assert dlg.template_list.count() == count_before
+
+    def test_no_callback_skips_delete(self, qtbot, templates):
+        """Without a delete callback, _on_delete is a no-op."""
+        from GUI.template_dialog import NewFromTemplateDialog
+
+        dlg = NewFromTemplateDialog(templates, delete_callback=None)
+        qtbot.addWidget(dlg)
+
+        dlg.template_list.setCurrentRow(4)
+        count_before = dlg.template_list.count()
+        dlg._on_delete()
+        assert dlg.template_list.count() == count_before
+
+    def test_cannot_delete_builtin(self, qtbot, templates):
+        """_on_delete is a no-op for built-in templates."""
+        from GUI.template_dialog import NewFromTemplateDialog
+
+        callback = MagicMock(return_value=True)
+        dlg = NewFromTemplateDialog(templates, delete_callback=callback)
+        qtbot.addWidget(dlg)
+
+        # Select built-in template
+        dlg.template_list.setCurrentRow(1)
+        dlg._on_delete()
+        callback.assert_not_called()


### PR DESCRIPTION
## Summary
- **NewFromTemplateDialog** no longer holds a `TemplateManager` reference. It receives a pre-fetched `list[TemplateInfo]` and an optional `delete_callback`, keeping all CRUD in the controller layer.
- The call site in `FileOperationsMixin._on_new_from_template()` now passes `TemplateManager.list_templates()` and `TemplateManager.delete_template` as the callback.
- Added 14 new tests for the refactored dialog (construction, selection, delete callback, guard rails).

Closes #602

## Test plan
- [x] 14 new tests in `test_template_dialog.py` all pass
- [x] Full suite: 3136 passed (14 pre-existing failures in `test_settings_service.py` unrelated)
- [x] Formatting: `isort` + `black` clean
- [x] Pre-commit hooks pass