### PR TITLE
Log malformed lines in ASC parser and result parser

### DIFF
--- a/app/simulation/asc_parser.py
+++ b/app/simulation/asc_parser.py
@@ -184,7 +184,7 @@ def parse_asc(text):
                     )
                     wires.append((x1, y1, x2, y2))
                 except ValueError:
-                    pass
+                    logger.debug("Skipping WIRE with invalid coordinates: %s", stripped)
 
         elif stripped.startswith("FLAG "):
             parts = stripped.split()
@@ -194,7 +194,7 @@ def parse_asc(text):
                     label = parts[3]
                     flags.append((x, y, label))
                 except ValueError:
-                    pass
+                    logger.debug("Skipping FLAG with invalid coordinates: %s", stripped)
 
         elif stripped.startswith("SYMBOL "):
             # Save any previous symbol
@@ -218,6 +218,7 @@ def parse_asc(text):
                         "spice_model": None,
                     }
                 except ValueError:
+                    logger.debug("Skipping SYMBOL with invalid coordinates: %s", stripped)
                     current_symbol = None
 
         elif stripped.startswith("SYMATTR "):

--- a/app/simulation/result_parser.py
+++ b/app/simulation/result_parser.py
@@ -79,6 +79,7 @@ class ResultParser:
                             voltage = float(parts[1])
                             node_voltages[node_name] = voltage
                         except (ValueError, IndexError):
+                            logger.debug("Skipping unparseable voltage table line: %s", result_line)
                             continue
 
         # Pattern 3: ngspice print output format
@@ -134,6 +135,7 @@ class ResultParser:
                             data_row = [float(p) for p in parts[: len(headers)]]
                             sweep_data["data"].append(data_row)
                         except ValueError:
+                            logger.debug("Skipping unparseable DC sweep row: %s", line.strip())
                             continue
 
             return sweep_data if sweep_data["data"] else None
@@ -185,6 +187,7 @@ class ResultParser:
                                             ac_data["magnitude"][node] = []
                                         ac_data["magnitude"][node].append(float(parts[j]))
                         except (ValueError, IndexError):
+                            logger.debug("Skipping unparseable AC sweep row: %s", line.strip())
                             continue
 
             return ac_data if ac_data["frequencies"] else None
@@ -233,6 +236,7 @@ class ResultParser:
                                     elif "inoise" in h_lower:
                                         noise_data["inoise_spectrum"].append(float(parts[j]))
                         except (ValueError, IndexError):
+                            logger.debug("Skipping unparseable noise data row: %s", line.strip())
                             continue
 
             return noise_data if noise_data["frequencies"] else None
@@ -295,6 +299,7 @@ class ResultParser:
                                 }
                             )
                         except (ValueError, IndexError):
+                            logger.debug("Skipping unparseable sensitivity row: %s", stripped)
                             continue
                     elif len(parts) >= 3:
                         try:
@@ -310,6 +315,7 @@ class ResultParser:
                                 }
                             )
                         except (ValueError, IndexError):
+                            logger.debug("Skipping unparseable sensitivity row: %s", stripped)
                             continue
 
             return results if results else None
@@ -447,6 +453,7 @@ class ResultParser:
                         row_data = {headers[i]: float(parts[i]) for i in range(len(parts))}
                         results.append(row_data)
                     except (ValueError, IndexError):
+                        logger.debug("Skipping unparseable transient data row: %s", line.strip())
                         continue
 
             return results if results else None


### PR DESCRIPTION
## Summary - ASC parser: 3 silent except-pass blocks now log malformed WIRE/FLAG/SYMBOL lines at debug level - Result parser: 7 silent except-continue blocks now log unparseable data rows at debug level - Covers DC sweep, AC sweep, noise, sensitivity, transient, and voltage table inner loops Closes #503 ## Test plan - [ ] Import a valid ASC file and verify no debug noise in logs - [ ] Import an ASC file with corrupted coordinates and verify debug log messages appear - [ ] Run simulations and verify result parsing still works correctly Generated with [Claude Code](https://claude.com/claude-code)