### PR TITLE
Add voltage regulator subcircuits (7805, LM317, LM7812)

### DIFF
--- a/app/GUI/component_palette.py
+++ b/app/GUI/component_palette.py
@@ -1,4 +1,5 @@
 from controllers.settings_service import settings as app_settings
+from models.builtin_subcircuits import register_builtin_subcircuits
 from models.component import COMPONENT_CATEGORIES
 from PyQt6.QtCore import QMimeData, QSize, Qt, pyqtSignal
 from PyQt6.QtGui import QBrush, QDrag, QFont, QIcon, QPainter, QPen, QPixmap
@@ -6,6 +7,10 @@ from PyQt6.QtWidgets import QLineEdit, QTreeWidget, QTreeWidgetItem, QVBoxLayout
 
 from .component_item import COMPONENT_CLASSES
 from .styles import COMPONENTS, theme_manager
+
+# Register built-in subcircuit components (voltage regulators etc.) so they
+# appear in COMPONENT_CATEGORIES["Subcircuits"] before the palette is built.
+register_builtin_subcircuits()
 
 # Brief descriptions for each component type
 COMPONENT_TOOLTIPS = {

--- a/app/models/builtin_subcircuits.py
+++ b/app/models/builtin_subcircuits.py
@@ -1,0 +1,97 @@
+"""Built-in subcircuit definitions for common voltage regulators.
+
+Provides 7805, LM317, and LM7812 as built-in subcircuit components that are
+automatically registered into the component system on first import.
+
+Each has 3 terminals: IN, OUT, GND — matching real-world IC pinouts.
+"""
+
+from models.subcircuit_library import SubcircuitDefinition, register_subcircuit_component
+
+# ---------------------------------------------------------------------------
+# SPICE subcircuit definitions
+# ---------------------------------------------------------------------------
+
+_7805_SUBCKT = """\
+.subckt 7805 IN OUT GND
+* 7805 Fixed +5V voltage regulator (behavioral model)
+* Pins: IN=input, OUT=output (+5V), GND=ground
+Rin IN GND 1e6
+E_reg int_out GND IN GND 1
+R_limit int_out OUT 0.1
+V_ref ref GND 5.0
+B_clamp OUT GND V=min(V(int_out, GND), V(ref))
+R_out OUT GND 1e6
+.ends"""
+
+_LM317_SUBCKT = """\
+.subckt LM317 IN OUT ADJ
+* LM317 Adjustable positive voltage regulator (behavioral model)
+* Pins: IN=input, OUT=output, ADJ=adjust
+* Vout = 1.25 * (1 + R2/R1) where R1 is between OUT and ADJ
+* This model provides a 1.25V reference between OUT and ADJ
+Rin IN ADJ 1e6
+V_ref OUT ADJ 1.25
+R_in IN int1 0.1
+E_buf int1 ADJ OUT ADJ 1
+R_out OUT ADJ 1e6
+.ends"""
+
+_LM7812_SUBCKT = """\
+.subckt LM7812 IN OUT GND
+* LM7812 Fixed +12V voltage regulator (behavioral model)
+* Pins: IN=input, OUT=output (+12V), GND=ground
+Rin IN GND 1e6
+E_reg int_out GND IN GND 1
+R_limit int_out OUT 0.1
+V_ref ref GND 12.0
+B_clamp OUT GND V=min(V(int_out, GND), V(ref))
+R_out OUT GND 1e6
+.ends"""
+
+# ---------------------------------------------------------------------------
+# Built-in definitions
+# ---------------------------------------------------------------------------
+
+BUILTIN_SUBCIRCUITS: list[SubcircuitDefinition] = [
+    SubcircuitDefinition(
+        name="7805",
+        terminals=["IN", "OUT", "GND"],
+        spice_definition=_7805_SUBCKT,
+        description="Fixed +5V voltage regulator",
+        builtin=True,
+    ),
+    SubcircuitDefinition(
+        name="LM317",
+        terminals=["IN", "OUT", "ADJ"],
+        spice_definition=_LM317_SUBCKT,
+        description="Adjustable positive voltage regulator (1.25V ref)",
+        builtin=True,
+    ),
+    SubcircuitDefinition(
+        name="LM7812",
+        terminals=["IN", "OUT", "GND"],
+        spice_definition=_LM7812_SUBCKT,
+        description="Fixed +12V voltage regulator",
+        builtin=True,
+    ),
+]
+
+
+def register_builtin_subcircuits() -> None:
+    """Register all built-in subcircuit components into the component system.
+
+    Safe to call multiple times — already-registered components are skipped.
+    """
+    for defn in BUILTIN_SUBCIRCUITS:
+        register_subcircuit_component(defn)
+
+
+def load_builtin_subcircuits_into_library(library) -> None:
+    """Add built-in subcircuits to a SubcircuitLibrary instance.
+
+    Built-in definitions are marked ``builtin=True`` so they cannot be
+    deleted by users.
+    """
+    for defn in BUILTIN_SUBCIRCUITS:
+        library.add(defn, persist=True)

--- a/app/models/subcircuit_library.py
+++ b/app/models/subcircuit_library.py
@@ -114,6 +114,7 @@ class SubcircuitLibrary:
         self._library_dir = Path(library_dir) if library_dir else _DEFAULT_LIBRARY_DIR
         self._definitions: dict[str, SubcircuitDefinition] = {}
         self._load()
+        self._load_builtins()
 
     # -- Public API ----------------------------------------------------------
 
@@ -195,6 +196,17 @@ class SubcircuitLibrary:
                 self._definitions[defn.name] = defn
             except Exception:
                 logger.warning("Failed to load subcircuit from %s", path, exc_info=True)
+
+    def _load_builtins(self) -> None:
+        """Load built-in subcircuit definitions (e.g. voltage regulators)."""
+        try:
+            from models.builtin_subcircuits import BUILTIN_SUBCIRCUITS
+
+            for defn in BUILTIN_SUBCIRCUITS:
+                if defn.name not in self._definitions:
+                    self._definitions[defn.name] = defn
+        except ImportError:
+            pass
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/unit/test_subcircuit_library.py
+++ b/app/tests/unit/test_subcircuit_library.py
@@ -183,9 +183,11 @@ class TestSubcircuitLibrary:
         assert len(imported) == 1
         assert imported[0].name == "FROMTEXT"
 
-    def test_empty_library(self, tmp_path):
+    def test_library_from_nonexistent_dir_has_only_builtins(self, tmp_path):
         lib = SubcircuitLibrary(tmp_path / "nonexistent")
-        assert lib.names() == []
+        # Should contain only built-in subcircuits, no user-imported ones
+        for name in lib.names():
+            assert lib.get(name).builtin is True
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/unit/test_voltage_regulators.py
+++ b/app/tests/unit/test_voltage_regulators.py
@@ -1,0 +1,190 @@
+"""Tests for built-in voltage regulator subcircuit components (7805, LM317, LM7812)."""
+
+import pytest
+from models.builtin_subcircuits import BUILTIN_SUBCIRCUITS, register_builtin_subcircuits
+from models.component import (
+    COMPONENT_CATEGORIES,
+    COMPONENT_TYPES,
+    DEFAULT_VALUES,
+    SPICE_SYMBOLS,
+    TERMINAL_COUNTS,
+    TERMINAL_GEOMETRY,
+)
+from models.subcircuit_library import SubcircuitLibrary, register_subcircuit_component
+from simulation.netlist_generator import NetlistGenerator
+from tests.conftest import make_component, make_wire
+
+
+class TestBuiltinDefinitions:
+    """Test that built-in subcircuit definitions are correct."""
+
+    def test_three_builtins_defined(self):
+        assert len(BUILTIN_SUBCIRCUITS) == 3
+
+    @pytest.mark.parametrize("name", ["7805", "LM317", "LM7812"])
+    def test_builtin_has_three_terminals(self, name):
+        defn = next(d for d in BUILTIN_SUBCIRCUITS if d.name == name)
+        assert defn.terminal_count == 3
+
+    @pytest.mark.parametrize("name", ["7805", "LM317", "LM7812"])
+    def test_builtin_is_marked_builtin(self, name):
+        defn = next(d for d in BUILTIN_SUBCIRCUITS if d.name == name)
+        assert defn.builtin is True
+
+    @pytest.mark.parametrize("name", ["7805", "LM317", "LM7812"])
+    def test_builtin_has_valid_spice_definition(self, name):
+        defn = next(d for d in BUILTIN_SUBCIRCUITS if d.name == name)
+        assert f".subckt {name}" in defn.spice_definition
+        assert ".ends" in defn.spice_definition
+
+    def test_7805_terminals(self):
+        defn = next(d for d in BUILTIN_SUBCIRCUITS if d.name == "7805")
+        assert defn.terminals == ["IN", "OUT", "GND"]
+
+    def test_lm317_terminals(self):
+        defn = next(d for d in BUILTIN_SUBCIRCUITS if d.name == "LM317")
+        assert defn.terminals == ["IN", "OUT", "ADJ"]
+
+    def test_lm7812_terminals(self):
+        defn = next(d for d in BUILTIN_SUBCIRCUITS if d.name == "LM7812")
+        assert defn.terminals == ["IN", "OUT", "GND"]
+
+
+class TestRegistration:
+    """Test that voltage regulators are registered in the component system."""
+
+    @classmethod
+    def setup_class(cls):
+        register_builtin_subcircuits()
+
+    @pytest.mark.parametrize("name", ["7805", "LM317", "LM7812"])
+    def test_in_component_types(self, name):
+        assert name in COMPONENT_TYPES
+
+    @pytest.mark.parametrize("name", ["7805", "LM317", "LM7812"])
+    def test_spice_symbol_is_X(self, name):
+        assert SPICE_SYMBOLS[name] == "X"
+
+    @pytest.mark.parametrize("name", ["7805", "LM317", "LM7812"])
+    def test_terminal_count_is_3(self, name):
+        assert TERMINAL_COUNTS[name] == 3
+
+    @pytest.mark.parametrize("name", ["7805", "LM317", "LM7812"])
+    def test_has_terminal_geometry(self, name):
+        assert name in TERMINAL_GEOMETRY
+
+    @pytest.mark.parametrize("name", ["7805", "LM317", "LM7812"])
+    def test_default_value_is_name(self, name):
+        assert DEFAULT_VALUES[name] == name
+
+    def test_subcircuits_category_exists(self):
+        assert "Subcircuits" in COMPONENT_CATEGORIES
+
+    @pytest.mark.parametrize("name", ["7805", "LM317", "LM7812"])
+    def test_in_subcircuits_category(self, name):
+        assert name in COMPONENT_CATEGORIES["Subcircuits"]
+
+
+class TestLibraryIntegration:
+    """Test that builtins appear in SubcircuitLibrary."""
+
+    def test_builtins_in_default_library(self, tmp_path):
+        lib = SubcircuitLibrary(tmp_path / "lib")
+        assert lib.get("7805") is not None
+        assert lib.get("LM317") is not None
+        assert lib.get("LM7812") is not None
+
+    def test_builtins_cannot_be_deleted(self, tmp_path):
+        lib = SubcircuitLibrary(tmp_path / "lib")
+        assert lib.remove("7805") is False
+        assert lib.get("7805") is not None
+
+
+class TestNetlistGeneration:
+    """Test that voltage regulators generate correct netlist lines."""
+
+    @classmethod
+    def setup_class(cls):
+        register_builtin_subcircuits()
+
+    def _build_regulator_circuit(self, name, tmp_path):
+        """Build: Vin -- regulator -- GND, with output floating."""
+        from models.node import NodeData
+
+        v1 = make_component("Voltage Source", "V1", "12V", (0, 0))
+        reg = make_component(name, "X1", name, (100, 0))
+        gnd = make_component("Ground", "GND1", "0V", (200, 100))
+
+        components = {"V1": v1, "X1": reg, "GND1": gnd}
+
+        # Wire V1+ to regulator IN (terminal 0)
+        wires = [
+            make_wire("V1", 0, "X1", 0),
+            # Wire regulator GND (terminal 1 for output, terminal 2 for GND)
+            # Terminal order: IN=0, OUT=1, GND=2  (based on 3-terminal layout)
+            make_wire("X1", 1, "GND1", 0),  # OUT to GND (load)
+            make_wire("X1", 2, "GND1", 0),  # GND pin to GND
+            make_wire("V1", 1, "GND1", 0),  # V1- to GND
+        ]
+
+        node_in = NodeData(
+            terminals={("V1", 0), ("X1", 0)},
+            wire_indices={0},
+            auto_label="nodeIN",
+        )
+        node_gnd = NodeData(
+            terminals={("X1", 1), ("X1", 2), ("GND1", 0), ("V1", 1)},
+            wire_indices={1, 2, 3},
+            is_ground=True,
+            auto_label="0",
+        )
+        nodes = [node_in, node_gnd]
+
+        terminal_to_node = {
+            ("V1", 0): node_in,
+            ("X1", 0): node_in,
+            ("X1", 1): node_gnd,
+            ("X1", 2): node_gnd,
+            ("GND1", 0): node_gnd,
+            ("V1", 1): node_gnd,
+        }
+
+        return components, wires, nodes, terminal_to_node
+
+    @pytest.mark.parametrize("name", ["7805", "LM317", "LM7812"])
+    def test_netlist_has_x_prefix_instance(self, name, tmp_path):
+        components, wires, nodes, t2n = self._build_regulator_circuit(name, tmp_path)
+        gen = NetlistGenerator(components, wires, nodes, t2n, "DC Operating Point", {})
+        netlist = gen.generate()
+        # Should have XX1 ... <name>
+        assert "XX1" in netlist
+        assert name in netlist
+
+    @pytest.mark.parametrize("name", ["7805", "LM317", "LM7812"])
+    def test_netlist_has_subckt_definition(self, name, tmp_path):
+        import models.subcircuit_library as sl_mod
+
+        # Create a library with builtins (side effect: populates lib_dir)
+        lib_dir = tmp_path / "lib"
+        SubcircuitLibrary(lib_dir)
+
+        components, wires, nodes, t2n = self._build_regulator_circuit(name, tmp_path)
+
+        orig_default = sl_mod._DEFAULT_LIBRARY_DIR
+        sl_mod._DEFAULT_LIBRARY_DIR = lib_dir
+        try:
+            gen = NetlistGenerator(components, wires, nodes, t2n, "DC Operating Point", {})
+            netlist = gen.generate()
+        finally:
+            sl_mod._DEFAULT_LIBRARY_DIR = orig_default
+
+        assert f".subckt {name}" in netlist
+        assert ".ends" in netlist
+
+    def test_component_data_spice_symbol(self):
+        comp = make_component("7805", "X1", "7805", (0, 0))
+        assert comp.get_spice_symbol() == "X"
+
+    def test_component_data_terminal_count(self):
+        comp = make_component("7805", "X1", "7805", (0, 0))
+        assert comp.get_terminal_count() == 3


### PR DESCRIPTION
## Summary - Adds 7805, LM317, and LM7812 as built-in subcircuit components using the library from #237 - Each has a behavioral SPICE .subckt model, 3 terminals (IN/OUT/GND or IN/OUT/ADJ), and component palette entry - Built-in subcircuits auto-load into the SubcircuitLibrary and cannot be deleted by users - Registers at palette import time so they appear in the Subcircuits category ## Test plan - [x] 42 new unit tests covering definitions, registration, library integration, and netlist generation - [x] All 3289 tests pass (0 new failures) - [x] Lint and format checks pass Closes #244 Generated with [Claude Code](https://claude.com/claude-code)