### PR TITLE
Move NGSPICE command generation to simulation layer, presets to controller (#576)

### DIFF
--- a/app/GUI/analysis_dialog.py
+++ b/app/GUI/analysis_dialog.py
@@ -162,16 +162,18 @@ class AnalysisDialog(QDialog):
         },
     }
 
-    def __init__(self, analysis_type=None, parent=None, preset_manager=None):
+    def __init__(self, analysis_type=None, parent=None, simulation_ctrl=None, preset_manager=None):
         super().__init__(parent)
         self.analysis_type = analysis_type
         self.field_widgets = {}
         self._measurements = []  # list of measurement entry dicts
-        if preset_manager is None:
-            from simulation.preset_manager import PresetManager
+        if simulation_ctrl is not None:
+            self._ctrl = simulation_ctrl
+        else:
+            # Backward compatibility: wrap a preset_manager in a controller
+            from controllers.simulation_controller import SimulationController
 
-            preset_manager = PresetManager()
-        self._preset_manager = preset_manager
+            self._ctrl = SimulationController(preset_manager=preset_manager)
         self.init_ui()
 
     def init_ui(self):
@@ -364,68 +366,14 @@ class AnalysisDialog(QDialog):
             return None
 
     def get_ngspice_command(self):
-        """Generate NGSPICE command from parameters"""
+        """Generate NGSPICE command from parameters."""
         params = self.get_parameters()
         if params is None:
             return None
 
-        if self.analysis_type == "DC Operating Point":
-            return ".op"
+        from simulation.netlist_generator import generate_analysis_command
 
-        elif self.analysis_type == "DC Sweep":
-            source = params.get("source", "V1")
-            start = params.get("min", 0)
-            stop = params.get("max", 10)
-            step = params.get("step", 0.1)
-            return f".dc {source} {start} {stop} {step}"
-
-        elif self.analysis_type == "AC Sweep":
-            fstart = params.get("fStart", 1)
-            fstop = params.get("fStop", 1e6)
-            points = params.get("points", 100)
-            sweep_type = params.get("sweepType", "dec")
-            return f".ac {sweep_type} {points} {fstart} {fstop}"
-
-        elif self.analysis_type == "Transient":
-            tstep = params.get("step", 0.001)
-            tstop = params.get("duration", 1)
-            tstart = params.get("startTime", 0)
-            return f".tran {tstep} {tstop} {tstart}"
-
-        elif self.analysis_type == "Temperature Sweep":
-            tstart = params.get("tempStart", -40)
-            tstop = params.get("tempStop", 85)
-            tstep = params.get("tempStep", 25)
-            return f".step temp {tstart} {tstop} {tstep}"
-
-        elif self.analysis_type == "Noise":
-            output = params.get("output_node", "out")
-            source = params.get("source", "V1")
-            fstart = params.get("fStart", 1)
-            fstop = params.get("fStop", 1e6)
-            points = params.get("points", 100)
-            sweep_type = params.get("sweepType", "dec")
-            return f".noise v({output}) {source} {sweep_type} {points} {fstart} {fstop}"
-
-        elif self.analysis_type == "Sensitivity":
-            output = params.get("output_node", "out")
-            return f".sens v({output})"
-
-        elif self.analysis_type == "Transfer Function":
-            output_var = params.get("output_var", "v(out)")
-            input_source = params.get("input_source", "V1")
-            return f".tf {output_var} {input_source}"
-
-        elif self.analysis_type == "Pole-Zero":
-            inp = params.get("input_pos", "1")
-            inn = params.get("input_neg", "0")
-            outp = params.get("output_pos", "2")
-            outn = params.get("output_neg", "0")
-            tf_type = params.get("transfer_type", "vol")
-            pz_type = params.get("pz_type", "pz")
-            return f".pz {inp} {inn} {outp} {outn} {tf_type} {pz_type}"
-
-        return ""
+        return generate_analysis_command(self.analysis_type, params)
 
     # --- Measurement management ---
 
@@ -462,7 +410,7 @@ class AnalysisDialog(QDialog):
         self.preset_combo.clear()
         self.preset_combo.addItem("(none)")
 
-        presets = self._preset_manager.get_presets(self.analysis_type)
+        presets = self._ctrl.get_presets(self.analysis_type)
         for p in presets:
             suffix = " [built-in]" if p.get("builtin") else ""
             self.preset_combo.addItem(f"{p['name']}{suffix}", p["name"])
