### PR TITLE
Create QtDialogProvider implementing DialogProvider protocol (#655)

### DIFF
--- a/app/GUI/dialog_provider.py
+++ b/app/GUI/dialog_provider.py
@@ -1,0 +1,115 @@
+"""Qt implementations of DialogProvider and ProgressHandle protocols."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+from PyQt6.QtCore import QObject
+from PyQt6.QtWidgets import QFileDialog, QMessageBox, QProgressDialog
+
+
+class QtProgressHandle(QObject):
+    """Adapter wrapping QProgressDialog to satisfy the ProgressHandle protocol."""
+
+    def __init__(self, dialog: QProgressDialog) -> None:
+        super().__init__()
+        self._dialog = dialog
+        self._dialog.show()
+
+    def update(self, value: int, message: str = "") -> bool:
+        """Advance the progress bar.  Returns False if the user cancelled."""
+        if message:
+            self._dialog.setLabelText(message)
+        self._dialog.setValue(value)
+        # Process events so the dialog paints and cancel button responds.
+        from PyQt6.QtWidgets import QApplication
+
+        QApplication.processEvents()
+        return not self._dialog.wasCanceled()
+
+    def close(self) -> None:
+        """Close the progress dialog."""
+        self._dialog.close()
+
+
+class QtDialogProvider(QObject):
+    """Qt implementation of DialogProvider using standard Qt dialog classes."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._parent = parent
+
+    # --- File dialogs ---
+
+    def ask_save_file(self, title: str, filters: str, default_name: str = "") -> Optional[Path]:
+        """Show a save-file dialog.  Returns chosen path or None."""
+        filename, _ = QFileDialog.getSaveFileName(self._parent, title, default_name, filters)
+        return Path(filename) if filename else None
+
+    def ask_open_file(self, title: str, filters: str) -> Optional[Path]:
+        """Show an open-file dialog.  Returns chosen path or None."""
+        filename, _ = QFileDialog.getOpenFileName(self._parent, title, "", filters)
+        return Path(filename) if filename else None
+
+    # --- Confirmation / message dialogs ---
+
+    def confirm(self, title: str, message: str) -> bool:
+        """Show a yes/no confirmation.  Returns True for Yes."""
+        reply = QMessageBox.question(
+            self._parent,
+            title,
+            message,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+        return reply == QMessageBox.StandardButton.Yes
+
+    def show_error(self, title: str, message: str) -> None:
+        """Show an error message dialog."""
+        QMessageBox.critical(self._parent, title, message)
+
+    def show_warning(self, title: str, message: str) -> None:
+        """Show a warning message dialog."""
+        QMessageBox.warning(self._parent, title, message)
+
+    def show_info(self, title: str, message: str) -> None:
+        """Show an informational message dialog."""
+        QMessageBox.information(self._parent, title, message)
+
+    # --- Analysis configuration ---
+
+    def ask_analysis_params(self, analysis_type: str, current_params: dict) -> Optional[dict]:
+        """Show the analysis-parameter dialog.  Returns params dict or None."""
+        from .analysis_dialog import AnalysisDialog
+
+        dialog = AnalysisDialog(analysis_type=analysis_type, parent=self._parent)
+        if dialog.exec() == AnalysisDialog.DialogCode.Accepted:
+            return dialog.get_parameters()
+        return None
+
+    def ask_parameter_sweep_config(self, components: dict[str, Any]) -> Optional[dict]:
+        """Show the parameter-sweep configuration dialog.  Returns config or None."""
+        from .parameter_sweep_dialog import ParameterSweepDialog
+
+        dialog = ParameterSweepDialog(components=components, parent=self._parent)
+        if dialog.exec() == ParameterSweepDialog.DialogCode.Accepted:
+            return dialog.get_parameters()
+        return None
+
+    def ask_monte_carlo_config(self, components: dict[str, Any]) -> Optional[dict]:
+        """Show the Monte Carlo configuration dialog.  Returns config or None."""
+        from .monte_carlo_dialog import MonteCarloDialog
+
+        dialog = MonteCarloDialog(components=components, parent=self._parent)
+        if dialog.exec() == MonteCarloDialog.DialogCode.Accepted:
+            return dialog.get_parameters()
+        return None
+
+    # --- Progress ---
+
+    def create_progress(self, title: str, message: str, maximum: int) -> QtProgressHandle:
+        """Create a cancellable progress dialog.  Returns a QtProgressHandle."""
+        dialog = QProgressDialog(message, "Cancel", 0, maximum, self._parent)
+        dialog.setWindowTitle(title)
+        dialog.setMinimumDuration(0)
+        return QtProgressHandle(dialog)

--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -37,6 +37,7 @@ from PyQt6.QtWidgets import (
 from .circuit_canvas import CircuitCanvasView
 from .circuit_statistics_panel import CircuitStatisticsPanel
 from .component_palette import ComponentPalette
+from .dialog_provider import QtDialogProvider
 from .grading_panel import GradingPanel
 from .main_window_analysis import AnalysisSettingsMixin
 from .main_window_file_ops import FileOperationsMixin
@@ -96,6 +97,7 @@ class MainWindow(
         # Build UI
         self.init_ui()
         self.create_menu_bar()
+        self.dialogs = QtDialogProvider(self)
 
         # Wire up connections
         self._connect_signals()

--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -22,13 +22,7 @@ class FileOperationsMixin:
     def _on_new(self):
         """Create a new circuit"""
         if len(self.canvas.components) > 0:
-            reply = QMessageBox.question(
-                self,
-                "New Circuit",
-                "Current circuit will be lost. Continue?",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-            )
-            if reply == QMessageBox.StandardButton.No:
+            if not self.dialogs.confirm("New Circuit", "Current circuit will be lost. Continue?"):
                 return
 
         self.file_ctrl.new_circuit()
@@ -175,30 +169,30 @@ class FileOperationsMixin:
 
     def _on_save_as(self):
         """Save circuit to a new file"""
-        filename, _ = QFileDialog.getSaveFileName(self, "Save Circuit", "", "JSON Files (*.json);;All Files (*)")
-        if filename:
+        path = self.dialogs.ask_save_file("Save Circuit", "JSON Files (*.json);;All Files (*)")
+        if path:
             try:
                 # Phase 5: No sync needed - model always up to date
-                self.file_ctrl.save_circuit(filename)
+                self.file_ctrl.save_circuit(path)
                 self.file_ctrl.clear_auto_save()
                 self._set_dirty(False)
-                QMessageBox.information(self, "Success", "Circuit saved successfully!")
+                self.dialogs.show_info("Success", "Circuit saved successfully!")
             except (OSError, TypeError) as e:
-                QMessageBox.critical(self, "Error", f"Failed to save: {e}")
+                self.dialogs.show_error("Error", f"Failed to save: {e}")
 
     def _on_load(self):
         """Load circuit from file"""
-        filename, _ = QFileDialog.getOpenFileName(self, "Load Circuit", "", "JSON Files (*.json);;All Files (*)")
-        if filename:
+        path = self.dialogs.ask_open_file("Load Circuit", "JSON Files (*.json);;All Files (*)")
+        if path:
             try:
-                self.file_ctrl.load_circuit(filename)
+                self.file_ctrl.load_circuit(path)
                 # Phase 5: No sync needed - observer pattern rebuilds canvas
-                self.setWindowTitle(f"Circuit Design GUI - {filename}")
+                self.setWindowTitle(f"Circuit Design GUI - {path}")
                 self._sync_analysis_menu()
                 self._apply_default_zoom()
-                QMessageBox.information(self, "Success", "Circuit loaded successfully!")
+                self.dialogs.show_info("Success", "Circuit loaded successfully!")
             except (OSError, ValueError) as e:
-                QMessageBox.critical(self, "Error", f"Failed to load: {e}")
+                self.dialogs.show_error("Error", f"Failed to load: {e}")
 
     def _on_new_from_template(self):
         """Create a new circuit from an assignment template"""


### PR DESCRIPTION
## Summary - New :  wraps , , and ;  adapts  to satisfy the  protocol - : instantiates  - : uses  instead of inline  - : uses  instead of inline / - : uses  instead of inline / ## Test plan - [ ] All existing tests pass:  still uses  directly (source-inspecting tests preserved) - [ ] New  is importable and protocol-compliant 🤖 Generated with [Claude Code](https://claude.com/claude-code)