### PR TITLE
Move export dispatch logic from GUI views to controllers (#570)

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -359,8 +359,6 @@ class FileOperationsMixin:
 
     def _on_export_bom(self):
         """Export a Bill of Materials (BOM) as CSV or Excel."""
-        from simulation.bom_exporter import export_bom_csv, export_bom_excel, write_bom_csv
-
         if not self.model.components:
             QMessageBox.information(self, "Export BOM", "Nothing to export — the canvas is empty.")
             return
@@ -375,19 +373,19 @@ class FileOperationsMixin:
             return
 
         try:
+            # Ensure correct extension based on selected filter
+            if filename.lower().endswith(".xlsx") or "Excel" in selected_filter:
+                if not filename.lower().endswith(".xlsx"):
+                    filename += ".xlsx"
+            else:
+                if not filename.lower().endswith(".csv"):
+                    filename += ".csv"
+
             circuit_name = ""
             if hasattr(self, "file_ctrl") and self.file_ctrl.current_file:
                 circuit_name = self.file_ctrl.current_file.name
 
-            if filename.lower().endswith(".xlsx") or "Excel" in selected_filter:
-                if not filename.lower().endswith(".xlsx"):
-                    filename += ".xlsx"
-                export_bom_excel(self.model.components, filename, circuit_name=circuit_name)
-            else:
-                if not filename.lower().endswith(".csv"):
-                    filename += ".csv"
-                content = export_bom_csv(self.model.components, circuit_name=circuit_name)
-                write_bom_csv(content, filename)
+            self.file_ctrl.export_bom(filename, circuit_name=circuit_name)
 
             statusBar = self.statusBar()
             if statusBar:
@@ -397,8 +395,6 @@ class FileOperationsMixin:
 
     def _on_export_asc(self):
         """Export the circuit as an LTspice .asc schematic file."""
-        from simulation.asc_exporter import export_asc, write_asc
-
         if not self.model.components:
             QMessageBox.information(self, "Export LTspice", "Nothing to export — the canvas is empty.")
             return
@@ -413,8 +409,7 @@ class FileOperationsMixin:
             return
 
         try:
-            content = export_asc(self.model)
-            write_asc(content, filename)
+            self.file_ctrl.export_asc(filename)
             statusBar = self.statusBar()
             if statusBar:
                 statusBar.showMessage(f"LTspice schematic exported to {filename}", 3000)
@@ -528,25 +523,10 @@ class FileOperationsMixin:
             results_csv = None
             if self._last_results is not None:
                 try:
-                    from simulation.csv_exporter import (
-                        export_ac_results,
-                        export_dc_sweep_results,
-                        export_noise_results,
-                        export_op_results,
-                        export_transient_results,
-                    )
-
                     cn = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-                    dispatch = {
-                        "DC Operating Point": export_op_results,
-                        "DC Sweep": export_dc_sweep_results,
-                        "AC Sweep": export_ac_results,
-                        "Transient": export_transient_results,
-                        "Noise": export_noise_results,
-                    }
-                    func = dispatch.get(self._last_results_type)
-                    if func:
-                        results_csv = func(self._last_results, cn)
+                    results_csv = self.simulation_ctrl.generate_results_csv(
+                        self._last_results, self._last_results_type, cn
+                    )
                 except Exception:
                     pass
 
@@ -554,12 +534,12 @@ class FileOperationsMixin:
             results_xlsx_path = None
             if self._last_results is not None:
                 try:
-                    from simulation.excel_exporter import export_to_excel
-
                     cn = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
                     tmp_xlsx = tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False)
                     tmp_xlsx.close()
-                    export_to_excel(self._last_results, self._last_results_type, tmp_xlsx.name, cn)
+                    self.simulation_ctrl.export_results_excel(
+                        self._last_results, self._last_results_type, tmp_xlsx.name, cn
+                    )
                     results_xlsx_path = tmp_xlsx.name
                 except Exception:
                     pass
@@ -864,23 +844,14 @@ class FileOperationsMixin:
         import os
 
         try:
+            circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+
             if export_function == "export_netlist":
-                netlist = self.simulation_ctrl.generate_netlist()
-                with open(path, "w") as f:
-                    f.write(netlist)
+                self.simulation_ctrl.export_netlist(path)
             elif export_function == "export_image":
                 self.canvas.export_image(path, include_grid=False)
-            elif export_function == "export_bom_csv":
-                from simulation.bom_exporter import export_bom_csv, write_bom_csv
-
-                circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-                content = export_bom_csv(self.model.components, circuit_name=circuit_name)
-                write_bom_csv(content, path)
-            elif export_function == "export_bom_excel":
-                from simulation.bom_exporter import export_bom_excel
-
-                circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-                export_bom_excel(self.model.components, path, circuit_name=circuit_name)
+            elif export_function in ("export_bom_csv", "export_bom_excel"):
+                self.file_ctrl.export_bom(path, circuit_name=circuit_name)
             elif export_function == "export_results_csv":
                 self._re_export_results_csv(path)
             elif export_function == "export_results_excel":