@@ -481,7 +429,7 @@ class AnalysisDialog(QDialog):
         if preset_name is None:
             return
 
-        preset = self._preset_manager.get_preset_by_name(preset_name, self.analysis_type)
+        preset = self._ctrl.get_preset_by_name(preset_name, self.analysis_type)
         if preset is None:
             return
 
@@ -519,7 +467,7 @@ class AnalysisDialog(QDialog):
 
         name = name.strip()
         try:
-            self._preset_manager.save_preset(name, self.analysis_type, save_params)
+            self._ctrl.save_preset(name, self.analysis_type, save_params)
             self._refresh_preset_combo()
             # Select the newly saved preset
             for i in range(self.preset_combo.count()):
@@ -539,7 +487,7 @@ class AnalysisDialog(QDialog):
         if preset_name is None:
             return
 
-        preset = self._preset_manager.get_preset_by_name(preset_name, self.analysis_type)
+        preset = self._ctrl.get_preset_by_name(preset_name, self.analysis_type)
         if preset and preset.get("builtin"):
             QMessageBox.information(self, "Built-in Preset", "Built-in presets cannot be deleted.")
             return
@@ -551,7 +499,7 @@ class AnalysisDialog(QDialog):
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
         )
         if reply == QMessageBox.StandardButton.Yes:
-            self._preset_manager.delete_preset(preset_name, self.analysis_type)
+            self._ctrl.delete_preset(preset_name, self.analysis_type)
             self._refresh_preset_combo()
 
     def _update_delete_button(self):
@@ -562,5 +510,5 @@ class AnalysisDialog(QDialog):
             return
 
         preset_name = self.preset_combo.itemData(index)
-        preset = self._preset_manager.get_preset_by_name(preset_name, self.analysis_type)
+        preset = self._ctrl.get_preset_by_name(preset_name, self.analysis_type)
         self.delete_preset_btn.setEnabled(preset is not None and not preset.get("builtin", False))

--- a/app/GUI/main_window_analysis.py
+++ b/app/GUI/main_window_analysis.py
@@ -19,7 +19,7 @@ class AnalysisSettingsMixin:
 
     def set_analysis_dc(self):
         """Set analysis type to DC Sweep with parameters"""
-        dialog = AnalysisDialog("DC Sweep", self)
+        dialog = AnalysisDialog("DC Sweep", self, simulation_ctrl=self.simulation_ctrl)
         if dialog.exec() == QDialog.DialogCode.Accepted:
             params = dialog.get_parameters()
             if params:
@@ -38,7 +38,7 @@ class AnalysisSettingsMixin:
 
     def set_analysis_ac(self):
         """Set analysis type to AC Sweep with parameters"""
-        dialog = AnalysisDialog("AC Sweep", self)
+        dialog = AnalysisDialog("AC Sweep", self, simulation_ctrl=self.simulation_ctrl)
         if dialog.exec() == QDialog.DialogCode.Accepted:
             params = dialog.get_parameters()
             if params:
@@ -57,7 +57,7 @@ class AnalysisSettingsMixin:
 
     def set_analysis_transient(self):
         """Set analysis type to Transient with parameters"""
-        dialog = AnalysisDialog("Transient", self)
+        dialog = AnalysisDialog("Transient", self, simulation_ctrl=self.simulation_ctrl)
         if dialog.exec() == QDialog.DialogCode.Accepted:
             params = dialog.get_parameters()
             if params:
@@ -76,7 +76,7 @@ class AnalysisSettingsMixin:
 
     def set_analysis_temp_sweep(self):
         """Set analysis type to Temperature Sweep with parameters"""
-        dialog = AnalysisDialog("Temperature Sweep", self)
+        dialog = AnalysisDialog("Temperature Sweep", self, simulation_ctrl=self.simulation_ctrl)
         if dialog.exec() == QDialog.DialogCode.Accepted:
             params = dialog.get_parameters()
             if params:
@@ -98,7 +98,7 @@ class AnalysisSettingsMixin:
 
     def set_analysis_noise(self):
         """Set analysis type to Noise with parameters"""
