### PR TITLE
Add input validation to ComponentData and WireData from_dict

### DIFF
--- a/app/models/component.py
+++ b/app/models/component.py
@@ -400,7 +400,19 @@ class ComponentData:
 
         Handles both old-style class names (VoltageSource, OpAmp) and
         display names (Voltage Source, Op-Amp) in the 'type' field.
+
+        Raises:
+            ValueError: If required fields are missing or have wrong types.
         """
+        if not isinstance(data, dict):
+            raise ValueError(f"Expected dict, got {type(data).__name__}")
+        for key in ("id", "type", "value", "pos"):
+            if key not in data:
+                raise ValueError(f"Missing required field '{key}' in component data")
+        pos = data["pos"]
+        if not isinstance(pos, dict) or "x" not in pos or "y" not in pos:
+            raise ValueError("Component 'pos' must be a dict with 'x' and 'y' keys")
+
         raw_type = data["type"]
         # Normalize to display name
         component_type = _CLASS_TO_DISPLAY.get(raw_type, raw_type)

--- a/app/models/wire.py
+++ b/app/models/wire.py
@@ -76,7 +76,15 @@ class WireData:
         Deserialize wire from dictionary.
 
         Handles both old format (no waypoints) and new format (with waypoints).
+
+        Raises:
+            ValueError: If required fields are missing or have wrong types.
         """
+        if not isinstance(data, dict):
+            raise ValueError(f"Expected dict, got {type(data).__name__}")
+        for key in ("start_comp", "start_term", "end_comp", "end_term"):
+            if key not in data:
+                raise ValueError(f"Missing required field '{key}' in wire data")
         wire = cls(
             start_component_id=data["start_comp"],
             start_terminal=data["start_term"],

--- a/app/tests/unit/test_data_roundtrips_and_undo.py
+++ b/app/tests/unit/test_data_roundtrips_and_undo.py
@@ -876,3 +876,96 @@ class TestNodeConsistency:
 
         ground_nodes = [n for n in model.nodes if n.is_ground]
         assert len(ground_nodes) == 1
+
+
+# ===========================================================================
+# from_dict Input Validation  (#504)
+# ===========================================================================
+
+
+class TestComponentDataFromDictValidation:
+    """Issue #504: ComponentData.from_dict must reject invalid input."""
+
+    def test_non_dict_raises(self):
+        with pytest.raises(ValueError, match="Expected dict"):
+            ComponentData.from_dict("not a dict")
+
+    def test_list_raises(self):
+        with pytest.raises(ValueError, match="Expected dict"):
+            ComponentData.from_dict([1, 2, 3])
+
+    def test_none_raises(self):
+        with pytest.raises(ValueError, match="Expected dict"):
+            ComponentData.from_dict(None)
+
+    @pytest.mark.parametrize("missing_key", ["id", "type", "value", "pos"])
+    def test_missing_required_field(self, missing_key):
+        data = {
+            "id": "R1",
+            "type": "Resistor",
+            "value": "1k",
+            "pos": {"x": 0, "y": 0},
+        }
+        del data[missing_key]
+        with pytest.raises(ValueError, match=missing_key):
+            ComponentData.from_dict(data)
+
+    def test_pos_not_dict_raises(self):
+        data = {"id": "R1", "type": "Resistor", "value": "1k", "pos": [0, 0]}
+        with pytest.raises(ValueError, match="pos"):
+            ComponentData.from_dict(data)
+
+    def test_pos_missing_x_raises(self):
+        data = {"id": "R1", "type": "Resistor", "value": "1k", "pos": {"y": 0}}
+        with pytest.raises(ValueError, match="pos"):
+            ComponentData.from_dict(data)
+
+    def test_pos_missing_y_raises(self):
+        data = {"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0}}
+        with pytest.raises(ValueError, match="pos"):
+            ComponentData.from_dict(data)
+
+    def test_valid_data_succeeds(self):
+        data = {
+            "id": "R1",
+            "type": "Resistor",
+            "value": "1k",
+            "pos": {"x": 10, "y": 20},
+        }
+        comp = ComponentData.from_dict(data)
+        assert comp.component_id == "R1"
+        assert comp.position == (10, 20)
+
+
+class TestWireDataFromDictValidation:
+    """Issue #504: WireData.from_dict must reject invalid input."""
+
+    def test_non_dict_raises(self):
+        with pytest.raises(ValueError, match="Expected dict"):
+            WireData.from_dict("not a dict")
+
+    def test_list_raises(self):
+        with pytest.raises(ValueError, match="Expected dict"):
+            WireData.from_dict([1, 2])
+
+    def test_none_raises(self):
+        with pytest.raises(ValueError, match="Expected dict"):
+            WireData.from_dict(None)
+
+    @pytest.mark.parametrize("missing_key", ["start_comp", "start_term", "end_comp", "end_term"])
+    def test_missing_required_field(self, missing_key):
+        data = {
+            "start_comp": "R1",
+            "start_term": 0,
+            "end_comp": "R2",
+            "end_term": 1,
+        }
+        del data[missing_key]
+        with pytest.raises(ValueError, match=missing_key):
+            WireData.from_dict(data)
+
+    def test_valid_data_succeeds(self):
+        data = {"start_comp": "R1", "start_term": 0, "end_comp": "R2", "end_term": 1}
+        wire = WireData.from_dict(data)
+        assert wire.start_component_id == "R1"
+        assert wire.end_component_id == "R2"


### PR DESCRIPTION
## Summary -  now validates: input is a dict, required fields (uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu),4(adm),20(dialout),24(cdrom),25(floppy),27(sudo),29(audio),30(dip),44(video),46(plugdev), , , ) are present, and  is a dict with  and  keys -  now validates: input is a dict and required fields (, , , ) are present - Both raise  with descriptive messages on invalid input - 16 new unit tests covering all validation branches Closes #504 ## Test plan - [x] Unit tests for all validation branches (non-dict, missing fields, malformed pos) - [x] Existing round-trip tests still pass - [ ] CI green on all platforms Generated with [Claude Code](https://claude.com/claude-code)