### PR TITLE
Fix NMOS/PMOS transistor symbols to match ANSI/IEEE standard (#565)

### DIFF
--- a/app/GUI/renderers.py
+++ b/app/GUI/renderers.py
@@ -340,11 +340,13 @@ class IEEEMOSFETNMOS(ComponentRenderer):
         # Drain and source connections
         painter.drawLine(-5, -10, 20, -10)
         painter.drawLine(-5, 10, 20, 10)
-        # Body connection from center segment
-        painter.drawLine(-5, 0, 5, 0)
+        # Vertical bar connecting drain and source (body tied to source)
+        painter.drawLine(10, -10, 10, 10)
+        # Body connection from vertical bar toward channel
+        painter.drawLine(10, 0, -1, 0)
         # Arrow on body pointing INWARD (toward channel) for NMOS
-        painter.drawLine(5, 0, -1, -3)
-        painter.drawLine(5, 0, -1, 3)
+        painter.drawLine(-1, 0, 5, -3)
+        painter.drawLine(-1, 0, 5, 3)
 
     def get_obstacle_shape(self, component):
         return [(-12.0, -15.0), (12.0, -15.0), (12.0, 15.0), (-12.0, 15.0)]
@@ -365,13 +367,15 @@ class IEEEMOSFETPMOS(ComponentRenderer):
         # Drain and source connections
         painter.drawLine(-5, -10, 20, -10)
         painter.drawLine(-5, 10, 20, 10)
-        # Body connection from center segment
-        painter.drawLine(-5, 0, 5, 0)
+        # Vertical bar connecting drain and source (body tied to source)
+        painter.drawLine(10, -10, 10, 10)
+        # Body connection from channel toward vertical bar
+        painter.drawLine(-1, 0, 10, 0)
         # Arrow on body pointing OUTWARD (away from channel) for PMOS
-        painter.drawLine(-1, 0, 5, -3)
-        painter.drawLine(-1, 0, 5, 3)
-        # Bubble on gate for PMOS
-        painter.drawEllipse(-8, -2, 4, 4)
+        painter.drawLine(5, 0, -1, -3)
+        painter.drawLine(5, 0, -1, 3)
+        # Bubble on gate for PMOS (between gate plate and channel)
+        painter.drawEllipse(-9, -2, 4, 4)
 
     def get_obstacle_shape(self, component):
         return [(-12.0, -15.0), (12.0, -15.0), (12.0, 15.0), (-12.0, 15.0)]

--- a/app/tests/unit/test_renderer_symbols.py
+++ b/app/tests/unit/test_renderer_symbols.py
@@ -146,27 +146,52 @@ class TestMOSFETEnhancementMode:
         painter.drawEllipse.assert_not_called()
 
     def test_nmos_arrow_points_inward(self):
-        """NMOS arrow should point toward the channel (inward)."""
+        """NMOS arrow should point toward the channel (inward).
+
+        The arrowhead vertex (tip) should be at a smaller x than the barbs,
+        indicating the arrow points left toward the channel.
+        """
         renderer = IEEEMOSFETNMOS()
         painter = _make_mock_painter()
         comp = _make_mock_component(in_scene=False)
         renderer.draw(painter, comp)
         line_calls = painter.drawLine.call_args_list
-        # Arrow lines from body to channel: tip at negative x (toward channel)
-        # The arrowhead lines should converge leftward
-        arrowhead = [c for c in line_calls if c[0][0] == 5 and c[0][2] == -1]
+        # Arrowhead: two lines from tip (x=-1) with barbs toward x=5
+        arrowhead = [c for c in line_calls if c[0][0] == -1 and c[0][2] == 5]
         assert len(arrowhead) == 2
 
     def test_pmos_arrow_points_outward(self):
-        """PMOS arrow should point away from the channel (outward)."""
+        """PMOS arrow should point away from the channel (outward).
+
+        The arrowhead vertex (tip) should be at a larger x than the barbs,
+        indicating the arrow points right away from the channel.
+        """
         renderer = IEEEMOSFETPMOS()
         painter = _make_mock_painter()
         comp = _make_mock_component(in_scene=False)
         renderer.draw(painter, comp)
         line_calls = painter.drawLine.call_args_list
-        # Arrow lines from channel to body: tip at positive x (away from channel)
-        arrowhead = [c for c in line_calls if c[0][0] == -1 and c[0][2] == 5]
+        # Arrowhead: two lines from tip (x=5) with barbs toward x=-1
+        arrowhead = [c for c in line_calls if c[0][0] == 5 and c[0][2] == -1]
         assert len(arrowhead) == 2
+
+    def test_nmos_has_body_source_tie(self):
+        """NMOS should have a vertical bar connecting drain and source."""
+        renderer = IEEEMOSFETNMOS()
+        painter = _make_mock_painter()
+        comp = _make_mock_component(in_scene=False)
+        renderer.draw(painter, comp)
+        line_calls = painter.drawLine.call_args_list
+        assert call(10, -10, 10, 10) in line_calls
+
+    def test_pmos_has_body_source_tie(self):
+        """PMOS should have a vertical bar connecting drain and source."""
+        renderer = IEEEMOSFETPMOS()
+        painter = _make_mock_painter()
+        comp = _make_mock_component(in_scene=False)
+        renderer.draw(painter, comp)
+        line_calls = painter.drawLine.call_args_list
+        assert call(10, -10, 10, 10) in line_calls
 
 
 class TestRendererRegistration:


### PR DESCRIPTION
## Summary - Fixed swapped arrow directions on NMOS/PMOS MOSFET schematic symbols — NMOS arrow now correctly points inward (toward channel) and PMOS arrow points outward (away from channel) per IEEE Std 315 - Added vertical bar connecting drain and source lines to show standard 3-terminal body-source tie - Corrected PMOS gate bubble position to sit properly between gate plate and channel without overlap ## Test plan - [x] Updated  and  to verify correct arrow geometry - [x] Added  and  for vertical bar - [x] All 3138 existing tests pass - [ ] Visual inspection of MOSFET symbols on canvas Closes #565 🤖 Generated with [Claude Code](https://claude.com/claude-code)