### PR TITLE
Route all theme mutations through ThemeController (#632)

### DIFF
--- a/app/GUI/component_palette.py
+++ b/app/GUI/component_palette.py
@@ -388,7 +388,10 @@ class ComponentPalette(QWidget):
                 child.setIcon(0, create_component_icon(component_name))
             except Exception:
                 pass
-            child.setToolTip(0, COMPONENT_TOOLTIPS.get(component_name, f"Subcircuit: {component_name}"))
+            child.setToolTip(
+                0,
+                COMPONENT_TOOLTIPS.get(component_name, f"Subcircuit: {component_name}"),
+            )
             child.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable | Qt.ItemFlag.ItemIsDragEnabled)
 
         category_item.setExpanded(True)

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -692,8 +692,8 @@ class MenuBarMixin:
 
     def _set_theme_by_key(self, key):
         """Switch theme by key and apply it."""
-        from .styles import theme_manager
+        from controllers.theme_controller import theme_ctrl
 
-        theme_manager.set_theme_by_key(key)
+        theme_ctrl.set_theme_by_key(key)
         self._apply_theme()
         self._refresh_theme_menu()

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -1,6 +1,7 @@
 """Settings persistence, autosave, crash recovery, and window lifecycle for MainWindow."""
 
 from controllers.settings_service import settings
+from controllers.theme_controller import theme_ctrl
 from PyQt6.QtWidgets import QMessageBox
 
 from .styles import theme_manager
@@ -87,7 +88,7 @@ class SettingsMixin:
 
         saved_theme_key = settings.get("view/theme_key")
         if saved_theme_key and saved_theme_key != "light":
-            theme_manager.set_theme_by_key(saved_theme_key)
+            theme_ctrl.set_theme_by_key(saved_theme_key)
             self._apply_theme()
             if hasattr(self, "_refresh_theme_menu"):
                 self._refresh_theme_menu()

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -1,9 +1,10 @@
 """View operations: theme, visibility toggles, probe tool, zoom, and image export for MainWindow."""
 
+from controllers.theme_controller import theme_ctrl
 from PyQt6.QtWidgets import QApplication, QFileDialog, QMessageBox
 
 from .results_plot_dialog import ACSweepPlotDialog, DCSweepPlotDialog
-from .styles import DarkTheme, LightTheme, theme_manager
+from .styles import theme_manager
 from .waveform_dialog import WaveformDialog
 
 
@@ -13,10 +14,10 @@ class ViewOperationsMixin:
     def _set_theme(self, theme_name: str):
         """Switch the application theme (legacy: 'light' or 'dark' only)."""
         if theme_name == "dark":
-            theme_manager.set_theme(DarkTheme())
+            theme_ctrl.set_theme_by_key("dark")
             self.dark_theme_action.setChecked(True)
         else:
-            theme_manager.set_theme(LightTheme())
+            theme_ctrl.set_theme_by_key("light")
             self.light_theme_action.setChecked(True)
         self._apply_theme()
         if hasattr(self, "_refresh_theme_menu"):
@@ -32,7 +33,7 @@ class ViewOperationsMixin:
 
     def _set_symbol_style(self, style: str):
         """Switch the component symbol drawing style."""
-        theme_manager.set_symbol_style(style)
+        theme_ctrl.set_symbol_style(style)
         if style == "iec":
             self.iec_style_action.setChecked(True)
         else:
@@ -41,7 +42,7 @@ class ViewOperationsMixin:
 
     def _set_color_mode(self, mode: str):
         """Switch between per-type color and monochrome rendering."""
-        theme_manager.set_color_mode(mode)
+        theme_ctrl.set_color_mode(mode)
         if mode == "monochrome":
             self.monochrome_mode_action.setChecked(True)
         else:
@@ -50,7 +51,7 @@ class ViewOperationsMixin:
 
     def _set_wire_thickness(self, thickness: str):
         """Switch wire rendering thickness."""
-        theme_manager.set_wire_thickness(thickness)
+        theme_ctrl.set_wire_thickness(thickness)
         if hasattr(self, "wire_thickness_actions"):
             for t, action in self.wire_thickness_actions.items():
                 action.setChecked(t == thickness)
@@ -58,14 +59,14 @@ class ViewOperationsMixin:
 
     def _set_show_junction_dots(self, show: bool):
         """Toggle junction dot visibility at wire intersections."""
