### PR TITLE
Extract waveform config defaults to waveform_utils (#599)

### DIFF
--- a/app/models/component.py
+++ b/app/models/component.py
@@ -284,39 +284,10 @@ class ComponentData:
     def __post_init__(self):
         """Initialize waveform parameters for waveform sources."""
         if self.component_type == "Waveform Source" and self.waveform_params is None:
-            self.waveform_type = "SIN"
-            self.waveform_params = self._default_waveform_params()
+            from simulation.waveform_utils import DEFAULT_WAVEFORM_TYPE, default_waveform_params
 
-    @staticmethod
-    def _default_waveform_params() -> dict:
-        """Return default waveform parameters for all waveform types."""
-        return {
-            "SIN": {
-                "offset": "0",
-                "amplitude": "5",
-                "frequency": "1k",
-                "delay": "0",
-                "theta": "0",
-                "phase": "0",
-            },
-            "PULSE": {
-                "v1": "0",
-                "v2": "5",
-                "td": "0",
-                "tr": "1n",
-                "tf": "1n",
-                "pw": "500u",
-                "per": "1m",
-            },
-            "EXP": {
-                "v1": "0",
-                "v2": "5",
-                "td1": "0",
-                "tau1": "1u",
-                "td2": "2u",
-                "tau2": "2u",
-            },
-        }
+            self.waveform_type = DEFAULT_WAVEFORM_TYPE
+            self.waveform_params = default_waveform_params()
 
     def get_terminal_count(self) -> int:
         """Return number of terminals for this component type."""

--- a/app/simulation/waveform_utils.py
+++ b/app/simulation/waveform_utils.py
@@ -1,10 +1,48 @@
 """Waveform SPICE command generation utilities.
 
-Extracted from ComponentData.get_spice_value() (#574) to keep domain-specific
+Extracted from ComponentData (#574, #599) to keep domain-specific
 SPICE formatting logic in the simulation layer rather than the data model.
 """
 
 from typing import Optional
+
+DEFAULT_WAVEFORM_TYPE = "SIN"
+
+
+def default_waveform_params() -> dict:
+    """Return default waveform parameters for all waveform types.
+
+    Each key is a waveform type (``"SIN"``, ``"PULSE"``, ``"EXP"``),
+    and the value is a dict of parameter names to their default string
+    values.
+    """
+    return {
+        "SIN": {
+            "offset": "0",
+            "amplitude": "5",
+            "frequency": "1k",
+            "delay": "0",
+            "theta": "0",
+            "phase": "0",
+        },
+        "PULSE": {
+            "v1": "0",
+            "v2": "5",
+            "td": "0",
+            "tr": "1n",
+            "tf": "1n",
+            "pw": "500u",
+            "per": "1m",
+        },
+        "EXP": {
+            "v1": "0",
+            "v2": "5",
+            "td1": "0",
+            "tau1": "1u",
+            "td2": "2u",
+            "tau2": "2u",
+        },
+    }
 
 
 def format_waveform_spice_value(

--- a/app/tests/unit/test_waveform_utils.py
+++ b/app/tests/unit/test_waveform_utils.py
@@ -1,10 +1,11 @@
-"""Tests for waveform SPICE command generation (#574).
+"""Tests for waveform SPICE utilities (#574, #599).
 
 Verifies that format_waveform_spice_value produces correct SPICE strings
-for each supported waveform type.
+for each supported waveform type, and that default_waveform_params provides
+correct defaults.
 """
 
-from simulation.waveform_utils import format_waveform_spice_value
+from simulation.waveform_utils import DEFAULT_WAVEFORM_TYPE, default_waveform_params, format_waveform_spice_value
 
 
 class TestFormatWaveformSpiceValue:
@@ -79,6 +80,65 @@ class TestFormatWaveformSpiceValue:
         assert result.startswith("SIN(")
         assert "0" in result  # default offset
         assert "5" in result  # default amplitude
+
+
+class TestDefaultWaveformParams:
+    """Tests for default_waveform_params and DEFAULT_WAVEFORM_TYPE."""
+
+    def test_default_type_is_sin(self):
+        assert DEFAULT_WAVEFORM_TYPE == "SIN"
+
+    def test_contains_all_waveform_types(self):
+        params = default_waveform_params()
+        assert set(params.keys()) == {"SIN", "PULSE", "EXP"}
+
+    def test_sin_has_required_keys(self):
+        params = default_waveform_params()
+        assert set(params["SIN"].keys()) == {
+            "offset",
+            "amplitude",
+            "frequency",
+            "delay",
+            "theta",
+            "phase",
+        }
+
+    def test_pulse_has_required_keys(self):
+        params = default_waveform_params()
+        assert set(params["PULSE"].keys()) == {
+            "v1",
+            "v2",
+            "td",
+            "tr",
+            "tf",
+            "pw",
+            "per",
+        }
+
+    def test_exp_has_required_keys(self):
+        params = default_waveform_params()
+        assert set(params["EXP"].keys()) == {"v1", "v2", "td1", "tau1", "td2", "tau2"}
+
+    def test_returns_fresh_copy(self):
+        p1 = default_waveform_params()
+        p2 = default_waveform_params()
+        assert p1 is not p2
+        p1["SIN"]["offset"] = "999"
+        assert p2["SIN"]["offset"] == "0"
+
+    def test_component_data_uses_extracted_defaults(self):
+        """ComponentData.__post_init__ should use defaults from waveform_utils."""
+        from models.component import ComponentData
+
+        comp = ComponentData(
+            component_id="V1",
+            component_type="Waveform Source",
+            value="5V",
+            position=(0.0, 0.0),
+        )
+        assert comp.waveform_type == DEFAULT_WAVEFORM_TYPE
+        expected = default_waveform_params()
+        assert comp.waveform_params == expected
 
 
 class TestComponentDataDelegation:


### PR DESCRIPTION
## Summary - Moved _default_waveform_params() from ComponentData to simulation/waveform_utils.py as default_waveform_params() - Added DEFAULT_WAVEFORM_TYPE constant to waveform_utils.py - ComponentData.__post_init__ now imports and delegates to the extracted function - Added 7 tests validating the defaults (type keys, parameter keys, fresh copy, ComponentData integration) ## Test plan - [x] All 3188 existing tests pass - [x] 7 new TestDefaultWaveformParams tests validate the extracted API - [x] ComponentData still initializes waveform defaults correctly Closes #599