### PR TITLE
Add view protocol interfaces for new GUI

### DIFF
--- a/app/controllers/circuit_controller.py
+++ b/app/controllers/circuit_controller.py
@@ -487,3 +487,42 @@ class CircuitController:
     def clear_undo_history(self) -> None:
         """Clear the undo/redo history."""
         self.undo_manager.clear()
+
+    # --- Read-only query methods ---
+    # Views should use these instead of accessing self.model directly.
+
+    def get_component(self, component_id: str) -> Optional[ComponentData]:
+        """Return a single component by ID, or None."""
+        return self.model.components.get(component_id)
+
+    def get_components(self) -> dict[str, ComponentData]:
+        """Return a copy of the components dict."""
+        return dict(self.model.components)
+
+    def get_component_count(self) -> int:
+        """Return the number of components in the circuit."""
+        return len(self.model.components)
+
+    def get_wires(self) -> list[WireData]:
+        """Return a copy of the wires list."""
+        return list(self.model.wires)
+
+    def get_wire_count(self) -> int:
+        """Return the number of wires in the circuit."""
+        return len(self.model.wires)
+
+    def get_nodes(self) -> list:
+        """Return a copy of the nodes list."""
+        return list(self.model.nodes)
+
+    def get_annotations(self) -> list[AnnotationData]:
+        """Return a copy of the annotations list."""
+        return list(self.model.annotations)
+
+    def has_ground(self) -> bool:
+        """Return whether the circuit has a ground component."""
+        return any(n.is_ground for n in self.model.nodes)
+
+    def get_terminal_to_node(self) -> dict:
+        """Return a copy of the terminal-to-node mapping."""
+        return dict(self.model.terminal_to_node)

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -66,6 +66,17 @@ class SimulationController:
         self.model.analysis_type = analysis_type
         self.model.analysis_params = (params or {}).copy()
 
