### PR TITLE
Replace QSettings with JSON-file backend in SettingsService (#633)

### DIFF
--- a/app/controllers/settings_service.py
+++ b/app/controllers/settings_service.py
@@ -1,45 +1,110 @@
 """Centralized application settings persistence.
 
-All QSettings access goes through this module, ensuring a single point
-of contact for the platform's persistence layer.  GUI dialogs, mixins,
+Framework-agnostic JSON-file backend.  GUI dialogs, mixins,
 and controllers should import ``settings`` from this module rather than
-constructing ``QSettings`` directly.
+managing persistence directly.
 """
 
+import base64
 import json
+import os
+import sys
+from pathlib import Path
 from typing import Any, List
-
-from PyQt6.QtCore import QSettings
 
 _ORG = "SDSMT"
 _APP = "SDM Spice"
 
 
-class SettingsService:
-    """Thin wrapper around QSettings providing a single access point.
+def _default_settings_path() -> Path:
+    """Return the platform-appropriate settings file path."""
+    if sys.platform == "win32":
+        base = Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming"))
+    elif sys.platform == "darwin":
+        base = Path.home() / "Library" / "Preferences"
+    else:
+        base = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    return base / _ORG / _APP / "settings.json"
 
-    Typed helpers (``get_bool``, ``get_int``, etc.) handle the
-    string-coercion quirks of ``QSettings`` so callers don't have to.
+
+class SettingsService:
+    """JSON-file backed settings store providing a single access point.
+
+    Typed helpers (``get_bool``, ``get_int``, etc.) ensure callers
+    get the right Python type without manual coercion.
     """
 
-    def __init__(self) -> None:
-        self._qs = QSettings(_ORG, _APP)
+    def __init__(self, path: "Path | None" = None) -> None:
+        self._path = path or _default_settings_path()
+        self._data: dict = {}
+        self._load()
+
+    def _load(self) -> None:
+        """Load settings from disk (silently ignore missing/corrupt file)."""
+        try:
+            if self._path.exists():
+                with open(self._path, "r") as f:
+                    self._data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            self._data = {}
+
+    def _save(self) -> None:
+        """Persist settings to disk."""
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self._path, "w") as f:
+                json.dump(self._data, f, indent=2)
+        except OSError:
+            pass  # Best-effort persistence
+
+    @staticmethod
+    def _encode(value: Any) -> Any:
+        """Encode a value for JSON storage.
+
+        Binary data (``bytes``, ``bytearray``, or objects with a
+        ``data()`` method like ``QByteArray``) is base64-encoded so
+        callers can store opaque blobs without knowing about JSON.
+        """
+        # Duck-type byte-array objects (has .data() returning bytes) without framework imports
+        if hasattr(value, "data") and callable(value.data):
+            try:
+                raw = bytes(value.data())
+                return {"__bytes__": base64.b64encode(raw).decode("ascii")}
+            except (TypeError, AttributeError):
+                pass
+        if isinstance(value, (bytes, bytearray)):
+            return {"__bytes__": base64.b64encode(value).decode("ascii")}
+        return value
+
+    @staticmethod
+    def _decode(value: Any) -> Any:
+        """Decode a value from JSON storage."""
+        if isinstance(value, dict) and "__bytes__" in value:
+            return base64.b64decode(value["__bytes__"])
+        return value
 
     # -- generic -------------------------------------------------------
 
     def get(self, key: str, default: Any = None) -> Any:
         """Read a setting value (raw)."""
-        return self._qs.value(key, default)
+        val = self._data.get(key)
+        if val is None:
+            return default
+        return self._decode(val)
 
     def set(self, key: str, value: Any) -> None:
         """Write a setting value."""
-        self._qs.setValue(key, value)
+        if value is None:
+            self._data.pop(key, None)
+        else:
+            self._data[key] = self._encode(value)
+        self._save()
 
     # -- typed helpers --------------------------------------------------
 
     def get_bool(self, key: str, default: bool = False) -> bool:
-        """Read a boolean setting (handles QSettings string coercion)."""
-        val = self._qs.value(key)
+        """Read a boolean setting."""
+        val = self._data.get(key)
         if val is None:
             return default
         if isinstance(val, bool):
@@ -48,36 +113,41 @@ class SettingsService:
 
     def get_int(self, key: str, default: int = 0) -> int:
         """Read an integer setting."""
-        val = self._qs.value(key, default)
+        val = self._data.get(key)
         return int(val) if val is not None else default
 
     def get_float(self, key: str, default: float = 0.0) -> float:
         """Read a float setting."""
-        val = self._qs.value(key, default)
+        val = self._data.get(key)
         return float(val) if val is not None else default
 
     def get_str(self, key: str, default: str = "") -> str:
         """Read a string setting."""
-        val = self._qs.value(key, default)
+        val = self._data.get(key)
         return str(val) if val is not None else default
 
     def get_json(self, key: str, default: Any = None) -> Any:
         """Read a JSON-encoded setting."""
-        raw = self._qs.value(key)
+        raw = self._data.get(key)
         if raw is None:
             return default if default is not None else []
-        try:
-            return json.loads(raw) if isinstance(raw, str) else (default if default is not None else [])
-        except (json.JSONDecodeError, TypeError):
-            return default if default is not None else []
+        # Handle legacy string-encoded JSON (from a previous set() call)
+        if isinstance(raw, str):
+            try:
+                return json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                return default if default is not None else []
+        # Native JSON value (stored by set_json)
+        return raw
 
     def set_json(self, key: str, value: Any) -> None:
-        """Write a value as JSON string."""
-        self._qs.setValue(key, json.dumps(value))
+        """Write a value as a JSON-native setting."""
+        self._data[key] = value
+        self._save()
 
     def get_list(self, key: str) -> List[str]:
-        """Read a list setting (QSettings may return a single string or a list)."""
-        val = self._qs.value(key, [])
+        """Read a list setting."""
+        val = self._data.get(key)
         if not isinstance(val, list):
             return []
         return val

--- a/app/tests/unit/test_settings_service.py
+++ b/app/tests/unit/test_settings_service.py
@@ -1,19 +1,21 @@
-"""Tests for centralized SettingsService (#598).
+"""Tests for centralized SettingsService (#598, #633).
 
 Verifies that:
 - SettingsService provides typed accessors (get_bool, get_int, etc.)
 - All production code uses the centralized service instead of QSettings directly
 - JSON round-trip works correctly
+- Controller layer is free of PyQt6 imports
 """
 
 import json
+import pathlib
 
 import pytest
 from controllers.settings_service import SettingsService, settings
 
 
 class TestSettingsServiceTypedHelpers:
-    """Test the typed helper methods handle QSettings string coercion."""
+    """Test the typed helper methods."""
 
     @pytest.fixture(autouse=True)
     def _clean(self):
@@ -95,6 +97,48 @@ class TestSettingsServiceTypedHelpers:
         assert isinstance(settings, SettingsService)
 
 
+class TestSettingsServiceJsonFile:
+    """Test the JSON-file backend specifics."""
+
+    def test_constructor_with_custom_path(self, tmp_path):
+        path = tmp_path / "test_settings.json"
+        svc = SettingsService(path=path)
+        svc.set("key", "value")
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["key"] == "value"
+
+    def test_load_from_existing_file(self, tmp_path):
+        path = tmp_path / "test_settings.json"
+        path.write_text(json.dumps({"saved": 123}))
+        svc = SettingsService(path=path)
+        assert svc.get_int("saved") == 123
+
+    def test_corrupt_file_ignored(self, tmp_path):
+        path = tmp_path / "test_settings.json"
+        path.write_text("NOT VALID JSON{{{")
+        svc = SettingsService(path=path)
+        assert svc.get("anything") is None
+
+    def test_bytes_round_trip(self, tmp_path):
+        path = tmp_path / "test_settings.json"
+        svc = SettingsService(path=path)
+        original = b"\x00\x01\x02hello"
+        svc.set("binary", original)
+        assert svc.get("binary") == original
+        # Reload from disk
+        svc2 = SettingsService(path=path)
+        assert svc2.get("binary") == original
+
+    def test_set_none_removes_key(self, tmp_path):
+        path = tmp_path / "test_settings.json"
+        svc = SettingsService(path=path)
+        svc.set("key", "value")
+        assert svc.get("key") == "value"
+        svc.set("key", None)
+        assert svc.get("key") is None
+
+
 class TestNoDirectQSettingsInProduction:
     """Verify production code no longer imports QSettings directly."""
 
@@ -114,12 +158,8 @@ class TestNoDirectQSettingsInProduction:
     @pytest.mark.parametrize("rel_path", _GUI_FILES + _CONTROLLER_FILES)
     def test_no_direct_qsettings_import(self, rel_path):
         """No production file should import QSettings directly."""
-        import importlib
-        import pathlib
-
         base = pathlib.Path(__file__).resolve().parent.parent.parent / "app" / rel_path
         if not base.exists():
-            # Resolve relative to app/ in case cwd differs
             import os
 
             base = pathlib.Path(os.getcwd()) / rel_path
@@ -129,8 +169,6 @@ class TestNoDirectQSettingsInProduction:
     @pytest.mark.parametrize("rel_path", _GUI_FILES + _CONTROLLER_FILES)
     def test_uses_settings_service(self, rel_path):
         """All production files should import from settings_service."""
-        import pathlib
-
         base = pathlib.Path(__file__).resolve().parent.parent.parent / "app" / rel_path
         if not base.exists():
             import os
@@ -138,3 +176,25 @@ class TestNoDirectQSettingsInProduction:
             base = pathlib.Path(os.getcwd()) / rel_path
         source = base.read_text()
         assert "settings_service" in source, f"{rel_path} does not use settings_service"
+
+
+class TestControllerLayerNoPyQt6:
+    """Verify the controller layer does not import from PyQt6 (#633)."""
+
+    _CONTROLLER_FILES = [
+        "controllers/settings_service.py",
+        "controllers/file_controller.py",
+        "controllers/recent_exports.py",
+    ]
+
+    @pytest.mark.parametrize("rel_path", _CONTROLLER_FILES)
+    def test_no_pyqt6_import(self, rel_path):
+        """Controller files must not import from PyQt6."""
+        base = pathlib.Path(__file__).resolve().parent.parent.parent / "app" / rel_path
+        if not base.exists():
+            import os
+
+            base = pathlib.Path(os.getcwd()) / rel_path
+        source = base.read_text()
+        assert "from PyQt6" not in source, f"{rel_path} imports from PyQt6"
+        assert "import PyQt6" not in source, f"{rel_path} imports PyQt6"


### PR DESCRIPTION
## Summary - Removes the  dependency from , making the controller layer fully framework-agnostic - Replaces with a JSON-file backend that stores settings at a platform-appropriate config path ( on Linux,  on Windows,  on macOS) - Binary data (, ) is transparently base64-encoded via duck-typing so GUI callers (e.g. ) continue working without changes ## Test plan - [x] All existing  tests pass (bool, int, float, str, json, list) - [x] New  tests verify: custom path, reload from disk, corrupt file handling, bytes round-trip, set-None removal - [x] New  tests verify no  /  in , ,  - [ ] CI passes all tests Closes #633 🤖 Generated with [Claude Code](https://claude.com/claude-code)