### PR TITLE
Route ComponentItem and WireItem model mutations through controller (#631)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -338,7 +338,7 @@ class CircuitCanvasView(QGraphicsView):
 
     def _handle_wire_lock_changed(self, data) -> None:
         """Update wire visual when lock state changes."""
-        wire_index, locked = data
+        wire_index, wire = data
         if 0 <= wire_index < len(self.wires):
             self.wires[wire_index].update()
 
@@ -347,9 +347,6 @@ class CircuitCanvasView(QGraphicsView):
         if 0 <= wire_index < len(self.wires):
             wire = self.wires[wire_index]
             wire.update_position()
-            # Sync the new waypoints back to the model
-            model_wire = self.controller.model.wires[wire_index]
-            model_wire.waypoints = [(wp.x(), wp.y()) for wp in wire.waypoints]
 
     # ===================================================================
     # Scene item callbacks (avoid hierarchy climbing in items)
@@ -359,11 +356,25 @@ class CircuitCanvasView(QGraphicsView):
         """Relay a routing-failure message from a wire item to the UI."""
         self.statusMessage.emit(message, 5000)
 
-    def on_wire_waypoints_changed(self, wire_item) -> None:
+    def on_wire_waypoints_changed(self, wire_item, waypoints=None) -> None:
         """Handle manual waypoint adjustment from a wire item."""
         if self.controller and wire_item in self.wires:
             idx = self.wires.index(wire_item)
-            self.controller.update_wire_waypoints(idx, wire_item.model.waypoints)
+            wps = waypoints if waypoints is not None else wire_item.model.waypoints
+            self.controller.update_wire_waypoints(idx, wps)
+            self.controller.set_wire_locked(idx, True)
+
+    def on_wire_routing_complete(self, wire_item, waypoints, runtime=0.0, iterations=0, routing_failed=False):
+        """Persist pathfinding results from a wire item through the controller."""
+        if self.controller and wire_item in self.wires:
+            idx = self.wires.index(wire_item)
+            self.controller.update_wire_routing_result(idx, waypoints, runtime, iterations, routing_failed)
+        else:
+            # Wire not yet tracked (during construction) — write directly
+            wire_item.model.waypoints = waypoints
+            wire_item.model.runtime = runtime
+            wire_item.model.iterations = iterations
+            wire_item.model.routing_failed = routing_failed
 
     def _handle_annotation_added(self, annotation_data) -> None:
         """Create AnnotationItem when annotation added to model."""

--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -272,13 +272,12 @@ class ComponentGraphicsItem(QGraphicsItem):
                 QMessageBox.warning(None, "Invalid Value", error_msg)
                 return
 
-            self.value = new_value
-            self.update()
-            if self.scene() is not None:
-                self.scene().update()
-            # Sync to controller model so netlist generation sees the updated value
+            # Route through controller; observer callback syncs the local model
             if self.canvas and hasattr(self.canvas, "controller") and self.canvas.controller:
                 self.canvas.controller.update_component_value(self.component_id, new_value)
+            else:
+                self.model.value = new_value
+                self.update()
 
     # --- Geometry ---
 
@@ -315,25 +314,6 @@ class ComponentGraphicsItem(QGraphicsItem):
             new_x = tx * cos_a - ty * sin_a
             new_y = tx * sin_a + ty * cos_a
             self.terminals.append(QPointF(new_x, new_y))
-
-    def rotate_component(self, clockwise=True):
-        """Rotate component by 90 degrees"""
-        if clockwise:
-            self.rotation_angle = (self.rotation_angle + 90) % 360
-        else:
-            self.rotation_angle = (self.rotation_angle - 90) % 360
-
-        self.update_terminals()
-        self.update()
-
-    def flip_component(self, horizontal=True):
-        """Flip component horizontally or vertically"""
-        if horizontal:
-            self.model.flip_h = not self.model.flip_h
-        else:
-            self.model.flip_v = not self.model.flip_v
-        self.update_terminals()
-        self.update()
 
     def set_grading_state(self, state, feedback=""):
         """Set the grading overlay state for this component.

--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -347,17 +347,13 @@ class MainWindow(
                 statusBar.showMessage(f"Updated {component_id} value to {new_value}", 2000)
 
         elif property_name == "rotation":
-            component = self.canvas.components.get(component_id)
-            if not component:
-                return
-            component.rotation_angle = new_value
-            component.update_terminals()
-            component.update()
-            self.canvas.reroute_connected_wires(component)
+            self.circuit_ctrl.set_component_rotation(component_id, new_value)
             statusBar = self.statusBar()
             if statusBar:
                 statusBar.showMessage(f"Rotated {component_id} to {new_value}°", 2000)
-            self.properties_panel.show_component(component)
+            component = self.canvas.components.get(component_id)
+            if component:
+                self.properties_panel.show_component(component)
 
         elif property_name == "waveform":
             waveform_type, params = new_value

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -132,19 +132,22 @@ class WireGraphicsItem(QGraphicsPathItem):
     def runtime(self):
         return self.model.runtime
 
-    @runtime.setter
-    def runtime(self, value):
-        self.model.runtime = value
-
     @property
     def iterations(self):
         return self.model.iterations
 
-    @iterations.setter
-    def iterations(self, value):
-        self.model.iterations = value
-
     # --- Methods ---
+
+    def _persist_routing_result(self, waypoints, runtime=0.0, iterations=0, routing_failed=False):
+        """Persist pathfinding results through the controller when available."""
+        if self.canvas and hasattr(self.canvas, "on_wire_routing_complete"):
+            self.canvas.on_wire_routing_complete(self, waypoints, runtime, iterations, routing_failed)
+        else:
+            # Fallback during initialisation (wire not yet in canvas.wires)
+            self.model.waypoints = waypoints
+            self.model.runtime = runtime
+            self.model.iterations = iterations
+            self.model.routing_failed = routing_failed
 
     def show_drag_preview(self):
         """Show a straight-line preview during component drag.
@@ -240,11 +243,8 @@ class WireGraphicsItem(QGraphicsPathItem):
             # Convert tuple waypoints back to QPointF for Qt drawing
             self.waypoints = [QPointF(wp[0], wp[1]) for wp in tuple_waypoints]
 
-            # Store in model
-            self.model.runtime = runtime
-            self.model.iterations = iterations
-            self.model.routing_failed = routing_failed
-            self.model.waypoints = list(tuple_waypoints)
+            # Persist through controller (falls back to direct model write during init)
+            self._persist_routing_result(list(tuple_waypoints), runtime, iterations, routing_failed)
 
             if routing_failed:
                 logger.warning(
@@ -259,13 +259,11 @@ class WireGraphicsItem(QGraphicsPathItem):
         else:
             # Fallback to direct line
             self.waypoints = [start_qpt, end_qpt]
-            self.model.runtime = 0.0
-            self.model.iterations = 0
-            self.model.routing_failed = False
-            self.model.waypoints = [
+            fallback_wps = [
                 (start_qpt.x(), start_qpt.y()),
                 (end_qpt.x(), end_qpt.y()),
             ]
+            self._persist_routing_result(fallback_wps)
 
         # Create path from waypoints
         path = QPainterPath()
@@ -404,18 +402,19 @@ class WireGraphicsItem(QGraphicsPathItem):
 
     def _finish_waypoint_drag(self):
         """Called by WaypointHandle on mouse release to persist changes."""
-        # Sync to model
-        self.model.waypoints = [
+        tuple_waypoints = [
             (
                 wp.x() if isinstance(wp, QPointF) else wp[0],
                 wp.y() if isinstance(wp, QPointF) else wp[1],
             )
             for wp in self.waypoints
         ]
-        self.model.locked = True
-        # Notify via canvas (avoids calling controller private methods)
+        # Persist waypoints and lock through canvas -> controller
         if self.canvas and hasattr(self.canvas, "on_wire_waypoints_changed"):
-            self.canvas.on_wire_waypoints_changed(self)
+            self.canvas.on_wire_waypoints_changed(self, tuple_waypoints)
+        else:
+            self.model.waypoints = tuple_waypoints
+            self.model.locked = True
 
     def _rebuild_path_from_waypoints(self):
         """Rebuild the QPainterPath from the current waypoints list."""

--- a/app/controllers/circuit_controller.py
+++ b/app/controllers/circuit_controller.py
@@ -121,6 +121,16 @@ class CircuitController:
         component.rotation = (component.rotation + delta) % 360
         self._notify("component_rotated", component)
 
+    def set_component_rotation(self, component_id: str, rotation: int) -> None:
+        """Set a component's rotation to an exact value. Locked components cannot be rotated."""
+        if self.is_component_locked(component_id):
+            return
+        component = self.model.components.get(component_id)
+        if component is None:
+            return
+        component.rotation = rotation % 360
+        self._notify("component_rotated", component)
+
     def flip_component(self, component_id: str, horizontal: bool = True) -> None:
         """Flip (mirror) a component. Locked components cannot be flipped."""
         if self.is_component_locked(component_id):
@@ -272,6 +282,34 @@ class CircuitController:
             wire = self.model.wires[wire_index]
             wire.waypoints = waypoints
             self._notify("wire_routed", (wire_index, wire))
+
+    def update_wire_routing_result(
+        self,
+        wire_index: int,
+        waypoints: list[tuple[float, float]],
+        runtime: float = 0.0,
+        iterations: int = 0,
+        routing_failed: bool = False,
+    ) -> None:
+        """Store pathfinding results for a wire.
+
+        Called after the view runs pathfinding so routing metadata
+        is persisted through the controller rather than via direct model writes.
+        """
+        if 0 <= wire_index < len(self.model.wires):
+            wire = self.model.wires[wire_index]
+            wire.waypoints = waypoints
+            wire.runtime = runtime
+            wire.iterations = iterations
+            wire.routing_failed = routing_failed
+            self._notify("wire_routed", (wire_index, wire))
+
+    def set_wire_locked(self, wire_index: int, locked: bool) -> None:
+        """Set whether a wire's path is locked (skip auto-reroute)."""
+        if 0 <= wire_index < len(self.model.wires):
+            wire = self.model.wires[wire_index]
+            wire.locked = locked
+            self._notify("wire_lock_changed", (wire_index, wire))
 
     # --- Circuit operations ---
 

--- a/app/tests/unit/test_circuit_controller.py
+++ b/app/tests/unit/test_circuit_controller.py
@@ -405,6 +405,50 @@ class TestClipboardPublicAPI:
         assert controller.get_clipboard_paste_count() == 2
 
 
+class TestWireRoutingAPI:
+    """Verify wire routing result and lock state are persisted through the controller."""
+
+    def test_update_wire_routing_result(self, controller, events):
+        """update_wire_routing_result stores pathfinding metadata."""
+        recorded, callback = events
+        controller.add_component("Resistor", (0.0, 0.0))
+        controller.add_component("Resistor", (100.0, 0.0))
+        controller.add_wire("R1", 1, "R2", 0)
+        controller.add_observer(callback)
+        wps = [(0.0, 0.0), (50.0, 0.0), (100.0, 0.0)]
+        controller.update_wire_routing_result(0, wps, runtime=0.05, iterations=42, routing_failed=False)
+        wire = controller.model.wires[0]
+        assert wire.waypoints == wps
+        assert wire.runtime == 0.05
+        assert wire.iterations == 42
+        assert wire.routing_failed is False
+        assert recorded[-1][0] == "wire_routed"
+
+    def test_set_wire_locked(self, controller, events):
+        """set_wire_locked updates the lock flag and notifies."""
+        recorded, callback = events
+        controller.add_component("Resistor", (0.0, 0.0))
+        controller.add_component("Resistor", (100.0, 0.0))
+        controller.add_wire("R1", 1, "R2", 0)
+        controller.add_observer(callback)
+        controller.set_wire_locked(0, True)
+        assert controller.model.wires[0].locked is True
+        assert recorded[-1][0] == "wire_lock_changed"
+
+    def test_set_wire_locked_invalid_index(self, controller):
+        """set_wire_locked with invalid index does nothing."""
+        controller.set_wire_locked(99, True)  # Should not raise
+
+    def test_set_component_rotation(self, controller, events):
+        """set_component_rotation sets exact rotation value."""
+        recorded, callback = events
+        controller.add_component("Resistor", (0.0, 0.0))
+        controller.add_observer(callback)
+        controller.set_component_rotation("R1", 180)
+        assert controller.model.components["R1"].rotation == 180
+        assert recorded[-1][0] == "component_rotated"
+
+
 class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import controllers.circuit_controller as mod

--- a/app/tests/unit/test_scene_item_decoupling.py
+++ b/app/tests/unit/test_scene_item_decoupling.py
@@ -147,7 +147,9 @@ class TestWireItemDecoupling:
         wire.waypoints = [(0, 0), (50, 50), (100, 100)]
         wire._finish_waypoint_drag()
 
-        mock_canvas.on_wire_waypoints_changed.assert_called_once_with(wire)
+        mock_canvas.on_wire_waypoints_changed.assert_called_once()
+        call_args = mock_canvas.on_wire_waypoints_changed.call_args
+        assert call_args[0][0] is wire  # first positional arg is the wire item
 
     def test_no_window_statusbar_access_in_source(self):
         """Verify no window().statusBar() patterns remain in wire_item.py."""

--- a/app/tests/unit/test_waypoint_editing.py
+++ b/app/tests/unit/test_waypoint_editing.py
@@ -136,11 +136,12 @@ class TestWaypointDragging:
         wire_with_waypoints._move_waypoint(0, QPointF(999, 999))
         assert wire_with_waypoints.waypoints[0] == original_start
 
-    def test_finish_drag_syncs_model(self, wire_with_waypoints, qtbot):
+    def test_finish_drag_passes_waypoints_to_canvas(self, wire_with_waypoints, qtbot):
         wire_with_waypoints._move_waypoint(1, QPointF(60, 10))
         wire_with_waypoints._finish_waypoint_drag()
-        model_wps = wire_with_waypoints.model.waypoints
-        assert (60.0, 10.0) in model_wps
+        call_args = wire_with_waypoints.canvas.on_wire_waypoints_changed.call_args
+        waypoints = call_args[0][1]  # second positional arg
+        assert (60.0, 10.0) in waypoints
 
     def test_finish_drag_notifies_canvas_with_waypoints(self, wire_with_waypoints, qtbot):
         wire_with_waypoints._move_waypoint(1, QPointF(60, 10))

--- a/app/tests/unit/test_waypoint_editing.py
+++ b/app/tests/unit/test_waypoint_editing.py
@@ -142,16 +142,14 @@ class TestWaypointDragging:
         model_wps = wire_with_waypoints.model.waypoints
         assert (60.0, 10.0) in model_wps
 
-    def test_finish_drag_locks_wire(self, wire_with_waypoints, qtbot):
-        assert not wire_with_waypoints.model.locked
+    def test_finish_drag_notifies_canvas_with_waypoints(self, wire_with_waypoints, qtbot):
         wire_with_waypoints._move_waypoint(1, QPointF(60, 10))
         wire_with_waypoints._finish_waypoint_drag()
-        assert wire_with_waypoints.model.locked
-
-    def test_finish_drag_notifies_canvas(self, wire_with_waypoints, qtbot):
-        wire_with_waypoints._move_waypoint(1, QPointF(60, 10))
-        wire_with_waypoints._finish_waypoint_drag()
-        wire_with_waypoints.canvas.on_wire_waypoints_changed.assert_called_once_with(wire_with_waypoints)
+        wire_with_waypoints.canvas.on_wire_waypoints_changed.assert_called_once()
+        call_args = wire_with_waypoints.canvas.on_wire_waypoints_changed.call_args
+        assert call_args[0][0] is wire_with_waypoints
+        # Second arg is tuple waypoints list
+        assert isinstance(call_args[0][1], list)
 
     def test_path_rebuilt_after_move(self, wire_with_waypoints, qtbot):
         old_path = wire_with_waypoints.path()


### PR DESCRIPTION
## Summary - Remove dead  and  methods from ComponentGraphicsItem (canvas already routes through controller) - Fix  to route through  instead of writing  directly - Fix  rotation to use  instead of direct property write - Wire pathfinding results now persist through canvas callback ->  instead of direct model writes -  routes waypoints and lock flag through controller instead of direct model mutation - Remove / property setters from WireItem - Add , ,  to CircuitController ## Test plan - [x] New TestWireRoutingAPI tests verify update_wire_routing_result, set_wire_locked, set_component_rotation - [x] Updated test_waypoint_editing and test_scene_item_decoupling for new callback signatures - [ ] Existing tests continue to pass - [ ] CI passes on all platforms Closes #631