-        theme_manager.set_show_junction_dots(show)
+        theme_ctrl.set_show_junction_dots(show)
         if hasattr(self, "show_junction_dots_action"):
             self.show_junction_dots_action.setChecked(show)
         self.canvas.scene.update()
 
     def _set_routing_mode(self, mode: str):
         """Switch wire routing mode between orthogonal and diagonal."""
-        theme_manager.set_routing_mode(mode)
+        theme_ctrl.set_routing_mode(mode)
         if hasattr(self, "routing_mode_actions"):
             for m, action in self.routing_mode_actions.items():
                 action.setChecked(m == mode)

--- a/app/GUI/preferences_dialog.py
+++ b/app/GUI/preferences_dialog.py
@@ -1,6 +1,7 @@
 """Unified Preferences dialog for application settings."""
 
 from controllers.settings_service import settings
+from controllers.theme_controller import theme_ctrl
 from PyQt6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -69,7 +70,7 @@ class PreferencesDialog(QDialog):
 
     def _revert_settings(self):
         """Restore appearance and autosave to snapshot values."""
-        theme_manager.set_theme(self._snap_theme_obj)
+        theme_ctrl.set_theme(self._snap_theme_obj)
         self.main_window._apply_theme()
         self.main_window._set_symbol_style(self._snap_symbol_style)
         self.main_window._set_color_mode(self._snap_color_mode)
@@ -247,7 +248,7 @@ class PreferencesDialog(QDialog):
     def _on_theme_changed(self, index):
         if 0 <= index < len(self._theme_keys):
             key = self._theme_keys[index]
-            theme_manager.set_theme_by_key(key)
+            theme_ctrl.set_theme_by_key(key)
             self.main_window._apply_theme()
             self._update_theme_buttons()
             # Sync the View > Theme menu checkmarks
@@ -337,7 +338,7 @@ class PreferencesDialog(QDialog):
         stem = key[len("custom:") :]
         theme_store.delete_theme(stem)
         # Switch to Light theme
-        theme_manager.set_theme_by_key("light")
+        theme_ctrl.set_theme_by_key("light")
         self.main_window._apply_theme()
         self._populate_theme_combo()
         self.theme_combo.setCurrentIndex(0)

--- a/app/GUI/report_renderer.py
+++ b/app/GUI/report_renderer.py
@@ -54,20 +54,38 @@ class PDFReportRenderer:
         if data.config.include_netlist and data.netlist:
             if not first_page:
                 printer.newPage()
-            self._render_text_section(painter, printer, content_rect, "SPICE Netlist", data.netlist, monospace=True)
+            self._render_text_section(
+                painter,
+                printer,
+                content_rect,
+                "SPICE Netlist",
+                data.netlist,
+                monospace=True,
+            )
             first_page = False
 
         if data.config.include_analysis and data.analysis_text:
             if not first_page:
                 printer.newPage()
-            self._render_text_section(painter, printer, content_rect, "Analysis Configuration", data.analysis_text)
+            self._render_text_section(
+                painter,
+                printer,
+                content_rect,
+                "Analysis Configuration",
+                data.analysis_text,
+            )
             first_page = False
 
         if data.config.include_results and data.results_text:
             if not first_page:
                 printer.newPage()
             self._render_text_section(
-                painter, printer, content_rect, "Simulation Results", data.results_text, monospace=True
+                painter,
+                printer,
+                content_rect,
+                "Simulation Results",
+                data.results_text,
+                monospace=True,
             )
 
         painter.end()
@@ -97,7 +115,11 @@ class PDFReportRenderer:
         painter.setFont(subtitle_font)
         fm = QFontMetrics(subtitle_font)
         sub_width = fm.horizontalAdvance(data.subtitle)
-        painter.drawText(int(center_x - sub_width / 2), int(center_y + fm.height() * 2), data.subtitle)
+        painter.drawText(
+            int(center_x - sub_width / 2),
+            int(center_y + fm.height() * 2),
+            data.subtitle,
+        )
 
         # Analysis type if available
         if data.analysis_type:

--- a/app/controllers/theme_controller.py
+++ b/app/controllers/theme_controller.py
@@ -5,8 +5,14 @@ so that view-layer dialogs never mutate global theme_manager state
 directly.
 """
 
-from GUI.styles.theme import ThemeProtocol
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from services.theme_manager import theme_manager
+
+if TYPE_CHECKING:
+    from GUI.styles.theme import ThemeProtocol
 
 
 class ThemeController:
@@ -20,6 +26,30 @@ class ThemeController:
     def current_theme(self) -> ThemeProtocol:
         """Return the currently active theme."""
         return theme_manager.current_theme
+
+    def set_theme_by_key(self, key: str) -> None:
+        """Set theme by key string ('light', 'dark', or 'custom:<stem>')."""
+        theme_manager.set_theme_by_key(key)
+
+    def set_symbol_style(self, style: str) -> None:
+        """Set the symbol drawing style ('ieee' or 'iec')."""
+        theme_manager.set_symbol_style(style)
+
+    def set_color_mode(self, mode: str) -> None:
+        """Set the component color mode ('color' or 'monochrome')."""
+        theme_manager.set_color_mode(mode)
+
+    def set_wire_thickness(self, thickness: str) -> None:
+        """Set the wire rendering thickness ('thin', 'normal', or 'thick')."""
+        theme_manager.set_wire_thickness(thickness)
+
+    def set_show_junction_dots(self, show: bool) -> None:
+        """Set whether junction dots are shown at wire intersections."""
+        theme_manager.set_show_junction_dots(show)
+
+    def set_routing_mode(self, mode: str) -> None:
+        """Set the wire routing mode ('orthogonal' or 'diagonal')."""
+        theme_manager.set_routing_mode(mode)
 
 
 # Module-level singleton

--- a/app/tests/unit/test_netlist_generator.py
+++ b/app/tests/unit/test_netlist_generator.py
@@ -38,7 +38,14 @@ class TestGenerateAnalysisCommand:
     def test_noise(self):
         cmd = generate_analysis_command(
             "Noise",
-            {"output_node": "out", "source": "V1", "fStart": 1, "fStop": 1e6, "points": 100, "sweepType": "dec"},
+            {
+                "output_node": "out",
+                "source": "V1",
+                "fStart": 1,
+                "fStop": 1e6,
+                "points": 100,
+                "sweepType": "dec",
+            },
         )
         assert cmd.startswith(".noise v(out) V1")
 

--- a/app/tests/unit/test_theme_controller.py
+++ b/app/tests/unit/test_theme_controller.py
@@ -70,14 +70,14 @@ class TestControllerNoGuiImport:
     def test_no_gui_runtime_import(self):
         import controllers.theme_controller as tc
 
-        source = Path(tc.__file__).read_text()
+        source = Path(tc.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
 
     def test_gui_import_only_in_type_checking(self):
         """Any GUI.styles import must be inside TYPE_CHECKING block."""
         import controllers.theme_controller as tc
 
-        source = Path(tc.__file__).read_text()
+        source = Path(tc.__file__).read_text(encoding="utf-8")
         tree = ast.parse(source)
         for node in ast.walk(tree):
             is_from_import = isinstance(node, ast.ImportFrom)
@@ -112,7 +112,7 @@ class TestNoDirectMutationInGui:
         """No GUI file outside styles/ should call theme_manager.set_*."""
         violations = []
         for path in self._gui_python_files():
-            source = path.read_text()
+            source = path.read_text(encoding="utf-8")
             for line_no, line in enumerate(source.splitlines(), 1):
                 # Skip comments
                 stripped = line.lstrip()

--- a/app/tests/unit/test_theme_controller.py
+++ b/app/tests/unit/test_theme_controller.py
@@ -1,0 +1,125 @@
+"""Tests for ThemeController wrapper methods and GUI mutation routing."""
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from controllers.theme_controller import ThemeController, theme_ctrl
+
+
+class TestThemeControllerWrappers:
+    """Verify ThemeController delegates all mutations to theme_manager."""
+
+    def setup_method(self):
+        self.ctrl = ThemeController()
+
+    @patch("controllers.theme_controller.theme_manager")
+    def test_set_theme(self, mock_tm):
+        theme = MagicMock()
+        self.ctrl.set_theme(theme)
+        mock_tm.set_theme.assert_called_once_with(theme)
+
+    @patch("controllers.theme_controller.theme_manager")
+    def test_set_theme_by_key(self, mock_tm):
+        self.ctrl.set_theme_by_key("dark")
+        mock_tm.set_theme_by_key.assert_called_once_with("dark")
+
+    @patch("controllers.theme_controller.theme_manager")
+    def test_set_symbol_style(self, mock_tm):
+        self.ctrl.set_symbol_style("iec")
+        mock_tm.set_symbol_style.assert_called_once_with("iec")
+
+    @patch("controllers.theme_controller.theme_manager")
+    def test_set_color_mode(self, mock_tm):
+        self.ctrl.set_color_mode("monochrome")
+        mock_tm.set_color_mode.assert_called_once_with("monochrome")
+
+    @patch("controllers.theme_controller.theme_manager")
+    def test_set_wire_thickness(self, mock_tm):
+        self.ctrl.set_wire_thickness("thick")
+        mock_tm.set_wire_thickness.assert_called_once_with("thick")
+
+    @patch("controllers.theme_controller.theme_manager")
+    def test_set_show_junction_dots(self, mock_tm):
+        self.ctrl.set_show_junction_dots(False)
+        mock_tm.set_show_junction_dots.assert_called_once_with(False)
+
+    @patch("controllers.theme_controller.theme_manager")
+    def test_set_routing_mode(self, mock_tm):
+        self.ctrl.set_routing_mode("diagonal")
+        mock_tm.set_routing_mode.assert_called_once_with("diagonal")
+
+    @patch("controllers.theme_controller.theme_manager")
+    def test_current_theme_property(self, mock_tm):
+        mock_tm.current_theme = MagicMock()
+        result = self.ctrl.current_theme
+        assert result is mock_tm.current_theme
+
+
+class TestModuleSingleton:
+    """Verify the module-level singleton is a ThemeController."""
+
+    def test_singleton_type(self):
+        assert isinstance(theme_ctrl, ThemeController)
+
+
+class TestControllerNoGuiImport:
+    """Verify theme_controller.py has no runtime GUI imports."""
+
+    def test_no_gui_runtime_import(self):
+        import controllers.theme_controller as tc
+
+        source = Path(tc.__file__).read_text()
+        assert "PyQt" not in source
+
+    def test_gui_import_only_in_type_checking(self):
+        """Any GUI.styles import must be inside TYPE_CHECKING block."""
+        import controllers.theme_controller as tc
+
+        source = Path(tc.__file__).read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            is_from_import = isinstance(node, ast.ImportFrom)
+            if is_from_import and node.module and "GUI" in node.module:
+                # Must be inside TYPE_CHECKING, not at module top level
+                msg = f"GUI import '{node.module}' at line {node.lineno} is top-level"
+                assert node.col_offset > 0, msg
+
+
+class TestNoDirectMutationInGui:
+    """Verify GUI files do not call theme_manager.set_* directly."""
+
+    _MUTATION_METHODS = (
+        "set_theme(",
+        "set_theme_by_key(",
+        "set_symbol_style(",
+        "set_color_mode(",
+        "set_wire_thickness(",
+        "set_show_junction_dots(",
+        "set_routing_mode(",
+    )
+
+    def _gui_python_files(self):
+        gui_dir = Path(__file__).resolve().parent.parent.parent / "GUI"
+        files = []
+        for p in gui_dir.rglob("*.py"):
+            if "__pycache__" not in str(p) and "styles" not in p.parts:
+                files.append(p)
+        return files
+
+    def test_no_theme_manager_set_calls(self):
+        """No GUI file outside styles/ should call theme_manager.set_*."""
+        violations = []
+        for path in self._gui_python_files():
+            source = path.read_text()
+            for line_no, line in enumerate(source.splitlines(), 1):
+                # Skip comments
+                stripped = line.lstrip()
+                if stripped.startswith("#"):
+                    continue
+                for method in self._MUTATION_METHODS:
+                    if f"theme_manager.{method}" in line:
+                        violations.append(f"{path.name}:{line_no}: {line.strip()}")
+        msg = "Use theme_ctrl, not theme_manager.set_*:\n" + "\n".join(violations)
+        assert violations == [], msg


### PR DESCRIPTION
## Summary - Fix ThemeController to not import from GUI layer at runtime (use  guard for ) - Add 6 wrapper methods to ThemeController: , , , , ,  - Route all 11 direct  calls in the GUI layer through  instead - Add structural test enforcing no direct  calls in GUI files ## Test plan - [x] New  verifies all 7 mutation methods delegate to theme_manager - [x]  verifies no runtime GUI imports in theme_controller.py - [x]  scans GUI files for prohibited direct mutation calls - [ ] CI passes on all platforms Closes #632 🤖 Generated with [Claude Code](https://claude.com/claude-code)