@@ -897,16 +868,12 @@ class FileOperationsMixin:
                 with open(path, "w") as f:
                     f.write(content)
             elif export_function == "export_asc":
-                from simulation.asc_exporter import export_asc, write_asc
-
-                content = export_asc(self.model)
-                write_asc(content, path)
+                self.file_ctrl.export_asc(path)
             elif export_function == "export_results_markdown":
-                md = self._get_markdown_content()
-                if md:
-                    from simulation.markdown_exporter import write_markdown
-
-                    write_markdown(md, path)
+                if self._last_results is not None:
+                    self.simulation_ctrl.export_results_markdown(
+                        self._last_results, self._last_results_type, path, circuit_name
+                    )
             else:
                 QMessageBox.warning(self, "Re-export", f"Unknown export type: {export_function}")
                 return
@@ -923,26 +890,8 @@ class FileOperationsMixin:
             return
         import os
 
-        from simulation.csv_exporter import (
-            export_ac_results,
-            export_dc_sweep_results,
-            export_noise_results,
-            export_op_results,
-            export_transient_results,
-            write_csv,
-        )
-
         circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-        dispatch = {
-            "DC Operating Point": export_op_results,
-            "DC Sweep": export_dc_sweep_results,
-            "AC Sweep": export_ac_results,
-            "Transient": export_transient_results,
-            "Noise": export_noise_results,
-        }
-        func = dispatch.get(self._last_results_type)
-        if func:
-            write_csv(func(self._last_results, circuit_name), path)
+        self.simulation_ctrl.export_results_csv(self._last_results, self._last_results_type, path, circuit_name)
 
     def _re_export_results_excel(self, path):
         """Re-export simulation results to Excel at the given path."""
@@ -950,10 +899,8 @@ class FileOperationsMixin:
             return
         import os
 
-        from simulation.excel_exporter import export_to_excel
-
         circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-        export_to_excel(self._last_results, self._last_results_type, path, circuit_name)
+        self.simulation_ctrl.export_results_excel(self._last_results, self._last_results_type, path, circuit_name)
 
     # --- Recommended / Used-in-File Components ---
 

--- a/app/GUI/main_window_simulation.py
+++ b/app/GUI/main_window_simulation.py
@@ -32,7 +32,7 @@ class SimulationMixin:
     def export_netlist(self):
         """Export SPICE netlist to a .cir file."""
         try:
-            netlist = self.simulation_ctrl.generate_netlist()
+            self.simulation_ctrl.generate_netlist()
         except (ValueError, KeyError, TypeError) as e:
             QMessageBox.critical(self, "Error", f"Failed to generate netlist: {e}")
             return
@@ -52,12 +52,11 @@ class SimulationMixin:
             return
 
         try:
-            with open(filename, "w", encoding="utf-8") as f:
-                f.write(netlist)
+            self.simulation_ctrl.export_netlist(filename)
             statusBar = self.statusBar()
             if statusBar:
                 statusBar.showMessage(f"Netlist exported to {filename}", 3000)
-        except OSError as e:
+        except (ValueError, KeyError, TypeError, OSError) as e:
             QMessageBox.critical(self, "Error", f"Failed to export netlist: {e}")
 
     def run_simulation(self):
@@ -668,38 +667,17 @@ class SimulationMixin:
             self._show_plot_dialog(dialog_class(data, self))
 
     def export_results_csv(self):
-        """Export the last simulation results to a CSV file"""
+        """Export the last simulation results to a CSV file."""
         if self._last_results is None:
-            return
-
-        from simulation.csv_exporter import (
-            export_ac_results,
-            export_dc_sweep_results,
-            export_noise_results,
-            export_op_results,
-            export_transient_results,
-            write_csv,
-        )
-
-        circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-
-        if self._last_results_type == "DC Operating Point":
-            csv_content = export_op_results(self._last_results, circuit_name)
-        elif self._last_results_type == "DC Sweep":
-            csv_content = export_dc_sweep_results(self._last_results, circuit_name)
-        elif self._last_results_type == "AC Sweep":
-            csv_content = export_ac_results(self._last_results, circuit_name)
-        elif self._last_results_type == "Transient":
-            csv_content = export_transient_results(self._last_results, circuit_name)
-        elif self._last_results_type == "Noise":
-            csv_content = export_noise_results(self._last_results, circuit_name)
-        else:
             return
 
         filename, _ = QFileDialog.getSaveFileName(self, "Export Results to CSV", "", "CSV Files (*.csv);;All Files (*)")
         if filename:
             try:
-                write_csv(csv_content, filename)
+                circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+                self.simulation_ctrl.export_results_csv(
+                    self._last_results, self._last_results_type, filename, circuit_name
+                )
                 statusBar = self.statusBar()
                 if statusBar:
                     statusBar.showMessage(f"Results exported to {filename}", 3000)
@@ -711,16 +689,15 @@ class SimulationMixin:
         if self._last_results is None:
             return
 
-        from simulation.excel_exporter import export_to_excel
-
-        circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-
         filename, _ = QFileDialog.getSaveFileName(
             self, "Export Results to Excel", "", "Excel Files (*.xlsx);;All Files (*)"
         )
         if filename:
             try:
-                export_to_excel(self._last_results, self._last_results_type, filename, circuit_name)
+                circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+                self.simulation_ctrl.export_results_excel(
+                    self._last_results, self._last_results_type, filename, circuit_name
+                )
                 statusBar = self.statusBar()
                 if statusBar:
                     statusBar.showMessage(f"Results exported to {filename}", 3000)
@@ -732,27 +709,8 @@ class SimulationMixin:
         if self._last_results is None:
             return None
 
-        from simulation.markdown_exporter import (
-            export_ac_results,
-            export_dc_sweep_results,
-            export_noise_results,
-            export_op_results,
-            export_transient_results,
-        )
-
         circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
-
-        if self._last_results_type == "DC Operating Point":
-            return export_op_results(self._last_results, circuit_name)
-        elif self._last_results_type == "DC Sweep":
-            return export_dc_sweep_results(self._last_results, circuit_name)
-        elif self._last_results_type == "AC Sweep":
-            return export_ac_results(self._last_results, circuit_name)
-        elif self._last_results_type == "Transient":
-            return export_transient_results(self._last_results, circuit_name)
-        elif self._last_results_type == "Noise":
-            return export_noise_results(self._last_results, circuit_name)
-        return None
+        return self.simulation_ctrl.generate_results_markdown(self._last_results, self._last_results_type, circuit_name)
 
     def copy_results_markdown(self):
         """Copy the last simulation results as Markdown to the clipboard."""
@@ -768,11 +726,8 @@ class SimulationMixin:
 
     def export_results_markdown(self):
         """Export the last simulation results to a Markdown (.md) file."""
-        md_content = self._get_markdown_content()
-        if md_content is None:
+        if self._last_results is None:
             return
-
-        from simulation.markdown_exporter import write_markdown
 
         filename, _ = QFileDialog.getSaveFileName(
             self,
@@ -782,7 +737,10 @@ class SimulationMixin:
         )
         if filename:
             try:
-                write_markdown(md_content, filename)
+                circuit_name = os.path.basename(str(self.file_ctrl.current_file)) if self.file_ctrl.current_file else ""
+                self.simulation_ctrl.export_results_markdown(
+                    self._last_results, self._last_results_type, filename, circuit_name
+                )
                 statusBar = self.statusBar()
                 if statusBar:
                     statusBar.showMessage(f"Results exported to {filename}", 3000)

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -385,6 +385,33 @@ class FileController:
 
         return warnings
 
