### PR TITLE
Extract parameter validation and transformation from dialogs (#640)

### DIFF
--- a/app/GUI/analysis_dialog.py
+++ b/app/GUI/analysis_dialog.py
@@ -12,7 +12,7 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
 )
 
-from .format_utils import parse_value
+from .analysis_field_helpers import parse_field_widgets
 from .meas_dialog import ANALYSIS_DOMAIN_MAP, MeasurementDialog
 
 # Analysis types that support .meas directives
@@ -290,18 +290,9 @@ class AnalysisDialog(QDialog):
 
     def get_parameters(self):
         """Get parameters from dialog with validation"""
-        params = {"analysis_type": self.analysis_type}
-
         try:
-            for key, (widget, field_type) in self.field_widgets.items():
-                if field_type == "combo":
-                    params[key] = widget.currentText()
-                elif field_type == "float":
-                    params[key] = parse_value(widget.text())
-                elif field_type == "int":
-                    params[key] = int(parse_value(widget.text()))
-                else:  # text
-                    params[key] = widget.text()
+            params = parse_field_widgets(self.field_widgets)
+            params["analysis_type"] = self.analysis_type
 
             # Include measurement directives if any are configured
             if self._measurements:
@@ -309,7 +300,7 @@ class AnalysisDialog(QDialog):
 
             return params
 
-        except ValueError:
+        except (ValueError, TypeError):
             return None
 
     def get_ngspice_command(self):

--- a/app/GUI/analysis_field_helpers.py
+++ b/app/GUI/analysis_field_helpers.py
@@ -1,0 +1,87 @@
+"""Shared helpers for building and parsing analysis parameter form fields.
+
+Both the Monte Carlo dialog, Parameter Sweep dialog, and Analysis dialog
+share the same pattern for building form fields from ``ANALYSIS_CONFIGS``
+and parsing/validating the resulting widget values.  This module
+consolidates that logic so it lives in exactly one place.
+
+No simulation dependencies — only PyQt6 and format_utils.
+"""
+
+from PyQt6.QtWidgets import QComboBox, QFormLayout, QLineEdit
+
+from .format_utils import parse_value
+
+
+def build_analysis_fields(
+    form_layout: QFormLayout,
+    analysis_type: str,
+    field_widgets: dict,
+) -> None:
+    """Populate *form_layout* with widgets for *analysis_type*.
+
+    Clears the existing layout first, then creates one widget per field
+    defined in ``AnalysisDialog.ANALYSIS_CONFIGS[analysis_type]``.
+
+    Args:
+        form_layout: The QFormLayout to populate.
+        analysis_type: Key into ``AnalysisDialog.ANALYSIS_CONFIGS``.
+        field_widgets: Mutable dict that will be **cleared** and filled
+            with ``{key: (widget, field_type)}`` entries.
+    """
+    # Clear existing widgets
+    while form_layout.count():
+        item = form_layout.takeAt(0)
+        if item.widget():
+            item.widget().deleteLater()
+    field_widgets.clear()
+
+    from .analysis_dialog import AnalysisDialog
+
+    config = AnalysisDialog.ANALYSIS_CONFIGS.get(analysis_type, {})
+
+    tooltips = config.get("tooltips", {})
+    for field_config in config.get("fields", []):
+        if field_config[2] == "combo":
+            label, key, _, options, default = field_config
+            widget = QComboBox()
+            widget.addItems(options)
+            widget.setCurrentText(default)
+        else:
+            label, key, field_type, default = field_config
+            widget = QLineEdit(str(default))
+
+        tooltip = tooltips.get(key)
+        if tooltip:
+            widget.setToolTip(tooltip)
+
+        field_widgets[key] = (widget, field_config[2])
+        form_layout.addRow(f"{label}:", widget)
+
+
+def parse_field_widgets(field_widgets: dict) -> dict:
+    """Read values from *field_widgets* and return a parsed params dict.
+
+    Args:
+        field_widgets: ``{key: (QWidget, field_type)}`` where
+            *field_type* is ``"combo"``, ``"float"``, ``"int"``, or
+            ``"text"``.
+
+    Returns:
+        Dict of ``{key: parsed_value}``.
+
+    Raises:
+        ValueError, TypeError: If a numeric field contains an
+            unparseable value.
+    """
+    params: dict = {}
+    for key, (widget, field_type) in field_widgets.items():
+        if field_type == "combo":
+            params[key] = widget.currentText()
+        elif field_type == "float":
+            params[key] = parse_value(widget.text())
+        elif field_type == "int":
+            params[key] = int(parse_value(widget.text()))
+        else:
+            params[key] = widget.text()
+    return params

