### PR TITLE
Extract .meas directive building from GUI to simulation/ (#639)

### DIFF
--- a/app/GUI/analysis_dialog.py
+++ b/app/GUI/analysis_dialog.py
@@ -11,9 +11,10 @@ from PyQt6.QtWidgets import (
     QPushButton,
     QVBoxLayout,
 )
+from simulation.measurement_builder import ANALYSIS_DOMAIN_MAP
 
 from .format_utils import parse_value
-from .meas_dialog import ANALYSIS_DOMAIN_MAP, MeasurementDialog
+from .meas_dialog import MeasurementDialog
 from .validation_helpers import clear_field_error, set_field_error
 
 # Analysis types that support .meas directives

--- a/app/GUI/meas_dialog.py
+++ b/app/GUI/meas_dialog.py
@@ -23,80 +23,12 @@ from PyQt6.QtWidgets import (
     QTableWidgetItem,
     QVBoxLayout,
 )
+from simulation.measurement_builder import ANALYSIS_DOMAIN_MAP, MEAS_TYPES, build_directive
+
+# Re-export so existing imports from GUI.meas_dialog keep working.
+__all__ = ["ANALYSIS_DOMAIN_MAP", "MEAS_TYPES", "build_directive"]
 
 from .validation_helpers import clear_field_error, set_field_error
-
-# Maps the GUI analysis type name to the .meas domain keyword
-ANALYSIS_DOMAIN_MAP = {
-    "Transient": "tran",
-    "AC Sweep": "ac",
-    "DC Sweep": "dc",
-}
-
-# Measurement types offered in the GUI
-MEAS_TYPES = [
-    ("AVG", "Average value over a range"),
-    ("RMS", "Root-mean-square over a range"),
-    ("MIN", "Minimum value over a range"),
-    ("MAX", "Maximum value over a range"),
-    ("PP", "Peak-to-peak (max minus min)"),
-    ("INTEG", "Integral over a range"),
-    ("FIND_AT", "Find value at a specific point"),
-    ("FIND_WHEN", "Find value when a condition is met"),
-    ("TRIG_TARG", "Timing between trigger and target events"),
-]
-
-
-def build_directive(domain, name, meas_type, params):
-    """Build a .meas directive string from structured parameters.
-
-    Args:
-        domain: "tran", "ac", or "dc"
-        name: measurement name (e.g., "rise_time")
-        meas_type: one of the MEAS_TYPES keys
-        params: dict with type-specific fields
-
-    Returns:
-        str: a complete .meas directive
-    """
-    variable = params.get("variable", "v(out)")
-
-    if meas_type in ("AVG", "RMS", "MIN", "MAX", "PP", "INTEG"):
-        directive = f".meas {domain} {name} {meas_type} {variable}"
-        from_val = params.get("from_val", "").strip()
-        to_val = params.get("to_val", "").strip()
-        if from_val:
-            directive += f" FROM={from_val}"
-        if to_val:
-            directive += f" TO={to_val}"
-        return directive
-
-    if meas_type == "FIND_AT":
-        at_val = params.get("at_val", "0")
-        return f".meas {domain} {name} FIND {variable} AT={at_val}"
-
-    if meas_type == "FIND_WHEN":
-        when_var = params.get("when_var", "v(in)")
-        when_val = params.get("when_val", "0.5")
-        cross = params.get("cross", "")
-        directive = f".meas {domain} {name} FIND {variable} WHEN {when_var}={when_val}"
-        if cross:
-            directive += f" {cross}"
-        return directive
-
-    if meas_type == "TRIG_TARG":
-        trig_var = params.get("trig_var", "v(in)")
-        trig_val = params.get("trig_val", "0.5")
-        trig_edge = params.get("trig_edge", "RISE=1")
-        targ_var = params.get("targ_var", variable)
-        targ_val = params.get("targ_val", "0.5")
-        targ_edge = params.get("targ_edge", "RISE=1")
-        return (
-            f".meas {domain} {name} TRIG {trig_var} VAL={trig_val} {trig_edge} "
-            f"TARG {targ_var} VAL={targ_val} {targ_edge}"
-        )
-
-    return f".meas {domain} {name} {meas_type} {variable}"
 
 
 class MeasurementEntryDialog(QDialog):

--- a/app/simulation/measurement_builder.py
+++ b/app/simulation/measurement_builder.py
@@ -2,7 +2,7 @@
 Pure-logic builder for ngspice .meas directives.
 
 Extracted from GUI/meas_dialog.py so that measurement directive
-generation can be tested and reused without importing PyQt6.
+generation can be tested and reused without any GUI framework dependency.
 """
 
 # Maps the GUI analysis type name to the .meas domain keyword

--- a/app/simulation/measurement_builder.py
+++ b/app/simulation/measurement_builder.py
@@ -1,0 +1,78 @@
+"""
+Pure-logic builder for ngspice .meas directives.
+
+Extracted from GUI/meas_dialog.py so that measurement directive
+generation can be tested and reused without importing PyQt6.
+"""
+
+# Maps the GUI analysis type name to the .meas domain keyword
+ANALYSIS_DOMAIN_MAP = {
+    "Transient": "tran",
+    "AC Sweep": "ac",
+    "DC Sweep": "dc",
+}
+
+# Measurement types offered in the GUI
+MEAS_TYPES = [
+    ("AVG", "Average value over a range"),
+    ("RMS", "Root-mean-square over a range"),
+    ("MIN", "Minimum value over a range"),
+    ("MAX", "Maximum value over a range"),
+    ("PP", "Peak-to-peak (max minus min)"),
+    ("INTEG", "Integral over a range"),
+    ("FIND_AT", "Find value at a specific point"),
+    ("FIND_WHEN", "Find value when a condition is met"),
+    ("TRIG_TARG", "Timing between trigger and target events"),
+]
+
+
+def build_directive(domain, name, meas_type, params):
+    """Build a .meas directive string from structured parameters.
+
+    Args:
+        domain: "tran", "ac", or "dc"
+        name: measurement name (e.g., "rise_time")
+        meas_type: one of the MEAS_TYPES keys
+        params: dict with type-specific fields
+
+    Returns:
+        str: a complete .meas directive
+    """
+    variable = params.get("variable", "v(out)")
+
+    if meas_type in ("AVG", "RMS", "MIN", "MAX", "PP", "INTEG"):
+        directive = f".meas {domain} {name} {meas_type} {variable}"
+        from_val = params.get("from_val", "").strip()
+        to_val = params.get("to_val", "").strip()
+        if from_val:
+            directive += f" FROM={from_val}"
+        if to_val:
+            directive += f" TO={to_val}"
+        return directive
+
+    if meas_type == "FIND_AT":
+        at_val = params.get("at_val", "0")
+        return f".meas {domain} {name} FIND {variable} AT={at_val}"
+
+    if meas_type == "FIND_WHEN":
+        when_var = params.get("when_var", "v(in)")
+        when_val = params.get("when_val", "0.5")
+        cross = params.get("cross", "")
+        directive = f".meas {domain} {name} FIND {variable} WHEN {when_var}={when_val}"
+        if cross:
+            directive += f" {cross}"
+        return directive
+
+    if meas_type == "TRIG_TARG":
+        trig_var = params.get("trig_var", "v(in)")
+        trig_val = params.get("trig_val", "0.5")
+        trig_edge = params.get("trig_edge", "RISE=1")
+        targ_var = params.get("targ_var", variable)
+        targ_val = params.get("targ_val", "0.5")
+        targ_edge = params.get("targ_edge", "RISE=1")
+        return (
+            f".meas {domain} {name} TRIG {trig_var} VAL={trig_val} {trig_edge} "
+            f"TARG {targ_var} VAL={targ_val} {targ_edge}"
+        )
+
+    return f".meas {domain} {name} {meas_type} {variable}"

--- a/app/tests/unit/test_meas_dialog.py
+++ b/app/tests/unit/test_meas_dialog.py
@@ -1,7 +1,8 @@
 """Tests for the .meas directive GUI builder (meas_dialog.py)."""
 
 import pytest
-from GUI.meas_dialog import ANALYSIS_DOMAIN_MAP, MeasurementDialog, MeasurementEntryDialog, build_directive
+from GUI.meas_dialog import MeasurementDialog, MeasurementEntryDialog
+from simulation.measurement_builder import ANALYSIS_DOMAIN_MAP, build_directive
 
 # ---------------------------------------------------------------------------
 # build_directive unit tests
@@ -297,6 +298,36 @@ class TestAnalysisDialogMeasIntegration:
         params = dialog.get_parameters()
         assert params is not None
         assert "measurements" not in params
+
+
+# ---------------------------------------------------------------------------
+# Canonical location structural tests
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalLocation:
+    """Verify measurement_builder lives in simulation/ with no Qt deps."""
+
+    def test_module_in_simulation(self):
+        import simulation.measurement_builder as mb
+
+        assert "simulation" in mb.__file__
+
+    def test_no_qt_imports(self):
+        from pathlib import Path
+
+        import simulation.measurement_builder as mb
+
+        source = Path(mb.__file__).read_text(encoding="utf-8")
+        assert "PyQt" not in source
+
+    def test_backward_compat_reexport(self):
+        """GUI.meas_dialog still re-exports build_directive and constants."""
+        from GUI.meas_dialog import ANALYSIS_DOMAIN_MAP, MEAS_TYPES, build_directive
+
+        assert callable(build_directive)
+        assert isinstance(ANALYSIS_DOMAIN_MAP, dict)
+        assert isinstance(MEAS_TYPES, list)
 
     def test_meas_label_updates(self, qtbot):
         from GUI.analysis_dialog import AnalysisDialog


### PR DESCRIPTION
## Summary - Extracted , , and  from  to new  so directive generation has no PyQt6 dependency -  re-exports all symbols via  for backward compatibility -  imports  from canonical location - Added structural tests verifying the module lives in , has no Qt imports, and that the re-export shim works Closes #639 ## Test plan - [ ] Existing  unit tests pass (now importing from canonical location) - [ ]  structural tests verify no Qt deps and correct module path - [ ]  and  qtbot tests still pass - [ ]  tests still pass - [ ] Backward-compatible re-export verified by  🤖 Generated with [Claude Code](https://claude.com/claude-code)