+    # --- Export helpers ---
+
+    def export_bom(self, filepath: str, circuit_name: str = "") -> None:
+        """Export a Bill of Materials. Format is determined by file extension.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        from simulation.bom_exporter import export_bom_csv, export_bom_excel, write_bom_csv
+
+        if filepath.lower().endswith(".xlsx"):
+            export_bom_excel(self.model.components, filepath, circuit_name=circuit_name)
+        else:
+            content = export_bom_csv(self.model.components, circuit_name=circuit_name)
+            write_bom_csv(content, filepath)
+
+    def export_asc(self, filepath: str) -> None:
+        """Export the circuit as an LTspice .asc schematic.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        from simulation.asc_exporter import export_asc, write_asc
+
+        content = export_asc(self.model)
+        write_asc(content, filepath)
+
     def clear_auto_save(self) -> None:
         """Delete the auto-save recovery file if it exists."""
         try:

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -41,7 +41,12 @@ class SimulationController:
     Coordinates: validate -> generate netlist -> run ngspice -> parse results
     """
 
-    def __init__(self, model: Optional[CircuitModel] = None, circuit_ctrl=None, preset_manager=None):
+    def __init__(
+        self,
+        model: Optional[CircuitModel] = None,
+        circuit_ctrl=None,
+        preset_manager=None,
+    ):
         self.model = model or CircuitModel()
         self.circuit_ctrl = circuit_ctrl  # Phase 5: For observer notifications
         self._runner = None
@@ -124,7 +129,9 @@ class SimulationController:
 
         # 2. Generate wrdata path for transient
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        wrdata_filepath = os.path.join(self.runner.output_dir, f"wrdata_{timestamp}.txt")
+        wrdata_filepath = os.path.join(
+            self.runner.output_dir, f"wrdata_{timestamp}.txt"
+        )
 
         # 3. Generate netlist (include .meas directives if configured)
         meas_directives = self.model.analysis_params.get("measurements", [])
@@ -160,7 +167,12 @@ class SimulationController:
         success, output_file, stdout, stderr = self.runner.run_simulation(netlist)
         if not success:
             # Classify the error and attempt retry with relaxed tolerances
-            from simulation.convergence import RELAXED_OPTIONS, diagnose_error, format_user_message, is_retriable
+            from simulation.convergence import (
+                RELAXED_OPTIONS,
+                diagnose_error,
+                format_user_message,
+                is_retriable,
+            )
 
             diagnosis = diagnose_error(stderr, stdout)
             friendly_msg = format_user_message(diagnosis)
@@ -176,7 +188,9 @@ class SimulationController:
                     relaxed_netlist = None
 
                 if relaxed_netlist:
-                    retry_ok, retry_out, retry_stdout, retry_stderr = self.runner.run_simulation(relaxed_netlist)
+                    retry_ok, retry_out, retry_stdout, retry_stderr = (
+                        self.runner.run_simulation(relaxed_netlist)
+                    )
                     if retry_ok:
                         # Parse retried results, add warning about relaxed tolerances
                         result = self._parse_results(
@@ -185,7 +199,9 @@ class SimulationController:
                             netlist=relaxed_netlist,
                             raw_output=retry_stdout,
                             warnings=validation.warnings
-                            + ["Simulation converged with relaxed tolerances (results may be less accurate)."],
+                            + [
+                                "Simulation converged with relaxed tolerances (results may be less accurate)."
+                            ],
                         )
                         if self.circuit_ctrl:
                             self.circuit_ctrl._notify("simulation_completed", result)
@@ -288,7 +304,9 @@ class SimulationController:
                 raw_output=raw_output,
             )
 
-    def run_parameter_sweep(self, sweep_config: dict, progress_callback=None) -> SimulationResult:
+    def run_parameter_sweep(
+        self, sweep_config: dict, progress_callback=None
+    ) -> SimulationResult:
         """
         Run a parameter sweep: modify a component's value across a range
         and run the base analysis at each step.
@@ -344,7 +362,9 @@ class SimulationController:
         if num_steps <= 1:
             sweep_values = [start]
         else:
-            sweep_values = [start + (stop - start) * i / (num_steps - 1) for i in range(num_steps)]
+            sweep_values = [
+                start + (stop - start) * i / (num_steps - 1) for i in range(num_steps)
+            ]
 
         # Run sweep
         step_results = []
@@ -362,17 +382,25 @@ class SimulationController:
 
                 # Generate netlist
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-                wrdata_filepath = os.path.join(self.runner.output_dir, f"wrdata_sweep_{i}_{timestamp}.txt")
+                wrdata_filepath = os.path.join(
+                    self.runner.output_dir, f"wrdata_sweep_{i}_{timestamp}.txt"
+                )
 
                 try:
                     netlist = self.generate_netlist(wrdata_filepath=wrdata_filepath)
                 except (ValueError, KeyError, TypeError) as e:
-                    step_results.append(SimulationResult(success=False, error=f"Netlist generation failed: {e}"))
+                    step_results.append(
+                        SimulationResult(
+                            success=False, error=f"Netlist generation failed: {e}"
+                        )
+                    )
                     errors.append(f"Step {i + 1} ({comp.value}): netlist failed: {e}")
                     continue
 
                 # Run simulation