--- a/app/GUI/monte_carlo_dialog.py
+++ b/app/GUI/monte_carlo_dialog.py
@@ -15,12 +15,13 @@ from PyQt6.QtWidgets import (
     QGroupBox,
     QHeaderView,
     QLabel,
-    QLineEdit,
     QSpinBox,
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
 )
+
+from .analysis_field_helpers import build_analysis_fields, parse_field_widgets
 
 # Base analysis types available for Monte Carlo
 MC_BASE_ANALYSIS_TYPES = [
@@ -78,7 +79,7 @@ class MonteCarloDialog(QDialog):
         layout.addWidget(run_group)
 
         # Build initial base analysis fields
-        self._build_base_form()
+        self._rebuild_base_fields()
 
         # --- Tolerance Table ---
         tol_group = QGroupBox("Component Tolerances")
@@ -135,38 +136,15 @@ class MonteCarloDialog(QDialog):
         layout.addWidget(buttons)
 
     def _on_analysis_changed(self, analysis_type):
-        self._build_base_form()
+        self._rebuild_base_fields()
 
-    def _build_base_form(self):
+    def _rebuild_base_fields(self):
         """Build form fields for the selected base analysis type."""
-        while self._base_form.count():
-            item = self._base_form.takeAt(0)
-            if item.widget():
-                item.widget().deleteLater()
-        self._base_field_widgets.clear()
-
-        from .analysis_dialog import AnalysisDialog
-
-        analysis_type = self.analysis_combo.currentText()
-        config = AnalysisDialog.ANALYSIS_CONFIGS.get(analysis_type, {})
-
-        tooltips = config.get("tooltips", {})
-        for field_config in config.get("fields", []):
-            if field_config[2] == "combo":
-                label, key, _, options, default = field_config
-                widget = QComboBox()
-                widget.addItems(options)
-                widget.setCurrentText(default)
-            else:
-                label, key, field_type, default = field_config
-                widget = QLineEdit(str(default))
-
-            tooltip = tooltips.get(key)
-            if tooltip:
-                widget.setToolTip(tooltip)
-
-            self._base_field_widgets[key] = (widget, field_config[2])
-            self._base_form.addRow(f"{label}:", widget)
+        build_analysis_fields(
+            self._base_form,
+            self.analysis_combo.currentText(),
+            self._base_field_widgets,
+        )
 
     def get_parameters(self):
         """Get all Monte Carlo parameters.
@@ -176,23 +154,13 @@ class MonteCarloDialog(QDialog):
                             tolerances
             or None if validation fails.
         """
-        from .format_utils import parse_value
-
         try:
             num_runs = self.num_runs_spin.value()
             base_analysis_type = self.analysis_combo.currentText()
 
-            # Parse base analysis params
-            base_params = {"analysis_type": base_analysis_type}
-            for key, (widget, field_type) in self._base_field_widgets.items():
-                if field_type == "combo":
-                    base_params[key] = widget.currentText()
-                elif field_type == "float":
-                    base_params[key] = parse_value(widget.text())
-                elif field_type == "int":
-                    base_params[key] = int(parse_value(widget.text()))
-                else:
-                    base_params[key] = widget.text()
+            # Parse base analysis params via shared helper
+            base_params = parse_field_widgets(self._base_field_widgets)
+            base_params["analysis_type"] = base_analysis_type
 
             # Build tolerances from table
             tolerances = {}

--- a/app/GUI/parameter_sweep_dialog.py
+++ b/app/GUI/parameter_sweep_dialog.py
@@ -15,6 +15,7 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
 )
 
+from .analysis_field_helpers import build_analysis_fields, parse_field_widgets
 from .format_utils import format_value, parse_value
 
 # Component types whose primary value can be swept
@@ -116,7 +117,7 @@ class ParameterSweepDialog(QDialog):
         layout.addWidget(analysis_group)
 
         # Build initial base analysis form
-        self._build_base_form()
+        self._rebuild_base_fields()
 
         # --- Buttons ---
         buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
@@ -144,39 +145,15 @@ class ParameterSweepDialog(QDialog):
                 pass
 
     def _on_analysis_changed(self, analysis_type):
-        self._build_base_form()
+        self._rebuild_base_fields()
 
-    def _build_base_form(self):
+    def _rebuild_base_fields(self):
         """Build form fields for the selected base analysis type."""
