### PR TITLE
Move export dispatch logic from GUI views to controllers (#570)

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -359,8 +359,6 @@ class FileOperationsMixin:
 
     def _on_export_bom(self):
         """Export a Bill of Materials (BOM) as CSV or Excel."""
-        from simulation.bom_exporter import export_bom_csv, export_bom_excel, write_bom_csv
-
         if not self.model.components:
             QMessageBox.information(self, "Export BOM", "Nothing to export — the canvas is empty.")
             return
@@ -375,19 +373,19 @@ class FileOperationsMixin:
             return
 
         try:
+            # Ensure correct extension based on selected filter
+            if filename.lower().endswith(".xlsx") or "Excel" in selected_filter:
+                if not filename.lower().endswith(".xlsx"):
+                    filename += ".xlsx"
+            else:
+                if not filename.lower().endswith(".csv"):
+                    filename += ".csv"
+
             circuit_name = ""
             if hasattr(self, "file_ctrl") and self.file_ctrl.current_file:
                 circuit_name = self.file_ctrl.current_file.name
 
-            if filename.lower().endswith(".xlsx") or "Excel" in selected_filter:
-                if not filename.lower().endswith(".xlsx"):
-                    filename += ".xlsx"
-                export_bom_excel(self.model.components, filename, circuit_name=circuit_name)
-            else:
-                if not filename.lower().endswith(".csv"):
-                    filename += ".csv"
-                content = export_bom_csv(self.model.components, circuit_name=circuit_name)
-                write_bom_csv(content, filename)
+            self.file_ctrl.export_bom(filename, circuit_name=circuit_name)
 
             statusBar = self.statusBar()
             if statusBar:
@@ -397,8 +395,6 @@ class FileOperationsMixin:
 
     def _on_export_asc(self):
         """Export the circuit as an LTspice .asc schematic file."""
-        from simulation.asc_exporter import export_asc, write_asc
-
         if not self.model.components:
             QMessageBox.information(self, "Export LTspice", "Nothing to export — the canvas is empty.")
             return
@@ -413,8 +409,7 @@ class FileOperationsMixin:
             return
 
         try:
-            content = export_asc(self.model)
-            write_asc(content, filename)
+            self.file_ctrl.export_asc(filename)
             statusBar = self.statusBar()
             if statusBar:
                 statusBar.showMessage(f"LTspice schematic exported to {filename}", 3000)
@@ -528,25 +523,10 @@ class FileOperationsMixin:
             results_csv = None
             if self._last_results is not None:
                 try:
-                    from simulation.csv_exporter import (
-                        export_ac_results,
-                        export_dc_sweep_results,
-                        export_noise_results,
-                        export_op_results,
-                        export_transient_results,
-                    )
-
                     cn = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-                    dispatch = {
-                        "DC Operating Point": export_op_results,
-                        "DC Sweep": export_dc_sweep_results,
-                        "AC Sweep": export_ac_results,
-                        "Transient": export_transient_results,
-                        "Noise": export_noise_results,
-                    }
-                    func = dispatch.get(self._last_results_type)
-                    if func:
-                        results_csv = func(self._last_results, cn)
+                    results_csv = self.simulation_ctrl.generate_results_csv(
+                        self._last_results, self._last_results_type, cn
+                    )
                 except Exception:
                     pass
 
@@ -554,12 +534,12 @@ class FileOperationsMixin:
             results_xlsx_path = None
             if self._last_results is not None:
                 try:
-                    from simulation.excel_exporter import export_to_excel
-
                     cn = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
                     tmp_xlsx = tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False)
                     tmp_xlsx.close()
-                    export_to_excel(self._last_results, self._last_results_type, tmp_xlsx.name, cn)
+                    self.simulation_ctrl.export_results_excel(
+                        self._last_results, self._last_results_type, tmp_xlsx.name, cn
+                    )
                     results_xlsx_path = tmp_xlsx.name
                 except Exception:
                     pass
@@ -859,23 +839,14 @@ class FileOperationsMixin:
         import os
 
         try:
+            circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+
             if export_function == "export_netlist":
-                netlist = self.simulation_ctrl.generate_netlist()
-                with open(path, "w") as f:
-                    f.write(netlist)
+                self.simulation_ctrl.export_netlist(path)
             elif export_function == "export_image":
                 self.canvas.export_image(path, include_grid=False)
