### PR TITLE
Remove PyQt6 dependencies from services/report_generator.py (#629)

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -419,7 +419,8 @@ class FileOperationsMixin:
     def _on_generate_report(self):
         """Generate a comprehensive PDF circuit report."""
         from GUI.report_dialog import ReportDialog
-        from services.report_generator import ReportGenerator
+        from GUI.report_renderer import PDFReportRenderer
+        from services.report_generator import ReportDataBuilder
 
         # Determine circuit name from current file or default
         circuit_name = ""
@@ -453,14 +454,9 @@ class FileOperationsMixin:
             results_text = self.results_text.toPlainText()
 
         try:
-            generator = ReportGenerator(config)
-            generator.generate(
-                filepath=filename,
-                scene=self.canvas.scene,
-                model=self.model,
-                netlist=netlist,
-                results_text=results_text,
-            )
+            data = ReportDataBuilder.build(config, model=self.model, netlist=netlist, results_text=results_text)
+            renderer = PDFReportRenderer()
+            renderer.render(filepath=filename, data=data, scene=self.canvas.scene)
             QMessageBox.information(
                 self,
                 "Report Generated",

--- a/app/GUI/report_renderer.py
+++ b/app/GUI/report_renderer.py
@@ -1,0 +1,267 @@
+"""PDF report renderer using QPrinter/QPainter.
+
+This is the GUI-layer counterpart to services.report_generator.  It
+takes a ReportData bundle (assembled by ReportDataBuilder) and renders
+it to a multi-page PDF.  All Qt dependencies live here.
+"""
+
+from PyQt6.QtCore import QRectF, Qt
+from PyQt6.QtGui import QFont, QFontMetrics, QPainter
+from PyQt6.QtPrintSupport import QPrinter
+from services.report_generator import ReportData
+
+
+class PDFReportRenderer:
+    """Renders a ReportData bundle to a multi-page PDF via QPrinter/QPainter."""
+
+    MARGIN_RATIO = 0.05
+    TITLE_FONT_SIZE = 24
+    HEADING_FONT_SIZE = 16
+    BODY_FONT_SIZE = 10
+    CODE_FONT_SIZE = 9
+
+    def render(self, filepath: str, data: ReportData, scene=None) -> None:
+        """Render report data to a PDF file.
+
+        Args:
+            filepath: Output PDF file path.
+            data: Assembled report content from ReportDataBuilder.
+            scene: Optional QGraphicsScene for schematic rendering.
+        """
+        printer = QPrinter(QPrinter.PrinterMode.HighResolution)
+        printer.setOutputFormat(QPrinter.OutputFormat.PdfFormat)
+        printer.setOutputFileName(filepath)
+
+        painter = QPainter(printer)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        page_rect = QRectF(printer.pageRect(printer.Unit.DevicePixel))
+        margin = page_rect.width() * self.MARGIN_RATIO
+        content_rect = page_rect.adjusted(margin, margin, -margin, -margin)
+
+        first_page = True
+
+        if data.config.include_title:
+            self._render_title_page(painter, content_rect, data)
+            first_page = False
+
+        if data.config.include_schematic and scene is not None:
+            if not first_page:
+                printer.newPage()
+            self._render_schematic_page(painter, printer, content_rect, scene)
+            first_page = False
+
+        if data.config.include_netlist and data.netlist:
+            if not first_page:
+                printer.newPage()
+            self._render_text_section(painter, printer, content_rect, "SPICE Netlist", data.netlist, monospace=True)
+            first_page = False
+
+        if data.config.include_analysis and data.analysis_text:
+            if not first_page:
+                printer.newPage()
+            self._render_text_section(painter, printer, content_rect, "Analysis Configuration", data.analysis_text)
+            first_page = False
+
+        if data.config.include_results and data.results_text:
+            if not first_page:
+                printer.newPage()
+            self._render_text_section(
+                painter, printer, content_rect, "Simulation Results", data.results_text, monospace=True
+            )
+
+        painter.end()
+
+    # ------------------------------------------------------------------
+    # Private rendering helpers
+    # ------------------------------------------------------------------
+
+    def _render_title_page(self, painter: QPainter, rect: QRectF, data: ReportData) -> None:
+        """Render the title page with circuit name, date, and student name."""
+        painter.fillRect(rect, Qt.GlobalColor.white)
+
+        title_font = QFont("Helvetica", self.TITLE_FONT_SIZE, QFont.Weight.Bold)
+        subtitle_font = QFont("Helvetica", self.HEADING_FONT_SIZE)
+        body_font = QFont("Helvetica", self.BODY_FONT_SIZE)
+
+        center_y = rect.top() + rect.height() * 0.35
+        center_x = rect.left() + rect.width() / 2
+
+        # Circuit name
+        painter.setFont(title_font)
+        fm = QFontMetrics(title_font)
+        title_width = fm.horizontalAdvance(data.title)
+        painter.drawText(int(center_x - title_width / 2), int(center_y), data.title)
+
+        # Subtitle
+        painter.setFont(subtitle_font)
+        fm = QFontMetrics(subtitle_font)
+        sub_width = fm.horizontalAdvance(data.subtitle)
+        painter.drawText(int(center_x - sub_width / 2), int(center_y + fm.height() * 2), data.subtitle)
+
+        # Analysis type if available
+        if data.analysis_type:
+            analysis_line = f"Analysis: {data.analysis_type}"
+            fm_body = QFontMetrics(body_font)
+            painter.setFont(body_font)
+            al_width = fm_body.horizontalAdvance(analysis_line)
+            painter.drawText(
+                int(center_x - al_width / 2),
+                int(center_y + fm.height() * 4),
+                analysis_line,
+            )
+
+        # Component count
+        if data.component_count:
+            comp_line = f"Components: {data.component_count}"
+            painter.setFont(body_font)
+            fm_body = QFontMetrics(body_font)
+            cl_width = fm_body.horizontalAdvance(comp_line)
+            painter.drawText(
+                int(center_x - cl_width / 2),
+                int(center_y + fm.height() * 5),
+                comp_line,
+            )
+
+        # Date and student name at bottom
+        bottom_y = rect.top() + rect.height() * 0.7
+        painter.setFont(body_font)
+        fm = QFontMetrics(body_font)
+        line_height = fm.height() * 1.5
+
+        date_width = fm.horizontalAdvance(data.date_str)
+        painter.drawText(int(center_x - date_width / 2), int(bottom_y), data.date_str)
+
+        if data.config.student_name:
+            name_width = fm.horizontalAdvance(data.config.student_name)
+            painter.drawText(
+                int(center_x - name_width / 2),
+                int(bottom_y + line_height),
+                data.config.student_name,
+            )
+
+    def _render_schematic_page(self, painter: QPainter, printer: QPrinter, rect: QRectF, scene) -> None:
+        """Render the circuit schematic on a dedicated page."""
+        heading_font = QFont("Helvetica", self.HEADING_FONT_SIZE, QFont.Weight.Bold)
+        painter.setFont(heading_font)
+        fm = QFontMetrics(heading_font)
+        painter.drawText(int(rect.left()), int(rect.top() + fm.ascent()), "Schematic")
+
+        heading_height = fm.height() * 2
+
+        source_rect = self._get_scene_source_rect(scene)
+        if source_rect is None:
+            body_font = QFont("Helvetica", self.BODY_FONT_SIZE)
+            painter.setFont(body_font)
+            painter.drawText(
+                int(rect.left()),
+                int(rect.top() + heading_height + 50),
+                "(Empty canvas)",
+            )
+            return
+
+        avail = QRectF(
+            rect.left(),
+            rect.top() + heading_height,
+            rect.width(),
+            rect.height() - heading_height,
+        )
+
+        scale_x = avail.width() / source_rect.width()
+        scale_y = avail.height() / source_rect.height()
+        scale = min(scale_x, scale_y)
+
+        target_w = source_rect.width() * scale
+        target_h = source_rect.height() * scale
+        target_x = avail.left() + (avail.width() - target_w) / 2
+        target_y = avail.top() + (avail.height() - target_h) / 2
+        target_rect = QRectF(target_x, target_y, target_w, target_h)
+
+        painter.fillRect(target_rect, Qt.GlobalColor.white)
+        scene.render(painter, target=target_rect, source=source_rect)
+
+    def _render_text_section(
+        self,
+        painter: QPainter,
+        printer: QPrinter,
+        rect: QRectF,
+        heading: str,
+        text: str,
+        monospace: bool = False,
+    ) -> None:
+        """Render a text section with heading, handling page breaks."""
+        heading_font = QFont("Helvetica", self.HEADING_FONT_SIZE, QFont.Weight.Bold)
+        if monospace:
+            body_font = QFont("Courier", self.CODE_FONT_SIZE)
+        else:
+            body_font = QFont("Helvetica", self.BODY_FONT_SIZE)
+
+        painter.setFont(heading_font)
+        hfm = QFontMetrics(heading_font)
+        y = rect.top() + hfm.ascent()
+        painter.drawText(int(rect.left()), int(y), heading)
+        y += hfm.height() * 1.5
+
+        painter.drawLine(int(rect.left()), int(y), int(rect.left() + rect.width()), int(y))
+        y += hfm.height() * 0.5
+
+        painter.setFont(body_font)
+        bfm = QFontMetrics(body_font)
+        line_height = bfm.height() * 1.2
+        bottom = rect.top() + rect.height()
+
+        lines = text.split("\n")
+        for line in lines:
+            if y + line_height > bottom:
+                printer.newPage()
+                y = rect.top() + hfm.height()
+                painter.setFont(heading_font)
+                painter.drawText(
+                    int(rect.left()),
+                    int(rect.top() + hfm.ascent()),
+                    f"{heading} (continued)",
+                )
+                y += hfm.height() * 0.5
+                painter.drawLine(
+                    int(rect.left()),
+                    int(y),
+                    int(rect.left() + rect.width()),
+                    int(y),
+                )
+                y += hfm.height() * 0.5
+                painter.setFont(body_font)
+
+            elided = bfm.elidedText(line, Qt.TextElideMode.ElideRight, int(rect.width()))
+            painter.drawText(int(rect.left()), int(y), elided)
+            y += line_height
+
+    @staticmethod
+    def _get_scene_source_rect(scene) -> QRectF | None:
+        """Compute bounding rect of circuit items with padding.
+
+        Filters out grid/background items by checking for circuit item types.
+        Falls back to itemsBoundingRect if type checking is unavailable.
+        """
+        try:
+            from GUI.annotation_item import AnnotationItem
+            from GUI.component_item import ComponentGraphicsItem
+            from GUI.wire_item import WireGraphicsItem
+
+            circuit_items = [
+                item
+                for item in scene.items()
+                if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
+            ]
+            if not circuit_items:
+                return None
+            source_rect = circuit_items[0].sceneBoundingRect()
+            for item in circuit_items[1:]:
+                source_rect = source_rect.united(item.sceneBoundingRect())
+        except ImportError:
+            source_rect = scene.itemsBoundingRect()
+            if source_rect.isEmpty():
+                return None
+
+        padding = 40
+        source_rect.adjust(-padding, -padding, padding, padding)
+        return source_rect

--- a/app/services/report_generator.py
+++ b/app/services/report_generator.py
@@ -1,15 +1,12 @@
-"""PDF circuit report generator.
+"""Report data assembly for circuit reports.
 
-Renders multi-page PDF reports containing schematic image, SPICE netlist,
-analysis configuration, and simulation results using QPrinter/QPainter.
+Provides ReportConfig (what to include), ReportData (assembled content),
+and ReportDataBuilder (model-to-text logic).  Pure Python — no Qt or GUI
+dependencies.  The actual PDF rendering lives in GUI.report_renderer.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
-
-from PyQt6.QtCore import QRectF, Qt
-from PyQt6.QtGui import QFont, QFontMetrics, QPainter
-from PyQt6.QtPrintSupport import QPrinter
 
 
 @dataclass
@@ -25,264 +22,55 @@ class ReportConfig:
     circuit_name: str = ""
 
 
-class ReportGenerator:
-    """Generates multi-page PDF circuit reports.
+@dataclass
+class ReportData:
+    """Assembled report content ready for rendering.
 
-    Uses QPrinter/QPainter to render a structured report with optional
-    sections: title page, schematic image, SPICE netlist, analysis
-    configuration, and simulation results.
+    All fields are plain strings / ints so that any renderer (Qt, PIL,
+    ReportLab, …) can consume them without importing model classes.
     """
 
-    # Page layout constants (in device pixels at high-res)
-    MARGIN_RATIO = 0.05  # 5% margin on each side
-    TITLE_FONT_SIZE = 24
-    HEADING_FONT_SIZE = 16
-    BODY_FONT_SIZE = 10
-    CODE_FONT_SIZE = 9
+    config: ReportConfig = field(default_factory=ReportConfig)
+    title: str = ""
+    subtitle: str = "Circuit Analysis Report"
+    analysis_type: str = ""
+    component_count: int = 0
+    date_str: str = ""
+    analysis_text: str = ""
+    netlist: str = ""
+    results_text: str = ""
 
-    def __init__(self, config: ReportConfig):
-        self.config = config
 
-    def generate(
-        self,
-        filepath: str,
-        scene=None,
+class ReportDataBuilder:
+    """Assembles plain-text report content from model objects.
+
+    This is the services-layer piece: it reads model data and produces
+    a ReportData bundle that any renderer can consume.
+    """
+
+    @staticmethod
+    def build(
+        config: ReportConfig,
         model=None,
         netlist: str = "",
         results_text: str = "",
-    ) -> None:
-        """Generate a PDF report to the given file path.
+    ) -> ReportData:
+        """Build a ReportData from a config, optional model, and text blobs."""
+        data = ReportData(config=config)
+        data.title = config.circuit_name or "Circuit Report"
+        data.date_str = datetime.now().strftime("%B %d, %Y")
 
-        Args:
-            filepath: Output PDF file path.
-            scene: QGraphicsScene containing the circuit schematic.
-            model: CircuitModel with analysis type/params and component data.
-            netlist: SPICE netlist string.
-            results_text: Formatted simulation results text.
-        """
-        printer = QPrinter(QPrinter.PrinterMode.HighResolution)
-        printer.setOutputFormat(QPrinter.OutputFormat.PdfFormat)
-        printer.setOutputFileName(filepath)
+        if model is not None:
+            data.analysis_type = getattr(model, "analysis_type", "") or ""
+            data.component_count = len(getattr(model, "components", {}) or {})
+            data.analysis_text = ReportDataBuilder._format_analysis_config(model)
 
-        painter = QPainter(printer)
-        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        data.netlist = netlist
+        data.results_text = results_text
+        return data
 
-        page_rect = QRectF(printer.pageRect(printer.Unit.DevicePixel))
-        margin = page_rect.width() * self.MARGIN_RATIO
-        content_rect = page_rect.adjusted(margin, margin, -margin, -margin)
-
-        first_page = True
-
-        if self.config.include_title:
-            self._render_title_page(painter, content_rect, model)
-            first_page = False
-
-        if self.config.include_schematic and scene is not None:
-            if not first_page:
-                printer.newPage()
-            self._render_schematic_page(painter, printer, content_rect, scene)
-            first_page = False
-
-        if self.config.include_netlist and netlist:
-            if not first_page:
-                printer.newPage()
-            self._render_text_section(painter, printer, content_rect, "SPICE Netlist", netlist, monospace=True)
-            first_page = False
-
-        if self.config.include_analysis and model is not None:
-            if not first_page:
-                printer.newPage()
-            analysis_text = self._format_analysis_config(model)
-            self._render_text_section(painter, printer, content_rect, "Analysis Configuration", analysis_text)
-            first_page = False
-
-        if self.config.include_results and results_text:
-            if not first_page:
-                printer.newPage()
-            self._render_text_section(
-                painter,
-                printer,
-                content_rect,
-                "Simulation Results",
-                results_text,
-                monospace=True,
-            )
-
-        painter.end()
-
-    def _render_title_page(self, painter: QPainter, rect: QRectF, model=None) -> None:
-        """Render the title page with circuit name, date, and student name."""
-        painter.fillRect(rect, Qt.GlobalColor.white)
-
-        title_font = QFont("Helvetica", self.TITLE_FONT_SIZE, QFont.Weight.Bold)
-        subtitle_font = QFont("Helvetica", self.HEADING_FONT_SIZE)
-        body_font = QFont("Helvetica", self.BODY_FONT_SIZE)
-
-        center_y = rect.top() + rect.height() * 0.35
-        center_x = rect.left() + rect.width() / 2
-
-        # Circuit name
-        title = self.config.circuit_name or "Circuit Report"
-        painter.setFont(title_font)
-        fm = QFontMetrics(title_font)
-        title_width = fm.horizontalAdvance(title)
-        painter.drawText(int(center_x - title_width / 2), int(center_y), title)
-
-        # Subtitle
-        painter.setFont(subtitle_font)
-        subtitle = "Circuit Analysis Report"
-        fm = QFontMetrics(subtitle_font)
-        sub_width = fm.horizontalAdvance(subtitle)
-        painter.drawText(int(center_x - sub_width / 2), int(center_y + fm.height() * 2), subtitle)
-
-        # Analysis type if available
-        if model and model.analysis_type:
-            analysis_line = f"Analysis: {model.analysis_type}"
-            fm_body = QFontMetrics(body_font)
-            painter.setFont(body_font)
-            al_width = fm_body.horizontalAdvance(analysis_line)
-            painter.drawText(
-                int(center_x - al_width / 2),
-                int(center_y + fm.height() * 4),
-                analysis_line,
-            )
-
-        # Component count
-        if model and model.components:
-            comp_line = f"Components: {len(model.components)}"
-            painter.setFont(body_font)
-            fm_body = QFontMetrics(body_font)
-            cl_width = fm_body.horizontalAdvance(comp_line)
-            painter.drawText(
-                int(center_x - cl_width / 2),
-                int(center_y + fm.height() * 5),
-                comp_line,
-            )
-
-        # Date and student name at bottom
-        bottom_y = rect.top() + rect.height() * 0.7
-        painter.setFont(body_font)
-        fm = QFontMetrics(body_font)
-        line_height = fm.height() * 1.5
-
-        date_str = datetime.now().strftime("%B %d, %Y")
-        date_width = fm.horizontalAdvance(date_str)
-        painter.drawText(int(center_x - date_width / 2), int(bottom_y), date_str)
-
-        if self.config.student_name:
-            name_width = fm.horizontalAdvance(self.config.student_name)
-            painter.drawText(
-                int(center_x - name_width / 2),
-                int(bottom_y + line_height),
-                self.config.student_name,
-            )
-
-    def _render_schematic_page(self, painter: QPainter, printer: QPrinter, rect: QRectF, scene) -> None:
-        """Render the circuit schematic on a dedicated page."""
-        # Heading
-        heading_font = QFont("Helvetica", self.HEADING_FONT_SIZE, QFont.Weight.Bold)
-        painter.setFont(heading_font)
-        fm = QFontMetrics(heading_font)
-        painter.drawText(int(rect.left()), int(rect.top() + fm.ascent()), "Schematic")
-
-        heading_height = fm.height() * 2
-
-        # Compute source rect from circuit items (excluding grid)
-        source_rect = self._get_scene_source_rect(scene)
-        if source_rect is None:
-            body_font = QFont("Helvetica", self.BODY_FONT_SIZE)
-            painter.setFont(body_font)
-            painter.drawText(
-                int(rect.left()),
-                int(rect.top() + heading_height + 50),
-                "(Empty canvas)",
-            )
-            return
-
-        # Available area below heading
-        avail = QRectF(
-            rect.left(),
-            rect.top() + heading_height,
-            rect.width(),
-            rect.height() - heading_height,
-        )
-
-        # Scale to fit while preserving aspect ratio
-        scale_x = avail.width() / source_rect.width()
-        scale_y = avail.height() / source_rect.height()
-        scale = min(scale_x, scale_y)
-
-        target_w = source_rect.width() * scale
-        target_h = source_rect.height() * scale
-        target_x = avail.left() + (avail.width() - target_w) / 2
-        target_y = avail.top() + (avail.height() - target_h) / 2
-        target_rect = QRectF(target_x, target_y, target_w, target_h)
-
-        # White background for schematic area
-        painter.fillRect(target_rect, Qt.GlobalColor.white)
-        scene.render(painter, target=target_rect, source=source_rect)
-
-    def _render_text_section(
-        self,
-        painter: QPainter,
-        printer: QPrinter,
-        rect: QRectF,
-        heading: str,
-        text: str,
-        monospace: bool = False,
-    ) -> None:
-        """Render a text section with heading, handling page breaks."""
-        heading_font = QFont("Helvetica", self.HEADING_FONT_SIZE, QFont.Weight.Bold)
-        if monospace:
-            body_font = QFont("Courier", self.CODE_FONT_SIZE)
-        else:
-            body_font = QFont("Helvetica", self.BODY_FONT_SIZE)
-
-        # Draw heading
-        painter.setFont(heading_font)
-        hfm = QFontMetrics(heading_font)
-        y = rect.top() + hfm.ascent()
-        painter.drawText(int(rect.left()), int(y), heading)
-        y += hfm.height() * 1.5
-
-        # Draw separator line
-        painter.drawLine(int(rect.left()), int(y), int(rect.left() + rect.width()), int(y))
-        y += hfm.height() * 0.5
-
-        # Draw body text
-        painter.setFont(body_font)
-        bfm = QFontMetrics(body_font)
-        line_height = bfm.height() * 1.2
-        bottom = rect.top() + rect.height()
-
-        lines = text.split("\n")
-        for line in lines:
-            if y + line_height > bottom:
-                # New page
-                printer.newPage()
-                y = rect.top() + hfm.height()
-                painter.setFont(heading_font)
-                painter.drawText(
-                    int(rect.left()),
-                    int(rect.top() + hfm.ascent()),
-                    f"{heading} (continued)",
-                )
-                y += hfm.height() * 0.5
-                painter.drawLine(
-                    int(rect.left()),
-                    int(y),
-                    int(rect.left() + rect.width()),
-                    int(y),
-                )
-                y += hfm.height() * 0.5
-                painter.setFont(body_font)
-
-            # Truncate line if it's too wide
-            elided = bfm.elidedText(line, Qt.TextElideMode.ElideRight, int(rect.width()))
-            painter.drawText(int(rect.left()), int(y), elided)
-            y += line_height
-
-    def _format_analysis_config(self, model) -> str:
+    @staticmethod
+    def _format_analysis_config(model) -> str:
         """Format analysis type and parameters as readable text."""
         lines = []
         lines.append(f"Analysis Type: {model.analysis_type}")
@@ -291,7 +79,6 @@ class ReportGenerator:
         if model.analysis_params:
             lines.append("Parameters:")
             for key, value in model.analysis_params.items():
-                # Format parameter name nicely
                 display_key = key.replace("_", " ").title()
                 lines.append(f"  {display_key}: {value}")
         else:
@@ -301,7 +88,6 @@ class ReportGenerator:
         lines.append(f"Total Components: {len(model.components)}")
         lines.append(f"Total Wires: {len(model.wires)}")
 
-        # Component breakdown by type
         if model.components:
             lines.append("")
             lines.append("Component Summary:")
@@ -313,35 +99,3 @@ class ReportGenerator:
                 lines.append(f"  {ctype}: {count}")
 
         return "\n".join(lines)
-
-    @staticmethod
-    def _get_scene_source_rect(scene) -> QRectF | None:
-        """Compute bounding rect of circuit items with padding.
-
-        Filters out grid/background items by checking for circuit item types.
-        Falls back to itemsBoundingRect if type checking is unavailable.
-        """
-        try:
-            from GUI.annotation_item import AnnotationItem
-            from GUI.component_item import ComponentGraphicsItem
-            from GUI.wire_item import WireGraphicsItem
-
-            circuit_items = [
-                item
-                for item in scene.items()
-                if isinstance(item, (ComponentGraphicsItem, WireGraphicsItem, AnnotationItem))
-            ]
-            if not circuit_items:
-                return None
-            source_rect = circuit_items[0].sceneBoundingRect()
-            for item in circuit_items[1:]:
-                source_rect = source_rect.united(item.sceneBoundingRect())
-        except ImportError:
-            # Fallback for testing without full GUI imports
-            source_rect = scene.itemsBoundingRect()
-            if source_rect.isEmpty():
-                return None
-
-        padding = 40
-        source_rect.adjust(-padding, -padding, padding, padding)
-        return source_rect

--- a/app/tests/unit/test_report_generator.py
+++ b/app/tests/unit/test_report_generator.py
@@ -1,12 +1,9 @@
-"""Tests for PDF circuit report generation."""
-
-import os
-import tempfile
+"""Tests for report data assembly (pure Python, no Qt)."""
 
 import pytest
 from models.circuit import CircuitModel
 from models.component import ComponentData
-from services.report_generator import ReportConfig, ReportGenerator
+from services.report_generator import ReportConfig, ReportData, ReportDataBuilder
 
 # --- Fixtures ---
 
@@ -44,26 +41,6 @@ def configured_model():
     return model
 
 
-@pytest.fixture
-def sample_netlist():
-    return "My Test Circuit\n* Generated netlist\n\nR1 1 2 1k\nV1 1 0 5\n.op\n.end\n"
-
-
-@pytest.fixture
-def sample_results():
-    return (
-        "======================================================================\n"
-        "SIMULATION COMPLETE - DC Operating Point\n"
-        "======================================================================\n"
-        "\n"
-        "NODE VOLTAGES:\n"
-        "----------------------------------------\n"
-        "  1               :     5.000000 V\n"
-        "  2               :     2.500000 V\n"
-        "----------------------------------------\n"
-    )
-
-
 # --- ReportConfig tests ---
 
 
@@ -89,480 +66,81 @@ class TestReportConfig:
         assert config.circuit_name == "RC Filter"
 
 
-# --- ReportGenerator tests ---
+# --- ReportData tests ---
 
 
-class TestReportGeneratorTitleOnly:
-    """Test report generation with title page only (no Qt scene needed)."""
+class TestReportData:
+    def test_default_data(self):
+        data = ReportData()
+        assert data.title == ""
+        assert data.subtitle == "Circuit Analysis Report"
+        assert data.component_count == 0
+        assert data.netlist == ""
 
-    def test_generates_pdf_file(self, qtbot, simple_model):
-        config = ReportConfig(
-            include_title=True,
-            include_schematic=False,
-            include_netlist=False,
-            include_analysis=False,
-            include_results=False,
-            circuit_name="Test Circuit",
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            gen.generate(filepath=pdf_path, model=simple_model)
-            assert os.path.exists(pdf_path)
-            assert os.path.getsize(pdf_path) > 0
-        finally:
-            os.unlink(pdf_path)
-
-    def test_title_with_student_name(self, qtbot, simple_model):
-        config = ReportConfig(
-            include_title=True,
-            include_schematic=False,
-            include_netlist=False,
-            include_analysis=False,
-            include_results=False,
-            circuit_name="Voltage Divider",
-            student_name="Jane Doe",
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            gen.generate(filepath=pdf_path, model=simple_model)
-            assert os.path.exists(pdf_path)
-            assert os.path.getsize(pdf_path) > 100
-        finally:
-            os.unlink(pdf_path)
-
-    def test_title_without_model(self, qtbot):
-        config = ReportConfig(
-            include_title=True,
-            include_schematic=False,
-            include_netlist=False,
-            include_analysis=False,
-            include_results=False,
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            gen.generate(filepath=pdf_path)
-            assert os.path.exists(pdf_path)
-            assert os.path.getsize(pdf_path) > 0
-        finally:
-            os.unlink(pdf_path)
+    def test_data_with_config(self):
+        config = ReportConfig(circuit_name="My Circuit", student_name="Bob")
+        data = ReportData(config=config, title="My Circuit")
+        assert data.config.circuit_name == "My Circuit"
+        assert data.title == "My Circuit"
 
 
-class TestReportGeneratorNetlist:
-    """Test report generation with netlist section."""
-
-    def test_netlist_section(self, qtbot, simple_model, sample_netlist):
-        config = ReportConfig(
-            include_title=False,
-            include_schematic=False,
-            include_netlist=True,
-            include_analysis=False,
-            include_results=False,
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            gen.generate(filepath=pdf_path, model=simple_model, netlist=sample_netlist)
-            assert os.path.exists(pdf_path)
-            assert os.path.getsize(pdf_path) > 100
-        finally:
-            os.unlink(pdf_path)
-
-    def test_empty_netlist_skipped(self, qtbot):
-        config = ReportConfig(
-            include_title=True,
-            include_schematic=False,
-            include_netlist=True,
-            include_analysis=False,
-            include_results=False,
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            gen.generate(filepath=pdf_path, netlist="")
-            assert os.path.exists(pdf_path)
-        finally:
-            os.unlink(pdf_path)
+# --- ReportDataBuilder tests ---
 
 
-class TestReportGeneratorAnalysis:
-    """Test report generation with analysis configuration section."""
+class TestReportDataBuilder:
+    def test_build_minimal(self):
+        config = ReportConfig()
+        data = ReportDataBuilder.build(config)
+        assert data.title == "Circuit Report"
+        assert data.date_str != ""
+        assert data.component_count == 0
 
-    def test_analysis_section(self, qtbot, configured_model):
-        config = ReportConfig(
-            include_title=False,
-            include_schematic=False,
-            include_netlist=False,
-            include_analysis=True,
-            include_results=False,
-        )
-        gen = ReportGenerator(config)
+    def test_build_with_model(self, simple_model):
+        config = ReportConfig(circuit_name="Test Circuit")
+        data = ReportDataBuilder.build(config, model=simple_model)
+        assert data.title == "Test Circuit"
+        assert data.analysis_type == "DC Operating Point"
+        assert data.component_count == 2
+        assert "DC Operating Point" in data.analysis_text
 
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
+    def test_build_with_netlist_and_results(self):
+        config = ReportConfig()
+        data = ReportDataBuilder.build(config, netlist="R1 1 0 1k", results_text="V(1) = 5V")
+        assert data.netlist == "R1 1 0 1k"
+        assert data.results_text == "V(1) = 5V"
 
-        try:
-            gen.generate(filepath=pdf_path, model=configured_model)
-            assert os.path.exists(pdf_path)
-            assert os.path.getsize(pdf_path) > 100
-        finally:
-            os.unlink(pdf_path)
-
-    def test_analysis_with_empty_params(self, qtbot, simple_model):
-        config = ReportConfig(
-            include_title=False,
-            include_schematic=False,
-            include_netlist=False,
-            include_analysis=True,
-            include_results=False,
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            gen.generate(filepath=pdf_path, model=simple_model)
-            assert os.path.exists(pdf_path)
-        finally:
-            os.unlink(pdf_path)
+    def test_build_without_model(self):
+        config = ReportConfig(circuit_name="No Model")
+        data = ReportDataBuilder.build(config)
+        assert data.title == "No Model"
+        assert data.analysis_type == ""
+        assert data.analysis_text == ""
 
 
-class TestReportGeneratorResults:
-    """Test report generation with simulation results section."""
-
-    def test_results_section(self, qtbot, sample_results):
-        config = ReportConfig(
-            include_title=False,
-            include_schematic=False,
-            include_netlist=False,
-            include_analysis=False,
-            include_results=True,
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            gen.generate(filepath=pdf_path, results_text=sample_results)
-            assert os.path.exists(pdf_path)
-            assert os.path.getsize(pdf_path) > 100
-        finally:
-            os.unlink(pdf_path)
-
-
-class TestReportGeneratorSchematic:
-    """Test report generation with schematic rendering."""
-
-    def test_schematic_with_scene_items(self, qtbot):
-        from PyQt6.QtWidgets import QGraphicsEllipseItem, QGraphicsScene
-
-        scene = QGraphicsScene()
-        scene.addItem(QGraphicsEllipseItem(0, 0, 100, 100))
-        scene.addItem(QGraphicsEllipseItem(150, 0, 100, 100))
-
-        config = ReportConfig(
-            include_title=False,
-            include_schematic=True,
-            include_netlist=False,
-            include_analysis=False,
-            include_results=False,
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            gen.generate(filepath=pdf_path, scene=scene)
-            assert os.path.exists(pdf_path)
-            assert os.path.getsize(pdf_path) > 100
-        finally:
-            os.unlink(pdf_path)
-
-    def test_schematic_with_empty_scene(self, qtbot):
-        from PyQt6.QtWidgets import QGraphicsScene
-
-        scene = QGraphicsScene()
-
-        config = ReportConfig(
-            include_title=False,
-            include_schematic=True,
-            include_netlist=False,
-            include_analysis=False,
-            include_results=False,
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            gen.generate(filepath=pdf_path, scene=scene)
-            assert os.path.exists(pdf_path)
-        finally:
-            os.unlink(pdf_path)
-
-
-class TestReportGeneratorFullReport:
-    """Test generation of a complete multi-section report."""
-
-    def test_full_report(self, qtbot, configured_model, sample_netlist, sample_results):
-        from PyQt6.QtWidgets import QGraphicsEllipseItem, QGraphicsScene
-
-        scene = QGraphicsScene()
-        scene.addItem(QGraphicsEllipseItem(0, 0, 100, 50))
-
-        config = ReportConfig(
-            include_title=True,
-            include_schematic=True,
-            include_netlist=True,
-            include_analysis=True,
-            include_results=True,
-            circuit_name="Full Report Test",
-            student_name="Test Student",
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            gen.generate(
-                filepath=pdf_path,
-                scene=scene,
-                model=configured_model,
-                netlist=sample_netlist,
-                results_text=sample_results,
-            )
-            assert os.path.exists(pdf_path)
-            # Full report should be reasonably large
-            assert os.path.getsize(pdf_path) > 500
-        finally:
-            os.unlink(pdf_path)
-
-    def test_all_sections_disabled_produces_valid_pdf(self, qtbot):
-        """Even with all sections off, should produce a valid (tiny) PDF."""
-        config = ReportConfig(
-            include_title=False,
-            include_schematic=False,
-            include_netlist=False,
-            include_analysis=False,
-            include_results=False,
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            gen.generate(filepath=pdf_path)
-            assert os.path.exists(pdf_path)
-        finally:
-            os.unlink(pdf_path)
-
-    def test_schematic_only_no_simulation(self, qtbot, simple_model, sample_netlist):
-        """Common case: report with schematic and netlist but no sim results."""
-        from PyQt6.QtWidgets import QGraphicsRectItem, QGraphicsScene
-
-        scene = QGraphicsScene()
-        scene.addItem(QGraphicsRectItem(0, 0, 60, 30))
-
-        config = ReportConfig(
-            include_title=True,
-            include_schematic=True,
-            include_netlist=True,
-            include_analysis=True,
-            include_results=False,
-            circuit_name="RC Filter",
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            gen.generate(
-                filepath=pdf_path,
-                scene=scene,
-                model=simple_model,
-                netlist=sample_netlist,
-            )
-            assert os.path.exists(pdf_path)
-            assert os.path.getsize(pdf_path) > 200
-        finally:
-            os.unlink(pdf_path)
+# --- _format_analysis_config tests ---
 
 
 class TestFormatAnalysisConfig:
     """Test the analysis config formatting helper."""
 
     def test_format_op_analysis(self, simple_model):
-        gen = ReportGenerator(ReportConfig())
-        text = gen._format_analysis_config(simple_model)
+        text = ReportDataBuilder._format_analysis_config(simple_model)
         assert "DC Operating Point" in text
         assert "Total Components: 2" in text
 
     def test_format_ac_analysis(self, configured_model):
-        gen = ReportGenerator(ReportConfig())
-        text = gen._format_analysis_config(configured_model)
+        text = ReportDataBuilder._format_analysis_config(configured_model)
         assert "AC Sweep" in text
         assert "Sweep Type" in text
         assert "100" in text
         assert "Total Components: 4" in text
 
     def test_format_component_summary(self, configured_model):
-        gen = ReportGenerator(ReportConfig())
-        text = gen._format_analysis_config(configured_model)
+        text = ReportDataBuilder._format_analysis_config(configured_model)
         assert "Resistor: 2" in text
         assert "Capacitor: 1" in text
         assert "Voltage Source: 1" in text
 
     def test_format_empty_params(self, simple_model):
-        gen = ReportGenerator(ReportConfig())
-        text = gen._format_analysis_config(simple_model)
+        text = ReportDataBuilder._format_analysis_config(simple_model)
         assert "(default)" in text
-
-
-class TestGetSceneSourceRect:
-    """Test the scene source rect computation."""
-
-    def test_returns_none_for_empty_scene(self, qtbot):
-        from PyQt6.QtWidgets import QGraphicsScene
-
-        scene = QGraphicsScene()
-        result = ReportGenerator._get_scene_source_rect(scene)
-        assert result is None
-
-    def test_returns_none_for_non_circuit_items(self, qtbot):
-        """Non-circuit items (e.g. grid) are filtered out, returning None."""
-        from PyQt6.QtWidgets import QGraphicsEllipseItem, QGraphicsScene
-
-        scene = QGraphicsScene()
-        scene.addItem(QGraphicsEllipseItem(10, 20, 100, 50))
-        result = ReportGenerator._get_scene_source_rect(scene)
-        # Should be None because QGraphicsEllipseItem is not a circuit item
-        assert result is None
-
-    def test_returns_rect_via_render_pipeline(self, qtbot):
-        """Schematic page renders without crashing even with generic items."""
-        from PyQt6.QtWidgets import QGraphicsRectItem, QGraphicsScene
-
-        scene = QGraphicsScene()
-        scene.addItem(QGraphicsRectItem(0, 0, 200, 100))
-
-        config = ReportConfig(
-            include_title=False,
-            include_schematic=True,
-            include_netlist=False,
-            include_analysis=False,
-            include_results=False,
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            # Should not crash - empty scene path handles gracefully
-            gen.generate(filepath=pdf_path, scene=scene)
-            assert os.path.exists(pdf_path)
-        finally:
-            os.unlink(pdf_path)
-
-
-class TestReportGeneratorLongText:
-    """Test pagination for long text sections."""
-
-    def test_long_netlist_paginates(self, qtbot):
-        """A very long netlist should not crash and should produce a multi-page PDF."""
-        long_netlist = "\n".join([f"R{i} n{i} n{i + 1} {i}k" for i in range(200)])
-
-        config = ReportConfig(
-            include_title=False,
-            include_schematic=False,
-            include_netlist=True,
-            include_analysis=False,
-            include_results=False,
-        )
-        gen = ReportGenerator(config)
-
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
-            pdf_path = f.name
-
-        try:
-            gen.generate(filepath=pdf_path, netlist=long_netlist)
-            assert os.path.exists(pdf_path)
-            # Multi-page PDF should be larger than single-page
-            assert os.path.getsize(pdf_path) > 1000
-        finally:
-            os.unlink(pdf_path)
-
-
-class TestReportDialog:
-    """Test the report dialog configuration."""
-
-    def test_dialog_creates(self, qtbot):
-        from GUI.report_dialog import ReportDialog
-
-        dialog = ReportDialog(circuit_name="Test", has_results=True)
-        qtbot.addWidget(dialog)
-        assert dialog.windowTitle() == "Generate Circuit Report"
-
-    def test_dialog_default_config(self, qtbot):
-        from GUI.report_dialog import ReportDialog
-
-        dialog = ReportDialog(circuit_name="Test Circuit", has_results=True)
-        qtbot.addWidget(dialog)
-        config = dialog.get_config()
-        assert config.include_title is True
-        assert config.include_schematic is True
-        assert config.include_netlist is True
-        assert config.include_analysis is True
-        assert config.include_results is True
-        assert config.circuit_name == "Test Circuit"
-
-    def test_dialog_no_results(self, qtbot):
-        from GUI.report_dialog import ReportDialog
-
-        dialog = ReportDialog(has_results=False)
-        qtbot.addWidget(dialog)
-        config = dialog.get_config()
-        # Results checkbox should be unchecked when no results available
-        assert config.include_results is False
-
-    def test_dialog_student_name(self, qtbot):
-        from GUI.report_dialog import ReportDialog
-
-        dialog = ReportDialog()
-        qtbot.addWidget(dialog)
-        dialog._student_name.setText("Jane Doe")
-        config = dialog.get_config()
-        assert config.student_name == "Jane Doe"
-
-    def test_dialog_circuit_name_override(self, qtbot):
-        from GUI.report_dialog import ReportDialog
-
-        dialog = ReportDialog(circuit_name="Original")
-        qtbot.addWidget(dialog)
-        dialog._circuit_name.setText("Modified")
-        config = dialog.get_config()
-        assert config.circuit_name == "Modified"

--- a/app/tests/unit/test_report_renderer.py
+++ b/app/tests/unit/test_report_renderer.py
@@ -1,0 +1,506 @@
+"""Tests for PDF report rendering (Qt-dependent)."""
+
+import os
+import tempfile
+
+import pytest
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from services.report_generator import ReportConfig, ReportDataBuilder
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def simple_model():
+    """A simple circuit model with a few components."""
+    model = CircuitModel()
+    model.components = {
+        "R1": ComponentData("R1", "Resistor", "1k", (100, 100)),
+        "V1": ComponentData("V1", "Voltage Source", "5", (0, 100)),
+    }
+    model.analysis_type = "DC Operating Point"
+    model.analysis_params = {}
+    return model
+
+
+@pytest.fixture
+def configured_model():
+    """A model with analysis params and multiple component types."""
+    model = CircuitModel()
+    model.components = {
+        "R1": ComponentData("R1", "Resistor", "1k", (100, 100)),
+        "R2": ComponentData("R2", "Resistor", "2k", (200, 100)),
+        "C1": ComponentData("C1", "Capacitor", "1u", (100, 200)),
+        "V1": ComponentData("V1", "Voltage Source", "5", (0, 100)),
+    }
+    model.analysis_type = "AC Sweep"
+    model.analysis_params = {
+        "sweep_type": "dec",
+        "num_points": "100",
+        "fStart": "1",
+        "fStop": "100k",
+    }
+    return model
+
+
+@pytest.fixture
+def sample_netlist():
+    return "My Test Circuit\n* Generated netlist\n\nR1 1 2 1k\nV1 1 0 5\n.op\n.end\n"
+
+
+@pytest.fixture
+def sample_results():
+    return (
+        "======================================================================\n"
+        "SIMULATION COMPLETE - DC Operating Point\n"
+        "======================================================================\n"
+        "\n"
+        "NODE VOLTAGES:\n"
+        "----------------------------------------\n"
+        "  1               :     5.000000 V\n"
+        "  2               :     2.500000 V\n"
+        "----------------------------------------\n"
+    )
+
+
+def _build_and_render(config, filepath, model=None, netlist="", results_text="", scene=None):
+    """Helper: build report data then render to PDF."""
+    from GUI.report_renderer import PDFReportRenderer
+
+    data = ReportDataBuilder.build(config, model=model, netlist=netlist, results_text=results_text)
+    renderer = PDFReportRenderer()
+    renderer.render(filepath=filepath, data=data, scene=scene)
+
+
+# --- Renderer tests ---
+
+
+class TestRendererTitleOnly:
+    """Test report rendering with title page only (no Qt scene needed)."""
+
+    def test_generates_pdf_file(self, qtbot, simple_model):
+        config = ReportConfig(
+            include_title=True,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+            circuit_name="Test Circuit",
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(config, pdf_path, model=simple_model)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 0
+        finally:
+            os.unlink(pdf_path)
+
+    def test_title_with_student_name(self, qtbot, simple_model):
+        config = ReportConfig(
+            include_title=True,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+            circuit_name="Voltage Divider",
+            student_name="Jane Doe",
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(config, pdf_path, model=simple_model)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 100
+        finally:
+            os.unlink(pdf_path)
+
+    def test_title_without_model(self, qtbot):
+        config = ReportConfig(
+            include_title=True,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(config, pdf_path)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 0
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestRendererNetlist:
+    """Test report rendering with netlist section."""
+
+    def test_netlist_section(self, qtbot, simple_model, sample_netlist):
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=False,
+            include_netlist=True,
+            include_analysis=False,
+            include_results=False,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(config, pdf_path, model=simple_model, netlist=sample_netlist)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 100
+        finally:
+            os.unlink(pdf_path)
+
+    def test_empty_netlist_skipped(self, qtbot):
+        config = ReportConfig(
+            include_title=True,
+            include_schematic=False,
+            include_netlist=True,
+            include_analysis=False,
+            include_results=False,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(config, pdf_path, netlist="")
+            assert os.path.exists(pdf_path)
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestRendererAnalysis:
+    """Test report rendering with analysis configuration section."""
+
+    def test_analysis_section(self, qtbot, configured_model):
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=True,
+            include_results=False,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(config, pdf_path, model=configured_model)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 100
+        finally:
+            os.unlink(pdf_path)
+
+    def test_analysis_with_empty_params(self, qtbot, simple_model):
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=True,
+            include_results=False,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(config, pdf_path, model=simple_model)
+            assert os.path.exists(pdf_path)
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestRendererResults:
+    """Test report rendering with simulation results section."""
+
+    def test_results_section(self, qtbot, sample_results):
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=True,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(config, pdf_path, results_text=sample_results)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 100
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestRendererSchematic:
+    """Test report rendering with schematic rendering."""
+
+    def test_schematic_with_scene_items(self, qtbot):
+        from PyQt6.QtWidgets import QGraphicsEllipseItem, QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(QGraphicsEllipseItem(0, 0, 100, 100))
+        scene.addItem(QGraphicsEllipseItem(150, 0, 100, 100))
+
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=True,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(config, pdf_path, scene=scene)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 100
+        finally:
+            os.unlink(pdf_path)
+
+    def test_schematic_with_empty_scene(self, qtbot):
+        from PyQt6.QtWidgets import QGraphicsScene
+
+        scene = QGraphicsScene()
+
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=True,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(config, pdf_path, scene=scene)
+            assert os.path.exists(pdf_path)
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestRendererFullReport:
+    """Test generation of a complete multi-section report."""
+
+    def test_full_report(self, qtbot, configured_model, sample_netlist, sample_results):
+        from PyQt6.QtWidgets import QGraphicsEllipseItem, QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(QGraphicsEllipseItem(0, 0, 100, 50))
+
+        config = ReportConfig(
+            include_title=True,
+            include_schematic=True,
+            include_netlist=True,
+            include_analysis=True,
+            include_results=True,
+            circuit_name="Full Report Test",
+            student_name="Test Student",
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(
+                config,
+                pdf_path,
+                model=configured_model,
+                netlist=sample_netlist,
+                results_text=sample_results,
+                scene=scene,
+            )
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 500
+        finally:
+            os.unlink(pdf_path)
+
+    def test_all_sections_disabled_produces_valid_pdf(self, qtbot):
+        """Even with all sections off, should produce a valid (tiny) PDF."""
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=False,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(config, pdf_path)
+            assert os.path.exists(pdf_path)
+        finally:
+            os.unlink(pdf_path)
+
+    def test_schematic_only_no_simulation(self, qtbot, simple_model, sample_netlist):
+        """Common case: report with schematic and netlist but no sim results."""
+        from PyQt6.QtWidgets import QGraphicsRectItem, QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(QGraphicsRectItem(0, 0, 60, 30))
+
+        config = ReportConfig(
+            include_title=True,
+            include_schematic=True,
+            include_netlist=True,
+            include_analysis=True,
+            include_results=False,
+            circuit_name="RC Filter",
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(
+                config,
+                pdf_path,
+                model=simple_model,
+                netlist=sample_netlist,
+                scene=scene,
+            )
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 200
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestGetSceneSourceRect:
+    """Test the scene source rect computation."""
+
+    def test_returns_none_for_empty_scene(self, qtbot):
+        from GUI.report_renderer import PDFReportRenderer
+        from PyQt6.QtWidgets import QGraphicsScene
+
+        scene = QGraphicsScene()
+        result = PDFReportRenderer._get_scene_source_rect(scene)
+        assert result is None
+
+    def test_returns_none_for_non_circuit_items(self, qtbot):
+        """Non-circuit items (e.g. grid) are filtered out, returning None."""
+        from GUI.report_renderer import PDFReportRenderer
+        from PyQt6.QtWidgets import QGraphicsEllipseItem, QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(QGraphicsEllipseItem(10, 20, 100, 50))
+        result = PDFReportRenderer._get_scene_source_rect(scene)
+        assert result is None
+
+    def test_returns_rect_via_render_pipeline(self, qtbot):
+        """Schematic page renders without crashing even with generic items."""
+        from PyQt6.QtWidgets import QGraphicsRectItem, QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(QGraphicsRectItem(0, 0, 200, 100))
+
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=True,
+            include_netlist=False,
+            include_analysis=False,
+            include_results=False,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(config, pdf_path, scene=scene)
+            assert os.path.exists(pdf_path)
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestRendererLongText:
+    """Test pagination for long text sections."""
+
+    def test_long_netlist_paginates(self, qtbot):
+        """A very long netlist should not crash and should produce a multi-page PDF."""
+        long_netlist = "\n".join([f"R{i} n{i} n{i + 1} {i}k" for i in range(200)])
+
+        config = ReportConfig(
+            include_title=False,
+            include_schematic=False,
+            include_netlist=True,
+            include_analysis=False,
+            include_results=False,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            pdf_path = f.name
+
+        try:
+            _build_and_render(config, pdf_path, netlist=long_netlist)
+            assert os.path.exists(pdf_path)
+            assert os.path.getsize(pdf_path) > 1000
+        finally:
+            os.unlink(pdf_path)
+
+
+class TestReportDialog:
+    """Test the report dialog configuration."""
+
+    def test_dialog_creates(self, qtbot):
+        from GUI.report_dialog import ReportDialog
+
+        dialog = ReportDialog(circuit_name="Test", has_results=True)
+        qtbot.addWidget(dialog)
+        assert dialog.windowTitle() == "Generate Circuit Report"
+
+    def test_dialog_default_config(self, qtbot):
+        from GUI.report_dialog import ReportDialog
+
+        dialog = ReportDialog(circuit_name="Test Circuit", has_results=True)
+        qtbot.addWidget(dialog)
+        config = dialog.get_config()
+        assert config.include_title is True
+        assert config.include_schematic is True
+        assert config.include_netlist is True
+        assert config.include_analysis is True
+        assert config.include_results is True
+        assert config.circuit_name == "Test Circuit"
+
+    def test_dialog_no_results(self, qtbot):
+        from GUI.report_dialog import ReportDialog
+
+        dialog = ReportDialog(has_results=False)
+        qtbot.addWidget(dialog)
+        config = dialog.get_config()
+        assert config.include_results is False
+
+    def test_dialog_student_name(self, qtbot):
+        from GUI.report_dialog import ReportDialog
+
+        dialog = ReportDialog()
+        qtbot.addWidget(dialog)
+        dialog._student_name.setText("Jane Doe")
+        config = dialog.get_config()
+        assert config.student_name == "Jane Doe"
+
+    def test_dialog_circuit_name_override(self, qtbot):
+        from GUI.report_dialog import ReportDialog
+
+        dialog = ReportDialog(circuit_name="Original")
+        qtbot.addWidget(dialog)
+        dialog._circuit_name.setText("Modified")
+        config = dialog.get_config()
+        assert config.circuit_name == "Modified"


### PR DESCRIPTION
## Summary - Split  into two layers to fix services → GUI dependency violation - ****: Now contains only pure Python code —  dataclass,  dataclass, and  class. Zero Qt/GUI imports. - ****: New file with  that handles all QPrinter/QPainter rendering and GUI item imports - Updated  caller to use the split architecture - Split tests into pure-Python service tests and Qt-dependent renderer tests Closes #629 ## Test plan - [ ]  passes — pure Python tests for , ,  (no qtbot needed) - [ ]  passes — Qt-dependent PDF rendering tests (title, netlist, analysis, results, schematic, full report, pagination) - [ ]  tests still pass - [ ] Verify  has zero PyQt6 or GUI imports - [ ] Verify PDF report generation still works end-to-end from the GUI 🤖 Generated with [Claude Code](https://claude.com/claude-code)