-        # Clear existing
-        while self._base_form.count():
-            item = self._base_form.takeAt(0)
-            if item.widget():
-                item.widget().deleteLater()
-        self._base_field_widgets.clear()
-
-        from .analysis_dialog import AnalysisDialog
-
-        analysis_type = self.analysis_combo.currentText()
-        config = AnalysisDialog.ANALYSIS_CONFIGS.get(analysis_type, {})
-
-        tooltips = config.get("tooltips", {})
-        for field_config in config.get("fields", []):
-            if field_config[2] == "combo":
-                label, key, _, options, default = field_config
-                widget = QComboBox()
-                widget.addItems(options)
-                widget.setCurrentText(default)
-            else:
-                label, key, field_type, default = field_config
-                widget = QLineEdit(str(default))
-
-            tooltip = tooltips.get(key)
-            if tooltip:
-                widget.setToolTip(tooltip)
-
-            self._base_field_widgets[key] = (widget, field_config[2])
-            self._base_form.addRow(f"{label}:", widget)
+        build_analysis_fields(
+            self._base_form,
+            self.analysis_combo.currentText(),
+            self._base_field_widgets,
+        )
 
     def get_parameters(self):
         """
@@ -201,17 +178,9 @@ class ParameterSweepDialog(QDialog):
 
             base_analysis_type = self.analysis_combo.currentText()
 
-            # Parse base analysis params
-            base_params = {"analysis_type": base_analysis_type}
-            for key, (widget, field_type) in self._base_field_widgets.items():
-                if field_type == "combo":
-                    base_params[key] = widget.currentText()
-                elif field_type == "float":
-                    base_params[key] = parse_value(widget.text())
-                elif field_type == "int":
-                    base_params[key] = int(parse_value(widget.text()))
-                else:
-                    base_params[key] = widget.text()
+            # Parse base analysis params via shared helper
+            base_params = parse_field_widgets(self._base_field_widgets)
+            base_params["analysis_type"] = base_analysis_type
 
             return {
                 "component_id": component_id,

--- a/app/tests/unit/test_analysis_field_helpers.py
+++ b/app/tests/unit/test_analysis_field_helpers.py
@@ -1,0 +1,212 @@
+"""Tests for GUI.analysis_field_helpers — shared build/parse functions."""
+
+import pytest
+from PyQt6.QtWidgets import QComboBox, QFormLayout, QLineEdit, QWidget
+
+# ---------------------------------------------------------------------------
+# build_analysis_fields
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAnalysisFields:
+    """Tests for build_analysis_fields()."""
+
+    def test_populates_transient_fields(self, qtbot):
+        parent = QWidget()
+        qtbot.addWidget(parent)
+        form = QFormLayout(parent)
+        widgets = {}
+
+        from GUI.analysis_field_helpers import build_analysis_fields
+
+        build_analysis_fields(form, "Transient", widgets)
+
+        assert "duration" in widgets
+        assert "step" in widgets
+        assert "startTime" in widgets
+        # Each entry is (widget, field_type)
+        assert widgets["duration"][1] == "float"
+        assert isinstance(widgets["duration"][0], QLineEdit)
+
+    def test_populates_ac_sweep_with_combo(self, qtbot):
+        parent = QWidget()
+        qtbot.addWidget(parent)
+        form = QFormLayout(parent)
+        widgets = {}
+
+        from GUI.analysis_field_helpers import build_analysis_fields
+
+        build_analysis_fields(form, "AC Sweep", widgets)
+
+        assert "sweepType" in widgets
+        w, ft = widgets["sweepType"]
+        assert ft == "combo"
+        assert isinstance(w, QComboBox)
+        assert w.currentText() == "dec"
+
+    def test_dc_op_has_no_fields(self, qtbot):
+        parent = QWidget()
+        qtbot.addWidget(parent)
+        form = QFormLayout(parent)
+        widgets = {}
+
+        from GUI.analysis_field_helpers import build_analysis_fields
+
+        build_analysis_fields(form, "DC Operating Point", widgets)
+
+        assert widgets == {}
+
+    def test_clears_previous_fields(self, qtbot):
+        parent = QWidget()
+        qtbot.addWidget(parent)
+        form = QFormLayout(parent)
+        widgets = {}
+
+        from GUI.analysis_field_helpers import build_analysis_fields
+
+        build_analysis_fields(form, "Transient", widgets)
+        assert len(widgets) == 3
+
+        build_analysis_fields(form, "DC Operating Point", widgets)
+        assert widgets == {}
+
+    def test_unknown_type_produces_empty(self, qtbot):
+        parent = QWidget()
+        qtbot.addWidget(parent)
+        form = QFormLayout(parent)
+        widgets = {}
+
+        from GUI.analysis_field_helpers import build_analysis_fields
+
+        build_analysis_fields(form, "NonexistentAnalysis", widgets)
+        assert widgets == {}
+
+    def test_tooltips_applied(self, qtbot):
+        parent = QWidget()
+        qtbot.addWidget(parent)
+        form = QFormLayout(parent)
+        widgets = {}
+
+        from GUI.analysis_field_helpers import build_analysis_fields
+
+        build_analysis_fields(form, "Transient", widgets)
+        # duration should have a tooltip
+        assert widgets["duration"][0].toolTip() != ""
+
+
+# ---------------------------------------------------------------------------
+# parse_field_widgets
+# ---------------------------------------------------------------------------
+
+
+class TestParseFieldWidgets:
+    """Tests for parse_field_widgets()."""
+
+    def test_parses_float_with_si_prefix(self, qtbot):
+        parent = QWidget()
+        qtbot.addWidget(parent)
+
+        w = QLineEdit("10k")
+        w.setParent(parent)
+        widgets = {"resistance": (w, "float")}
+
+        from GUI.analysis_field_helpers import parse_field_widgets
+
+        result = parse_field_widgets(widgets)
+        assert result["resistance"] == pytest.approx(10_000.0)
+
+    def test_parses_int(self, qtbot):
+        parent = QWidget()
+        qtbot.addWidget(parent)
+
+        w = QLineEdit("100")
+        w.setParent(parent)
+        widgets = {"points": (w, "int")}
+
+        from GUI.analysis_field_helpers import parse_field_widgets
+
+        result = parse_field_widgets(widgets)
+        assert result["points"] == 100
+        assert isinstance(result["points"], int)
+
+    def test_parses_combo(self, qtbot):
+        parent = QWidget()
+        qtbot.addWidget(parent)
+
+        w = QComboBox()
+        w.addItems(["dec", "oct", "lin"])
+        w.setCurrentText("oct")
+        w.setParent(parent)
+        widgets = {"sweepType": (w, "combo")}
+
+        from GUI.analysis_field_helpers import parse_field_widgets
+
+        result = parse_field_widgets(widgets)
+        assert result["sweepType"] == "oct"
+
+    def test_parses_text(self, qtbot):
+        parent = QWidget()
+        qtbot.addWidget(parent)
+
+        w = QLineEdit("V1")
+        w.setParent(parent)
+        widgets = {"source": (w, "text")}
+
+        from GUI.analysis_field_helpers import parse_field_widgets
+
+        result = parse_field_widgets(widgets)
+        assert result["source"] == "V1"
+
+    def test_raises_on_invalid_float(self, qtbot):
+        parent = QWidget()
+        qtbot.addWidget(parent)
+
+        w = QLineEdit("not_a_number")
+        w.setParent(parent)
+        widgets = {"bad": (w, "float")}
+
+        from GUI.analysis_field_helpers import parse_field_widgets
+
+        with pytest.raises(ValueError):
+            parse_field_widgets(widgets)
+
+    def test_parses_mixed_fields(self, qtbot):
+        """parse_field_widgets handles a realistic mix of field types."""
+        parent = QWidget()
+        qtbot.addWidget(parent)
+
+        duration = QLineEdit("10m")
+        duration.setParent(parent)
+        step = QLineEdit("1u")
+        step.setParent(parent)
+        points = QLineEdit("100")
+        points.setParent(parent)
+        sweep = QComboBox()
+        sweep.addItems(["dec", "oct", "lin"])
+        sweep.setParent(parent)
+        source = QLineEdit("V1")
+        source.setParent(parent)
+
+        widgets = {
+            "duration": (duration, "float"),
+            "step": (step, "float"),
+            "points": (points, "int"),
+            "sweepType": (sweep, "combo"),
+            "source": (source, "text"),
+        }
+
+        from GUI.analysis_field_helpers import parse_field_widgets
+
+        result = parse_field_widgets(widgets)
+
+        assert result["duration"] == pytest.approx(0.01)
+        assert result["step"] == pytest.approx(1e-6)
+        assert result["points"] == 100
+        assert result["sweepType"] == "dec"
+        assert result["source"] == "V1"
+
+    def test_empty_widgets_dict(self):
+        from GUI.analysis_field_helpers import parse_field_widgets
+
+        result = parse_field_widgets({})
+        assert result == {}


### PR DESCRIPTION
## Summary
- Extract duplicated build_analysis_fields() and parse_field_widgets() into a new GUI/analysis_field_helpers.py module
- Update MonteCarloDialog, ParameterSweepDialog, and AnalysisDialog to delegate form-building and parameter-parsing to the shared helpers
- Add unit tests for the extracted helper functions

Closes #640

## Test plan
- [ ] Verify Monte Carlo dialog builds base analysis fields correctly for each analysis type
- [ ] Verify Parameter Sweep dialog builds base analysis fields correctly for each analysis type
- [ ] Verify Analysis dialog get_parameters() returns correct parsed values
- [ ] Run test_analysis_field_helpers.py tests (build + parse coverage)
- [ ] Run existing test_monte_carlo.py and test_parameter_sweep.py tests