### PR TITLE
Route observer callbacks and model mutations through controller (#637)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -266,36 +266,28 @@ class CircuitCanvasView(QGraphicsView):
                 self.viewport().update()
 
     def _handle_component_rotated(self, component_data) -> None:
-        """Update graphics item rotation"""
+        """Update graphics item rotation from authoritative model data."""
         comp = self.components.get(component_data.component_id)
         if comp:
-            comp.rotation_angle = component_data.rotation
+            comp.sync_from_data(component_data)
             comp.update_terminals()
             comp.update()
             self.reroute_connected_wires(comp)
 
     def _handle_component_flipped(self, component_data) -> None:
-        """Update graphics item flip"""
+        """Update graphics item flip from authoritative model data."""
         comp = self.components.get(component_data.component_id)
         if comp:
-            # Sync flip state: the graphics item holds a separate ComponentData
-            # copy (created via from_dict in _handle_component_added), so we
-            # must propagate the controller model's flip values explicitly before
-            # calling update_terminals() or paint().
-            comp.model.flip_h = component_data.flip_h
-            comp.model.flip_v = component_data.flip_v
+            comp.sync_from_data(component_data)
             comp.update_terminals()
             comp.update()
             self.reroute_connected_wires(comp)
 
     def _handle_component_value_changed(self, component_data) -> None:
-        """Update graphics item value display and related fields."""
+        """Update graphics item value display from authoritative model data."""
         comp = self.components.get(component_data.component_id)
         if comp:
-            comp.value = component_data.value
-            comp.model.waveform_type = component_data.waveform_type
-            comp.model.waveform_params = component_data.waveform_params
-            comp.model.initial_condition = component_data.initial_condition
+            comp.sync_from_data(component_data)
             comp.update()
 
     def _handle_wire_added(self, wire_data) -> None:
@@ -1415,15 +1407,17 @@ class CircuitCanvasView(QGraphicsView):
         if self.controller.has_clipboard_content():
             new_components, new_wires = self.controller.paste_components()
         elif not self._clipboard.is_empty():
-            # Sync canvas clipboard to controller, then paste via controller
-            self.controller._clipboard = ClipboardData(
-                components=list(self._clipboard.components),
-                wires=list(self._clipboard.wires),
-                paste_count=self._clipboard.paste_count,
+            # Sync canvas clipboard to controller via public API, then paste
+            self.controller.set_clipboard(
+                ClipboardData(
+                    components=list(self._clipboard.components),
+                    wires=list(self._clipboard.wires),
+                    paste_count=self._clipboard.paste_count,
+                )
             )
             new_components, new_wires = self.controller.paste_components()
             # Keep canvas clipboard paste_count in sync
-            self._clipboard.paste_count = self.controller._clipboard.paste_count
+            self._clipboard.paste_count = self.controller.get_clipboard_paste_count()
         else:
             return
 
@@ -2024,9 +2018,13 @@ class CircuitCanvasView(QGraphicsView):
         self.obstacle_boundary_items.append(terminal_legend_text)
 
     def get_model_components(self):
-        """Return dict of component_id -> ComponentData for simulation use."""
-        for comp_item in self.components.values():
-            comp_item.model.position = (comp_item.pos().x(), comp_item.pos().y())
+        """Return dict of component_id -> ComponentData for simulation use.
+
+        Uses the controller's model as the single source of truth.
+        Falls back to the graphics items' local models if no controller.
+        """
+        if self.controller:
+            return dict(self.controller.model.components)
         return {comp_id: comp_item.model for comp_id, comp_item in self.components.items()}
 
     def get_model_wires(self):
@@ -2125,7 +2123,14 @@ class CircuitCanvasView(QGraphicsView):
         painter.end()
 
     def to_dict(self):
-        """Serialize circuit to dictionary"""
+        """Serialize circuit to dictionary.
+
+        Uses the controller's model as the single source of truth when
+        available; falls back to local graphics items for legacy callers.
+        """
+        if self.controller:
+            return self.controller.model.to_dict()
+
         data = {
             "components": [comp.to_dict() for comp in self.components.values()],
             "wires": [wire.to_dict() for wire in self.wires],

--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -104,6 +104,22 @@ class ComponentGraphicsItem(QGraphicsItem):
     def initial_condition(self, v):
         self.model.initial_condition = v
 
+    def sync_from_data(self, component_data) -> None:
+        """Sync the graphics item's local model from authoritative controller data.
+
+        Called by observer callbacks to propagate model changes without
+        the graphics item performing direct model mutations.  Updates
+        visual-relevant fields and refreshes the graphics.
+        """
+        self.model.rotation = component_data.rotation
+        self.model.flip_h = component_data.flip_h
+        self.model.flip_v = component_data.flip_v
+        self.model.value = component_data.value
+        self.model.waveform_type = component_data.waveform_type
+        self.model.waveform_params = component_data.waveform_params
+        self.model.initial_condition = component_data.initial_condition
+        self.model.position = component_data.position
+
     # --- Event handlers ---
 
     def set_locked(self, locked: bool) -> None:
@@ -456,17 +472,17 @@ class ComponentGraphicsItem(QGraphicsItem):
         return super().itemChange(change, value)
 
     def _schedule_controller_update(self):
-        """Sync model position immediately, debounce wire rerouting (Phase 5)"""
+        """Sync local model position immediately, debounce wire rerouting (Phase 5)"""
         if self._position_update_timer:
             self._position_update_timer.stop()
         if not self.canvas or not hasattr(self.canvas, "controller") or not self.canvas.controller:
             return
 
-        # Sync model position immediately (lightweight attribute assignment)
+        # Sync local model position immediately (lightweight attribute assignment).
+        # The canonical controller model is updated via the debounced
+        # _notify_controller_position -> controller.move_component() call below.
         if self._pending_position:
-            comp = self.canvas.controller.model.components.get(self.component_id)
-            if comp:
-                comp.position = self._pending_position
+            self.model.position = self._pending_position
 
         # Debounce observer notification (triggers expensive wire rerouting).
         # Reuse a single timer to avoid QTimer object churn (#194).

--- a/app/controllers/circuit_controller.py
+++ b/app/controllers/circuit_controller.py
@@ -436,6 +436,14 @@ class CircuitController:
         """Return whether the clipboard has content to paste."""
         return not self._clipboard.is_empty()
 
+    def set_clipboard(self, clipboard: ClipboardData) -> None:
+        """Replace the controller's clipboard with the given data."""
+        self._clipboard = clipboard
+
+    def get_clipboard_paste_count(self) -> int:
+        """Return the current clipboard paste count."""
+        return self._clipboard.paste_count
+
     # --- Undo/Redo operations ---
 
     def execute_command(self, command) -> None:

--- a/app/tests/unit/test_circuit_controller.py
+++ b/app/tests/unit/test_circuit_controller.py
@@ -332,6 +332,30 @@ class TestNodeManagementThroughController:
         assert len(controller.model.nodes) == 2
 
 
+class TestClipboardPublicAPI:
+    """Verify clipboard operations use public controller API."""
+
+    def test_set_clipboard(self, controller):
+        """set_clipboard replaces internal clipboard."""
+        from models.clipboard import ClipboardData
+
+        controller.add_component("Resistor", (0.0, 0.0))
+        comp_dict = controller.model.components["R1"].to_dict()
+        cb = ClipboardData(components=[comp_dict], wires=[], paste_count=0)
+        controller.set_clipboard(cb)
+        assert controller.has_clipboard_content()
+
+    def test_get_clipboard_paste_count(self, controller):
+        """get_clipboard_paste_count reflects paste operations."""
+        controller.add_component("Resistor", (0.0, 0.0))
+        controller.copy_components(["R1"])
+        assert controller.get_clipboard_paste_count() == 0
+        controller.paste_components()
+        assert controller.get_clipboard_paste_count() == 1
+        controller.paste_components()
+        assert controller.get_clipboard_paste_count() == 2
+
+
 class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import controllers.circuit_controller as mod


### PR DESCRIPTION
## Summary - Add  to ComponentGraphicsItem for clean one-way data flow from controller model - Observer callbacks use sync_from_data() instead of direct model attribute writes -  and  use controller model as source of truth - Add / public API to controller -  syncs local model only, not controller model directly ## Test plan - [ ] New TestClipboardPublicAPI tests verify set_clipboard and paste_count API - [ ] Existing tests continue to pass - [ ] CI passes Closes #637