### PR TITLE
Replace module-level global counter with NodeLabelGenerator (#597)

### DIFF
--- a/app/models/node.py
+++ b/app/models/node.py
@@ -9,14 +9,28 @@ same voltage).
 from dataclasses import dataclass, field
 from typing import Optional
 
-# Module-level counter for generating unique node labels
-_node_counter = 0
 
+class NodeLabelGenerator:
+    """Encapsulates the counter used to generate unique node labels.
 
-def reset_node_counter():
-    """Reset the node label counter. Call when starting a new circuit."""
-    global _node_counter
-    _node_counter = 0
+    Each call to :meth:`next_label` returns labels in sequence:
+    ``nodeA``, ``nodeB``, ... ``nodeZ``, ``nodeAA``, ``nodeAB``, ...
+
+    Call :meth:`reset` when starting a new circuit.
+    """
+
+    def __init__(self) -> None:
+        self._counter: int = 0
+
+    def reset(self) -> None:
+        """Reset the counter to zero."""
+        self._counter = 0
+
+    def next_label(self) -> str:
+        """Return the next label and advance the counter."""
+        label = _generate_label(self._counter)
+        self._counter += 1
+        return label
 
 
 def _generate_label(index: int) -> str:
@@ -36,6 +50,15 @@ def _generate_label(index: int) -> str:
         first = (index // 26) - 1
         second = index % 26
         return "node" + chr(ord("A") + first) + chr(ord("A") + second)
+
+
+# Default module-level generator used by NodeData.__post_init__
+_default_generator = NodeLabelGenerator()
+
+
+def reset_node_counter():
+    """Reset the node label counter. Call when starting a new circuit."""
+    _default_generator.reset()
 
 
 @dataclass
@@ -68,9 +91,7 @@ class NodeData:
             if self.is_ground:
                 self.auto_label = "0"
             else:
-                global _node_counter
-                self.auto_label = _generate_label(_node_counter)
-                _node_counter += 1
+                self.auto_label = _default_generator.next_label()
 
     def get_label(self) -> str:
         """

--- a/app/tests/unit/test_node.py
+++ b/app/tests/unit/test_node.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock
 
 from models.circuit import CircuitModel
-from models.node import NodeData, _generate_label, reset_node_counter
+from models.node import NodeData, NodeLabelGenerator, _generate_label, reset_node_counter
 
 
 class TestNodeCustomLabel:
@@ -54,6 +54,38 @@ class TestNodeLabelGeneration:
     def test_ground_node_auto_label_is_zero(self):
         node = NodeData(is_ground=True)
         assert node.auto_label == "0"
+
+
+class TestNodeLabelGenerator:
+    """Tests for the NodeLabelGenerator class."""
+
+    def test_generates_sequential_labels(self):
+        gen = NodeLabelGenerator()
+        assert gen.next_label() == "nodeA"
+        assert gen.next_label() == "nodeB"
+        assert gen.next_label() == "nodeC"
+
+    def test_reset_restarts_sequence(self):
+        gen = NodeLabelGenerator()
+        gen.next_label()
+        gen.next_label()
+        gen.reset()
+        assert gen.next_label() == "nodeA"
+
+    def test_independent_instances(self):
+        gen1 = NodeLabelGenerator()
+        gen2 = NodeLabelGenerator()
+        assert gen1.next_label() == "nodeA"
+        assert gen2.next_label() == "nodeA"
+        assert gen1.next_label() == "nodeB"
+        assert gen2.next_label() == "nodeB"
+
+    def test_wraps_to_double_letters(self):
+        gen = NodeLabelGenerator()
+        for _ in range(26):
+            gen.next_label()
+        assert gen.next_label() == "nodeAA"
+        assert gen.next_label() == "nodeAB"
 
 
 class TestNodeMerge:


### PR DESCRIPTION
## Summary - Introduced NodeLabelGenerator class encapsulating the node label counter - Replaced module-level _node_counter global with a default NodeLabelGenerator instance - reset_node_counter() delegates to the default instance, preserving backward compatibility - Added 4 tests for NodeLabelGenerator (sequential labels, reset, independent instances, double-letter wrap) ## Test plan - [x] All 3174 existing tests pass unchanged - [x] 4 new TestNodeLabelGenerator tests validate the class API - [x] Existing callers of reset_node_counter() work without modification Closes #597