### PR TITLE
Add test coverage for NgspiceRunner, FileController imports, and power calculator

### DIFF
--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -632,6 +632,79 @@ class TestExportAsc:
         assert len(content) > 0
 
 
+class TestImportNetlist:
+    """Tests for FileController.import_netlist (#502)."""
+
+    @patch("controllers.file_controller.settings")
+    def test_import_simple_netlist(self, mock_settings, tmp_path):
+        """A valid SPICE netlist should populate the model."""
+        mock_settings.get_list.return_value = []
+        netlist = tmp_path / "circuit.cir"
+        netlist.write_text("Test Circuit\nV1 1 0 DC 5V\nR1 1 0 1k\n.op\n.end\n")
+        model = CircuitModel()
+        ctrl = FileController(model)
+        ctrl.import_netlist(netlist)
+        assert len(ctrl.model.components) > 0
+        assert ctrl.current_file is None  # import clears current_file
+
+    @patch("controllers.file_controller.settings")
+    def test_import_netlist_file_not_found(self, mock_settings, tmp_path):
+        """Missing file should raise OSError."""
+        ctrl = FileController(CircuitModel())
+        with pytest.raises(OSError):
+            ctrl.import_netlist(tmp_path / "nonexistent.cir")
+
+    @patch("controllers.file_controller.settings")
+    def test_import_netlist_sets_analysis(self, mock_settings, tmp_path):
+        """Analysis directives should be extracted from the netlist."""
+        mock_settings.get_list.return_value = []
+        netlist = tmp_path / "tran.cir"
+        netlist.write_text("Transient Test\nV1 1 0 DC 5V\nR1 1 0 1k\n.tran 1u 1m\n.end\n")
+        ctrl = FileController(CircuitModel())
+        ctrl.import_netlist(netlist)
+        assert ctrl.model.analysis_type == "Transient"
+
+
+class TestImportAsc:
+    """Tests for FileController.import_asc (#502)."""
+
+    @patch("controllers.file_controller.settings")
+    def test_import_simple_asc(self, mock_settings, tmp_path):
+        """A valid ASC file should populate the model."""
+        mock_settings.get_list.return_value = []
+        asc = tmp_path / "circuit.asc"
+        asc.write_text(
+            "Version 4\nSHEET 1 880 680\n"
+            "SYMBOL res 160 128 R0\n"
+            "SYMATTR InstName R1\nSYMATTR Value 1k\n"
+            "SYMBOL voltage 48 128 R0\n"
+            "SYMATTR InstName V1\nSYMATTR Value 5\n"
+            "WIRE 160 128 48 128\n"
+        )
+        ctrl = FileController(CircuitModel())
+        warnings = ctrl.import_asc(asc)
+        assert isinstance(warnings, list)
+        assert len(ctrl.model.components) > 0
+
+    @patch("controllers.file_controller.settings")
+    def test_import_asc_file_not_found(self, mock_settings, tmp_path):
+        """Missing file should raise OSError."""
+        ctrl = FileController(CircuitModel())
+        with pytest.raises(OSError):
+            ctrl.import_asc(tmp_path / "nonexistent.asc")
+
+
+class TestImportCircuitikz:
+    """Tests for FileController.import_circuitikz (#502)."""
+
+    @patch("controllers.file_controller.settings")
+    def test_import_circuitikz_file_not_found(self, mock_settings, tmp_path):
+        """Missing file should raise OSError."""
+        ctrl = FileController(CircuitModel())
+        with pytest.raises(OSError):
+            ctrl.import_circuitikz(tmp_path / "nonexistent.tex")
+
+
 class TestQtDependencies:
     def test_settings_service_used_for_recent_files(self):
         """FileController uses centralized SettingsService for persistence (#598)."""

