### PR TITLE
Guard against division by zero in FFT analysis

### DIFF
--- a/app/simulation/fft_analysis.py
+++ b/app/simulation/fft_analysis.py
@@ -64,6 +64,8 @@ def compute_fft(
 
     # Calculate sample rate from time array
     dt = np.mean(np.diff(time))
+    if dt <= 0:
+        raise ValueError("Time data must be strictly increasing (mean time step is <= 0)")
     sample_rate = 1.0 / dt
     n_samples = len(signal)
 

--- a/app/tests/unit/test_fft_analysis.py
+++ b/app/tests/unit/test_fft_analysis.py
@@ -84,6 +84,22 @@ class TestComputeFFT:
         with pytest.raises(ValueError, match="at least 4 samples"):
             compute_fft(time, signal)
 
+    def test_constant_time_raises(self):
+        """Test FFT with all-identical timestamps raises ValueError, not ZeroDivisionError."""
+        time = np.array([0.0, 0.0, 0.0, 0.0])
+        signal = np.array([1.0, 2.0, 3.0, 4.0])
+
+        with pytest.raises(ValueError, match="strictly increasing"):
+            compute_fft(time, signal)
+
+    def test_decreasing_time_raises(self):
+        """Test FFT with decreasing timestamps raises ValueError."""
+        time = np.array([1.0, 0.75, 0.5, 0.25])
+        signal = np.array([1.0, 2.0, 3.0, 4.0])
+
+        with pytest.raises(ValueError, match="strictly increasing"):
+            compute_fft(time, signal)
+
     def test_magnitude_db_range(self):
         """Test that magnitude_db values are reasonable."""
         time = np.linspace(0, 1, 100, endpoint=False)


### PR DESCRIPTION
## Summary - compute_fft() now validates that the mean time step (dt) is positive before computing sample_rate = 1/dt - Raises descriptive ValueError instead of crashing with ZeroDivisionError on degenerate time data - Covers constant timestamps (all identical) and decreasing timestamps Closes #518 ## Test plan - [x] test_constant_time_raises: all-identical timestamps raise ValueError - [x] test_decreasing_time_raises: reversed timestamps raise ValueError - [ ] CI green on all platforms Generated with [Claude Code](https://claude.com/claude-code)