-                success, output_file, stdout, stderr = self.runner.run_simulation(netlist)
+                success, output_file, stdout, stderr = self.runner.run_simulation(
+                    netlist
+                )
                 if not success:
                     step_results.append(
                         SimulationResult(
@@ -425,7 +453,9 @@ class SimulationController:
             warnings=validation.warnings,
         )
 
-    def run_monte_carlo(self, mc_config: dict, progress_callback=None) -> SimulationResult:
+    def run_monte_carlo(
+        self, mc_config: dict, progress_callback=None
+    ) -> SimulationResult:
         """
         Run Monte Carlo analysis: vary component values randomly and run
         the base analysis N times.
@@ -500,16 +530,24 @@ class SimulationController:
                 run_values.append(values_this_run)
 
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-                wrdata_filepath = os.path.join(self.runner.output_dir, f"wrdata_mc_{i}_{timestamp}.txt")
+                wrdata_filepath = os.path.join(
+                    self.runner.output_dir, f"wrdata_mc_{i}_{timestamp}.txt"
+                )
 
                 try:
                     netlist = self.generate_netlist(wrdata_filepath=wrdata_filepath)
                 except (ValueError, KeyError, TypeError) as e:
-                    step_results.append(SimulationResult(success=False, error=f"Netlist generation failed: {e}"))
+                    step_results.append(
+                        SimulationResult(
+                            success=False, error=f"Netlist generation failed: {e}"
+                        )
+                    )
                     errors.append(f"Run {i + 1}: netlist failed: {e}")
                     continue
 
-                success, output_file, stdout, stderr = self.runner.run_simulation(netlist)
+                success, output_file, stdout, stderr = self.runner.run_simulation(
+                    netlist
+                )
                 if not success:
                     step_results.append(
                         SimulationResult(
@@ -575,7 +613,10 @@ class SimulationController:
             per-component metrics and *summary_text* is a pre-formatted string.
             If no metrics are available, returns ``([], "")``.
         """
-        from simulation.power_metrics import compute_transient_power_metrics, format_power_summary
+        from simulation.power_metrics import (
+            compute_transient_power_metrics,
+            format_power_summary,
+        )
 
         metrics = compute_transient_power_metrics(tran_data, components)
         if metrics:
@@ -661,3 +702,110 @@ class SimulationController:
         from simulation.netlist_generator import generate_analysis_command
 
         return generate_analysis_command(analysis_type, params)
+
+    # --- Export helpers ---
+
+    def export_netlist(self, filepath: str) -> None:
+        """Generate a SPICE netlist and write it to a file.
+
+        Raises:
+            ValueError, KeyError, TypeError: If netlist generation fails.
+            OSError: If the file cannot be written.
+        """
+        netlist = self.generate_netlist()
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.write(netlist)
+
+    def generate_results_csv(
+        self, results, results_type: str, circuit_name: str = ""
+    ) -> Optional[str]:
+        """Generate CSV content from simulation results.
+
+        Returns None if the results type is not supported for CSV export.
+        """
+        from simulation.csv_exporter import (
+            export_ac_results,
+            export_dc_sweep_results,
+            export_noise_results,
+            export_op_results,
+            export_transient_results,
+        )
+
+        dispatch = {
+            "DC Operating Point": export_op_results,
+            "DC Sweep": export_dc_sweep_results,
+            "AC Sweep": export_ac_results,
+            "Transient": export_transient_results,
+            "Noise": export_noise_results,
+        }
+        func = dispatch.get(results_type)
+        if func is None:
+            return None
+        return func(results, circuit_name)
+
+    def export_results_csv(
+        self, results, results_type: str, filepath: str, circuit_name: str = ""
+    ) -> None:
+        """Export simulation results to a CSV file.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        from simulation.csv_exporter import write_csv
+
+        content = self.generate_results_csv(results, results_type, circuit_name)
+        if content is not None:
+            write_csv(content, filepath)
+
+    def export_results_excel(
+        self, results, results_type: str, filepath: str, circuit_name: str = ""
+    ) -> None:
+        """Export simulation results to an Excel (.xlsx) file.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        from simulation.excel_exporter import export_to_excel
+
+        export_to_excel(results, results_type, filepath, circuit_name)
+
+    def generate_results_markdown(
+        self, results, results_type: str, circuit_name: str = ""
+    ) -> Optional[str]:
+        """Generate Markdown content from simulation results.
+
+        Returns None if the results type is not supported.
+        """
+        from simulation.markdown_exporter import (
+            export_ac_results,
+            export_dc_sweep_results,
+            export_noise_results,
+            export_op_results,
+            export_transient_results,
+        )
+
+        dispatch = {
+            "DC Operating Point": export_op_results,
+            "DC Sweep": export_dc_sweep_results,
+            "AC Sweep": export_ac_results,
+            "Transient": export_transient_results,
+            "Noise": export_noise_results,
+        }
+        func = dispatch.get(results_type)
+        if func is None:
+            return None
+        return func(results, circuit_name)
+
+    def export_results_markdown(
+        self, results, results_type: str, filepath: str, circuit_name: str = ""
+    ) -> None:
+        """Export simulation results to a Markdown file.
+
+        Raises:
+            OSError: If the file cannot be written.
+        """
+        from simulation.markdown_exporter import write_markdown
+
+        content = self.generate_results_markdown(results, results_type, circuit_name)
+        if content is not None:
+            write_markdown(content, filepath)

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -129,9 +129,7 @@ class SimulationController:
 
         # 2. Generate wrdata path for transient
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        wrdata_filepath = os.path.join(
-            self.runner.output_dir, f"wrdata_{timestamp}.txt"
-        )
+        wrdata_filepath = os.path.join(self.runner.output_dir, f"wrdata_{timestamp}.txt")
 
         # 3. Generate netlist (include .meas directives if configured)
         meas_directives = self.model.analysis_params.get("measurements", [])
@@ -167,12 +165,7 @@ class SimulationController:
         success, output_file, stdout, stderr = self.runner.run_simulation(netlist)
         if not success:
             # Classify the error and attempt retry with relaxed tolerances
-            from simulation.convergence import (
-                RELAXED_OPTIONS,
-                diagnose_error,
-                format_user_message,
-                is_retriable,
-            )
+            from simulation.convergence import RELAXED_OPTIONS, diagnose_error, format_user_message, is_retriable
 
             diagnosis = diagnose_error(stderr, stdout)
             friendly_msg = format_user_message(diagnosis)
@@ -188,9 +181,7 @@ class SimulationController:
                     relaxed_netlist = None
 
                 if relaxed_netlist:
-                    retry_ok, retry_out, retry_stdout, retry_stderr = (
-                        self.runner.run_simulation(relaxed_netlist)
-                    )
+                    retry_ok, retry_out, retry_stdout, retry_stderr = self.runner.run_simulation(relaxed_netlist)
                     if retry_ok:
                         # Parse retried results, add warning about relaxed tolerances
                         result = self._parse_results(
@@ -199,9 +190,7 @@ class SimulationController:
                             netlist=relaxed_netlist,
                             raw_output=retry_stdout,
                             warnings=validation.warnings
-                            + [
-                                "Simulation converged with relaxed tolerances (results may be less accurate)."
-                            ],
+                            + ["Simulation converged with relaxed tolerances (results may be less accurate)."],
                         )
                         if self.circuit_ctrl:
                             self.circuit_ctrl._notify("simulation_completed", result)
@@ -304,9 +293,7 @@ class SimulationController:
                 raw_output=raw_output,
             )
 
