### PR TITLE
Extract ResultsPanel widget implementing ResultsDisplayProtocol (#654)

### DIFF
--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -29,7 +29,6 @@ from PyQt6.QtWidgets import (
     QSplitter,
     QStackedWidget,
     QTabWidget,
-    QTextEdit,
     QVBoxLayout,
     QWidget,
 )
@@ -47,6 +46,7 @@ from .main_window_settings import SettingsMixin
 from .main_window_simulation import SimulationMixin
 from .main_window_view import ViewOperationsMixin
 from .properties_panel import PropertiesPanel
+from .results_panel import ResultsPanel
 from .styles import DEFAULT_SPLITTER_SIZES, DEFAULT_WINDOW_SIZE, theme_manager
 
 logger = logging.getLogger(__name__)
@@ -124,6 +124,8 @@ class MainWindow(
         self.palette.componentDoubleClicked.connect(self.canvas.add_component_at_center)
         self.properties_panel.property_changed.connect(self.on_property_changed)
         self.circuit_ctrl.add_observer(self._on_dirty_change)
+        # Wire results panel display delegate to SimulationMixin handler.
+        self.results_panel._display_delegate = self._display_simulation_results
 
     def init_ui(self):
         """Initialize user interface"""
@@ -187,29 +189,17 @@ class MainWindow(
         # Results / Netlist tabbed panel
         self.results_tabs = QTabWidget()
 
-        # Tab 1: Simulation Results
-        results_widget = QWidget()
-        results_layout = QVBoxLayout(results_widget)
-        results_header = QHBoxLayout()
-        results_header.addWidget(QLabel("Simulation Results"))
-        self.btn_export_csv = QPushButton("Export CSV")
-        self.btn_export_csv.setEnabled(False)
-        self.btn_export_csv.clicked.connect(self.export_results_csv)
-        results_header.addWidget(self.btn_export_csv)
-        self.btn_export_excel = QPushButton("Export Excel")
-        self.btn_export_excel.setEnabled(False)
-        self.btn_export_excel.clicked.connect(self.export_results_excel)
-        results_header.addWidget(self.btn_export_excel)
-        self.btn_copy_markdown = QPushButton("Copy Markdown")
-        self.btn_copy_markdown.setEnabled(False)
-        self.btn_copy_markdown.clicked.connect(self.copy_results_markdown)
-        results_header.addWidget(self.btn_copy_markdown)
-        results_header.addStretch()
-        results_layout.addLayout(results_header)
-        self.results_text = QTextEdit()
-        self.results_text.setReadOnly(True)
-        results_layout.addWidget(self.results_text)
-        self.results_tabs.addTab(results_widget, "Results")
+        # Tab 1: Simulation Results (extracted into ResultsPanel)
+        self.results_panel = ResultsPanel(parent=self)
+        self.results_panel.btn_export_csv.clicked.connect(self.export_results_csv)
+        self.results_panel.btn_export_excel.clicked.connect(self.export_results_excel)
+        self.results_panel.btn_copy_markdown.clicked.connect(self.copy_results_markdown)
+        # Backward-compat aliases so existing SimulationMixin code works unchanged.
+        self.results_text = self.results_panel.results_text
+        self.btn_export_csv = self.results_panel.btn_export_csv
+        self.btn_export_excel = self.results_panel.btn_export_excel
+        self.btn_copy_markdown = self.results_panel.btn_copy_markdown
+        self.results_tabs.addTab(self.results_panel, "Results")
 
         # Tab 2: Netlist Preview
         from .netlist_preview import NetlistPreviewWidget
@@ -217,6 +207,8 @@ class MainWindow(
         self.netlist_preview = NetlistPreviewWidget()
         self.netlist_preview.refresh_btn.clicked.connect(self._refresh_netlist_preview)
         self.results_tabs.addTab(self.netlist_preview, "Netlist")
+        # Wire netlist preview into results panel for set_netlist_preview() delegation.
+        self.results_panel._netlist_preview_widget = self.netlist_preview
 
         center_splitter.addWidget(self.results_tabs)
         center_splitter.setSizes(DEFAULT_SPLITTER_SIZES)

--- a/app/GUI/main_window_simulation.py
+++ b/app/GUI/main_window_simulation.py
@@ -22,10 +22,8 @@ class SimulationMixin:
         try:
             # Phase 5: No sync needed - model always up to date
             netlist = self.simulation_ctrl.generate_netlist()
-            self.results_text.setPlainText("SPICE Netlist:\n\n" + netlist)
-            # Also update the netlist preview tab
-            if hasattr(self, "netlist_preview"):
-                self.netlist_preview.set_netlist(netlist)
+            self.results_panel.display_text("SPICE Netlist:\n\n" + netlist)
+            self.results_panel.set_netlist_preview(netlist)
         except (ValueError, KeyError, TypeError) as e:
             QMessageBox.critical(self, "Error", f"Failed to generate netlist: {e}")
 
@@ -70,8 +68,8 @@ class SimulationMixin:
                 # Phase 5: No sync needed - model always up to date
                 result = self.simulation_ctrl.run_simulation()
 
-            # Display results (view responsibility)
-            self._display_simulation_results(result)
+            # Display results via ResultsPanel (delegates to _display_simulation_results).
+            self.results_panel.display_simulation_result(result)
 
         except (OSError, ValueError, KeyError, TypeError, RuntimeError) as e:
             logger.error("Simulation failed: %s", e, exc_info=True)

--- a/app/GUI/results_panel.py
+++ b/app/GUI/results_panel.py
@@ -1,0 +1,81 @@
+"""Standalone simulation results display widget (ResultsDisplayProtocol)."""
+
+from __future__ import annotations
+
+from PyQt6.QtWidgets import QHBoxLayout, QLabel, QPushButton, QTextEdit, QVBoxLayout, QWidget
+
+
+class ResultsPanel(QWidget):
+    """Widget that owns the simulation results UI and implements ResultsDisplayProtocol.
+
+    The panel holds the results text area and export buttons that were previously
+    inlined inside MainWindow.init_ui().  MainWindow wires up the export callbacks
+    and the _display_delegate so that display_simulation_result() can delegate to
+    the SimulationMixin handler while still satisfying the protocol contract.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        # Set by MainWindow after construction to wire up the complex display handler.
+        self._display_delegate = None
+        # Set by MainWindow after the NetlistPreviewWidget is created.
+        self._netlist_preview_widget = None
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        # Header row with export buttons
+        header = QHBoxLayout()
+        header.addWidget(QLabel("Simulation Results"))
+
+        self.btn_export_csv = QPushButton("Export CSV")
+        self.btn_export_csv.setEnabled(False)
+        header.addWidget(self.btn_export_csv)
+
+        self.btn_export_excel = QPushButton("Export Excel")
+        self.btn_export_excel.setEnabled(False)
+        header.addWidget(self.btn_export_excel)
+
+        self.btn_copy_markdown = QPushButton("Copy Markdown")
+        self.btn_copy_markdown.setEnabled(False)
+        header.addWidget(self.btn_copy_markdown)
+
+        header.addStretch()
+        layout.addLayout(header)
+
+        # Read-only results text area
+        self.results_text = QTextEdit()
+        self.results_text.setReadOnly(True)
+        layout.addWidget(self.results_text)
+
+    # --- ResultsDisplayProtocol ---
+
+    def display_simulation_result(self, result) -> None:
+        """Display a complete simulation result (ResultsDisplayProtocol).
+
+        Delegates to the SimulationMixin handler registered via _display_delegate
+        so that all analysis-type-specific logic stays in the mixin.
+        """
+        if self._display_delegate is not None:
+            self._display_delegate(result)
+
+    def display_text(self, text: str) -> None:
+        """Display plain text in the results area (ResultsDisplayProtocol)."""
+        self.results_text.setPlainText(text)
+
+    def set_netlist_preview(self, netlist: str) -> None:
+        """Update the netlist preview tab (ResultsDisplayProtocol)."""
+        if self._netlist_preview_widget is not None:
+            self._netlist_preview_widget.set_netlist(netlist)
+
+    def clear(self) -> None:
+        """Clear all displayed results (ResultsDisplayProtocol)."""
+        self.results_text.clear()
+
+    def set_export_enabled(self, enabled: bool) -> None:
+        """Enable or disable all export buttons (ResultsDisplayProtocol)."""
+        self.btn_export_csv.setEnabled(enabled)
+        self.btn_export_excel.setEnabled(enabled)
+        self.btn_copy_markdown.setEnabled(enabled)


### PR DESCRIPTION
## Summary - New :  owns the results text area and export buttons, implementing all 5  methods - : replaces inline results widget with ; backward-compat aliases (, ) preserve existing code - : delegates to  and  - : delegates to  which calls  via stored delegate ## Test plan - [ ] All existing tests pass: , , and all simulation methods remain on SimulationMixin - [ ] Backward-compat aliases ensure no breakage of existing references 🤖 Generated with [Claude Code](https://claude.com/claude-code)