-        dialog = AnalysisDialog("Noise", self)
+        dialog = AnalysisDialog("Noise", self, simulation_ctrl=self.simulation_ctrl)
         if dialog.exec() == QDialog.DialogCode.Accepted:
             params = dialog.get_parameters()
             if params:

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -41,10 +41,11 @@ class SimulationController:
     Coordinates: validate -> generate netlist -> run ngspice -> parse results
     """
 
-    def __init__(self, model: Optional[CircuitModel] = None, circuit_ctrl=None):
+    def __init__(self, model: Optional[CircuitModel] = None, circuit_ctrl=None, preset_manager=None):
         self.model = model or CircuitModel()
         self.circuit_ctrl = circuit_ctrl  # Phase 5: For observer notifications
         self._runner = None
+        self._preset_manager = preset_manager
 
     @property
     def runner(self):
@@ -626,3 +627,37 @@ class SimulationController:
         from simulation.monte_carlo import format_spice_value
 
         return format_spice_value(value)
+
+    # --- Preset management ---
+
+    @property
+    def preset_manager(self):
+        """Lazy initialization of PresetManager."""
+        if self._preset_manager is None:
+            from simulation.preset_manager import PresetManager
+
+            self._preset_manager = PresetManager()
+        return self._preset_manager
+
+    def get_presets(self, analysis_type=None):
+        """Return presets, optionally filtered by analysis type."""
+        return self.preset_manager.get_presets(analysis_type)
+
+    def get_preset_by_name(self, name, analysis_type=None):
+        """Look up a preset by name (and optionally analysis type)."""
+        return self.preset_manager.get_preset_by_name(name, analysis_type)
+
+    def save_preset(self, name, analysis_type, params):
+        """Save a user preset. Raises ValueError for built-in presets."""
+        return self.preset_manager.save_preset(name, analysis_type, params)
+
+    def delete_preset(self, name, analysis_type=None):
+        """Delete a user preset. Returns True if deleted."""
+        return self.preset_manager.delete_preset(name, analysis_type)
+
+    @staticmethod
+    def generate_analysis_command(analysis_type: str, params: dict) -> str:
+        """Generate a SPICE analysis directive from type and parameters."""
+        from simulation.netlist_generator import generate_analysis_command
+
+        return generate_analysis_command(analysis_type, params)

--- a/app/simulation/__init__.py
+++ b/app/simulation/__init__.py
@@ -1,6 +1,6 @@
 from . import circuitikz_exporter, convergence, csv_exporter
 from .circuit_validator import validate_circuit
-from .netlist_generator import NetlistGenerator
+from .netlist_generator import NetlistGenerator, generate_analysis_command
 from .ngspice_runner import NgspiceRunner
 from .result_parser import ResultParser
 
@@ -12,4 +12,5 @@ __all__ = [
     "csv_exporter",
     "circuitikz_exporter",
     "convergence",
+    "generate_analysis_command",
 ]

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -9,6 +9,80 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def generate_analysis_command(analysis_type: str, params: dict) -> str:
+    """Generate a SPICE analysis directive from type and parameters.
+
+    This is the single source of truth for mapping analysis type + params
+    to a SPICE command string.  Both the dialog preview and the netlist
+    generator delegate here.
+
+    Args:
+        analysis_type: Analysis type name (e.g. "DC Sweep", "AC Sweep").
+        params: Analysis parameters dict (keys vary by type).
+
+    Returns:
+        SPICE directive string (e.g. ".dc V1 0 10 0.1"), or "" if
+        the analysis type is unknown.
+    """
+    if analysis_type in ("DC Operating Point", "Operational Point"):
+        return ".op"
+
+    if analysis_type == "DC Sweep":
+        source = params.get("source", "V1")
+        start = params.get("min", 0)
+        stop = params.get("max", 10)
+        step = params.get("step", 0.1)
+        return f".dc {source} {start} {stop} {step}"
+
+    if analysis_type == "AC Sweep":
+        fstart = params.get("fStart", 1)
+        fstop = params.get("fStop", 1e6)
+        points = params.get("points", 100)
+        sweep_type = params.get("sweepType", params.get("sweep_type", "dec"))
+        return f".ac {sweep_type} {points} {fstart} {fstop}"
+
+    if analysis_type == "Transient":
+        tstep = params.get("step", 0.001)
+        tstop = params.get("duration", 1)
+        tstart = params.get("startTime", params.get("start", 0))
+        return f".tran {tstep} {tstop} {tstart}"
+
+    if analysis_type == "Temperature Sweep":
+        tstart = params.get("tempStart", -40)
+        tstop = params.get("tempStop", 85)
+        tstep = params.get("tempStep", 25)
+        return f".step temp {tstart} {tstop} {tstep}"
+
+    if analysis_type == "Noise":
+        output = params.get("output_node", "out")
+        source = params.get("source", "V1")
+        fstart = params.get("fStart", 1)
+        fstop = params.get("fStop", 1e6)
+        points = params.get("points", 100)
+        sweep_type = params.get("sweepType", params.get("sweep_type", "dec"))
+        return f".noise v({output}) {source} {sweep_type} {points} {fstart} {fstop}"
+
+    if analysis_type == "Sensitivity":
+        output = params.get("output_node", "out")
+        return f".sens v({output})"
+
+    if analysis_type == "Transfer Function":
+        output_var = params.get("output_var", "v(out)")
+        input_source = params.get("input_source", "V1")
+        return f".tf {output_var} {input_source}"
+
+    if analysis_type == "Pole-Zero":
+        inp = params.get("input_pos", "1")
+        inn = params.get("input_neg", "0")
+        outp = params.get("output_pos", "2")
+        outn = params.get("output_neg", "0")
+        tf_type = params.get("transfer_type", "vol")
+        pz_type = params.get("pz_type", "pz")
+        return f".pz {inp} {inn} {outp} {outn} {tf_type} {pz_type}"
+
+    return ""
+
+
 class NetlistGenerator:
     """Generates SPICE netlists from circuit components and nodes.
 
