### PR TITLE
Subcircuit library: import and manage external .subckt definitions

### DIFF
--- a/app/GUI/component_palette.py
+++ b/app/GUI/component_palette.py
@@ -350,6 +350,44 @@ class ComponentPalette(QWidget):
                 self.tree_widget.takeTopLevelItem(index)
             self._used_in_file_item = None
 
+    def refresh_subcircuits(self) -> None:
+        """Rebuild the 'Subcircuits' category from COMPONENT_CATEGORIES.
+
+        Call this after importing new subcircuit definitions to update the
+        palette without recreating the entire widget.
+        """
+        category_name = "Subcircuits"
+        component_names = COMPONENT_CATEGORIES.get(category_name, [])
+
+        # Remove existing Subcircuits category if present
+        if category_name in self._category_items:
+            old_item = self._category_items.pop(category_name)
+            idx = self.tree_widget.indexOfTopLevelItem(old_item)
+            if idx >= 0:
+                self.tree_widget.takeTopLevelItem(idx)
+
+        if not component_names:
+            return
+
+        # Create category item
+        category_item = QTreeWidgetItem(self.tree_widget, [category_name])
+        category_item.setFlags(Qt.ItemFlag.ItemIsEnabled)
+        bold_font = QFont()
+        bold_font.setBold(True)
+        category_item.setFont(0, bold_font)
+        self._category_items[category_name] = category_item
+
+        for component_name in component_names:
+            child = QTreeWidgetItem(category_item, [component_name])
+            try:
+                child.setIcon(0, create_component_icon(component_name))
+            except Exception:
+                pass
+            child.setToolTip(0, COMPONENT_TOOLTIPS.get(component_name, f"Subcircuit: {component_name}"))
+            child.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsDragEnabled)
+
+        category_item.setExpanded(True)
+
     def get_all_component_items(self) -> list[QTreeWidgetItem]:
         """Return all component (leaf) items across all categories."""
         items = []

