### PR TITLE
Propagate result parser errors instead of returning empty data

### DIFF
--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -243,6 +243,7 @@ class SimulationController:
     ) -> SimulationResult:
         """Parse simulation results based on analysis type."""
         from simulation import ResultParser
+        from simulation.result_parser import ResultParseError
 
         analysis = self.model.analysis_type
 
@@ -295,7 +296,7 @@ class SimulationController:
                 measurements=meas_results,
             )
 
-        except (ValueError, IndexError, KeyError, OSError) as e:
+        except (ResultParseError, ValueError, IndexError, KeyError, OSError) as e:
             logger.error("Result parsing failed: %s", e, exc_info=True)
             return SimulationResult(
                 success=False,

--- a/app/simulation/__init__.py
+++ b/app/simulation/__init__.py
@@ -2,12 +2,13 @@ from . import circuitikz_exporter, convergence, csv_exporter
 from .circuit_semantic_validator import validate_circuit
 from .netlist_generator import NetlistGenerator, generate_analysis_command
 from .ngspice_runner import NgspiceRunner
-from .result_parser import ResultParser
+from .result_parser import ResultParseError, ResultParser
 
 __all__ = [
     "validate_circuit",
     "NetlistGenerator",
     "NgspiceRunner",
+    "ResultParseError",
     "ResultParser",
     "csv_exporter",
     "circuitikz_exporter",

--- a/app/simulation/result_parser.py
+++ b/app/simulation/result_parser.py
@@ -12,7 +12,12 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "ResultParser",
+    "ResultParseError",
 ]
+
+
+class ResultParseError(Exception):
+    """Raised when simulation output cannot be parsed."""
 
 
 class ResultParser:
@@ -133,9 +138,8 @@ class ResultParser:
 
             return sweep_data if sweep_data["data"] else None
 
-        except (ValueError, IndexError, KeyError) as e:
-            logger.error("Error parsing DC results: %s", e)
-            return None
+        except (ValueError, IndexError, KeyError, AttributeError) as e:
+            raise ResultParseError(f"Error parsing DC results: {e}") from e
 
     @staticmethod
     def parse_ac_results(output):
@@ -185,9 +189,8 @@ class ResultParser:
 
             return ac_data if ac_data["frequencies"] else None
 
-        except (ValueError, IndexError, KeyError) as e:
-            logger.error("Error parsing AC results: %s", e)
-            return None
+        except (ValueError, IndexError, KeyError, AttributeError) as e:
+            raise ResultParseError(f"Error parsing AC results: {e}") from e
 
     @staticmethod
     def parse_noise_results(output):
@@ -234,9 +237,8 @@ class ResultParser:
 
             return noise_data if noise_data["frequencies"] else None
 
-        except (ValueError, IndexError, KeyError) as e:
-            logger.error("Error parsing noise results: %s", e)
-            return None
+        except (ValueError, IndexError, KeyError, AttributeError) as e:
+            raise ResultParseError(f"Error parsing noise results: {e}") from e
 
     @staticmethod
     def parse_sensitivity_results(output):
@@ -313,8 +315,7 @@ class ResultParser:
             return results if results else None
 
         except (ValueError, IndexError, AttributeError) as e:
-            logger.error("Error parsing sensitivity results: %s", e, exc_info=True)
-            return None
+            raise ResultParseError(f"Error parsing sensitivity results: {e}") from e
 
     @staticmethod
     def parse_tf_results(output):
@@ -361,8 +362,7 @@ class ResultParser:
             return results if results else None
 
         except (ValueError, IndexError, AttributeError) as e:
-            logger.error("Error parsing TF results: %s", e, exc_info=True)
-            return None
+            raise ResultParseError(f"Error parsing TF results: {e}") from e
 
     @staticmethod
     def parse_pz_results(output):
@@ -414,8 +414,7 @@ class ResultParser:
             return {"poles": poles, "zeros": zeros}
 
         except (ValueError, IndexError, AttributeError) as e:
-            logger.error("Error parsing PZ results: %s", e, exc_info=True)
-            return None
+            raise ResultParseError(f"Error parsing PZ results: {e}") from e
 
     @staticmethod
     def parse_transient_results(filepath):
@@ -451,12 +450,10 @@ class ResultParser:
                         continue
 
             return results if results else None
-        except FileNotFoundError:
-            logger.error("wrdata file not found at %s", filepath)
-            return None
+        except FileNotFoundError as e:
+            raise ResultParseError(f"wrdata file not found at {filepath}") from e
         except (OSError, ValueError, IndexError, KeyError) as e:
-            logger.error("Error parsing wrdata file: %s", e, exc_info=True)
-            return None
+            raise ResultParseError(f"Error parsing wrdata file: {e}") from e
 
     @staticmethod
     def format_results_as_table(results):

--- a/app/tests/unit/test_result_parser.py
+++ b/app/tests/unit/test_result_parser.py
@@ -5,7 +5,7 @@ Tests for simulation/result_parser.py — ngspice output parsing.
 import os
 
 import pytest
-from simulation.result_parser import ResultParser
+from simulation.result_parser import ResultParseError, ResultParser
 
 # ── parse_op_results ─────────────────────────────────────────────────
 
@@ -148,9 +148,9 @@ class TestParseTransientResults:
         assert "out" in headers
         assert "i_v1#branch" in headers
 
-    def test_missing_file_returns_none(self):
-        result = ResultParser.parse_transient_results("/nonexistent/path.txt")
-        assert result is None
+    def test_missing_file_raises_parse_error(self):
+        with pytest.raises(ResultParseError, match="wrdata file not found"):
+            ResultParser.parse_transient_results("/nonexistent/path.txt")
 
     def test_empty_file_returns_none(self, tmp_path):
         wrdata = tmp_path / "empty.txt"
@@ -186,3 +186,38 @@ class TestFormatResultsAsTable:
     def test_none_input(self):
         result = ResultParser.format_results_as_table(None)
         assert "No data" in result
+
+
+# ── ResultParseError propagation ────────────────────────────────────
+
+
+class TestParseErrorPropagation:
+    """Verify that parse failures raise ResultParseError instead of returning None."""
+
+    def test_dc_parse_error_on_non_string(self):
+        with pytest.raises(ResultParseError, match="DC results"):
+            ResultParser.parse_dc_results(None)
+
+    def test_ac_parse_error_on_non_string(self):
+        with pytest.raises(ResultParseError, match="AC results"):
+            ResultParser.parse_ac_results(None)
+
+    def test_noise_parse_error_on_non_string(self):
+        with pytest.raises(ResultParseError, match="noise results"):
+            ResultParser.parse_noise_results(None)
+
+    def test_sensitivity_parse_error_on_non_string(self):
+        with pytest.raises(ResultParseError, match="sensitivity results"):
+            ResultParser.parse_sensitivity_results(None)
+
+    def test_tf_parse_error_on_non_string(self):
+        with pytest.raises(ResultParseError, match="TF results"):
+            ResultParser.parse_tf_results(None)
+
+    def test_pz_parse_error_on_non_string(self):
+        with pytest.raises(ResultParseError, match="PZ results"):
+            ResultParser.parse_pz_results(None)
+
+    def test_transient_parse_error_on_missing_file(self):
+        with pytest.raises(ResultParseError, match="wrdata file not found"):
+            ResultParser.parse_transient_results("/nonexistent/path.txt")


### PR DESCRIPTION
## Summary - Added ResultParseError exception to simulation/result_parser.py - All parser methods (DC, AC, noise, sensitivity, TF, PZ, transient) now raise ResultParseError on actual parse failures instead of silently returning None - Controller _parse_results() catches ResultParseError and returns success=False with error message - Empty-but-valid outputs (no data found in well-formed output) still return None as before Closes #494 ## Test plan - [ ] Verify existing parser tests pass (valid data, empty strings) - [ ] Verify new ResultParseError propagation tests pass for all parser methods - [ ] Run simulation with valid circuit and confirm results display correctly - [ ] Corrupt output data and confirm error is reported to user Generated with [Claude Code](https://claude.com/claude-code)