+    # --- Read-only query methods ---
+    # Views should use these instead of accessing self.model directly.
+
+    def get_analysis_type(self) -> str:
+        """Return the current analysis type."""
+        return self.model.analysis_type
+
+    def get_analysis_params(self) -> dict:
+        """Return a copy of the current analysis parameters."""
+        return self.model.analysis_params.copy()
+
     def validate_circuit(self) -> SimulationResult:
         """
         Validate the circuit before simulation.

--- a/app/docs/gui-protocol-guide.md
+++ b/app/docs/gui-protocol-guide.md
@@ -1,0 +1,361 @@
+# GUI Protocol Guide
+
+How to build a new GUI for Spice-GUI using the protocol interfaces.
+
+## Architecture
+
+```
+models/          Pure Python dataclasses — the source of truth
+controllers/     Pure Python logic — no Qt imports
+protocols/       typing.Protocol contracts between controllers and views
+GUI/             PyQt6 implementation (existing, reference)
+your_gui/        Your new implementation
+```
+
+The controllers own the model and expose all mutations as methods.
+Views register as observers to stay in sync.
+Views never write to the model directly.
+
+## Bootstrap
+
+```python
+from models.circuit import CircuitModel
+from controllers.circuit_controller import CircuitController
+from controllers.file_controller import FileController
+from controllers.simulation_controller import SimulationController
+
+# 1. Create model
+model = CircuitModel()
+
+# 2. Create controllers
+circuit_ctrl = CircuitController(model)
+file_ctrl = FileController(model, circuit_ctrl)
+sim_ctrl = SimulationController(model, circuit_ctrl)
+
+# 3. Create your views (implementing the protocols)
+canvas = MyCanvas()
+properties = MyPropertiesPanel()
+palette = MyPalette()
+results = MyResultsDisplay()
+dialogs = MyDialogProvider()
+
+# 4. Wire the observer
+circuit_ctrl.add_observer(canvas.handle_observer_event)
+
+# 5. Wire callbacks
+palette.set_component_selected_callback(
+    lambda comp_type: circuit_ctrl.add_component(comp_type, (0, 0))
+)
+properties.set_property_change_callback(on_property_changed)
+
+def on_property_changed(component_id, prop_name, new_value):
+    if prop_name == "value":
+        circuit_ctrl.update_component_value(component_id, new_value)
+    elif prop_name == "waveform":
+        wtype, params = new_value
+        circuit_ctrl.update_component_waveform(component_id, wtype, params)
+    elif prop_name == "initial_condition":
+        circuit_ctrl.update_component_initial_condition(component_id, new_value)
+```
+
+## Observer Events
+
+When the model changes, every registered observer receives `(event, data)`.
+See `protocols/events.py` for the full list.
+
+### Handling events in your canvas
+
+```python
+def handle_observer_event(self, event: str, data):
+    handlers = {
+        "component_added":    self._on_component_added,
+        "component_removed":  self._on_component_removed,
+        "component_moved":    self._on_component_moved,
+        "component_rotated":  self._on_component_rotated,
+        "component_flipped":  self._on_component_flipped,
+        "component_value_changed": self._on_component_value_changed,
+        "wire_added":         self._on_wire_added,
+        "wire_removed":       self._on_wire_removed,
+        "wire_routed":        self._on_wire_routed,
+        "circuit_cleared":    self._on_circuit_cleared,
+        "nodes_rebuilt":      self._on_nodes_rebuilt,
+        "model_loaded":       self._on_model_loaded,
+        "annotation_added":   self._on_annotation_added,
+        "annotation_removed": self._on_annotation_removed,
+        "annotation_updated": self._on_annotation_updated,
+    }
+    handler = handlers.get(event)
+    if handler:
+        handler(data)
+```
+
+### Event payload reference
+
+| Event | Data type | When |
+|-------|-----------|------|
+| `component_added` | `ComponentData` | New component created |
+| `component_removed` | `str` (component_id) | Component deleted |
+| `component_moved` | `ComponentData` | Position changed |
+| `component_rotated` | `ComponentData` | Rotation changed |
+| `component_flipped` | `ComponentData` | Flip state changed |
+| `component_value_changed` | `ComponentData` | Value, waveform, or IC changed |
+| `wire_added` | `WireData` | New wire connection |
+| `wire_removed` | `int` (wire_index) | Wire deleted |
+| `wire_routed` | `tuple[int, WireData]` | Wire waypoints updated |
+| `wire_lock_changed` | `tuple[int, bool]` | Wire lock toggled |
+| `circuit_cleared` | `None` | Full reset |
+| `nodes_rebuilt` | `None` | Node graph recalculated |
+| `model_loaded` | `None` | Circuit loaded from file |
+| `model_saved` | `None` | Circuit saved |
+| `simulation_started` | `None` | Sim pipeline begins |
+| `simulation_completed` | `SimulationResult` | Sim pipeline ends |
+| `annotation_added` | `AnnotationData` | Annotation created |
+| `annotation_removed` | `int` | Annotation deleted |
+| `annotation_updated` | `AnnotationData` | Annotation text changed |
+| `net_name_changed` | `NodeData` | Custom node label set |
+| `locked_components_changed` | `list[str]` | Lock set changed |
+| `recommended_components_changed` | `list[str]` | Recommended list updated |
+
+## Controller Methods by User Action
+
+### Adding a component
+
+```python
+component_data = circuit_ctrl.add_component("Resistor", (100.0, 200.0))
+# Observer receives: ("component_added", component_data)
+```
+
+Available types: see `models.component.COMPONENT_TYPES` and `COMPONENT_CATEGORIES`.
+
+### Moving a component
+
+```python
+circuit_ctrl.move_component("R1", (150.0, 250.0))
+# Observer receives: ("component_moved", component_data)
+```
+
+### Rotating / flipping
+
+```python
+circuit_ctrl.rotate_component("R1", clockwise=True)
+circuit_ctrl.flip_component("R1", horizontal=True)
+```
+
+### Changing a value
+
+```python
+circuit_ctrl.update_component_value("R1", "4.7k")
+circuit_ctrl.update_component_waveform("V1", "SINE", {"amplitude": "5", "frequency": "1k"})
+circuit_ctrl.update_component_initial_condition("C1", "0V")
+```
+
+### Adding a wire
+
+```python
+wire = circuit_ctrl.add_wire("R1", 0, "R2", 1, waypoints=[(100, 200), (150, 200)])
+# Observer receives: ("wire_added", wire)
+```
+
+Terminal indices are 0-based. Use `ComponentData.get_terminal_positions()` for positions.
+
+### Removing components / wires
+
+```python
+circuit_ctrl.remove_component("R1")  # Also removes connected wires
+circuit_ctrl.remove_wire(0)          # By index into wires list
+```
+
+### Undo / redo
+
+For undoable operations, wrap in a Command:
+
+```python
+from controllers.commands import AddComponentCommand
+
+cmd = AddComponentCommand(circuit_ctrl, "Resistor", (100, 200))
+circuit_ctrl.execute_command(cmd)
+
+circuit_ctrl.undo()  # Removes the component
+circuit_ctrl.redo()  # Re-adds it
+```
+
+### Copy / paste / cut
+
+```python
+circuit_ctrl.copy_components(["R1", "R2"])
+new_comps, new_wires = circuit_ctrl.paste_components(offset=(40, 40))
+circuit_ctrl.cut_components(["R1", "R2"])
+```
+
+### File operations
+
+```python
+file_ctrl.new_circuit()
+file_ctrl.save_circuit("/path/to/file.json")
+file_ctrl.load_circuit("/path/to/file.json")
+
+# Recent files
+recent = file_ctrl.get_recent_files()
+
+# Auto-save recovery
+if file_ctrl.has_auto_save():
+    file_ctrl.load_auto_save()
+```
+
+### Simulation
+
+```python
+sim_ctrl.set_analysis("Transient", {"stop_time": "10m", "step": "1u"})
+
+result = sim_ctrl.validate_circuit()
+if not result.success:
+    dialogs.show_error("Validation Failed", "\n".join(result.errors))
+    return
+
+result = sim_ctrl.run_simulation()
+if result.success:
+    results_display.display_simulation_result(result)
+else:
+    dialogs.show_error("Simulation Failed", result.error)
+```
+
+### Querying state (read-only)
+
+Use controller query methods instead of accessing `model` directly:
+
+```python
+# Good — goes through controller
+components = circuit_ctrl.get_components()
+count = circuit_ctrl.get_component_count()
+comp = circuit_ctrl.get_component("R1")
+wires = circuit_ctrl.get_wires()
+analysis = sim_ctrl.get_analysis_type()
+params = sim_ctrl.get_analysis_params()
+
+# Bad — bypasses controller
+components = model.components      # Don't do this
+analysis = model.analysis_type     # Don't do this
+```
+
+## Model Data Structures
+
+All models are pure Python dataclasses. Import from `models/`.
+
+### ComponentData (`models/component.py`)
+
+```python
+@dataclass
+class ComponentData:
+    component_id: str           # "R1", "V2", etc.
+    component_type: str         # "Resistor", "Voltage Source", etc.
+    value: str                  # "1k", "5V", etc.
+    position: tuple[float, float]
+    rotation: int = 0           # 0, 90, 180, 270
+    flip_h: bool = False
+    flip_v: bool = False
+    waveform_type: Optional[str] = None
+    waveform_params: Optional[dict] = None
+    initial_condition: Optional[str] = None
+```
+
+Key methods:
+- `get_terminal_count() -> int`
+- `get_terminal_positions() -> list[tuple[float, float]]` (world coords, after transform)
+- `get_spice_symbol() -> str`
+
+### WireData (`models/wire.py`)
+
+```python
+@dataclass
+class WireData:
+    start_component_id: str
+    start_terminal: int
+    end_component_id: str
+    end_terminal: int
+    waypoints: list[tuple[float, float]] = []
+    locked: bool = False
+```
+
+### NodeData (`models/node.py`)
+
+```python
+@dataclass
+class NodeData:
+    terminals: set[tuple[str, int]]  # (component_id, terminal_index)
+    wire_indices: set[int]
+    is_ground: bool = False
+    custom_label: Optional[str] = None
+    auto_label: str = ""
+```
+
+Key method: `get_label() -> str` (custom label if set, else auto label).
+
+### AnnotationData (`models/annotation.py`)
+
+```python
+@dataclass
+class AnnotationData:
+    text: str = "Annotation"
+    x: float = 0.0
+    y: float = 0.0
+    font_size: int = 10
+    bold: bool = False
+    color: str = ""  # hex
+```
+
+### SimulationResult (`controllers/simulation_controller.py`)
+
+```python
+@dataclass
+class SimulationResult:
+    success: bool
+    analysis_type: str = ""
+    data: Any = None
+    errors: list[str] = []
+    warnings: list[str] = []
+    error: str = ""
+    netlist: str = ""
+    raw_output: str = ""
+    measurements: Optional[dict] = None
+```
+
+## Protocols Checklist
+
+Implement these protocols to get a working GUI:
+
+| Protocol | File | Purpose | Priority |
+|----------|------|---------|----------|
+| `CircuitCanvasProtocol` | `protocols/canvas.py` | Drawing surface | Must have |
+| `PropertiesPanelProtocol` | `protocols/properties.py` | Property editor | Must have |
+| `ComponentPaletteProtocol` | `protocols/palette.py` | Component selector | Must have |
+| `ResultsDisplayProtocol` | `protocols/results.py` | Simulation output | Must have |
+| `DialogProvider` | `protocols/dialogs.py` | Modal interactions | Must have |
+| `ApplicationShellProtocol` | `protocols/application.py` | Top-level window | Must have |
+| `ProgressHandle` | `protocols/dialogs.py` | Progress bars | Nice to have |
+
+## Theme
+
+The existing `ThemeProtocol` in `GUI/styles/theme.py` returns Qt types (`QColor`, `QPen`, etc.).
+Since both GUIs use PyQt6, you can use it directly.
+For non-Qt rendering paths, use `theme.color_hex(key)` which returns hex strings.
+
+## Wire Routing
+
+The pathfinding algorithms in `algorithms/` are pure Python and framework-agnostic.
+You can reuse them for wire routing — only the rendering needs reimplementation.
+
+```python
+from algorithms.wire_routing import route_wire
+
+waypoints = route_wire(start_pos, end_pos, obstacles, algorithm="idastar")
+```
+
+## Reference Implementation
+
+The existing PyQt6 GUI in `GUI/` satisfies these protocols.
+Key files to study:
+
+- `GUI/circuit_canvas.py` — `CircuitCanvasProtocol` reference (observer dispatch at lines 140-176)
+- `GUI/properties_panel.py` — `PropertiesPanelProtocol` reference
+- `GUI/component_palette.py` — `ComponentPaletteProtocol` reference
+- `GUI/main_window.py` — `ApplicationShellProtocol` reference (bootstrap at lines 73-127)

--- a/app/protocols/__init__.py
+++ b/app/protocols/__init__.py
@@ -1,0 +1,26 @@
+"""
+View-layer protocols for Spice-GUI.
+
+These ``typing.Protocol`` classes define the contracts between the
+controller/model layer and any GUI implementation.  The existing
+PyQt6 GUI satisfies these protocols implicitly.  A new GUI must
+implement them explicitly.
+
+Usage::
+
+    from protocols import CircuitCanvasProtocol, DialogProvider
+
+    class MyCanvas(CircuitCanvasProtocol):
+        def handle_observer_event(self, event, data):
+            ...
+"""
+
+from .application import ApplicationShellProtocol as ApplicationShellProtocol
+from .canvas import CircuitCanvasProtocol as CircuitCanvasProtocol
+from .dialogs import DialogProvider as DialogProvider
+from .dialogs import ProgressHandle as ProgressHandle
+from .events import EVENT_PAYLOADS as EVENT_PAYLOADS
+from .events import ObserverEvent as ObserverEvent
+from .palette import ComponentPaletteProtocol as ComponentPaletteProtocol
+from .properties import PropertiesPanelProtocol as PropertiesPanelProtocol
+from .results import ResultsDisplayProtocol as ResultsDisplayProtocol

--- a/app/protocols/application.py
+++ b/app/protocols/application.py
@@ -1,0 +1,61 @@
+"""Protocol for the top-level application shell."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from controllers.circuit_controller import CircuitController
+    from controllers.file_controller import FileController
+    from controllers.simulation_controller import SimulationController
+
+
+@runtime_checkable
+class ApplicationShellProtocol(Protocol):
+    """Contract for the top-level application window.
+
+    The shell owns the three controllers and wires together the view
+    protocols.  It is the single integration point — the one place
+    that knows about all the pieces.
+
+    Required attributes (set during ``__init__``):
+
+    ============== ==========================================
+    Attribute      Type
+    ============== ==========================================
+    circuit_ctrl   ``CircuitController``
+    file_ctrl      ``FileController``
+    simulation_ctrl ``SimulationController``
+    ============== ==========================================
+
+    Bootstrap pattern::
+
+        model = CircuitModel()
+        circuit_ctrl = CircuitController(model)
+        file_ctrl = FileController(model, circuit_ctrl)
+        simulation_ctrl = SimulationController(model, circuit_ctrl)
+
+        canvas = MyCanvas()
+        circuit_ctrl.add_observer(canvas.handle_observer_event)
+    """
+
+    @property
+    def circuit_ctrl(self) -> CircuitController: ...
+
+    @property
+    def file_ctrl(self) -> FileController: ...
+
+    @property
+    def simulation_ctrl(self) -> SimulationController: ...
+
+    def set_window_title(self, title: str) -> None:
+        """Update the window title bar."""
+        ...
+
+    def show_status_message(self, message: str, timeout_ms: int = 3000) -> None:
+        """Show a transient message in the status bar."""
+        ...
+
+    def set_dirty(self, dirty: bool) -> None:
+        """Mark the document as having unsaved changes."""
+        ...