-    def run_parameter_sweep(
-        self, sweep_config: dict, progress_callback=None
-    ) -> SimulationResult:
+    def run_parameter_sweep(self, sweep_config: dict, progress_callback=None) -> SimulationResult:
         """
         Run a parameter sweep: modify a component's value across a range
         and run the base analysis at each step.
@@ -362,9 +349,7 @@ class SimulationController:
         if num_steps <= 1:
             sweep_values = [start]
         else:
-            sweep_values = [
-                start + (stop - start) * i / (num_steps - 1) for i in range(num_steps)
-            ]
+            sweep_values = [start + (stop - start) * i / (num_steps - 1) for i in range(num_steps)]
 
         # Run sweep
         step_results = []
@@ -382,25 +367,17 @@ class SimulationController:
 
                 # Generate netlist
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-                wrdata_filepath = os.path.join(
-                    self.runner.output_dir, f"wrdata_sweep_{i}_{timestamp}.txt"
-                )
+                wrdata_filepath = os.path.join(self.runner.output_dir, f"wrdata_sweep_{i}_{timestamp}.txt")
 
                 try:
                     netlist = self.generate_netlist(wrdata_filepath=wrdata_filepath)
                 except (ValueError, KeyError, TypeError) as e:
-                    step_results.append(
-                        SimulationResult(
-                            success=False, error=f"Netlist generation failed: {e}"
-                        )
-                    )
+                    step_results.append(SimulationResult(success=False, error=f"Netlist generation failed: {e}"))
                     errors.append(f"Step {i + 1} ({comp.value}): netlist failed: {e}")
                     continue
 
                 # Run simulation
-                success, output_file, stdout, stderr = self.runner.run_simulation(
-                    netlist
-                )
+                success, output_file, stdout, stderr = self.runner.run_simulation(netlist)
                 if not success:
                     step_results.append(
                         SimulationResult(
@@ -453,9 +430,7 @@ class SimulationController:
             warnings=validation.warnings,
         )
 
-    def run_monte_carlo(
-        self, mc_config: dict, progress_callback=None
-    ) -> SimulationResult:
+    def run_monte_carlo(self, mc_config: dict, progress_callback=None) -> SimulationResult:
         """
         Run Monte Carlo analysis: vary component values randomly and run
         the base analysis N times.
@@ -530,24 +505,16 @@ class SimulationController:
                 run_values.append(values_this_run)
 
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-                wrdata_filepath = os.path.join(
-                    self.runner.output_dir, f"wrdata_mc_{i}_{timestamp}.txt"
-                )
+                wrdata_filepath = os.path.join(self.runner.output_dir, f"wrdata_mc_{i}_{timestamp}.txt")
 
                 try:
                     netlist = self.generate_netlist(wrdata_filepath=wrdata_filepath)
                 except (ValueError, KeyError, TypeError) as e:
-                    step_results.append(
-                        SimulationResult(
-                            success=False, error=f"Netlist generation failed: {e}"
-                        )
-                    )
+                    step_results.append(SimulationResult(success=False, error=f"Netlist generation failed: {e}"))
                     errors.append(f"Run {i + 1}: netlist failed: {e}")
                     continue
 
