### PR TITLE
Route GUI simulation calls through SimulationController (#581)

### DIFF
--- a/app/GUI/analysis_dialog.py
+++ b/app/GUI/analysis_dialog.py
@@ -1,3 +1,4 @@
+from controllers.simulation_controller import SimulationController
 from PyQt6.QtWidgets import (
     QComboBox,
     QDialog,
@@ -11,14 +12,13 @@ from PyQt6.QtWidgets import (
     QPushButton,
     QVBoxLayout,
 )
-from simulation.measurement_builder import ANALYSIS_DOMAIN_MAP
 from utils.format_utils import parse_value
 
 from .meas_dialog import MeasurementDialog
 from .validation_helpers import clear_field_error, set_field_error
 
 # Analysis types that support .meas directives
-_MEAS_SUPPORTED_TYPES = set(ANALYSIS_DOMAIN_MAP.keys())
+_MEAS_SUPPORTED_TYPES = set(SimulationController.get_analysis_domain_map().keys())
 
 
 class AnalysisDialog(QDialog):
@@ -372,15 +372,13 @@ class AnalysisDialog(QDialog):
         if params is None:
             return None
 
-        from simulation.netlist_generator import generate_analysis_command
-
-        return generate_analysis_command(self.analysis_type, params)
+        return SimulationController.generate_analysis_command(self.analysis_type, params)
 
     # --- Measurement management ---
 
     def _open_meas_dialog(self):
         """Open the measurement configuration dialog."""
-        domain = ANALYSIS_DOMAIN_MAP.get(self.analysis_type, "tran")
+        domain = SimulationController.get_analysis_domain_map().get(self.analysis_type, "tran")
         dialog = MeasurementDialog(
             domain=domain,
             parent=self,

--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -464,8 +464,6 @@ class FileOperationsMixin:
         import os
         import tempfile
 
-        from simulation.bundle_exporter import create_bundle, suggest_bundle_name
-
         if not self.model.components:
             QMessageBox.information(self, "Export Bundle", "Nothing to export — the canvas is empty.")
             return
@@ -474,7 +472,7 @@ class FileOperationsMixin:
         if self.file_ctrl.current_file:
             circuit_name = self.file_ctrl.current_file.name
 
-        suggested = suggest_bundle_name(circuit_name)
+        suggested = self.simulation_ctrl.suggest_bundle_name(circuit_name)
         filename, _ = QFileDialog.getSaveFileName(
             self,
             "Export Lab Bundle",
@@ -537,7 +535,7 @@ class FileOperationsMixin:
                 except Exception:
                     logger.warning("Bundle export: Excel results export failed", exc_info=True)
 
-            included = create_bundle(
+            included = self.simulation_ctrl.create_bundle(
                 filepath=filename,
                 circuit_json=circuit_json,
                 netlist=netlist,
@@ -850,14 +848,7 @@ class FileOperationsMixin:
             elif export_function == "export_results_excel":
                 self._re_export_results_excel(path)
             elif export_function == "export_circuitikz":
-                from simulation.circuitikz_exporter import generate
-
-                content = generate(
-                    self.model.components,
-                    self.model.wires,
-                    self.model.nodes,
-                    self.model.terminal_to_node,
-                )
+                content = self.simulation_ctrl.generate_circuitikz()
                 with open(path, "w") as f:
                     f.write(content)
             elif export_function == "export_asc":

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -419,8 +419,6 @@ class ViewOperationsMixin:
         """Export the circuit as a CircuiTikZ LaTeX file."""
         import os
 
-        from simulation.circuitikz_exporter import generate
-
         from .circuitikz_options_dialog import CircuiTikZOptionsDialog
 
         model = self.circuit_ctrl.model
@@ -434,14 +432,8 @@ class ViewOperationsMixin:
             return
         opts = dialog.get_options()
 
-        model.rebuild_nodes()
-
         try:
-            tikz_code = generate(
-                components=model.components,
-                wires=model.wires,
-                nodes=model.nodes,
-                terminal_to_node=model.terminal_to_node,
+            tikz_code = self.sim_ctrl.generate_circuitikz(
                 standalone=opts["standalone"],
                 circuit_name=(os.path.basename(self.file_ctrl.current_file) if self.file_ctrl.current_file else ""),
                 scale=opts["scale"],
@@ -481,23 +473,13 @@ class ViewOperationsMixin:
 
     def copy_circuitikz(self):
         """Copy the CircuiTikZ environment block to the clipboard."""
-        from simulation.circuitikz_exporter import generate
-
         model = self.circuit_ctrl.model
         if not model.components:
             self.statusBar().showMessage("Nothing to copy — the canvas is empty.", 3000)
             return
 
-        model.rebuild_nodes()
-
         try:
-            tikz_code = generate(
-                components=model.components,
-                wires=model.wires,
-                nodes=model.nodes,
-                terminal_to_node=model.terminal_to_node,
-                standalone=False,
-            )
+            tikz_code = self.sim_ctrl.generate_circuitikz(standalone=False)
         except Exception as e:
             QMessageBox.critical(self, "Error", f"Failed to generate CircuiTikZ: {e}")
             return

--- a/app/GUI/meas_dialog.py
+++ b/app/GUI/meas_dialog.py
@@ -7,6 +7,7 @@ needing to know the exact syntax.  Supports statistical measures
 FIND...WHEN), and timing measurements (TRIG...TARG).
 """
 
+from controllers.simulation_controller import SimulationController
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
     QComboBox,
@@ -23,7 +24,10 @@ from PyQt6.QtWidgets import (
     QTableWidgetItem,
     QVBoxLayout,
 )
-from simulation.measurement_builder import ANALYSIS_DOMAIN_MAP, MEAS_TYPES, build_directive
+
+ANALYSIS_DOMAIN_MAP = SimulationController.get_analysis_domain_map()
+MEAS_TYPES = SimulationController.get_meas_types()
+build_directive = SimulationController.build_meas_directive
 
 # Re-export so existing imports from GUI.meas_dialog keep working.
 __all__ = ["ANALYSIS_DOMAIN_MAP", "MEAS_TYPES", "build_directive"]

--- a/app/GUI/monte_carlo_dialog.py
+++ b/app/GUI/monte_carlo_dialog.py
@@ -5,6 +5,7 @@ Allows users to set number of runs, per-component tolerances and
 distribution, and select the base analysis type.
 """
 
+from controllers.simulation_controller import SimulationController
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
     QComboBox,
@@ -42,10 +43,9 @@ class MonteCarloDialog(QDialog):
         self.setMinimumWidth(550)
         self.setMinimumHeight(400)
 
-        from simulation.monte_carlo import MC_ELIGIBLE_TYPES
-
         self._components = components
-        self._eligible = {cid: comp for cid, comp in components.items() if comp.component_type in MC_ELIGIBLE_TYPES}
+        mc_eligible = SimulationController.get_mc_eligible_types()
+        self._eligible = {cid: comp for cid, comp in components.items() if comp.component_type in mc_eligible}
         self._base_field_widgets = {}
         self._init_ui()
 
@@ -110,13 +110,11 @@ class MonteCarloDialog(QDialog):
 
                 # Tolerance spin
                 tol_spin = QDoubleSpinBox()
-                from simulation.monte_carlo import DEFAULT_TOLERANCES
-
                 tol_spin.setRange(0.0, 50.0)
                 tol_spin.setSuffix("%")
                 tol_spin.setDecimals(1)
                 tol_spin.setToolTip("Component value tolerance as a percentage (0-50%)")
-                default_tol = DEFAULT_TOLERANCES.get(comp.component_type, 5.0)
+                default_tol = SimulationController.get_mc_default_tolerance(comp.component_type)
                 tol_spin.setValue(default_tol)
                 self.tol_table.setCellWidget(row, 2, tol_spin)
 

--- a/app/GUI/results_plot_dialog.py
+++ b/app/GUI/results_plot_dialog.py
@@ -461,9 +461,9 @@ class ACSweepPlotDialog(QDialog):
         if self._sim_ctrl is not None:
             markers = self._sim_ctrl.compute_frequency_markers(frequencies, mag_vals, phase_vals)
         else:
-            from simulation.freq_markers import compute_markers
+            from controllers.simulation_controller import SimulationController
 
-            markers = compute_markers(frequencies, mag_vals, phase_vals)
+            markers = SimulationController.compute_frequency_markers(frequencies, mag_vals, phase_vals)
 
         if markers["peak_gain_db"] is None:
             self._marker_summary.setPlainText("No markers computed (insufficient data).")

--- a/app/GUI/waveform_dialog.py
+++ b/app/GUI/waveform_dialog.py
@@ -572,13 +572,13 @@ class WaveformDialog(QDialog):
 
     def _export_csv(self):
         """Export current view data to CSV."""
-        from simulation.csv_exporter import export_transient_results, write_csv
+        from controllers.simulation_controller import SimulationController
 
-        csv_content = export_transient_results(self.view_data)
         filename, _ = QFileDialog.getSaveFileName(self, "Export Results to CSV", "", "CSV Files (*.csv);;All Files (*)")
         if filename:
             try:
-                write_csv(csv_content, filename)
+                ctrl = self._sim_ctrl or SimulationController()
+                ctrl.export_results_csv(self.view_data, "Transient", filename)
                 QMessageBox.information(self, "Success", f"Exported to {filename}")
             except OSError as e:
                 QMessageBox.critical(self, "Error", f"Failed to export: {e}")

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -678,6 +678,45 @@ class SimulationController:
 
         return generate_analysis_command(analysis_type, params)
 
+    # --- Measurement / analysis metadata ---
+
+    @staticmethod
+    def get_analysis_domain_map() -> dict:
+        """Return mapping of analysis types to measurement domains."""
+        from simulation.measurement_builder import ANALYSIS_DOMAIN_MAP
+
+        return ANALYSIS_DOMAIN_MAP
+
+    @staticmethod
+    def get_meas_types() -> dict:
+        """Return the measurement type definitions."""
+        from simulation.measurement_builder import MEAS_TYPES
+
+        return MEAS_TYPES
+
+    @staticmethod
+    def build_meas_directive(meas_type: str, **kwargs) -> str:
+        """Build a .meas directive string."""
+        from simulation.measurement_builder import build_directive
+
+        return build_directive(meas_type, **kwargs)
+
+    # --- Monte Carlo metadata ---
+
+    @staticmethod
+    def get_mc_eligible_types() -> set:
+        """Return the set of component types eligible for Monte Carlo analysis."""
+        from simulation.monte_carlo import MC_ELIGIBLE_TYPES
+
+        return MC_ELIGIBLE_TYPES
+
+    @staticmethod
+    def get_mc_default_tolerance(component_type: str) -> float:
+        """Return the default tolerance percentage for a component type."""
+        from simulation.monte_carlo import DEFAULT_TOLERANCES
+
+        return DEFAULT_TOLERANCES.get(component_type, 5.0)
+
     # --- Export helpers ---
 
     def export_netlist(self, filepath: str) -> None:
@@ -774,3 +813,35 @@ class SimulationController:
         content = self.generate_results_markdown(results, results_type, circuit_name)
         if content is not None:
             write_markdown(content, filepath)
+
+    def generate_circuitikz(self, **kwargs) -> str:
+        """Generate CircuiTikZ LaTeX code from the current circuit model."""
+        from simulation.circuitikz_exporter import generate
+
+        self.model.rebuild_nodes()
+        return generate(
+            components=self.model.components,
+            wires=self.model.wires,
+            nodes=self.model.nodes,
+            terminal_to_node=self.model.terminal_to_node,
+            **kwargs,
+        )
+
+    @staticmethod
+    def suggest_bundle_name(circuit_name: str) -> str:
+        """Suggest a filename for a lab bundle export."""
+        from simulation.bundle_exporter import suggest_bundle_name
+
+        return suggest_bundle_name(circuit_name)
+
+    @staticmethod
+    def create_bundle(filepath: str, **kwargs) -> str:
+        """Create a ZIP bundle of circuit artifacts for lab submission.
+
+        Delegates to ``simulation.bundle_exporter.create_bundle``.
+        Accepts the same keyword arguments (circuit_json, netlist,
+        schematic_png, results_csv, etc.).
+        """
+        from simulation.bundle_exporter import create_bundle
+
+        return create_bundle(filepath, **kwargs)

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -695,11 +695,11 @@ class SimulationController:
         return MEAS_TYPES
 
     @staticmethod
-    def build_meas_directive(meas_type: str, **kwargs) -> str:
+    def build_meas_directive(domain: str, name: str, meas_type: str, params: dict) -> str:
         """Build a .meas directive string."""
         from simulation.measurement_builder import build_directive
 
-        return build_directive(meas_type, **kwargs)
+        return build_directive(domain, name, meas_type, params)
 
     # --- Monte Carlo metadata ---
 


### PR DESCRIPTION
## Summary - Add wrapper methods to SimulationController for circuitikz generation, bundle export, Monte Carlo metadata, and measurement constants - Replace all direct simulation module imports in the GUI layer with controller method calls - Eliminates 11 direct simulation imports across 7 GUI files ## Test plan - [ ] CI passes (no behavioral changes, only import routing) - [ ] Manual: run simulation, verify results display correctly - [ ] Manual: export CircuiTikZ, verify output identical - [ ] Manual: configure Monte Carlo dialog, verify eligible types and tolerances shown Closes #581