--- a/app/GUI/subcircuit_dialog.py
+++ b/app/GUI/subcircuit_dialog.py
@@ -1,0 +1,150 @@
+"""Dialog for importing, browsing, and managing the subcircuit library."""
+
+from models.subcircuit_library import SubcircuitLibrary, register_subcircuit_component
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QDialog,
+    QFileDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+
+class SubcircuitLibraryDialog(QDialog):
+    """Dialog to import, view, and delete subcircuit definitions."""
+
+    def __init__(self, library: SubcircuitLibrary, parent=None):
+        super().__init__(parent)
+        self._library = library
+        self.setWindowTitle("Subcircuit Library")
+        self.setMinimumSize(600, 400)
+        self._build_ui()
+        self._refresh_table()
+
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+
+        # Description
+        desc = QLabel("Manage imported .subckt definitions. Imported subcircuits appear in the component palette.")
+        desc.setWordWrap(True)
+        layout.addWidget(desc)
+
+        # Table
+        self._table = QTableWidget()
+        self._table.setColumnCount(4)
+        self._table.setHorizontalHeaderLabels(["Name", "Terminals", "Description", "Built-in"])
+        self._table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self._table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        header = self._table.horizontalHeader()
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
+        layout.addWidget(self._table)
+
+        # Buttons
+        btn_layout = QHBoxLayout()
+        self._import_btn = QPushButton("Import .subckt File...")
+        self._import_btn.clicked.connect(self._on_import)
+        btn_layout.addWidget(self._import_btn)
+
+        self._delete_btn = QPushButton("Delete Selected")
+        self._delete_btn.clicked.connect(self._on_delete)
+        btn_layout.addWidget(self._delete_btn)
+
+        btn_layout.addStretch()
+
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.accept)
+        btn_layout.addWidget(close_btn)
+
+        layout.addLayout(btn_layout)
+
+    def _refresh_table(self):
+        names = self._library.names()
+        self._table.setRowCount(len(names))
+        for row, name in enumerate(names):
+            defn = self._library.get(name)
+            self._table.setItem(row, 0, QTableWidgetItem(name))
+            self._table.setItem(row, 1, QTableWidgetItem(", ".join(defn.terminals)))
+            self._table.setItem(row, 2, QTableWidgetItem(defn.description))
+            builtin_item = QTableWidgetItem("Yes" if defn.builtin else "No")
+            builtin_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+            self._table.setItem(row, 3, builtin_item)
+
+    def _on_import(self):
+        paths, _ = QFileDialog.getOpenFileNames(
+            self,
+            "Import Subcircuit File(s)",
+            "",
+            "SPICE files (*.subckt *.sub *.lib *.sp *.spice *.cir *.mod);;All files (*)",
+        )
+        if not paths:
+            return
+
+        imported = []
+        errors = []
+        for path in paths:
+            try:
+                defs = self._library.import_file(path)
+                for d in defs:
+                    register_subcircuit_component(d)
+                imported.extend(defs)
+            except Exception as exc:
+                errors.append(f"{path}: {exc}")
+
+        self._refresh_table()
+
+        if errors:
+            QMessageBox.warning(
+                self,
+                "Import Errors",
+                "Some files could not be imported:\n\n" + "\n".join(errors),
+            )
+        elif imported:
+            names = ", ".join(d.name for d in imported)
+            QMessageBox.information(self, "Import Successful", f"Imported subcircuits: {names}")
+
+    def _on_delete(self):
+        selected_rows = set()
+        for item in self._table.selectedItems():
+            selected_rows.add(item.row())
+
+        if not selected_rows:
+            return
+
+        names_to_delete = []
+        for row in sorted(selected_rows):
+            name_item = self._table.item(row, 0)
+            if name_item:
+                names_to_delete.append(name_item.text())
+
+        # Check for built-ins
+        builtin_names = [n for n in names_to_delete if self._library.get(n) and self._library.get(n).builtin]
+        if builtin_names:
+            QMessageBox.warning(
+                self,
+                "Cannot Delete",
+                f"Built-in subcircuits cannot be deleted: {', '.join(builtin_names)}",
+            )
+            names_to_delete = [n for n in names_to_delete if n not in builtin_names]
+
+        if not names_to_delete:
+            return
+
+        reply = QMessageBox.question(
+            self,
+            "Confirm Delete",
+            f"Delete {len(names_to_delete)} subcircuit(s)?\n\n" + ", ".join(names_to_delete),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            for name in names_to_delete:
+                self._library.remove(name)
+            self._refresh_table()

--- a/app/models/subcircuit_library.py
+++ b/app/models/subcircuit_library.py
@@ -1,0 +1,378 @@
+"""
+SubcircuitLibrary - Manages external .subckt definitions for use as components.
+
+Provides parsing, storage, persistence, and dynamic registration of subcircuit
+definitions so they appear in the component palette and generate correct netlists.
+
+No Qt dependencies -- pure Python model.
+"""
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Default persistence directory
+_DEFAULT_LIBRARY_DIR = Path.home() / ".spice-gui" / "library"
+
+
+@dataclass
+class SubcircuitDefinition:
+    """A parsed .subckt definition that can be placed as a component."""
+
+    name: str  # Subcircuit name (e.g. "7805")
+    terminals: list[str]  # Ordered terminal/pin names from .subckt header
+    spice_definition: str  # Full SPICE text (.subckt ... .ends)
+    description: str = ""  # Human-readable description
+    builtin: bool = False  # True for built-in subcircuits (not user-deletable)
+
+    @property
+    def terminal_count(self) -> int:
+        return len(self.terminals)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SubcircuitDefinition":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+def parse_subckt(text: str) -> list[SubcircuitDefinition]:
+    """Parse one or more .subckt definitions from raw SPICE text.
+
+    Args:
+        text: Raw text that may contain one or more .subckt/.ends blocks,
+              optionally with comments and other SPICE directives mixed in.
+
+    Returns:
+        List of SubcircuitDefinition objects parsed from the text.
+
+    Raises:
+        ValueError: If no valid .subckt definitions are found.
+    """
+    definitions: list[SubcircuitDefinition] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        # Match .subckt header (case-insensitive)
+        match = re.match(r"\.subckt\s+(\S+)\s+(.*)", line, re.IGNORECASE)
+        if match:
+            name = match.group(1)
+            # Terminal names are everything after the subcircuit name,
+            # excluding optional params (key=value pairs)
+            raw_terminals = match.group(2).split()
+            terminals = [t for t in raw_terminals if "=" not in t]
+
+            # Collect lines until .ends
+            block_lines = [lines[i]]
+            i += 1
+            while i < len(lines):
+                block_lines.append(lines[i])
+                if lines[i].strip().lower().startswith(".ends"):
+                    break
+                i += 1
+
+            # Extract description from comment lines inside the block
+            desc_parts = []
+            for bl in block_lines[1:]:
+                stripped = bl.strip()
+                if stripped.startswith("*"):
+                    desc_parts.append(stripped[1:].strip())
+                elif not stripped.lower().startswith(".ends"):
+                    break
+
+            definitions.append(
+                SubcircuitDefinition(
+                    name=name,
+                    terminals=terminals,
+                    spice_definition="\n".join(block_lines),
+                    description=" ".join(desc_parts) if desc_parts else "",
+                )
+            )
+        i += 1
+
+    if not definitions:
+        raise ValueError("No valid .subckt definitions found in the provided text")
+
+    return definitions
+
+
+class SubcircuitLibrary:
+    """Manages a collection of subcircuit definitions with persistence.
+
+    Definitions are stored as individual JSON files in the library directory
+    (default: ``~/.spice-gui/library/``).  The library is loaded on
+    construction and can be modified at runtime.
+    """
+
+    def __init__(self, library_dir: str | Path | None = None):
+        self._library_dir = Path(library_dir) if library_dir else _DEFAULT_LIBRARY_DIR
+        self._definitions: dict[str, SubcircuitDefinition] = {}
+        self._load()
+
+    # -- Public API ----------------------------------------------------------
+
+    @property
+    def definitions(self) -> dict[str, SubcircuitDefinition]:
+        """Return a copy of the name -> definition mapping."""
+        return dict(self._definitions)
+
+    def get(self, name: str) -> SubcircuitDefinition | None:
+        return self._definitions.get(name)
+
+    def names(self) -> list[str]:
+        return sorted(self._definitions.keys())
+
+    def add(self, definition: SubcircuitDefinition, *, persist: bool = True) -> None:
+        """Add or replace a subcircuit definition."""
+        self._definitions[definition.name] = definition
+        if persist:
+            self._save_one(definition)
+
+    def remove(self, name: str) -> bool:
+        """Remove a subcircuit by name. Returns True if removed."""
+        defn = self._definitions.pop(name, None)
+        if defn is None:
+            return False
+        if defn.builtin:
+            # Re-insert -- built-ins cannot be removed
+            self._definitions[name] = defn
+            return False
+        path = self._path_for(name)
+        if path.exists():
+            path.unlink()
+        return True
+
+    def import_file(self, filepath: str | Path) -> list[SubcircuitDefinition]:
+        """Parse a .subckt file and add all definitions to the library.
+
+        Returns the list of newly imported definitions.
+        """
+        text = Path(filepath).read_text(encoding="utf-8", errors="replace")
+        defs = parse_subckt(text)
+        for d in defs:
+            self.add(d)
+        return defs
+
+    def import_text(self, text: str) -> list[SubcircuitDefinition]:
+        """Parse raw SPICE text and add all definitions to the library."""
+        defs = parse_subckt(text)
+        for d in defs:
+            self.add(d)
+        return defs
+
+    # -- Registration into the component system ------------------------------
+
+    def register_all(self) -> None:
+        """Register all library subcircuits into the component system dicts."""
+        for defn in self._definitions.values():
+            register_subcircuit_component(defn)
+
+    # -- Persistence ---------------------------------------------------------
+
+    def _path_for(self, name: str) -> Path:
+        # Sanitise name for filesystem
+        safe = re.sub(r"[^\w\-.]", "_", name)
+        return self._library_dir / f"{safe}.json"
+
+    def _save_one(self, defn: SubcircuitDefinition) -> None:
+        self._library_dir.mkdir(parents=True, exist_ok=True)
+        path = self._path_for(defn.name)
+        path.write_text(json.dumps(defn.to_dict(), indent=2), encoding="utf-8")
+
+    def _load(self) -> None:
+        if not self._library_dir.is_dir():
+            return
+        for path in sorted(self._library_dir.glob("*.json")):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                defn = SubcircuitDefinition.from_dict(data)
+                self._definitions[defn.name] = defn
+            except Exception:
+                logger.warning("Failed to load subcircuit from %s", path, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Dynamic component-system registration
+# ---------------------------------------------------------------------------
+
+
+def _generate_terminal_geometry(terminal_count: int):
+    """Generate terminal positions for a subcircuit with *terminal_count* pins.
+
+    Uses the same 3-terminal layout as Op-Amp for 3 terminals (IN on left-top,
+    OUT on right, GND on left-bottom).  For other counts, distributes
+    terminals evenly on left/right sides.
+    """
+    if terminal_count == 1:
+        return (15, 15, [(-30, 0)])
+    if terminal_count == 2:
+        return (15, 15, None)  # standard horizontal layout
+    if terminal_count == 3:
+        # Same as Op-Amp: left-top, left-bottom, right-center
+        return (20, 10, [(-30, -10), (-30, 10), (30, 0)])
+    # Even split: ceil(n/2) on left, floor(n/2) on right
+    left_count = (terminal_count + 1) // 2
+    right_count = terminal_count - left_count
+    spacing = 20
+    terminals = []
+    # Left side
+    total_left = (left_count - 1) * spacing
+    for i in range(left_count):
+        y = -total_left / 2 + i * spacing
+        terminals.append((-30, y))
+    # Right side
+    total_right = (right_count - 1) * spacing
+    for i in range(right_count):
+        y = -total_right / 2 + i * spacing
+        terminals.append((30, y))
+    return (20, 10, terminals)
+
+
+def register_subcircuit_component(defn: SubcircuitDefinition) -> None:
+    """Register a SubcircuitDefinition into the component system dictionaries.
+
+    This makes the subcircuit available as a placeable component: it appears
+    in COMPONENT_TYPES, can be created via CircuitController.add_component(),
+    and generates correct netlist lines.
+    """
+    from models.component import (
+        COMPONENT_CATEGORIES,
+        COMPONENT_COLORS,
+        COMPONENT_TYPES,
+        DEFAULT_VALUES,
+        SPICE_SYMBOLS,
+        TERMINAL_COUNTS,
+        TERMINAL_GEOMETRY,
+    )
+
+    name = defn.name
+
+    # Skip if already registered
+    if name in SPICE_SYMBOLS:
+        return
+
+    # Add to COMPONENT_TYPES
+    if name not in COMPONENT_TYPES:
+        COMPONENT_TYPES.append(name)
+
+    # SPICE symbol is always "X" for subcircuit instances
+    SPICE_SYMBOLS[name] = "X"
+
+    # Terminal count
+    TERMINAL_COUNTS[name] = defn.terminal_count
+
+    # Default value: subcircuit name (used as the .subckt model reference)
+    DEFAULT_VALUES[name] = name
+
+    # Color -- use a consistent colour for all subcircuits
+    COMPONENT_COLORS[name] = "#FF6F00"
+
+    # Terminal geometry
+    TERMINAL_GEOMETRY[name] = _generate_terminal_geometry(defn.terminal_count)
+
+    # Add to "Subcircuits" category
+    if "Subcircuits" not in COMPONENT_CATEGORIES:
+        COMPONENT_CATEGORIES["Subcircuits"] = []
+    if name not in COMPONENT_CATEGORIES["Subcircuits"]:
+        COMPONENT_CATEGORIES["Subcircuits"].append(name)
+
+    # Update COMPONENTS dict in styles/constants
+    try:
+        from GUI.styles.constants import _COLOR_KEYS, COMPONENTS
+
+        _COLOR_KEYS[name] = "component_subcircuit"
+        COMPONENTS[name] = {
+            "symbol": "X",
+            "terminals": defn.terminal_count,
+            "color_key": "component_subcircuit",
+        }
+    except Exception:
+        pass  # OK if GUI not available (headless tests)
+
+    # Register graphics class and renderer
+    _register_graphics(name, defn)
+
+
+def _register_graphics(name: str, defn: SubcircuitDefinition) -> None:
+    """Register a ComponentGraphicsItem subclass and renderer for *name*."""
+    try:
+        from GUI.component_item import COMPONENT_CLASSES, ComponentGraphicsItem
+
+        # Create a dynamic subclass for this subcircuit type
+        if name not in COMPONENT_CLASSES:
+            cls = type(
+                f"Subcircuit_{name}",
+                (ComponentGraphicsItem,),
+                {
+                    "type_name": name,
+                    "__init__": lambda self, component_id, model=None, _tn=name: ComponentGraphicsItem.__init__(
+                        self, component_id, _tn, model=model
+                    ),
+                },
+            )
+            COMPONENT_CLASSES[name] = cls
+    except Exception:
+        pass  # GUI not importable in headless/model-only tests
+
+    try:
+        from GUI.renderers import _make_iec_delegate, register
+
+        _register_subcircuit_renderer(name, defn, register, _make_iec_delegate)
+    except Exception:
+        pass
+
+
+def _register_subcircuit_renderer(name, defn, register_fn, make_iec_delegate_fn):
+    """Register IEEE + IEC renderers for a subcircuit component."""
+    from GUI.renderers import ComponentRenderer, _bounding_rect_obstacle
+
+    class SubcircuitRenderer(ComponentRenderer):
+        """Generic box renderer for subcircuit components."""
+
+        def __init__(self, defn):
+            self._defn = defn
+
+        def draw(self, painter, component):
+            # Draw a rectangular box
+            painter.drawRect(-18, -15, 36, 30)
+
+            # Draw terminal connection lines
+            if component.scene() is not None:
+                tc = self._defn.terminal_count
+                if tc == 2:
+                    painter.drawLine(-30, 0, -18, 0)
+                    painter.drawLine(18, 0, 30, 0)
+                elif tc == 3:
+                    painter.drawLine(-30, -10, -18, -10)
+                    painter.drawLine(-30, 10, -18, 10)
+                    painter.drawLine(18, 0, 30, 0)
+                else:
+                    # Draw leads for custom terminal positions
+                    geom = self._defn and _generate_terminal_geometry(tc)
+                    if geom and geom[2]:
+                        for tx, ty in geom[2]:
+                            if tx < 0:
+                                painter.drawLine(int(tx), int(ty), -18, int(ty))
+                            else:
+                                painter.drawLine(18, int(ty), int(tx), int(ty))
+
+            # Draw subcircuit name inside the box
+            from PyQt6.QtCore import QRectF
+
+            painter.drawText(QRectF(-16, -12, 32, 24), 0x0084, self._defn.name)
+
+        def get_obstacle_shape(self, component):
+            return _bounding_rect_obstacle(component)
+
+    renderer = SubcircuitRenderer(defn)
+    try:
+        register_fn(name, "ieee", renderer)
+        register_fn(name, "iec", make_iec_delegate_fn(renderer))
+    except Exception:
+        pass

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -140,6 +140,9 @@ class NetlistGenerator:
             lines.append(OPAMP_SUBCIRCUITS[model_name])
             lines.append("")
 
+        # Add subcircuit definitions from the subcircuit library
+        self._inject_subcircuit_definitions(lines)
+
         # Build node connectivity map
         node_map = {}  # (comp_id, term_index) -> node_number
         next_node = 1
@@ -307,6 +310,10 @@ class NetlistGenerator:
                 lines.append(f"{prim_name} {nodes[0]} {nodes[1]} {l_prim}")
                 lines.append(f"{sec_name} {nodes[2]} {nodes[3]} {l_sec}")
                 lines.append(f"K_{comp_id} {prim_name} {sec_name} {coupling}")
+            elif comp.get_spice_symbol() == "X":
+                # Generic subcircuit instance (from subcircuit library)
+                # X<name> node1 node2 ... subckt_name
+                lines.append(f"X{comp_id} {' '.join(nodes)} {comp.value}")
 
         # Add BJT model directives
         bjt_models = set()
@@ -393,6 +400,27 @@ class NetlistGenerator:
         lines.append(".end")
 
         return "\n".join(lines)
+
+    def _inject_subcircuit_definitions(self, lines):
+        """Inject .subckt definitions for any subcircuit-library components used."""
+        try:
+            from models.subcircuit_library import SubcircuitLibrary
+
+            library = SubcircuitLibrary()
+        except Exception:
+            return
+
+        subckt_names_used = set()
+        for comp in self.components.values():
+            if comp.get_spice_symbol() == "X" and comp.component_type != "Op-Amp":
+                subckt_names_used.add(comp.value)
+
+        for subckt_name in sorted(subckt_names_used):
+            defn = library.get(subckt_name)
+            if defn is not None:
+                lines.append(f"* {subckt_name} Subcircuit")
+                lines.append(defn.spice_definition)
+                lines.append("")
 
     def _generate_analysis_commands(self, node_labels, node_map):
         """Generate analysis-specific SPICE commands"""

--- a/app/tests/unit/test_subcircuit_library.py
+++ b/app/tests/unit/test_subcircuit_library.py
@@ -1,0 +1,338 @@
+"""Tests for the subcircuit library: parsing, persistence, registration, and netlist integration."""
+
+import pytest
+from models.subcircuit_library import (
+    SubcircuitDefinition,
+    SubcircuitLibrary,
+    parse_subckt,
+    register_subcircuit_component,
+)
+
+# ---------------------------------------------------------------------------
+# Parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseSubckt:
+    """Tests for the .subckt parser."""
+
+    def test_parse_simple_subcircuit(self):
+        text = ".subckt MYAMP inp inn out\nE1 out 0 inp inn 1e6\n.ends"
+        defs = parse_subckt(text)
+        assert len(defs) == 1
+        assert defs[0].name == "MYAMP"
+        assert defs[0].terminals == ["inp", "inn", "out"]
+        assert ".subckt MYAMP" in defs[0].spice_definition
+        assert ".ends" in defs[0].spice_definition
+
+    def test_parse_multiple_subcircuits(self):
+        text = ".subckt SUB1 a b\nR1 a b 1k\n.ends\n\n.subckt SUB2 x y z\nR1 x y 2k\nR2 y z 3k\n.ends\n"
+        defs = parse_subckt(text)
+        assert len(defs) == 2
+        assert defs[0].name == "SUB1"
+        assert defs[0].terminals == ["a", "b"]
+        assert defs[1].name == "SUB2"
+        assert defs[1].terminals == ["x", "y", "z"]
+
+    def test_parse_with_params(self):
+        text = ".subckt MYCOMP a b c GAIN=100\nE1 c 0 a b {GAIN}\n.ends"
+        defs = parse_subckt(text)
+        assert len(defs) == 1
+        # GAIN=100 should be excluded from terminals
+        assert defs[0].terminals == ["a", "b", "c"]
+
+    def test_parse_case_insensitive(self):
+        text = ".SUBCKT UPPER in out\nR1 in out 1k\n.ENDS"
+        defs = parse_subckt(text)
+        assert len(defs) == 1
+        assert defs[0].name == "UPPER"
+
+    def test_parse_with_comments(self):
+        text = (
+            ".subckt COMMENTED a b\n"
+            "* This is a comment describing the subcircuit\n"
+            "* Another comment line\n"
+            "R1 a b 1k\n"
+            ".ends"
+        )
+        defs = parse_subckt(text)
+        assert len(defs) == 1
+        assert "comment describing" in defs[0].description
+
+    def test_parse_no_subcircuit_raises(self):
+        with pytest.raises(ValueError, match="No valid .subckt"):
+            parse_subckt("R1 1 2 1k\n.end")
+
+    def test_parse_empty_text_raises(self):
+        with pytest.raises(ValueError, match="No valid .subckt"):
+            parse_subckt("")
+
+    def test_parse_mixed_content(self):
+        text = "* Some header\n.param VCC=5\n.subckt HIDDEN a b\nR1 a b 1k\n.ends\n* trailing content\n"
+        defs = parse_subckt(text)
+        assert len(defs) == 1
+        assert defs[0].name == "HIDDEN"
+
+
+# ---------------------------------------------------------------------------
+# SubcircuitDefinition tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubcircuitDefinition:
+    def test_terminal_count(self):
+        d = SubcircuitDefinition(
+            name="TEST",
+            terminals=["a", "b", "c"],
+            spice_definition=".subckt TEST a b c\n.ends",
+        )
+        assert d.terminal_count == 3
+
+    def test_serialization_roundtrip(self):
+        d = SubcircuitDefinition(
+            name="TEST",
+            terminals=["in", "out", "gnd"],
+            spice_definition=".subckt TEST in out gnd\nR1 in out 1k\n.ends",
+            description="A test subcircuit",
+            builtin=True,
+        )
+        data = d.to_dict()
+        d2 = SubcircuitDefinition.from_dict(data)
+        assert d2.name == d.name
+        assert d2.terminals == d.terminals
+        assert d2.spice_definition == d.spice_definition
+        assert d2.description == d.description
+        assert d2.builtin == d.builtin
+
+
+# ---------------------------------------------------------------------------
+# SubcircuitLibrary persistence tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubcircuitLibrary:
+    def test_add_and_get(self, tmp_path):
+        lib = SubcircuitLibrary(tmp_path / "lib")
+        defn = SubcircuitDefinition(
+            name="MYCOMP",
+            terminals=["a", "b"],
+            spice_definition=".subckt MYCOMP a b\nR1 a b 1k\n.ends",
+        )
+        lib.add(defn)
+        assert lib.get("MYCOMP") is defn
+        assert "MYCOMP" in lib.names()
+
+    def test_persistence_roundtrip(self, tmp_path):
+        lib_dir = tmp_path / "lib"
+        lib = SubcircuitLibrary(lib_dir)
+        defn = SubcircuitDefinition(
+            name="PERSIST",
+            terminals=["x", "y"],
+            spice_definition=".subckt PERSIST x y\nR1 x y 2k\n.ends",
+            description="Persisted",
+        )
+        lib.add(defn)
+
+        # Verify file was written
+        files = list(lib_dir.glob("*.json"))
+        assert len(files) == 1
+
+        # Load fresh library from same directory
+        lib2 = SubcircuitLibrary(lib_dir)
+        loaded = lib2.get("PERSIST")
+        assert loaded is not None
+        assert loaded.terminals == ["x", "y"]
+        assert loaded.description == "Persisted"
+
+    def test_remove(self, tmp_path):
+        lib = SubcircuitLibrary(tmp_path / "lib")
+        defn = SubcircuitDefinition(
+            name="REMOVEME",
+            terminals=["a", "b"],
+            spice_definition=".subckt REMOVEME a b\n.ends",
+        )
+        lib.add(defn)
+        assert lib.remove("REMOVEME") is True
+        assert lib.get("REMOVEME") is None
+
+    def test_remove_builtin_fails(self, tmp_path):
+        lib = SubcircuitLibrary(tmp_path / "lib")
+        defn = SubcircuitDefinition(
+            name="BUILTIN",
+            terminals=["a", "b"],
+            spice_definition=".subckt BUILTIN a b\n.ends",
+            builtin=True,
+        )
+        lib.add(defn)
+        assert lib.remove("BUILTIN") is False
+        assert lib.get("BUILTIN") is not None
+
+    def test_import_file(self, tmp_path):
+        lib = SubcircuitLibrary(tmp_path / "lib")
+        subckt_file = tmp_path / "test.subckt"
+        subckt_file.write_text(".subckt FROMFILE a b c\nR1 a b 1k\nR2 b c 2k\n.ends\n")
+        imported = lib.import_file(subckt_file)
+        assert len(imported) == 1
+        assert imported[0].name == "FROMFILE"
+        assert lib.get("FROMFILE") is not None
+
+    def test_import_text(self, tmp_path):
+        lib = SubcircuitLibrary(tmp_path / "lib")
+        text = ".subckt FROMTEXT x y\nR1 x y 1k\n.ends"
+        imported = lib.import_text(text)
+        assert len(imported) == 1
+        assert imported[0].name == "FROMTEXT"
+
+    def test_empty_library(self, tmp_path):
+        lib = SubcircuitLibrary(tmp_path / "nonexistent")
+        assert lib.names() == []
+
+
+# ---------------------------------------------------------------------------
+# Component registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubcircuitRegistration:
+    def test_register_adds_to_component_system(self, tmp_path):
+        from models.component import (
+            COMPONENT_CATEGORIES,
+            COMPONENT_TYPES,
+            DEFAULT_VALUES,
+            SPICE_SYMBOLS,
+            TERMINAL_COUNTS,
+            TERMINAL_GEOMETRY,
+        )
+
+        defn = SubcircuitDefinition(
+            name="TEST_REG_237",
+            terminals=["in", "out", "gnd"],
+            spice_definition=".subckt TEST_REG_237 in out gnd\nR1 in out 1k\n.ends",
+        )
+        register_subcircuit_component(defn)
+
+        assert "TEST_REG_237" in COMPONENT_TYPES
+        assert SPICE_SYMBOLS["TEST_REG_237"] == "X"
+        assert TERMINAL_COUNTS["TEST_REG_237"] == 3
+        assert DEFAULT_VALUES["TEST_REG_237"] == "TEST_REG_237"
+        assert "TEST_REG_237" in TERMINAL_GEOMETRY
+        assert "Subcircuits" in COMPONENT_CATEGORIES
+        assert "TEST_REG_237" in COMPONENT_CATEGORIES["Subcircuits"]
+
+    def test_register_idempotent(self, tmp_path):
+        from models.component import COMPONENT_TYPES
+
+        defn = SubcircuitDefinition(
+            name="TEST_IDEMPOTENT_237",
+            terminals=["a", "b"],
+            spice_definition=".subckt TEST_IDEMPOTENT_237 a b\nR1 a b 1k\n.ends",
+        )
+        register_subcircuit_component(defn)
+        count_before = COMPONENT_TYPES.count("TEST_IDEMPOTENT_237")
+        register_subcircuit_component(defn)
+        count_after = COMPONENT_TYPES.count("TEST_IDEMPOTENT_237")
+        assert count_before == count_after == 1
+
+
+# ---------------------------------------------------------------------------
+# Netlist integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubcircuitNetlist:
+    def _make_subcircuit_circuit(self, subckt_name, terminal_count):
+        """Build a minimal circuit using a subcircuit component."""
+        from models.node import NodeData
+        from tests.conftest import make_component, make_wire
+
+        # Register the subcircuit so TERMINAL_COUNTS etc. are set
+        defn = SubcircuitDefinition(
+            name=subckt_name,
+            terminals=[f"t{i}" for i in range(terminal_count)],
+            spice_definition=f".subckt {subckt_name} "
+            + " ".join(f"t{i}" for i in range(terminal_count))
+            + "\nR1 t0 t1 1k\n.ends",
+        )
+        register_subcircuit_component(defn)
+
+        # Build circuit: V1 -- subcircuit -- GND
+        v1 = make_component("Voltage Source", "V1", "5V", (0, 0))
+        sub = make_component(subckt_name, "X1", subckt_name, (100, 0))
+        gnd = make_component("Ground", "GND1", "0V", (200, 0))
+
+        components = {"V1": v1, "X1": sub, "GND1": gnd}
+
+        # Wire V1+ to sub terminal 0
+        wires = [make_wire("V1", 0, "X1", 0)]
+        # Wire remaining sub terminals to GND
+        for i in range(1, terminal_count):
+            wires.append(make_wire("X1", i, "GND1", 0))
+        # Wire V1- to GND
+        wires.append(make_wire("V1", 1, "GND1", 0))
+
+        node_v = NodeData(
+            terminals={("V1", 0), ("X1", 0)},
+            wire_indices={0},
+            auto_label="nodeV",
+        )
+        gnd_terminals = {("GND1", 0), ("V1", 1)}
+        gnd_wires = set()
+        for i in range(1, terminal_count):
+            gnd_terminals.add(("X1", i))
+            gnd_wires.add(i)
+        gnd_wires.add(len(wires) - 1)
+        node_gnd = NodeData(
+            terminals=gnd_terminals,
+            wire_indices=gnd_wires,
+            is_ground=True,
+            auto_label="0",
+        )
+        nodes = [node_v, node_gnd]
+
+        terminal_to_node = {("V1", 0): node_v, ("X1", 0): node_v}
+        for i in range(1, terminal_count):
+            terminal_to_node[("X1", i)] = node_gnd
+        terminal_to_node[("GND1", 0)] = node_gnd
+        terminal_to_node[("V1", 1)] = node_gnd
+
+        return components, wires, nodes, terminal_to_node
+
+    def test_subcircuit_netlist_contains_instance_line(self, tmp_path):
+        from simulation.netlist_generator import NetlistGenerator
+
+        components, wires, nodes, t2n = self._make_subcircuit_circuit("NETTEST_237", 3)
+        gen = NetlistGenerator(components, wires, nodes, t2n, "DC Operating Point", {})
+        netlist = gen.generate()
+
+        # Should contain X-prefixed instance line
+        assert "XX1" in netlist
+        assert "NETTEST_237" in netlist
+
+    def test_subcircuit_netlist_contains_definition(self, tmp_path):
+        from simulation.netlist_generator import NetlistGenerator
+
+        # Ensure subcircuit is in a library the generator can find
+        lib = SubcircuitLibrary(tmp_path / "lib")
+        defn = SubcircuitDefinition(
+            name="DEFTEST_237",
+            terminals=["a", "b"],
+            spice_definition=".subckt DEFTEST_237 a b\nR1 a b 1k\n.ends",
+        )
+        lib.add(defn)
+        register_subcircuit_component(defn)
+
+        components, wires, nodes, t2n = self._make_subcircuit_circuit("DEFTEST_237", 2)
+
+        # Monkey-patch the library lookup to use our temp library
+        import models.subcircuit_library as sl_mod
+
+        orig_default = sl_mod._DEFAULT_LIBRARY_DIR
+        sl_mod._DEFAULT_LIBRARY_DIR = tmp_path / "lib"
+        try:
+            gen = NetlistGenerator(components, wires, nodes, t2n, "DC Operating Point", {})
+            netlist = gen.generate()
+        finally:
+            sl_mod._DEFAULT_LIBRARY_DIR = orig_default
+
+        assert ".subckt DEFTEST_237 a b" in netlist
+        assert ".ends" in netlist


### PR DESCRIPTION
## Summary - Adds  manager that parses  files, stores definitions, and persists them to  - Imported subcircuits dynamically register into the component system (types, terminals, renderers) and appear in the palette under a Subcircuits category - Netlist generator injects  definitions and generates correct -prefix instance lines - UI dialog () for importing, browsing, and deleting subcircuit definitions ## Test plan - [x] 21 new unit tests covering parsing, persistence, registration, and netlist integration - [x] All 3212 existing tests pass (14 pre-existing failures in  unrelated to this change) - [x] Lint and format checks pass Closes #237 🤖 Generated with [Claude Code](https://claude.com/claude-code)