### PR TITLE
Extract waveform SPICE command generation to simulation layer (#574)

### DIFF
--- a/app/models/component.py
+++ b/app/models/component.py
@@ -380,36 +380,16 @@ class ComponentData:
         """
         Return the SPICE value string for this component.
 
-        For waveform sources, generates the full waveform specification.
+        For waveform sources, delegates to
+        :func:`simulation.waveform_utils.format_waveform_spice_value`.
         For other components, returns the value as-is.
         """
-        if self.component_type != "Waveform Source" or self.waveform_params is None:
+        if self.component_type != "Waveform Source":
             return self.value
 
-        wtype = self.waveform_type or "SIN"
-        params = self.waveform_params.get(wtype, {})
+        from simulation.waveform_utils import format_waveform_spice_value
 
-        if wtype == "SIN":
-            return (
-                f"SIN({params.get('offset', '0')} {params.get('amplitude', '5')} "
-                f"{params.get('frequency', '1k')} {params.get('delay', '0')} "
-                f"{params.get('theta', '0')} {params.get('phase', '0')})"
-            )
-        elif wtype == "PULSE":
-            return (
-                f"PULSE({params.get('v1', '0')} {params.get('v2', '5')} "
-                f"{params.get('td', '0')} {params.get('tr', '1n')} "
-                f"{params.get('tf', '1n')} {params.get('pw', '500u')} "
-                f"{params.get('per', '1m')})"
-            )
-        elif wtype == "EXP":
-            return (
-                f"EXP({params.get('v1', '0')} {params.get('v2', '5')} "
-                f"{params.get('td1', '0')} {params.get('tau1', '1u')} "
-                f"{params.get('td2', '2u')} {params.get('tau2', '2u')})"
-            )
-        else:
-            return self.value
+        return format_waveform_spice_value(self.waveform_type, self.waveform_params, self.value)
 
     def to_dict(self) -> dict:
         """

--- a/app/simulation/waveform_utils.py
+++ b/app/simulation/waveform_utils.py
@@ -1,0 +1,52 @@
+"""Waveform SPICE command generation utilities.
+
+Extracted from ComponentData.get_spice_value() (#574) to keep domain-specific
+SPICE formatting logic in the simulation layer rather than the data model.
+"""
+
+from typing import Optional
+
+
+def format_waveform_spice_value(
+    waveform_type: Optional[str],
+    waveform_params: Optional[dict],
+    fallback_value: str,
+) -> str:
+    """Generate a SPICE waveform source specification string.
+
+    Args:
+        waveform_type: Waveform type key (``"SIN"``, ``"PULSE"``, ``"EXP"``).
+        waveform_params: Dict mapping waveform type keys to parameter dicts.
+        fallback_value: Value to return when *waveform_params* is ``None``
+            or the *waveform_type* is unrecognised.
+
+    Returns:
+        A SPICE-compatible waveform specification string.
+    """
+    if waveform_params is None:
+        return fallback_value
+
+    wtype = waveform_type or "SIN"
+    params = waveform_params.get(wtype, {})
+
+    if wtype == "SIN":
+        return (
+            f"SIN({params.get('offset', '0')} {params.get('amplitude', '5')} "
+            f"{params.get('frequency', '1k')} {params.get('delay', '0')} "
+            f"{params.get('theta', '0')} {params.get('phase', '0')})"
+        )
+    elif wtype == "PULSE":
+        return (
+            f"PULSE({params.get('v1', '0')} {params.get('v2', '5')} "
+            f"{params.get('td', '0')} {params.get('tr', '1n')} "
+            f"{params.get('tf', '1n')} {params.get('pw', '500u')} "
+            f"{params.get('per', '1m')})"
+        )
+    elif wtype == "EXP":
+        return (
+            f"EXP({params.get('v1', '0')} {params.get('v2', '5')} "
+            f"{params.get('td1', '0')} {params.get('tau1', '1u')} "
+            f"{params.get('td2', '2u')} {params.get('tau2', '2u')})"
+        )
+    else:
+        return fallback_value

--- a/app/tests/unit/test_waveform_utils.py
+++ b/app/tests/unit/test_waveform_utils.py
@@ -1,0 +1,108 @@
+"""Tests for waveform SPICE command generation (#574).
+
+Verifies that format_waveform_spice_value produces correct SPICE strings
+for each supported waveform type.
+"""
+
+from simulation.waveform_utils import format_waveform_spice_value
+
+
+class TestFormatWaveformSpiceValue:
+    """Test format_waveform_spice_value for each waveform type."""
+
+    def test_sin_default_params(self):
+        params = {
+            "SIN": {
+                "offset": "0",
+                "amplitude": "5",
+                "frequency": "1k",
+                "delay": "0",
+                "theta": "0",
+                "phase": "0",
+            }
+        }
+        result = format_waveform_spice_value("SIN", params, "fallback")
+        assert result.startswith("SIN(")
+        assert "5" in result
+        assert "1k" in result
+
+    def test_pulse_params(self):
+        params = {
+            "PULSE": {
+                "v1": "0",
+                "v2": "3.3",
+                "td": "1u",
+                "tr": "10n",
+                "tf": "10n",
+                "pw": "50u",
+                "per": "100u",
+            }
+        }
+        result = format_waveform_spice_value("PULSE", params, "fallback")
+        assert result.startswith("PULSE(")
+        assert "3.3" in result
+        assert "50u" in result
+
+    def test_exp_params(self):
+        params = {
+            "EXP": {
+                "v1": "0",
+                "v2": "5",
+                "td1": "0",
+                "tau1": "1u",
+                "td2": "2u",
+                "tau2": "2u",
+            }
+        }
+        result = format_waveform_spice_value("EXP", params, "fallback")
+        assert result.startswith("EXP(")
+        assert "5" in result
+
+    def test_none_params_returns_fallback(self):
+        result = format_waveform_spice_value("SIN", None, "5V")
+        assert result == "5V"
+
+    def test_unknown_type_returns_fallback(self):
+        result = format_waveform_spice_value("UNKNOWN", {"UNKNOWN": {}}, "5V")
+        assert result == "5V"
+
+    def test_none_waveform_type_defaults_to_sin(self):
+        params = {"SIN": {"offset": "0", "amplitude": "10", "frequency": "2k"}}
+        result = format_waveform_spice_value(None, params, "fallback")
+        assert result.startswith("SIN(")
+        assert "10" in result
+
+    def test_missing_param_keys_use_defaults(self):
+        """When param dict is empty, built-in defaults fill in."""
+        params = {"SIN": {}}
+        result = format_waveform_spice_value("SIN", params, "fallback")
+        assert result.startswith("SIN(")
+        assert "0" in result  # default offset
+        assert "5" in result  # default amplitude
+
+
+class TestComponentDataDelegation:
+    """Verify ComponentData.get_spice_value delegates to the utility."""
+
+    def test_waveform_source_delegates(self):
+        from models.component import ComponentData
+
+        comp = ComponentData(
+            component_id="V1",
+            component_type="Waveform Source",
+            value="5V",
+            position=(0.0, 0.0),
+        )
+        result = comp.get_spice_value()
+        assert result.startswith("SIN(")
+
+    def test_non_waveform_returns_value(self):
+        from models.component import ComponentData
+
+        comp = ComponentData(
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(0.0, 0.0),
+        )
+        assert comp.get_spice_value() == "1k"


### PR DESCRIPTION
## Summary - Extracted waveform SPICE formatting from ComponentData to simulation.waveform_utils - ComponentData.get_spice_value() now delegates to the simulation layer ## Test plan - [x] New test_waveform_utils.py covers all waveform types and edge cases - [x] All 3159 tests pass Closes #574