### PR TITLE
Remove direct model mutations from graphics items (#579)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -368,7 +368,9 @@ class CircuitCanvasView(QGraphicsView):
             idx = self.wires.index(wire_item)
             self.controller.update_wire_routing_result(idx, waypoints, runtime, iterations, routing_failed)
         else:
-            # Wire not yet tracked (during construction) — write directly
+            # Construction-time initialisation: wire not yet registered with
+            # the controller, so we populate the model as part of object setup.
+            # Once the wire enters controller.add_wire() this path is never hit.
             wire_item.model.waypoints = waypoints
             wire_item.model.runtime = runtime
             wire_item.model.iterations = iterations

--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -72,10 +72,6 @@ class ComponentGraphicsItem(QGraphicsItem):
     def component_id(self):
         return self.model.component_id
 
-    @component_id.setter
-    def component_id(self, value):
-        self.model.component_id = value
-
     @property
     def component_type(self):
         return self.model.component_type
@@ -84,25 +80,13 @@ class ComponentGraphicsItem(QGraphicsItem):
     def value(self):
         return self.model.value
 
-    @value.setter
-    def value(self, v):
-        self.model.value = v
-
     @property
     def rotation_angle(self):
         return self.model.rotation
 
-    @rotation_angle.setter
-    def rotation_angle(self, v):
-        self.model.rotation = v
-
     @property
     def initial_condition(self):
         return self.model.initial_condition
-
-    @initial_condition.setter
-    def initial_condition(self, v):
-        self.model.initial_condition = v
 
     def sync_from_data(self, component_data) -> None:
         """Sync the graphics item's local model from authoritative controller data.
@@ -273,9 +257,6 @@ class ComponentGraphicsItem(QGraphicsItem):
             # Route through controller; observer callback syncs the local model
             if self.canvas and hasattr(self.canvas, "controller") and self.canvas.controller:
                 self.canvas.controller.update_component_value(self.component_id, new_value)
-            else:
-                self.model.value = new_value
-                self.update()
 
     # --- Geometry ---
 
@@ -456,9 +437,10 @@ class ComponentGraphicsItem(QGraphicsItem):
         if not self.canvas or not hasattr(self.canvas, "controller") or not self.canvas.controller:
             return
 
-        # Sync local model position immediately (lightweight attribute assignment).
-        # The canonical controller model is updated via the debounced
-        # _notify_controller_position -> controller.move_component() call below.
+        # Sync the *local rendering copy* of position immediately so
+        # paint/terminal queries stay consistent during drag.  The
+        # authoritative controller model is updated via the debounced
+        # _notify_controller_position → controller.move_component() call.
         if self._pending_position:
             self.model.position = self._pending_position
 
@@ -487,10 +469,14 @@ class ComponentGraphicsItem(QGraphicsItem):
         return self.pos() + self.terminals[index]
 
     def to_dict(self):
-        """Serialize component to dictionary via the model"""
-        # Sync Qt position to model before serializing
-        self.model.position = (self.pos().x(), self.pos().y())
-        return self.model.to_dict()
+        """Serialize component to dictionary via the model.
+
+        Reads the authoritative Qt position for serialization without
+        mutating the model object (model is owned by the controller).
+        """
+        d = self.model.to_dict()
+        d["pos"] = {"x": self.pos().x(), "y": self.pos().y()}
+        return d
 
     @staticmethod
     def from_dict(data_dict):
@@ -564,22 +550,14 @@ class WaveformVoltageSource(ComponentGraphicsItem):
     def __init__(self, component_id, model=None):
         super().__init__(component_id, self.type_name, model=model)
 
-    # Waveform properties delegated to model
+    # Waveform properties delegated to model (read-only; mutations go through controller)
     @property
     def waveform_type(self):
         return self.model.waveform_type
 
-    @waveform_type.setter
-    def waveform_type(self, v):
-        self.model.waveform_type = v
-
     @property
     def waveform_params(self):
         return self.model.waveform_params
-
-    @waveform_params.setter
-    def waveform_params(self, v):
-        self.model.waveform_params = v
 
     def get_spice_value(self):
         """Generate SPICE waveform specification (delegates to model)"""

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -139,15 +139,9 @@ class WireGraphicsItem(QGraphicsPathItem):
     # --- Methods ---
 
     def _persist_routing_result(self, waypoints, runtime=0.0, iterations=0, routing_failed=False):
-        """Persist pathfinding results through the controller when available."""
+        """Persist pathfinding results through the canvas/controller."""
         if self.canvas and hasattr(self.canvas, "on_wire_routing_complete"):
             self.canvas.on_wire_routing_complete(self, waypoints, runtime, iterations, routing_failed)
-        else:
-            # Fallback during initialisation (wire not yet in canvas.wires)
-            self.model.waypoints = waypoints
-            self.model.runtime = runtime
-            self.model.iterations = iterations
-            self.model.routing_failed = routing_failed
 
     def show_drag_preview(self):
         """Show a straight-line preview during component drag.
@@ -412,9 +406,6 @@ class WireGraphicsItem(QGraphicsPathItem):
         # Persist waypoints and lock through canvas -> controller
         if self.canvas and hasattr(self.canvas, "on_wire_waypoints_changed"):
             self.canvas.on_wire_waypoints_changed(self, tuple_waypoints)
-        else:
-            self.model.waypoints = tuple_waypoints
-            self.model.locked = True
 
     def _rebuild_path_from_waypoints(self):
         """Rebuild the QPainterPath from the current waypoints list."""

--- a/app/tests/unit/test_graphics_item_readonly.py
+++ b/app/tests/unit/test_graphics_item_readonly.py
@@ -1,0 +1,115 @@
+"""Verify that ComponentGraphicsItem and WireGraphicsItem treat model as read-only.
+
+These tests enforce the MVC boundary: graphics items expose data properties
+as read-only and never bypass the controller to mutate the model directly.
+See issue #579.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+# ---------------------------------------------------------------------------
+# ComponentGraphicsItem property-setter removal
+# ---------------------------------------------------------------------------
+
+# We cannot instantiate the full Qt graphics items in headless mode, so we
+# verify the *class descriptors* directly — if a property has no setter the
+# assignment will raise AttributeError at the language level.
+
+
+def _make_component_item_class():
+    """Import ComponentGraphicsItem, skipping if Qt unavailable."""
+    try:
+        from GUI.component_item import ComponentGraphicsItem
+
+        return ComponentGraphicsItem
+    except (ImportError, RuntimeError):
+        pytest.skip("PyQt6 not available in this environment")
+
+
+def _make_waveform_source_class():
+    """Import WaveformVoltageSource, skipping if Qt unavailable."""
+    try:
+        from GUI.component_item import WaveformVoltageSource
+
+        return WaveformVoltageSource
+    except (ImportError, RuntimeError):
+        pytest.skip("PyQt6 not available in this environment")
+
+
+class TestComponentGraphicsItemReadOnly:
+    """Ensure data-delegation properties on ComponentGraphicsItem have no setters."""
+
+    def test_value_is_readonly(self):
+        cls = _make_component_item_class()
+        prop = getattr(cls, "value", None)
+        assert isinstance(prop, property), "value should be a property"
+        assert prop.fset is None, "value property must not have a setter"
+
+    def test_rotation_angle_is_readonly(self):
+        cls = _make_component_item_class()
+        prop = getattr(cls, "rotation_angle", None)
+        assert isinstance(prop, property), "rotation_angle should be a property"
+        assert prop.fset is None, "rotation_angle property must not have a setter"
+
+    def test_initial_condition_is_readonly(self):
+        cls = _make_component_item_class()
+        prop = getattr(cls, "initial_condition", None)
+        assert isinstance(prop, property), "initial_condition should be a property"
+        assert prop.fset is None, "initial_condition property must not have a setter"
+
+    def test_component_id_is_readonly(self):
+        cls = _make_component_item_class()
+        prop = getattr(cls, "component_id", None)
+        assert isinstance(prop, property), "component_id should be a property"
+        assert prop.fset is None, "component_id property must not have a setter"
+
+
+class TestWaveformSourceReadOnly:
+    """Ensure waveform properties on WaveformVoltageSource have no setters."""
+
+    def test_waveform_type_is_readonly(self):
+        cls = _make_waveform_source_class()
+        prop = getattr(cls, "waveform_type", None)
+        assert isinstance(prop, property), "waveform_type should be a property"
+        assert prop.fset is None, "waveform_type property must not have a setter"
+
+    def test_waveform_params_is_readonly(self):
+        cls = _make_waveform_source_class()
+        prop = getattr(cls, "waveform_params", None)
+        assert isinstance(prop, property), "waveform_params should be a property"
+        assert prop.fset is None, "waveform_params property must not have a setter"
+
+
+class TestWireGraphicsItemNoFallback:
+    """Ensure WireGraphicsItem delegates routing persistence to canvas only."""
+
+    def test_persist_routing_result_no_fallback(self):
+        """_persist_routing_result should be a no-op when canvas is unavailable."""
+        try:
+            from GUI.wire_item import WireGraphicsItem
+        except (ImportError, RuntimeError):
+            pytest.skip("PyQt6 not available in this environment")
+
+        import inspect
+
+        source = inspect.getsource(WireGraphicsItem._persist_routing_result)
+        # The method should NOT contain direct model mutations
+        assert "self.model.waypoints" not in source
+
+    def test_finish_waypoint_drag_no_fallback(self):
+        """_finish_waypoint_drag should not contain direct model mutation fallback."""
+        try:
+            from GUI.wire_item import WireGraphicsItem
+        except (ImportError, RuntimeError):
+            pytest.skip("PyQt6 not available in this environment")
+
+        import inspect
+
+        source = inspect.getsource(WireGraphicsItem._finish_waypoint_drag)
+        assert "self.model.waypoints" not in source
+        assert "self.model.locked" not in source


### PR DESCRIPTION
## Summary - Remove all property setters (, , , , , ) from  and  — properties are now read-only, forcing all mutations through the controller - Remove fallback direct-model-write paths from  and  — these methods now delegate exclusively to the canvas/controller - Fix  to overlay Qt position without mutating the model object - Clarify construction-time model init comment in  ## Test plan - [ ] Verify existing tests pass (property setters removed, no external callers found) - [ ] New  regression tests confirm properties have no setters and wire methods have no model mutation fallbacks - [ ] Manual test: place components, edit values via double-click dialog, verify changes persist - [ ] Manual test: draw wires, drag waypoints, verify routing persists correctly Closes #579 🤖 Generated with [Claude Code](https://claude.com/claude-code)