--- a/app/protocols/canvas.py
+++ b/app/protocols/canvas.py
@@ -1,0 +1,96 @@
+"""Protocol for the circuit drawing surface."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class CircuitCanvasProtocol(Protocol):
+    """Contract for a circuit drawing surface.
+
+    The canvas registers as a ``CircuitController`` observer and reacts
+    to model-change events.  It also exposes methods that the application
+    shell delegates to for zoom, selection, and display toggles.
+
+    Minimal implementation checklist:
+        1. Call ``circuit_ctrl.add_observer(self.handle_observer_event)``
+           during initialisation.
+        2. Implement ``handle_observer_event`` to dispatch each event
+           string to an internal handler (see ``protocols.events`` for
+           the full event list and payload types).
+        3. Expose selection, zoom, and display-toggle methods so the
+           shell can wire them to menu/toolbar actions.
+    """
+
+    # --- Observer dispatch ---
+
+    def handle_observer_event(self, event: str, data: Any) -> None:
+        """Handle a ``CircuitController`` observer notification.
+
+        Dispatch based on *event* (see :pymod:`protocols.events`).
+        """
+        ...
+
+    # --- Selection ---
+
+    def get_selected_component_ids(self) -> list[str]:
+        """Return IDs of currently selected components."""
+        ...
+
+    def clear_selection(self) -> None:
+        """Deselect all items."""
+        ...
+
+    def select_components(self, component_ids: list[str]) -> None:
+        """Programmatically select the given components."""
+        ...
+
+    # --- Zoom ---
+
+    def zoom_in(self) -> None: ...
+    def zoom_out(self) -> None: ...
+
+    def zoom_fit(self) -> None:
+        """Fit all circuit content in the viewport."""
+        ...
+
+    def get_zoom_level(self) -> float:
+        """Return current zoom as a multiplier (1.0 = 100 %)."""
+        ...
+
+    # --- Display toggles ---
+
+    def set_show_component_labels(self, show: bool) -> None:
+        """Toggle component ID labels (R1, V1, etc.)."""
+        ...
+
+    def set_show_component_values(self, show: bool) -> None:
+        """Toggle component value labels (1k, 5V, etc.)."""
+        ...
+
+    def set_show_node_labels(self, show: bool) -> None:
+        """Toggle node labels (nodeA, nodeB, etc.)."""
+        ...
+
+    # --- Operating-point annotations ---
+
+    def set_node_voltages(self, voltages: dict[str, float]) -> None:
+        """Display operating-point voltage annotations on nodes."""
+        ...
+
+    def clear_op_annotations(self) -> None:
+        """Remove all operating-point annotations."""
+        ...
+
+    # --- Image export ---
+
+    def export_image(self, filepath: str, include_grid: bool = False) -> None:
+        """Render the canvas to an image file (PNG, SVG, etc.)."""
+        ...
+
+    # --- Theme ---
+
+    def refresh_theme(self) -> None:
+        """Re-apply the current theme to all visual elements."""
+        ...

--- a/app/protocols/dialogs.py
+++ b/app/protocols/dialogs.py
@@ -1,0 +1,75 @@
+"""Protocols for modal dialog interactions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    pass
+
+
+@runtime_checkable
+class ProgressHandle(Protocol):
+    """Handle returned by ``DialogProvider.create_progress``."""
+
+    def update(self, value: int, message: str = "") -> bool:
+        """Advance the progress bar.
+
+        Returns ``False`` if the user cancelled.
+        """
+        ...
+
+    def close(self) -> None:
+        """Close the progress dialog."""
+        ...
+
+
+@runtime_checkable
+class DialogProvider(Protocol):
+    """Contract for modal dialogs that collect user input.
+
+    Each method shows a dialog and returns the result, or ``None``
+    if the user cancelled.  This decouples dialog presentation from
+    business logic.
+    """
+
+    # --- File dialogs ---
+
+    def ask_save_file(self, title: str, filters: str, default_name: str = "") -> Optional[Path]:
+        """Show a save-file dialog.  Returns chosen path or ``None``."""
+        ...
+
+    def ask_open_file(self, title: str, filters: str) -> Optional[Path]:
+        """Show an open-file dialog.  Returns chosen path or ``None``."""
+        ...
+
+    # --- Confirmation / message dialogs ---
+
+    def confirm(self, title: str, message: str) -> bool:
+        """Show a yes/no confirmation.  Returns ``True`` for yes."""
+        ...
+
+    def show_error(self, title: str, message: str) -> None: ...
+    def show_warning(self, title: str, message: str) -> None: ...
+    def show_info(self, title: str, message: str) -> None: ...
+
+    # --- Analysis configuration ---
+
+    def ask_analysis_params(self, analysis_type: str, current_params: dict) -> Optional[dict]:
+        """Show analysis-parameter dialog.  Returns params or ``None``."""
+        ...
+
+    def ask_parameter_sweep_config(self, components: dict[str, Any]) -> Optional[dict]:
+        """Show parameter-sweep configuration.  Returns config or ``None``."""
+        ...
+
+    def ask_monte_carlo_config(self, components: dict[str, Any]) -> Optional[dict]:
+        """Show Monte Carlo configuration.  Returns config or ``None``."""
+        ...
+
+    # --- Progress ---
+
+    def create_progress(self, title: str, message: str, maximum: int) -> ProgressHandle:
+        """Create a progress dialog.  Returns a handle for updates."""
+        ...