-            elif export_function == "export_bom_csv":
-                from simulation.bom_exporter import export_bom_csv, write_bom_csv
-
-                circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-                content = export_bom_csv(self.model.components, circuit_name=circuit_name)
-                write_bom_csv(content, path)
-            elif export_function == "export_bom_excel":
-                from simulation.bom_exporter import export_bom_excel
-
-                circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-                export_bom_excel(self.model.components, path, circuit_name=circuit_name)
+            elif export_function in ("export_bom_csv", "export_bom_excel"):
+                self.file_ctrl.export_bom(path, circuit_name=circuit_name)
             elif export_function == "export_results_csv":
                 self._re_export_results_csv(path)
             elif export_function == "export_results_excel":
@@ -892,16 +863,12 @@ class FileOperationsMixin:
                 with open(path, "w") as f:
                     f.write(content)
             elif export_function == "export_asc":
-                from simulation.asc_exporter import export_asc, write_asc
-
-                content = export_asc(self.model)
-                write_asc(content, path)
+                self.file_ctrl.export_asc(path)
             elif export_function == "export_results_markdown":
-                md = self._get_markdown_content()
-                if md:
-                    from simulation.markdown_exporter import write_markdown
-
-                    write_markdown(md, path)
+                if self._last_results is not None:
+                    self.simulation_ctrl.export_results_markdown(
+                        self._last_results, self._last_results_type, path, circuit_name
+                    )
             else:
                 QMessageBox.warning(self, "Re-export", f"Unknown export type: {export_function}")
                 return
@@ -918,26 +885,8 @@ class FileOperationsMixin:
             return
         import os
 
-        from simulation.csv_exporter import (
-            export_ac_results,
-            export_dc_sweep_results,
-            export_noise_results,
-            export_op_results,
-            export_transient_results,
-            write_csv,
-        )
-
         circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-        dispatch = {
-            "DC Operating Point": export_op_results,
-            "DC Sweep": export_dc_sweep_results,
-            "AC Sweep": export_ac_results,
-            "Transient": export_transient_results,
-            "Noise": export_noise_results,
-        }
-        func = dispatch.get(self._last_results_type)
-        if func:
-            write_csv(func(self._last_results, circuit_name), path)
+        self.simulation_ctrl.export_results_csv(self._last_results, self._last_results_type, path, circuit_name)
 
     def _re_export_results_excel(self, path):
         """Re-export simulation results to Excel at the given path."""
@@ -945,10 +894,8 @@ class FileOperationsMixin:
             return
         import os
 
-        from simulation.excel_exporter import export_to_excel
-
         circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-        export_to_excel(self._last_results, self._last_results_type, path, circuit_name)
+        self.simulation_ctrl.export_results_excel(self._last_results, self._last_results_type, path, circuit_name)
 
     # --- Recommended / Used-in-File Components ---
 

--- a/app/GUI/main_window_simulation.py
+++ b/app/GUI/main_window_simulation.py
@@ -32,7 +32,7 @@ class SimulationMixin:
     def export_netlist(self):
         """Export SPICE netlist to a .cir file."""
         try:
-            netlist = self.simulation_ctrl.generate_netlist()
+            self.simulation_ctrl.generate_netlist()
         except (ValueError, KeyError, TypeError) as e:
             QMessageBox.critical(self, "Error", f"Failed to generate netlist: {e}")
             return
@@ -52,12 +52,11 @@ class SimulationMixin:
             return
 
         try:
-            with open(filename, "w", encoding="utf-8") as f:
-                f.write(netlist)
+            self.simulation_ctrl.export_netlist(filename)
             statusBar = self.statusBar()
             if statusBar:
                 statusBar.showMessage(f"Netlist exported to {filename}", 3000)
-        except OSError as e:
+        except (ValueError, KeyError, TypeError, OSError) as e:
             QMessageBox.critical(self, "Error", f"Failed to export netlist: {e}")
 
     def run_simulation(self):
@@ -668,38 +667,17 @@ class SimulationMixin:
             self._show_plot_dialog(dialog_class(data, self))
 
     def export_results_csv(self):
-        """Export the last simulation results to a CSV file"""
+        """Export the last simulation results to a CSV file."""
         if self._last_results is None:
-            return
-
-        from simulation.csv_exporter import (
-            export_ac_results,
-            export_dc_sweep_results,
-            export_noise_results,
-            export_op_results,
-            export_transient_results,
-            write_csv,
-        )
-
-        circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-
-        if self._last_results_type == "DC Operating Point":
-            csv_content = export_op_results(self._last_results, circuit_name)
-        elif self._last_results_type == "DC Sweep":
-            csv_content = export_dc_sweep_results(self._last_results, circuit_name)
-        elif self._last_results_type == "AC Sweep":
-            csv_content = export_ac_results(self._last_results, circuit_name)
-        elif self._last_results_type == "Transient":
-            csv_content = export_transient_results(self._last_results, circuit_name)
-        elif self._last_results_type == "Noise":
-            csv_content = export_noise_results(self._last_results, circuit_name)
-        else:
             return
 
         filename, _ = QFileDialog.getSaveFileName(self, "Export Results to CSV", "", "CSV Files (*.csv);;All Files (*)")
         if filename:
             try:
-                write_csv(csv_content, filename)
+                circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+                self.simulation_ctrl.export_results_csv(
+                    self._last_results, self._last_results_type, filename, circuit_name
+                )
                 statusBar = self.statusBar()
                 if statusBar:
                     statusBar.showMessage(f"Results exported to {filename}", 3000)
@@ -711,16 +689,15 @@ class SimulationMixin:
         if self._last_results is None:
             return
 
-        from simulation.excel_exporter import export_to_excel
-
-        circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-
         filename, _ = QFileDialog.getSaveFileName(
             self, "Export Results to Excel", "", "Excel Files (*.xlsx);;All Files (*)"
         )
         if filename:
             try:
-                export_to_excel(self._last_results, self._last_results_type, filename, circuit_name)
+                circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+                self.simulation_ctrl.export_results_excel(
+                    self._last_results, self._last_results_type, filename, circuit_name
+                )
                 statusBar = self.statusBar()
                 if statusBar:
                     statusBar.showMessage(f"Results exported to {filename}", 3000)
@@ -732,27 +709,8 @@ class SimulationMixin:
         if self._last_results is None:
             return None
 
-        from simulation.markdown_exporter import (
-            export_ac_results,
-            export_dc_sweep_results,
-            export_noise_results,
-            export_op_results,
-            export_transient_results,
-        )
-
         circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-
-        if self._last_results_type == "DC Operating Point":
-            return export_op_results(self._last_results, circuit_name)
-        elif self._last_results_type == "DC Sweep":
-            return export_dc_sweep_results(self._last_results, circuit_name)
-        elif self._last_results_type == "AC Sweep":
-            return export_ac_results(self._last_results, circuit_name)
-        elif self._last_results_type == "Transient":
-            return export_transient_results(self._last_results, circuit_name)
-        elif self._last_results_type == "Noise":
-            return export_noise_results(self._last_results, circuit_name)
-        return None
+        return self.simulation_ctrl.generate_results_markdown(self._last_results, self._last_results_type, circuit_name)
 
     def copy_results_markdown(self):
         """Copy the last simulation results as Markdown to the clipboard."""
@@ -768,11 +726,8 @@ class SimulationMixin:
 
     def export_results_markdown(self):
         """Export the last simulation results to a Markdown (.md) file."""
-        md_content = self._get_markdown_content()
-        if md_content is None:
+        if self._last_results is None:
             return
-
-        from simulation.markdown_exporter import write_markdown
 
         filename, _ = QFileDialog.getSaveFileName(
             self,
@@ -782,7 +737,10 @@ class SimulationMixin:
         )
         if filename:
             try:
-                write_markdown(md_content, filename)
+                circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+                self.simulation_ctrl.export_results_markdown(
+                    self._last_results, self._last_results_type, filename, circuit_name
+                )
                 statusBar = self.statusBar()
                 if statusBar:
                     statusBar.showMessage(f"Results exported to {filename}", 3000)

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -385,6 +385,33 @@ class FileController:
 
         return warnings
 
+    # --- Export helpers ---
+
+    def export_bom(self, filepath: str, circuit_name: str = "") -> None:
+        """Export a Bill of Materials. Format is determined by file extension.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        from simulation.bom_exporter import export_bom_csv, export_bom_excel, write_bom_csv
+
+        if filepath.lower().endswith(".xlsx"):
+            export_bom_excel(self.model.components, filepath, circuit_name=circuit_name)
+        else:
+            content = export_bom_csv(self.model.components, circuit_name=circuit_name)
+            write_bom_csv(content, filepath)
+
+    def export_asc(self, filepath: str) -> None:
+        """Export the circuit as an LTspice .asc schematic.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        from simulation.asc_exporter import export_asc, write_asc
+
+        content = export_asc(self.model)
+        write_asc(content, filepath)
+
     def clear_auto_save(self) -> None:
         """Delete the auto-save recovery file if it exists."""
         try:

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -626,3 +626,100 @@ class SimulationController:
         from simulation.monte_carlo import format_spice_value
 
         return format_spice_value(value)
