### PR TITLE
Route ThemeEditorDialog mutations through controller (#600)

### DIFF
--- a/app/GUI/theme_editor_dialog.py
+++ b/app/GUI/theme_editor_dialog.py
@@ -1,5 +1,6 @@
 """Theme editor dialog for creating and editing custom color themes."""
 
+from controllers.theme_controller import theme_ctrl
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import (
@@ -18,7 +19,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from .styles import CustomTheme, DarkTheme, LightTheme, theme_manager
+from .styles import CustomTheme, DarkTheme, LightTheme
 
 # Color groups exposed in the editor (subset of all theme keys)
 COLOR_GROUPS = [
@@ -68,17 +69,18 @@ COLOR_GROUPS = [
 class ThemeEditorDialog(QDialog):
     """Dialog for creating/editing a custom color theme."""
 
-    def __init__(self, parent=None, edit_theme=None):
+    def __init__(self, parent=None, edit_theme=None, controller=None):
         super().__init__(parent)
         self.setWindowTitle("Theme Editor")
         self.setMinimumSize(480, 600)
 
+        self._ctrl = controller or theme_ctrl
         self._result_theme = None
         self._color_buttons = {}  # key -> QPushButton
         self._hex_labels = {}  # key -> QLabel
 
         # Snapshot current theme for revert on cancel
-        self._snap_theme = theme_manager.current_theme
+        self._snap_theme = self._ctrl.current_theme
 
         # Load base colors
         if edit_theme is not None and isinstance(edit_theme, CustomTheme):
@@ -203,7 +205,7 @@ class ThemeEditorDialog(QDialog):
         overrides = {k: v for k, v in self._colors.items() if v != base_theme._colors.get(k)}
 
         preview = CustomTheme(name=name, base=base, colors=overrides, theme_is_dark=is_dark)
-        theme_manager.set_theme(preview)
+        self._ctrl.set_theme(preview)
 
     def _on_ok(self):
         name = self.name_edit.text().strip()
@@ -219,17 +221,17 @@ class ThemeEditorDialog(QDialog):
         overrides = {k: v for k, v in self._colors.items() if v != base_theme._colors.get(k)}
 
         self._result_theme = CustomTheme(name=name, base=base, colors=overrides, theme_is_dark=is_dark)
-        theme_manager.set_theme(self._result_theme)
+        self._ctrl.set_theme(self._result_theme)
         self.accept()
 
     def _on_cancel(self):
         # Revert to snapshot
-        theme_manager.set_theme(self._snap_theme)
+        self._ctrl.set_theme(self._snap_theme)
         self.reject()
 
     def closeEvent(self, event):
         if self.result() != QDialog.DialogCode.Accepted:
-            theme_manager.set_theme(self._snap_theme)
+            self._ctrl.set_theme(self._snap_theme)
         super().closeEvent(event)
 
     def get_theme(self):

--- a/app/controllers/theme_controller.py
+++ b/app/controllers/theme_controller.py
@@ -1,0 +1,26 @@
+"""Controller for theme mutations.
+
+Routes all runtime theme changes through a single point of control
+so that view-layer dialogs never mutate global theme_manager state
+directly.
+"""
+
+from GUI.styles import theme_manager
+from GUI.styles.theme import ThemeProtocol
+
+
+class ThemeController:
+    """Thin controller that wraps theme_manager mutation methods."""
+
+    def set_theme(self, theme: ThemeProtocol) -> None:
+        """Apply *theme* as the active application theme."""
+        theme_manager.set_theme(theme)
+
+    @property
+    def current_theme(self) -> ThemeProtocol:
+        """Return the currently active theme."""
+        return theme_manager.current_theme
+
+
+# Module-level singleton
+theme_ctrl = ThemeController()

--- a/app/tests/unit/test_theme_editor_dialog.py
+++ b/app/tests/unit/test_theme_editor_dialog.py
@@ -72,6 +72,39 @@ class TestNameRequired:
         mock_warning.assert_called_once()
 
 
+class TestControllerRouting:
+    """Verify theme mutations are routed through the controller."""
+
+    def test_preview_calls_controller_set_theme(self, qtbot):
+        ctrl = MagicMock()
+        ctrl.current_theme = LightTheme()
+        dlg = ThemeEditorDialog(controller=ctrl)
+        qtbot.addWidget(dlg)
+
+        dlg._apply_preview()
+        ctrl.set_theme.assert_called_once()
+
+    def test_ok_calls_controller_set_theme(self, qtbot):
+        ctrl = MagicMock()
+        ctrl.current_theme = LightTheme()
+        dlg = ThemeEditorDialog(controller=ctrl)
+        qtbot.addWidget(dlg)
+
+        dlg.name_edit.setText("Test Theme")
+        dlg._on_ok()
+        ctrl.set_theme.assert_called()
+
+    def test_cancel_reverts_via_controller(self, qtbot):
+        snap = LightTheme()
+        ctrl = MagicMock()
+        ctrl.current_theme = snap
+        dlg = ThemeEditorDialog(controller=ctrl)
+        qtbot.addWidget(dlg)
+
+        dlg._on_cancel()
+        ctrl.set_theme.assert_called_once_with(snap)
+
+
 class TestResetButton:
     """Verify reset restores base colors."""
 


### PR DESCRIPTION
## Summary - Created  with a  class that wraps  and  - Refactored  to accept an optional  parameter and route all theme mutations (preview, OK, cancel/revert) through the controller instead of directly calling  - Added 3 new tests verifying controller routing for preview, OK, and cancel paths Closes #600 ## Test plan - [x] All 3139 tests pass (3136 existing + 3 new controller routing tests) - [x] Existing ThemeEditorDialog tests continue to pass (backward compatible via default singleton) - [x] Pre-commit hooks pass (ruff, isort, black) 🤖 Generated with [Claude Code](https://claude.com/claude-code)