@@ -324,71 +398,25 @@ class NetlistGenerator:
         """Generate analysis-specific SPICE commands"""
         lines = ["", "* Analysis Command"]
 
-        if self.analysis_type in ["DC Operating Point", "Operational Point"]:
-            lines.append(".op")
-
-        elif self.analysis_type == "DC Sweep":
+        if self.analysis_type == "DC Sweep":
+            # Special handling: fall back to first voltage source if none specified
             params = self.analysis_params
-            # Use user-selected source if provided, otherwise fall back to first voltage source
             source_name = params.get("source")
             if not source_name:
                 voltage_sources = [c for c in self.components.values() if c.component_type == "Voltage Source"]
                 source_name = voltage_sources[0].component_id if voltage_sources else None
-            if source_name:
-                lines.append(f".dc {source_name} {params['min']} {params['max']} {params['step']}")
-            else:
+            if not source_name:
                 lines.append("* Warning: DC Sweep requires a voltage source")
                 lines.append(".op")
-
-        elif self.analysis_type == "AC Sweep":
-            params = self.analysis_params
-            sweep_type = params.get("sweep_type", "dec")
-            lines.append(f".ac {sweep_type} {params['points']} {params['fStart']} {params['fStop']}")
-
-        elif self.analysis_type == "Transient":
-            params = self.analysis_params
-            tstart = params.get("start", 0)
-            lines.append(f".tran {params['step']} {params['duration']} {tstart}")
-
+            else:
+                effective_params = dict(params, source=source_name)
+                lines.append(generate_analysis_command(self.analysis_type, effective_params))
         elif self.analysis_type == "Temperature Sweep":
-            params = self.analysis_params
-            temp_start = params.get("tempStart", -40)
-            temp_stop = params.get("tempStop", 85)
-            temp_step = params.get("tempStep", 25)
-            # DC operating point as the base analysis, swept over temperature
+            # Temperature sweep needs .op before .step
             lines.append(".op")
-            lines.append(f".step temp {temp_start} {temp_stop} {temp_step}")
-
-        elif self.analysis_type == "Noise":
-            params = self.analysis_params
-            output_node = params.get("output_node", "out")
-            source = params.get("source", "V1")
-            sweep_type = params.get("sweepType", "dec")
-            pts = params.get("points", 100)
-            fstart = params.get("fStart", 1)
-            fstop = params.get("fStop", 1e6)
-            lines.append(f".noise v({output_node}) {source} {sweep_type} {pts} {fstart} {fstop}")
-
-        elif self.analysis_type == "Sensitivity":
-            params = self.analysis_params
-            output_node = params.get("output_node", "out")
-            lines.append(f".sens v({output_node})")
-
-        elif self.analysis_type == "Transfer Function":
-            params = self.analysis_params
-            output_var = params.get("output_var", "v(out)")
-            input_source = params.get("input_source", "V1")
-            lines.append(f".tf {output_var} {input_source}")
-
-        elif self.analysis_type == "Pole-Zero":
-            params = self.analysis_params
-            inp = params.get("input_pos", "1")
-            inn = params.get("input_neg", "0")
-            outp = params.get("output_pos", "2")
-            outn = params.get("output_neg", "0")
-            tf_type = params.get("transfer_type", "vol")
-            pz_type = params.get("pz_type", "pz")
-            lines.append(f".pz {inp} {inn} {outp} {outn} {tf_type} {pz_type}")
+            lines.append(generate_analysis_command(self.analysis_type, self.analysis_params))
+        else:
+            lines.append(generate_analysis_command(self.analysis_type, self.analysis_params))
 
         # Add control block for running simulation and getting output
         lines.append("")

