### PR TITLE
Route node access and mutations through controller API (#638)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -1730,14 +1730,15 @@ class CircuitCanvasView(QGraphicsView):
         return QPointF(avg_x, avg_y)
 
     def find_node_at_position(self, scene_pos):
-        """Find a node near the given scene position"""
+        """Find a node near the given scene position."""
         for comp_id, comp in self.components.items():
             for term_idx in range(len(comp.terminals)):
                 term_pos = comp.get_terminal_pos(term_idx)
                 distance = (term_pos - scene_pos).manhattanLength()
                 if distance < 20:
-                    terminal_key = (comp_id, term_idx)
-                    return self.terminal_to_node.get(terminal_key)
+                    if self.controller:
+                        return self.controller.find_node_for_terminal(comp_id, term_idx)
+                    return self.terminal_to_node.get((comp_id, term_idx))
         return None
 
     def label_node(self, node):
@@ -1757,11 +1758,10 @@ class CircuitCanvasView(QGraphicsView):
 
         if ok:
             new_label = text.strip() if text else None
-            # Use public controller API to set net name and notify observers
-            if self.controller:
-                self.controller.set_net_name(node, new_label)
-            else:
-                node.set_custom_label(new_label)
+            if not self.controller:
+                logger.warning("Cannot set net name: no controller available")
+                return
+            self.controller.set_net_name(node, new_label)
             self.scene.update()
             viewPort = self.viewport()
             if viewPort is None:
@@ -1823,10 +1823,13 @@ class CircuitCanvasView(QGraphicsView):
         self.draw_grid()
         self.components = {}
         self.wires = []
-        self.nodes = []
-        self.terminal_to_node = {}
         self.annotations = []
         self.component_counter = DEFAULT_COMPONENT_COUNTER.copy()
+        if self.controller:
+            self._sync_nodes_from_model()
+        else:
+            self.nodes = []
+            self.terminal_to_node = {}
 
     def toggle_obstacle_boundaries(self, show=None):
         """
@@ -2047,6 +2050,8 @@ class CircuitCanvasView(QGraphicsView):
         The terminal_to_node dict maps (comp_id, term_idx) -> NodeData,
         sharing the same NodeData objects as the returned list.
         """
+        if self.controller:
+            return self.controller.get_nodes_and_terminal_map()
         return list(self.nodes), dict(self.terminal_to_node)
 
     def export_image(self, filepath, include_grid=True):

--- a/app/controllers/circuit_controller.py
+++ b/app/controllers/circuit_controller.py
@@ -285,6 +285,17 @@ class CircuitController:
         self.model.rebuild_nodes()
         self._notify("nodes_rebuilt", None)
 
+    def get_nodes_and_terminal_map(self) -> tuple[list, dict]:
+        """Return (nodes, terminal_to_node) from the model.
+
+        Returns copies so callers cannot mutate the model's internal state.
+        """
+        return list(self.model.nodes), dict(self.model.terminal_to_node)
+
+    def find_node_for_terminal(self, comp_id: str, term_idx: int):
+        """Look up the node for a given terminal, or None."""
+        return self.model.terminal_to_node.get((comp_id, term_idx))
+
     def set_net_name(self, node, label) -> None:
         """Set a custom net name on a node and notify observers."""
         node.set_custom_label(label)

--- a/app/tests/unit/test_circuit_controller.py
+++ b/app/tests/unit/test_circuit_controller.py
@@ -332,6 +332,55 @@ class TestNodeManagementThroughController:
         assert len(controller.model.nodes) == 2
 
 
+class TestNodeAccessAPI:
+    """Verify node access methods on the controller."""
+
+    def test_get_nodes_and_terminal_map_empty(self, controller):
+        """Returns empty collections when no wires exist."""
+        nodes, term_map = controller.get_nodes_and_terminal_map()
+        assert nodes == []
+        assert term_map == {}
+
+    def test_get_nodes_and_terminal_map_with_wire(self, controller):
+        """Returns node and terminal mapping after a wire is added."""
+        controller.add_component("Resistor", (0.0, 0.0))
+        controller.add_component("Resistor", (100.0, 0.0))
+        controller.add_wire("R1", 1, "R2", 0)
+        nodes, term_map = controller.get_nodes_and_terminal_map()
+        assert len(nodes) == 1
+        assert ("R1", 1) in term_map
+        assert ("R2", 0) in term_map
+        # Returns copies, not references to internal state
+        nodes.clear()
+        assert len(controller.model.nodes) == 1
+
+    def test_find_node_for_terminal_found(self, controller):
+        """Finds the correct node for a connected terminal."""
+        controller.add_component("Resistor", (0.0, 0.0))
+        controller.add_component("Resistor", (100.0, 0.0))
+        controller.add_wire("R1", 1, "R2", 0)
+        node = controller.find_node_for_terminal("R1", 1)
+        assert node is not None
+        assert ("R1", 1) in node.terminals
+
+    def test_find_node_for_terminal_not_found(self, controller):
+        """Returns None for an unconnected terminal."""
+        controller.add_component("Resistor", (0.0, 0.0))
+        assert controller.find_node_for_terminal("R1", 0) is None
+
+    def test_set_net_name_updates_node(self, controller, events):
+        """set_net_name updates the node label and notifies observers."""
+        recorded, callback = events
+        controller.add_component("Resistor", (0.0, 0.0))
+        controller.add_component("Resistor", (100.0, 0.0))
+        controller.add_wire("R1", 1, "R2", 0)
+        controller.add_observer(callback)
+        node = controller.model.nodes[0]
+        controller.set_net_name(node, "Vout")
+        assert node.custom_label == "Vout"
+        assert recorded[-1][0] == "net_name_changed"
+
+
 class TestClipboardPublicAPI:
     """Verify clipboard operations use public controller API."""
 


### PR DESCRIPTION
## Summary - Add  and  to CircuitController for clean node data access - Canvas  now delegates to controller instead of returning local copies - Canvas  uses controller lookup when available - Remove  fallback that bypassed controller with direct  -  uses  instead of directly clearing node state ## Test plan - [x] New TestNodeAccessAPI tests verify get_nodes_and_terminal_map, find_node_for_terminal, set_net_name - [ ] Existing tests continue to pass - [ ] CI passes on all platforms Closes #638 🤖 Generated with [Claude Code](https://claude.com/claude-code)