--- a/app/protocols/events.py
+++ b/app/protocols/events.py
@@ -1,0 +1,73 @@
+"""
+Observer event contract for CircuitController notifications.
+
+Every view that registers as a CircuitController observer receives
+``(event_name: str, data)`` callbacks. This module defines the
+complete set of event names and their expected payload types.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+# All events emitted by CircuitController._notify
+ObserverEvent = Literal[
+    "component_added",
+    "component_removed",
+    "component_moved",
+    "component_rotated",
+    "component_flipped",
+    "component_value_changed",
+    "wire_added",
+    "wire_removed",
+    "wire_routed",
+    "wire_lock_changed",
+    "wire_reroute_requested",
+    "circuit_cleared",
+    "nodes_rebuilt",
+    "model_loaded",
+    "model_saved",
+    "simulation_started",
+    "simulation_completed",
+    "annotation_added",
+    "annotation_removed",
+    "annotation_updated",
+    "net_name_changed",
+    "locked_components_changed",
+    "recommended_components_changed",
+]
+
+# Payload type documentation.
+# Import paths are relative to the ``app`` package.
+#
+#   from models.component import ComponentData
+#   from models.wire import WireData
+#   from models.node import NodeData
+#   from models.annotation import AnnotationData
+#   from controllers.simulation_controller import SimulationResult
+#
+EVENT_PAYLOADS: dict[str, str] = {
+    "component_added": "ComponentData",
+    "component_removed": "str  # component_id",
+    "component_moved": "ComponentData",
+    "component_rotated": "ComponentData",
+    "component_flipped": "ComponentData",
+    "component_value_changed": "ComponentData",
+    "wire_added": "WireData",
+    "wire_removed": "int  # wire_index",
+    "wire_routed": "tuple[int, WireData]  # (wire_index, wire_data)",
+    "wire_lock_changed": "tuple[int, bool]  # (wire_index, locked)",
+    "wire_reroute_requested": "int  # wire_index",
+    "circuit_cleared": "None",
+    "nodes_rebuilt": "None",
+    "model_loaded": "None",
+    "model_saved": "None",
+    "simulation_started": "None",
+    "simulation_completed": "SimulationResult",
+    "annotation_added": "AnnotationData",
+    "annotation_removed": "int  # annotation_index",
+    "annotation_updated": "AnnotationData",
+    "net_name_changed": "NodeData",
+    "locked_components_changed": "list[str]  # component_ids",
+    "recommended_components_changed": "list[str]  # component_types",
+}

--- a/app/protocols/palette.py
+++ b/app/protocols/palette.py
@@ -1,0 +1,31 @@
+"""Protocol for the component selection palette."""
+
+from __future__ import annotations
+
+from typing import Callable, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ComponentPaletteProtocol(Protocol):
+    """Contract for a component selection widget.
+
+    Displays available component types organised by category.
+    Supports add-to-canvas via double-click, drag-and-drop, or
+    equivalent interaction.
+
+    Callback signature::
+
+        on_component_selected(component_type: str)
+    """
+
+    def set_component_selected_callback(self, callback: Callable[[str], None]) -> None:
+        """Register the callback for adding a component to the canvas."""
+        ...
+
+    def set_recommended_components(self, component_types: list[str]) -> None:
+        """Update the recommended / highlighted section."""
+        ...
+
+    def set_filter_text(self, text: str) -> None:
+        """Filter the palette to show only matching components."""
+        ...

--- a/app/protocols/properties.py
+++ b/app/protocols/properties.py
@@ -1,0 +1,52 @@
+"""Protocol for the component property editor panel."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol, runtime_checkable
+
+from models.component import ComponentData
+
+
+@runtime_checkable
+class PropertiesPanelProtocol(Protocol):
+    """Contract for a panel that displays and edits component properties.
+
+    The panel receives a ``ComponentData`` reference and lets the user
+    modify values.  Changes are communicated back to the shell via a
+    registered callback.
+
+    Callback signature::
+
+        on_property_changed(component_id: str, property_name: str, new_value: Any)
+
+    Recognised *property_name* values:
+
+    =========== ======================================
+    Name        Value type
+    =========== ======================================
+    value       ``str``
+    rotation    ``int`` (degrees: 0, 90, 180, 270)
+    waveform    ``tuple[str, dict]`` (type, params)
+    initial_condition  ``Optional[str]``
+    =========== ======================================
+    """
+
+    def show_component(self, component: ComponentData) -> None:
+        """Display properties for the given component."""
+        ...
+
+    def show_multi_selection(self, count: int) -> None:
+        """Show a summary when multiple components are selected."""
+        ...
+
+    def show_no_selection(self) -> None:
+        """Show the empty / no-selection state."""
+        ...
+
+    def set_property_change_callback(self, callback: Callable[[str, str, Any], None]) -> None:
+        """Register the callback invoked when the user edits a property.
+
+        Args:
+            callback: ``(component_id, property_name, new_value)``
+        """
+        ...