+
+    # --- Export helpers ---
+
+    def export_netlist(self, filepath: str) -> None:
+        """Generate a SPICE netlist and write it to a file.
+
+        Raises:
+            ValueError, KeyError, TypeError: If netlist generation fails.
+            OSError: If the file cannot be written.
+        """
+        netlist = self.generate_netlist()
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.write(netlist)
+
+    def generate_results_csv(self, results, results_type: str, circuit_name: str = "") -> Optional[str]:
+        """Generate CSV content from simulation results.
+
+        Returns None if the results type is not supported for CSV export.
+        """
+        from simulation.csv_exporter import (
+            export_ac_results,
+            export_dc_sweep_results,
+            export_noise_results,
+            export_op_results,
+            export_transient_results,
+        )
+
+        dispatch = {
+            "DC Operating Point": export_op_results,
+            "DC Sweep": export_dc_sweep_results,
+            "AC Sweep": export_ac_results,
+            "Transient": export_transient_results,
+            "Noise": export_noise_results,
+        }
+        func = dispatch.get(results_type)
+        if func is None:
+            return None
+        return func(results, circuit_name)
+
+    def export_results_csv(self, results, results_type: str, filepath: str, circuit_name: str = "") -> None:
+        """Export simulation results to a CSV file.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        from simulation.csv_exporter import write_csv
+
+        content = self.generate_results_csv(results, results_type, circuit_name)
+        if content is not None:
+            write_csv(content, filepath)
+
+    def export_results_excel(self, results, results_type: str, filepath: str, circuit_name: str = "") -> None:
+        """Export simulation results to an Excel (.xlsx) file.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        from simulation.excel_exporter import export_to_excel
+
+        export_to_excel(results, results_type, filepath, circuit_name)
+
+    def generate_results_markdown(self, results, results_type: str, circuit_name: str = "") -> Optional[str]:
+        """Generate Markdown content from simulation results.
+
+        Returns None if the results type is not supported.
+        """
+        from simulation.markdown_exporter import (
+            export_ac_results,
+            export_dc_sweep_results,
+            export_noise_results,
+            export_op_results,
+            export_transient_results,
+        )
+
+        dispatch = {
+            "DC Operating Point": export_op_results,
+            "DC Sweep": export_dc_sweep_results,
+            "AC Sweep": export_ac_results,
+            "Transient": export_transient_results,
+            "Noise": export_noise_results,
+        }
+        func = dispatch.get(results_type)
+        if func is None:
+            return None
+        return func(results, circuit_name)
+
+    def export_results_markdown(self, results, results_type: str, filepath: str, circuit_name: str = "") -> None:
+        """Export simulation results to a Markdown file.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        from simulation.markdown_exporter import write_markdown
+
+        content = self.generate_results_markdown(results, results_type, circuit_name)
+        if content is not None:
+            write_markdown(content, filepath)

--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -584,6 +584,42 @@ class TestAnnotationsAndRecommendedComponents:
         assert ctrl2.model.analysis_type == "AC Sweep"
 
 
+class TestExportBom:
+    """Tests for FileController.export_bom (Issue #570)."""
+
+    @patch("controllers.file_controller.settings")
+    def test_export_bom_csv(self, mock_settings, tmp_path):
+        model = _build_simple_circuit()
+        ctrl = FileController(model)
+        filepath = tmp_path / "bom.csv"
+        ctrl.export_bom(str(filepath), circuit_name="test")
+        assert filepath.exists()
+        content = filepath.read_text()
+        assert "R1" in content or "Resistor" in content
+
+    @patch("controllers.file_controller.settings")
+    def test_export_bom_excel(self, mock_settings, tmp_path):
+        model = _build_simple_circuit()
+        ctrl = FileController(model)
+        filepath = tmp_path / "bom.xlsx"
+        ctrl.export_bom(str(filepath), circuit_name="test")
+        assert filepath.exists()
+
+
+class TestExportAsc:
+    """Tests for FileController.export_asc (Issue #570)."""
+
+    @patch("controllers.file_controller.settings")
+    def test_export_asc_writes_file(self, mock_settings, tmp_path):
+        model = _build_simple_circuit()
+        ctrl = FileController(model)
+        filepath = tmp_path / "circuit.asc"
+        ctrl.export_asc(str(filepath))
+        assert filepath.exists()
+        content = filepath.read_text()
+        assert len(content) > 0
+
+
 class TestQtDependencies:
     def test_settings_service_used_for_recent_files(self):
         """FileController uses centralized SettingsService for persistence (#598)."""

--- a/app/tests/unit/test_noise_analysis.py
+++ b/app/tests/unit/test_noise_analysis.py
@@ -346,10 +346,10 @@ class TestNoiseCSVExport:
         assert "Input Noise" in csv
 
     def test_csv_export_handles_noise_type(self):
-        """main_window_simulation CSV export should route noise results."""
-        from GUI.main_window_simulation import SimulationMixin
+        """SimulationController CSV dispatch should route noise results."""
+        from controllers.simulation_controller import SimulationController
 
-        source = inspect.getsource(SimulationMixin.export_results_csv)
+        source = inspect.getsource(SimulationController.generate_results_csv)
         assert "export_noise_results" in source
         assert '"Noise"' in source
 

--- a/app/tests/unit/test_simulation_controller.py
+++ b/app/tests/unit/test_simulation_controller.py
@@ -226,6 +226,80 @@ class TestRunSimulation:
         assert mock_runner.run_simulation.call_count == 2
 
 
+class TestExportNetlist:
+    def test_export_netlist_writes_file(self, tmp_path):
+        model = _build_simple_circuit()
+        ctrl = SimulationController(model)
+        filepath = tmp_path / "test.cir"
+        ctrl.export_netlist(str(filepath))
+        assert filepath.exists()
+        content = filepath.read_text()
+        assert ".op" in content.lower() or ".end" in content.lower()
+
+    def test_export_netlist_raises_on_bad_path(self):
+        model = _build_simple_circuit()
+        ctrl = SimulationController(model)
+        with pytest.raises(OSError):
+            ctrl.export_netlist("/nonexistent/dir/test.cir")
+
+
+class TestExportResultsCSV:
+    def test_generate_results_csv_returns_content_for_op(self):
+        ctrl = SimulationController()
+        op_results = {"v(1)": 5.0, "v(2)": 3.3}
+        content = ctrl.generate_results_csv(op_results, "DC Operating Point", "test")
+        assert content is not None
+        assert "v(1)" in content or "5.0" in content
+
+    def test_generate_results_csv_returns_none_for_unsupported(self):
+        ctrl = SimulationController()
+        content = ctrl.generate_results_csv({}, "Pole-Zero", "test")
+        assert content is None
+
+    def test_export_results_csv_writes_file(self, tmp_path):
+        ctrl = SimulationController()
+        op_results = {"v(1)": 5.0, "v(2)": 3.3}
+        filepath = tmp_path / "results.csv"
+        ctrl.export_results_csv(op_results, "DC Operating Point", str(filepath), "test")
+        assert filepath.exists()
+
+    def test_export_results_csv_skips_unsupported_type(self, tmp_path):
+        ctrl = SimulationController()
+        filepath = tmp_path / "results.csv"
+        ctrl.export_results_csv({}, "Pole-Zero", str(filepath), "test")
+        assert not filepath.exists()
+
+
+class TestExportResultsExcel:
+    def test_export_results_excel_writes_file(self, tmp_path):
+        ctrl = SimulationController()
+        op_results = {"v(1)": 5.0}
+        filepath = tmp_path / "results.xlsx"
+        ctrl.export_results_excel(op_results, "DC Operating Point", str(filepath), "test")
+        assert filepath.exists()
+
+
+class TestExportResultsMarkdown:
+    def test_generate_results_markdown_returns_content(self):
+        ctrl = SimulationController()
+        op_results = {"v(1)": 5.0}
+        content = ctrl.generate_results_markdown(op_results, "DC Operating Point", "test")
+        assert content is not None
+        assert "v(1)" in content or "5.0" in content
+
+    def test_generate_results_markdown_returns_none_for_unsupported(self):
+        ctrl = SimulationController()
+        content = ctrl.generate_results_markdown({}, "Sensitivity", "test")
+        assert content is None
+
+    def test_export_results_markdown_writes_file(self, tmp_path):
+        ctrl = SimulationController()
+        op_results = {"v(1)": 5.0}
+        filepath = tmp_path / "results.md"
+        ctrl.export_results_markdown(op_results, "DC Operating Point", str(filepath), "test")
+        assert filepath.exists()
+
+
 class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import controllers.simulation_controller as mod


### PR DESCRIPTION
## Summary - Moved export I/O dispatch logic from  and  to  and  - GUI views now only handle file dialogs and status messages; all export dispatch + file writes go through controllers -  gains: , , , , ,  -  gains: ,  - Re-export and bundle export paths also updated to route through controllers ## Test plan - [ ] Existing tests pass (no Qt dependencies added to controllers) - [ ] New unit tests for  export methods (netlist, CSV, Excel, Markdown) - [ ] New unit tests for  export methods (BOM CSV/Excel, ASC) - [ ] Verify  still passes (no Qt in simulation_controller.py) Closes #570 🤖 Generated with [Claude Code](https://claude.com/claude-code)