--- a/app/tests/unit/test_ngspice_runner.py
+++ b/app/tests/unit/test_ngspice_runner.py
@@ -1,10 +1,116 @@
-"""Tests for NgspiceRunner - empty output detection (#497)."""
+"""Tests for NgspiceRunner (#497, #502)."""
 
 import os
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 from simulation.ngspice_runner import NgspiceRunner
+
+
+class TestInit:
+    """Constructor tests."""
+
+    def test_creates_output_dir(self, tmp_path):
+        output_dir = tmp_path / "sim_out"
+        runner = NgspiceRunner(output_dir=str(output_dir))
+        assert output_dir.exists()
+        assert runner.ngspice_cmd is None
+
+
+class TestFindNgspice:
+    """Tests for find_ngspice()."""
+
+    def test_found_via_shutil_which(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        with patch("simulation.ngspice_runner.shutil.which", return_value="/usr/bin/ngspice"):
+            result = runner.find_ngspice()
+        assert result == "/usr/bin/ngspice"
+        assert runner.ngspice_cmd == "/usr/bin/ngspice"
+
+    def test_not_found_returns_none(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        with (
+            patch("simulation.ngspice_runner.shutil.which", return_value=None),
+            patch("simulation.ngspice_runner.os.path.exists", return_value=False),
+        ):
+            result = runner.find_ngspice()
+        assert result is None
+        assert runner.ngspice_cmd is None
+
+    def test_fallback_path_found(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+
+        def fake_exists(path):
+            return path == "/usr/local/bin/ngspice"
+
+        with (
+            patch("simulation.ngspice_runner.shutil.which", return_value=None),
+            patch("simulation.ngspice_runner.platform.system", return_value="Linux"),
+            patch("simulation.ngspice_runner.os.path.exists", side_effect=fake_exists),
+        ):
+            result = runner.find_ngspice()
+        assert result == "/usr/local/bin/ngspice"
+
+
+class TestRunSimulation:
+    """Tests for run_simulation()."""
+
+    def test_ngspice_not_found(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        with (
+            patch("simulation.ngspice_runner.shutil.which", return_value=None),
+            patch("simulation.ngspice_runner.os.path.exists", return_value=False),
+        ):
+            success, output_file, stdout, stderr = runner.run_simulation("test netlist")
+        assert success is False
+        assert "not found" in stderr
+
+    def test_timeout_returns_failure(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/usr/bin/ngspice"
+        with patch(
+            "simulation.ngspice_runner.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="ngspice", timeout=30),
+        ):
+            success, output_file, stdout, stderr = runner.run_simulation("test netlist")
+        assert success is False
+        assert "timed out" in stderr.lower()
+
+    def test_subprocess_error_returns_failure(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/usr/bin/ngspice"
+        with patch(
+            "simulation.ngspice_runner.subprocess.run",
+            side_effect=OSError("Permission denied"),
+        ):
+            success, output_file, stdout, stderr = runner.run_simulation("test netlist")
+        assert success is False
+        assert "Permission denied" in stderr
+
+    def test_netlist_write_error(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/usr/bin/ngspice"
+        with patch("builtins.open", side_effect=OSError("disk full")):
+            success, output_file, stdout, stderr = runner.run_simulation("test netlist")
+        assert success is False
+        assert "disk full" in stderr
+
+
+class TestReadOutput:
+    """Tests for read_output()."""
+
+    def test_reads_existing_file(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        outfile = tmp_path / "output.txt"
+        outfile.write_text("v(1) = 5.0\n")
+        result = runner.read_output(str(outfile))
+        assert "v(1) = 5.0" in result
+
+    def test_missing_file_returns_error_string(self, tmp_path):
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        result = runner.read_output("/nonexistent/output.txt")
+        assert "Error reading output" in result
 
 
 class TestEmptyOutputDetection:

--- a/app/tests/unit/test_power_dissipation.py
+++ b/app/tests/unit/test_power_dissipation.py
@@ -198,6 +198,60 @@ class TestCalculatePowerDictInput:
         assert result == {}
 
 
+class TestPowerEdgeCases:
+    """Edge case tests for power calculation (#502)."""
+
+    def test_empty_node_voltages_returns_empty(self):
+        r1 = ComponentData("R1", "Resistor", "1k", (0, 0))
+        nodeA = _make_node([("R1", 0)], "nodeA")
+        nodeB = _make_node([("R1", 1)], "nodeB")
+        result = calculate_power([r1], [nodeA, nodeB], {})
+        assert result == {}
+
+    def test_missing_terminal_mapping_skips_component(self):
+        """Component with no node mapping should be omitted, not crash."""
+        r1 = ComponentData("R1", "Resistor", "1k", (0, 0))
+        voltages = {"nodeA": 5.0, "nodeB": 0.0}
+        # No nodes mapped to R1 terminals
+        result = calculate_power([r1], [], voltages)
+        assert "R1" not in result
+
+    def test_current_source_power(self):
+        """Current source power = V_across * I."""
+        i1 = ComponentData("I1", "Current Source", "10m", (0, 0))
+        nodeA = _make_node([("I1", 0)], "nodeA")
+        nodeB = _make_node([("I1", 1)], "nodeB")
+        voltages = {"nodeA": 5.0, "nodeB": 0.0}
+        result = calculate_power([i1], [nodeA, nodeB], voltages)
+        assert result["I1"] == pytest.approx(0.05)
+
+    def test_capacitor_dc_power_is_zero(self):
+        """Capacitor DC power should be 0."""
+        c1 = ComponentData("C1", "Capacitor", "100u", (0, 0))
+        nodeA = _make_node([("C1", 0)], "nodeA")
+        nodeB = _make_node([("C1", 1)], "nodeB")
+        voltages = {"nodeA": 5.0, "nodeB": 0.0}
+        result = calculate_power([c1], [nodeA, nodeB], voltages)
+        assert result["C1"] == pytest.approx(0.0)
+
+    def test_voltage_source_without_current_is_omitted(self):
+        """Voltage source without branch current cannot compute power."""
+        v1 = ComponentData("V1", "Voltage Source", "5V", (0, 0))
+        nodeA = _make_node([("V1", 0)], "nodeA")
+        nodeB = _make_node([("V1", 1)], "nodeB")
+        voltages = {"nodeA": 5.0, "nodeB": 0.0}
+        result = calculate_power([v1], [nodeA, nodeB], voltages)
+        assert "V1" not in result
+
+    def test_ground_component_is_skipped(self):
+        """Ground components should be ignored entirely."""
+        gnd = ComponentData("GND1", "Ground", "0V", (0, 0))
+        nodeA = _make_node([("GND1", 0)], "0", is_ground=True)
+        voltages = {"0": 0.0}
+        result = calculate_power([gnd], [nodeA], voltages)
+        assert "GND1" not in result
+
+
 class TestTotalPower:
     """Test total power calculation."""
 


### PR DESCRIPTION
## Summary - NgspiceRunner: 10 new tests covering find_ngspice, run_simulation edge cases, read_output, init - FileController imports: 5 new tests for import_netlist, import_asc, import_circuitikz - PowerCalculator: 7 new edge case tests (empty voltages, missing mappings, current source, capacitor, voltage source, ground) Closes #502 ## Test plan - [ ] All new tests pass in CI across Python 3.11-3.13 on ubuntu and windows Generated with [Claude Code](https://claude.com/claude-code)