--- a/app/protocols/results.py
+++ b/app/protocols/results.py
@@ -1,0 +1,42 @@
+"""Protocol for simulation results display."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from controllers.simulation_controller import SimulationResult
+
+
+@runtime_checkable
+class ResultsDisplayProtocol(Protocol):
+    """Contract for displaying simulation results.
+
+    The shell calls these methods after running a simulation.  Different
+    analysis types produce different result formats; the implementation
+    should dispatch on ``result.analysis_type``.
+    """
+
+    def display_simulation_result(self, result: SimulationResult) -> None:
+        """Display a complete simulation result.
+
+        Dispatch based on ``result.analysis_type`` to show the
+        appropriate visualisation (table, plot, etc.).
+        """
+        ...
+
+    def display_text(self, text: str) -> None:
+        """Display plain text (netlist, error messages, etc.)."""
+        ...
+
+    def set_netlist_preview(self, netlist: str) -> None:
+        """Update the netlist preview tab."""
+        ...
+
+    def clear(self) -> None:
+        """Clear all displayed results."""
+        ...
+
+    def set_export_enabled(self, enabled: bool) -> None:
+        """Enable or disable export actions (CSV, Excel, Markdown)."""
+        ...


### PR DESCRIPTION
## Summary
- Define `typing.Protocol` classes in `app/protocols/` that formalize the contract between controllers and any GUI implementation
- Add read-only query methods to `CircuitController` and `SimulationController` so views never access `self.model` directly
- Include `docs/gui-protocol-guide.md` with bootstrap pattern, observer event reference, and controller method catalog

## New files
- `app/protocols/` (8 files): `events.py`, `canvas.py`, `properties.py`, `palette.py`, `results.py`, `dialogs.py`, `application.py`, `__init__.py`
- `app/docs/gui-protocol-guide.md`: Developer-facing guide for implementing a new GUI against these interfaces

## Modified files
- `app/controllers/circuit_controller.py`: Added `get_component()`, `get_components()`, `get_wires()`, `get_nodes()`, `get_annotations()`, `has_ground()`, `get_terminal_to_node()` query methods
- `app/controllers/simulation_controller.py`: Added `get_analysis_type()`, `get_analysis_params()` query methods

## Test plan
- [x] All 3310 existing tests pass
- [x] `from protocols import CircuitCanvasProtocol` imports cleanly
- [x] All query methods return correct values with empty and populated models
- [ ] Human programmer confirms guide is sufficient to start building new GUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)