### PR TITLE
Decouple NodeData.get_position from ComponentData (#573)

### DIFF
--- a/app/models/node.py
+++ b/app/models/node.py
@@ -133,32 +133,31 @@ class NodeData:
         if not self.custom_label:
             self.auto_label = "0"
 
-    def get_position(self, components: dict) -> Optional[tuple[float, float]]:
+    def get_position(
+        self,
+        terminal_positions: dict[tuple[str, int], tuple[float, float]],
+    ) -> Optional[tuple[float, float]]:
         """
         Get a representative position for label placement (average of all terminals).
 
         Args:
-            components: Dict mapping component_id to ComponentData objects.
+            terminal_positions: Mapping of ``(component_id, terminal_index)``
+                to ``(x, y)`` world-coordinate positions.  Callers are
+                responsible for computing these from their own layer
+                (e.g. from ComponentData or from the GUI scene).
 
         Returns:
-            Average (x, y) position of all terminals, or None if no terminals.
+            Average (x, y) position of all terminals, or None if no terminals
+            have a known position.
         """
         if not self.terminals:
             return None
 
-        positions = []
-        for comp_id, term_idx in self.terminals:
-            if comp_id in components:
-                comp = components[comp_id]
-                # Get terminal positions from ComponentData
-                term_positions = comp.get_terminal_positions()
-                if term_idx < len(term_positions):
-                    positions.append(term_positions[term_idx])
+        positions = [terminal_positions[t] for t in self.terminals if t in terminal_positions]
 
         if not positions:
             return None
 
-        # Return average position
         avg_x = sum(p[0] for p in positions) / len(positions)
         avg_y = sum(p[1] for p in positions) / len(positions)
         return (avg_x, avg_y)

--- a/app/tests/unit/test_node.py
+++ b/app/tests/unit/test_node.py
@@ -214,6 +214,53 @@ class TestRebuildNodesPreservesLabels:
         assert labels_found == {"Va", "Vb"}
 
 
+class TestGetPosition:
+    """Tests for NodeData.get_position with terminal_positions dict."""
+
+    def test_empty_terminals_returns_none(self):
+        node = NodeData(auto_label="nodeA")
+        assert node.get_position({}) is None
+
+    def test_single_terminal_returns_its_position(self):
+        node = NodeData(auto_label="nodeA")
+        node.add_terminal("R1", 0)
+        positions = {("R1", 0): (100.0, 200.0)}
+        assert node.get_position(positions) == (100.0, 200.0)
+
+    def test_averages_multiple_terminal_positions(self):
+        node = NodeData(auto_label="nodeA")
+        node.add_terminal("R1", 0)
+        node.add_terminal("R2", 1)
+        positions = {("R1", 0): (100.0, 200.0), ("R2", 1): (300.0, 400.0)}
+        result = node.get_position(positions)
+        assert result == (200.0, 300.0)
+
+    def test_missing_positions_are_skipped(self):
+        node = NodeData(auto_label="nodeA")
+        node.add_terminal("R1", 0)
+        node.add_terminal("R2", 1)
+        # Only R1 has a known position
+        positions = {("R1", 0): (100.0, 200.0)}
+        assert node.get_position(positions) == (100.0, 200.0)
+
+    def test_all_positions_missing_returns_none(self):
+        node = NodeData(auto_label="nodeA")
+        node.add_terminal("R1", 0)
+        assert node.get_position({}) is None
+
+    def test_accepts_plain_dict_no_component_data_needed(self):
+        """Verify the method works with a plain dict — no ComponentData import."""
+        node = NodeData(auto_label="nodeA")
+        node.add_terminal("C1", 0)
+        node.add_terminal("C1", 1)
+        positions: dict[tuple[str, int], tuple[float, float]] = {
+            ("C1", 0): (10.0, 20.0),
+            ("C1", 1): (30.0, 40.0),
+        }
+        result = node.get_position(positions)
+        assert result == (20.0, 30.0)
+
+
 class TestSetNetNamePublicAPI:
     """Tests that CircuitController.set_net_name() works correctly."""
 


### PR DESCRIPTION
## Summary - Changed  to accept a  instead of , removing the cross-model dependency on  - Callers now pass pre-computed  mappings from their own layer (GUI scene or model) - Added 6 tests covering empty terminals, single/multiple positions, missing positions, and verifying no ComponentData import is needed ## Test plan - [x] All 3161 existing tests pass - [x] 6 new  tests validate the refactored API - [x] No production callers exist yet — method is a clean API for future use Closes #573 🤖 Generated with [Claude Code](https://claude.com/claude-code)