### PR TITLE
Log I/O errors in auto-save and settings persistence

### DIFF
--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -6,9 +6,12 @@ Recent files tracking uses the centralized settings service for cross-session pe
 """
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import List, Optional
+
+logger = logging.getLogger(__name__)
 
 from controllers.settings_service import settings
 from models.circuit import CircuitModel
@@ -163,7 +166,7 @@ class FileController:
             with open(self._session_file, "w") as f:
                 f.write(os.path.abspath(str(self.current_file)) if self.current_file else "")
         except OSError:
-            pass  # Session save is best-effort
+            logger.warning("Failed to save session file %s", self._session_file, exc_info=True)
 
     def load_last_session(self) -> Optional[Path]:
         """
@@ -180,7 +183,7 @@ class FileController:
                     if path.exists():
                         return path
         except OSError:
-            pass
+            logger.warning("Failed to read session file %s", self._session_file, exc_info=True)
         return None
 
     def get_recent_files(self) -> List[str]:
@@ -244,7 +247,7 @@ class FileController:
             with open(self._autosave_file, "w") as f:
                 json.dump(data, f, indent=2)
         except (OSError, TypeError):
-            pass  # Auto-save is best-effort
+            logger.warning("Auto-save failed for %s", self._autosave_file, exc_info=True)
 
     def has_auto_save(self) -> bool:
         """Return True if an auto-save recovery file exists."""
@@ -276,6 +279,7 @@ class FileController:
 
             return source_path
         except (OSError, json.JSONDecodeError, ValueError):
+            logger.warning("Failed to load auto-save from %s", self._autosave_file, exc_info=True)
             return None
 
     def import_netlist(self, filepath) -> None:
@@ -417,4 +421,4 @@ class FileController:
         try:
             self._autosave_file.unlink(missing_ok=True)
         except OSError:
-            pass
+            logger.warning("Failed to delete auto-save file %s", self._autosave_file, exc_info=True)

--- a/app/controllers/settings_service.py
+++ b/app/controllers/settings_service.py
@@ -7,10 +7,13 @@ managing persistence directly.
 
 import base64
 import json
+import logging
 import os
 import sys
 from pathlib import Path
 from typing import Any, List
+
+logger = logging.getLogger(__name__)
 
 _ORG = "SDSMT"
 _APP = "SDM Spice"
@@ -40,12 +43,13 @@ class SettingsService:
         self._load()
 
     def _load(self) -> None:
-        """Load settings from disk (silently ignore missing/corrupt file)."""
+        """Load settings from disk, logging any I/O or corruption errors."""
         try:
             if self._path.exists():
                 with open(self._path, "r") as f:
                     self._data = json.load(f)
         except (json.JSONDecodeError, OSError):
+            logger.warning("Failed to load settings from %s", self._path, exc_info=True)
             self._data = {}
 
     def _save(self) -> None:
@@ -55,7 +59,7 @@ class SettingsService:
             with open(self._path, "w") as f:
                 json.dump(self._data, f, indent=2)
         except OSError:
-            pass  # Best-effort persistence
+            logger.warning("Failed to save settings to %s", self._path, exc_info=True)
 
     @staticmethod
     def _encode(value: Any) -> Any:


### PR DESCRIPTION
## Summary - Added logger to FileController and SettingsService - Replaced 7 silent except-pass blocks with logger.warning(exc_info=True) - Covers: session save/load, auto-save write/load/clear, settings load/save - Best-effort semantics preserved (operations still degrade gracefully) Closes #496 ## Test plan - [ ] Verify auto-save still works on normal operation - [ ] Simulate disk-full or permission error and check log output shows warnings - [ ] Settings load/save still graceful on corrupt settings.json Generated with [Claude Code](https://claude.com/claude-code)