-                success, output_file, stdout, stderr = self.runner.run_simulation(
-                    netlist
-                )
+                success, output_file, stdout, stderr = self.runner.run_simulation(netlist)
                 if not success:
                     step_results.append(
                         SimulationResult(
@@ -613,10 +580,7 @@ class SimulationController:
             per-component metrics and *summary_text* is a pre-formatted string.
             If no metrics are available, returns ``([], "")``.
         """
-        from simulation.power_metrics import (
-            compute_transient_power_metrics,
-            format_power_summary,
-        )
+        from simulation.power_metrics import compute_transient_power_metrics, format_power_summary
 
         metrics = compute_transient_power_metrics(tran_data, components)
         if metrics:
@@ -716,9 +680,7 @@ class SimulationController:
         with open(filepath, "w", encoding="utf-8") as f:
             f.write(netlist)
 
-    def generate_results_csv(
-        self, results, results_type: str, circuit_name: str = ""
-    ) -> Optional[str]:
+    def generate_results_csv(self, results, results_type: str, circuit_name: str = "") -> Optional[str]:
         """Generate CSV content from simulation results.
 
         Returns None if the results type is not supported for CSV export.
@@ -743,9 +705,7 @@ class SimulationController:
             return None
         return func(results, circuit_name)
 
-    def export_results_csv(
-        self, results, results_type: str, filepath: str, circuit_name: str = ""
-    ) -> None:
+    def export_results_csv(self, results, results_type: str, filepath: str, circuit_name: str = "") -> None:
         """Export simulation results to a CSV file.
 
         Raises:
@@ -757,9 +717,7 @@ class SimulationController:
         if content is not None:
             write_csv(content, filepath)
 
-    def export_results_excel(
-        self, results, results_type: str, filepath: str, circuit_name: str = ""
-    ) -> None:
+    def export_results_excel(self, results, results_type: str, filepath: str, circuit_name: str = "") -> None:
         """Export simulation results to an Excel (.xlsx) file.
 
         Raises:
@@ -769,9 +727,7 @@ class SimulationController:
 
         export_to_excel(results, results_type, filepath, circuit_name)
 
-    def generate_results_markdown(
-        self, results, results_type: str, circuit_name: str = ""
-    ) -> Optional[str]:
+    def generate_results_markdown(self, results, results_type: str, circuit_name: str = "") -> Optional[str]:
         """Generate Markdown content from simulation results.
 
         Returns None if the results type is not supported.
@@ -796,9 +752,7 @@ class SimulationController:
             return None
         return func(results, circuit_name)
 
-    def export_results_markdown(
-        self, results, results_type: str, filepath: str, circuit_name: str = ""
-    ) -> None:
+    def export_results_markdown(self, results, results_type: str, filepath: str, circuit_name: str = "") -> None:
         """Export simulation results to a Markdown file.
 
         Raises:

--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -596,6 +596,42 @@ class TestAnnotationsAndRecommendedComponents:
         assert ctrl2.model.analysis_type == "AC Sweep"
 
 
+class TestExportBom:
+    """Tests for FileController.export_bom (Issue #570)."""
+
+    @patch("controllers.file_controller.settings")
+    def test_export_bom_csv(self, mock_settings, tmp_path):
+        model = _build_simple_circuit()
+        ctrl = FileController(model)
+        filepath = tmp_path / "bom.csv"
+        ctrl.export_bom(str(filepath), circuit_name="test")
+        assert filepath.exists()
+        content = filepath.read_text()
+        assert "R1" in content or "Resistor" in content
+
+    @patch("controllers.file_controller.settings")
+    def test_export_bom_excel(self, mock_settings, tmp_path):
+        model = _build_simple_circuit()
+        ctrl = FileController(model)
+        filepath = tmp_path / "bom.xlsx"
+        ctrl.export_bom(str(filepath), circuit_name="test")
+        assert filepath.exists()
+
+
+class TestExportAsc:
+    """Tests for FileController.export_asc (Issue #570)."""
+
+    @patch("controllers.file_controller.settings")
+    def test_export_asc_writes_file(self, mock_settings, tmp_path):
+        model = _build_simple_circuit()
+        ctrl = FileController(model)
+        filepath = tmp_path / "circuit.asc"
+        ctrl.export_asc(str(filepath))
+        assert filepath.exists()
+        content = filepath.read_text()
+        assert len(content) > 0
+
+
 class TestQtDependencies:
     def test_settings_service_used_for_recent_files(self):
         """FileController uses centralized SettingsService for persistence (#598)."""

--- a/app/tests/unit/test_noise_analysis.py
+++ b/app/tests/unit/test_noise_analysis.py
@@ -346,10 +346,10 @@ class TestNoiseCSVExport:
         assert "Input Noise" in csv
 
     def test_csv_export_handles_noise_type(self):
-        """main_window_simulation CSV export should route noise results."""
-        from GUI.main_window_simulation import SimulationMixin
+        """SimulationController CSV dispatch should route noise results."""
+        from controllers.simulation_controller import SimulationController
 
-        source = inspect.getsource(SimulationMixin.export_results_csv)
+        source = inspect.getsource(SimulationController.generate_results_csv)
         assert "export_noise_results" in source
         assert '"Noise"' in source
 

--- a/app/tests/unit/test_noise_analysis.py
+++ b/app/tests/unit/test_noise_analysis.py
@@ -346,7 +346,7 @@ class TestNoiseCSVExport:
         assert "Input Noise" in csv
 
     def test_csv_export_handles_noise_type(self):
-        """SimulationController CSV dispatch should route noise results."""
+        """SimulationController CSV dispatch should route Noise results."""
         from controllers.simulation_controller import SimulationController
 
         source = inspect.getsource(SimulationController.generate_results_csv)

--- a/app/tests/unit/test_simulation_controller.py
+++ b/app/tests/unit/test_simulation_controller.py
@@ -226,6 +226,80 @@ class TestRunSimulation:
         assert mock_runner.run_simulation.call_count == 2
 
 
+class TestExportNetlist:
+    def test_export_netlist_writes_file(self, tmp_path):
+        model = _build_simple_circuit()
+        ctrl = SimulationController(model)
+        filepath = tmp_path / "test.cir"
+        ctrl.export_netlist(str(filepath))
+        assert filepath.exists()
+        content = filepath.read_text()
+        assert ".op" in content.lower() or ".end" in content.lower()
+
+    def test_export_netlist_raises_on_bad_path(self):
+        model = _build_simple_circuit()
+        ctrl = SimulationController(model)
+        with pytest.raises(OSError):
+            ctrl.export_netlist("/nonexistent/dir/test.cir")
+
+
+class TestExportResultsCSV:
+    def test_generate_results_csv_returns_content_for_op(self):
+        ctrl = SimulationController()
+        op_results = {"v(1)": 5.0, "v(2)": 3.3}
+        content = ctrl.generate_results_csv(op_results, "DC Operating Point", "test")
+        assert content is not None
+        assert "v(1)" in content or "5.0" in content
+
+    def test_generate_results_csv_returns_none_for_unsupported(self):
+        ctrl = SimulationController()
+        content = ctrl.generate_results_csv({}, "Pole-Zero", "test")
+        assert content is None
+
+    def test_export_results_csv_writes_file(self, tmp_path):
+        ctrl = SimulationController()
+        op_results = {"v(1)": 5.0, "v(2)": 3.3}
+        filepath = tmp_path / "results.csv"
+        ctrl.export_results_csv(op_results, "DC Operating Point", str(filepath), "test")
+        assert filepath.exists()
+
+    def test_export_results_csv_skips_unsupported_type(self, tmp_path):
+        ctrl = SimulationController()
+        filepath = tmp_path / "results.csv"
+        ctrl.export_results_csv({}, "Pole-Zero", str(filepath), "test")
+        assert not filepath.exists()
+
+
+class TestExportResultsExcel:
+    def test_export_results_excel_writes_file(self, tmp_path):
+        ctrl = SimulationController()
+        op_results = {"v(1)": 5.0}
+        filepath = tmp_path / "results.xlsx"
+        ctrl.export_results_excel(op_results, "DC Operating Point", str(filepath), "test")
+        assert filepath.exists()
+
+
+class TestExportResultsMarkdown:
+    def test_generate_results_markdown_returns_content(self):
+        ctrl = SimulationController()
+        op_results = {"v(1)": 5.0}
+        content = ctrl.generate_results_markdown(op_results, "DC Operating Point", "test")
+        assert content is not None
+        assert "v(1)" in content or "5.0" in content
+
+    def test_generate_results_markdown_returns_none_for_unsupported(self):
+        ctrl = SimulationController()
+        content = ctrl.generate_results_markdown({}, "Sensitivity", "test")
+        assert content is None
+
+    def test_export_results_markdown_writes_file(self, tmp_path):
+        ctrl = SimulationController()
+        op_results = {"v(1)": 5.0}
+        filepath = tmp_path / "results.md"
+        ctrl.export_results_markdown(op_results, "DC Operating Point", str(filepath), "test")
+        assert filepath.exists()
+
+
 class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import controllers.simulation_controller as mod


### PR DESCRIPTION
## Summary - Moved export I/O dispatch logic from main_window_simulation.py and main_window_file_ops.py to SimulationController and FileController - GUI views now only handle file dialogs and status messages; all export dispatch and file writes go through controllers - SimulationController gains: export_netlist, generate_results_csv, export_results_csv, export_results_excel, generate_results_markdown, export_results_markdown - FileController gains: export_bom, export_asc - Re-export and bundle export paths also updated to route through controllers - Updated structural test for noise CSV export to check controller instead of view ## Test plan - [ ] Existing tests pass (no Qt dependencies added to controllers) - [ ] New unit tests for SimulationController export methods - [ ] New unit tests for FileController export methods - [ ] Verify TestNoQtDependencies still passes Closes #570 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>