--- a/app/tests/unit/test_netlist_generator.py
+++ b/app/tests/unit/test_netlist_generator.py
@@ -6,7 +6,66 @@ import pytest
 from models.component import ComponentData
 from models.node import NodeData
 from models.wire import WireData
-from simulation.netlist_generator import NetlistGenerator
+from simulation.netlist_generator import NetlistGenerator, generate_analysis_command
+
+
+class TestGenerateAnalysisCommand:
+    """Tests for the standalone generate_analysis_command function (#576)."""
+
+    def test_dc_op(self):
+        assert generate_analysis_command("DC Operating Point", {}) == ".op"
+
+    def test_dc_sweep(self):
+        cmd = generate_analysis_command("DC Sweep", {"source": "V1", "min": 0, "max": 5, "step": 0.1})
+        assert cmd == ".dc V1 0 5 0.1"
+
+    def test_ac_sweep_with_camelcase_key(self):
+        cmd = generate_analysis_command("AC Sweep", {"fStart": 1, "fStop": 1e6, "points": 100, "sweepType": "dec"})
+        assert cmd == ".ac dec 100 1 1000000.0"
+
+    def test_ac_sweep_with_underscore_key(self):
+        cmd = generate_analysis_command("AC Sweep", {"fStart": 1, "fStop": 1e6, "points": 100, "sweep_type": "lin"})
+        assert cmd == ".ac lin 100 1 1000000.0"
+
+    def test_transient(self):
+        cmd = generate_analysis_command("Transient", {"step": 1e-6, "duration": 0.01, "startTime": 0})
+        assert cmd.startswith(".tran")
+
+    def test_temperature_sweep(self):
+        cmd = generate_analysis_command("Temperature Sweep", {"tempStart": -40, "tempStop": 85, "tempStep": 25})
+        assert cmd == ".step temp -40 85 25"
+
+    def test_noise(self):
+        cmd = generate_analysis_command(
+            "Noise",
+            {"output_node": "out", "source": "V1", "fStart": 1, "fStop": 1e6, "points": 100, "sweepType": "dec"},
+        )
+        assert cmd.startswith(".noise v(out) V1")
+
+    def test_sensitivity(self):
+        cmd = generate_analysis_command("Sensitivity", {"output_node": "out"})
+        assert cmd == ".sens v(out)"
+
+    def test_transfer_function(self):
+        cmd = generate_analysis_command("Transfer Function", {"output_var": "v(out)", "input_source": "V1"})
+        assert cmd == ".tf v(out) V1"
+
+    def test_pole_zero(self):
+        cmd = generate_analysis_command(
+            "Pole-Zero",
+            {
+                "input_pos": "1",
+                "input_neg": "0",
+                "output_pos": "2",
+                "output_neg": "0",
+                "transfer_type": "vol",
+                "pz_type": "pz",
+            },
+        )
+        assert cmd == ".pz 1 0 2 0 vol pz"
+
+    def test_unknown_type_returns_empty(self):
+        assert generate_analysis_command("Unknown", {}) == ""
 
 
 def _generate(


### PR DESCRIPTION
## Summary - Extracted  as a standalone function in  — single source of truth for SPICE directive generation -  now delegates to the simulation layer function instead of inline logic -  also delegates to the standalone function - Fixed / key mismatch between dialog params and netlist generator (both key variants now supported) - Moved preset management (CRUD) to  which owns the  instance -  now accepts  parameter; callers in  updated - Backward compatibility preserved via  parameter for existing tests ## Test plan - [ ] Existing  tests pass (ngspice command generation) - [ ] Existing  tests pass (preset CRUD, dialog integration) - [ ] New  tests for all analysis types - [ ] Existing netlist generation tests pass Closes #576 🤖 Generated with [Claude Code](https://claude.com/claude-code)