### PR TITLE
Decouple PreferencesDialog and GradingPanel from MainWindow internals (#585)

### DIFF
--- a/app/GUI/grading_panel.py
+++ b/app/GUI/grading_panel.py
@@ -39,9 +39,10 @@ class GradingPanel(QWidget):
     running the grader, and exporting results.
     """
 
-    def __init__(self, model: CircuitModel, parent=None):
+    def __init__(self, model: CircuitModel, parent=None, canvas=None):
         super().__init__(parent)
         self._model = model
+        self._canvas = canvas
         self._grader = None  # Lazy-initialized to avoid circular import
         self._rubric: Optional[Rubric] = None
         self._student_circuit: Optional[CircuitModel] = None
@@ -271,12 +272,13 @@ class GradingPanel(QWidget):
 
     # --- Highlight management ---
 
+    def set_canvas(self, canvas):
+        """Inject the circuit canvas reference for highlight management."""
+        self._canvas = canvas
+
     def _get_canvas(self):
-        """Get the circuit canvas from the parent window."""
-        parent = self.parent()
-        if parent is not None and hasattr(parent, "canvas"):
-            return parent.canvas
-        return None
+        """Return the injected circuit canvas, or None."""
+        return self._canvas
 
     def _clear_highlights(self):
         """Remove all grading overlays from canvas components."""

--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -113,7 +113,7 @@ class MainWindow(
         # Auto-save timer
         self._autosave_timer = QTimer(self)
         self._autosave_timer.timeout.connect(self._auto_save)
-        self._start_autosave_timer()
+        self.start_autosave_timer()
 
     # --- ApplicationShellProtocol properties ---
 
@@ -263,7 +263,7 @@ class MainWindow(
         right_panel_layout.addWidget(self.statistics_panel)
 
         # Instructor grading panel
-        self.grading_panel = GradingPanel(self.model, self)
+        self.grading_panel = GradingPanel(self.model, self, canvas=self.canvas)
         self.grading_panel.setVisible(False)
         right_panel_layout.addWidget(self.grading_panel)
 

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -322,19 +322,19 @@ class MenuBarMixin:
         self.theme_group.addAction(self.dark_theme_action)
 
         self._custom_theme_actions = []
-        self._refresh_theme_menu()
+        self.refresh_theme_menu()
 
         # Symbol Style submenu
         symbol_style_menu = view_menu.addMenu("&Symbol Style")
         self.ieee_style_action = QAction("&IEEE / ANSI (American)", self)
         self.ieee_style_action.setCheckable(True)
         self.ieee_style_action.setChecked(True)
-        self.ieee_style_action.triggered.connect(lambda: self._set_symbol_style("ieee"))
+        self.ieee_style_action.triggered.connect(lambda: self.set_symbol_style("ieee"))
         symbol_style_menu.addAction(self.ieee_style_action)
 
         self.iec_style_action = QAction("I&EC (European)", self)
         self.iec_style_action.setCheckable(True)
-        self.iec_style_action.triggered.connect(lambda: self._set_symbol_style("iec"))
+        self.iec_style_action.triggered.connect(lambda: self.set_symbol_style("iec"))
         symbol_style_menu.addAction(self.iec_style_action)
 
         self.symbol_style_group = QActionGroup(self)
@@ -346,12 +346,12 @@ class MenuBarMixin:
         self.color_mode_action = QAction("&Color (per component type)", self)
         self.color_mode_action.setCheckable(True)
         self.color_mode_action.setChecked(True)
-        self.color_mode_action.triggered.connect(lambda: self._set_color_mode("color"))
+        self.color_mode_action.triggered.connect(lambda: self.set_color_mode("color"))
         color_mode_menu.addAction(self.color_mode_action)
 
         self.monochrome_mode_action = QAction("&Monochrome", self)
         self.monochrome_mode_action.setCheckable(True)
-        self.monochrome_mode_action.triggered.connect(lambda: self._set_color_mode("monochrome"))
+        self.monochrome_mode_action.triggered.connect(lambda: self.set_color_mode("monochrome"))
         color_mode_menu.addAction(self.monochrome_mode_action)
 
         self.color_mode_group = QActionGroup(self)
@@ -364,20 +364,20 @@ class MenuBarMixin:
 
         thin_action = QAction("&Thin (1px)", self)
         thin_action.setCheckable(True)
-        thin_action.triggered.connect(lambda: self._set_wire_thickness("thin"))
+        thin_action.triggered.connect(lambda: self.set_wire_thickness("thin"))
         wire_thickness_menu.addAction(thin_action)
         self.wire_thickness_actions["thin"] = thin_action
 
         normal_action = QAction("&Normal (2px)", self)
         normal_action.setCheckable(True)
         normal_action.setChecked(True)
-        normal_action.triggered.connect(lambda: self._set_wire_thickness("normal"))
+        normal_action.triggered.connect(lambda: self.set_wire_thickness("normal"))
         wire_thickness_menu.addAction(normal_action)
         self.wire_thickness_actions["normal"] = normal_action
 
         thick_action = QAction("Thic&k (3px)", self)
         thick_action.setCheckable(True)
-        thick_action.triggered.connect(lambda: self._set_wire_thickness("thick"))
+        thick_action.triggered.connect(lambda: self.set_wire_thickness("thick"))
         wire_thickness_menu.addAction(thick_action)
         self.wire_thickness_actions["thick"] = thick_action
 
@@ -390,7 +390,7 @@ class MenuBarMixin:
         self.show_junction_dots_action = QAction("Show &Junction Dots", self)
         self.show_junction_dots_action.setCheckable(True)
         self.show_junction_dots_action.setChecked(True)
-        self.show_junction_dots_action.triggered.connect(self._set_show_junction_dots)
+        self.show_junction_dots_action.triggered.connect(self.set_show_junction_dots)
         view_menu.addAction(self.show_junction_dots_action)
 
         # Wire Routing Mode submenu
@@ -400,13 +400,13 @@ class MenuBarMixin:
         orthogonal_action = QAction("&Orthogonal (4-direction)", self)
         orthogonal_action.setCheckable(True)
         orthogonal_action.setChecked(True)
-        orthogonal_action.triggered.connect(lambda: self._set_routing_mode("orthogonal"))
+        orthogonal_action.triggered.connect(lambda: self.set_routing_mode("orthogonal"))
         routing_mode_menu.addAction(orthogonal_action)
         self.routing_mode_actions["orthogonal"] = orthogonal_action
 
         diagonal_action = QAction("&Diagonal (8-direction, 45°)", self)
         diagonal_action.setCheckable(True)
-        diagonal_action.triggered.connect(lambda: self._set_routing_mode("diagonal"))
+        diagonal_action.triggered.connect(lambda: self.set_routing_mode("diagonal"))
         routing_mode_menu.addAction(diagonal_action)
         self.routing_mode_actions["diagonal"] = diagonal_action
 
@@ -607,7 +607,7 @@ class MenuBarMixin:
             settings_menu.addSeparator()
 
             keybindings_action = QAction("&Keybindings...", self)
-            keybindings_action.triggered.connect(self._open_keybindings_dialog)
+            keybindings_action.triggered.connect(self.open_keybindings_dialog)
             settings_menu.addAction(keybindings_action)
 
         # Help menu
@@ -636,7 +636,7 @@ class MenuBarMixin:
         self._preferences_dialog = PreferencesDialog(self)
         self._preferences_dialog.show()
 
-    def _open_keybindings_dialog(self):
+    def open_keybindings_dialog(self):
         """Open the keybindings preferences dialog."""
         from .keybindings_dialog import KeybindingsDialog
 
@@ -651,7 +651,7 @@ class MenuBarMixin:
         for action_name, qaction in self._bound_actions.items():
             qaction.setShortcut(kb.get(action_name))
 
-    def _refresh_theme_menu(self):
+    def refresh_theme_menu(self):
         """Rebuild custom theme entries in the Theme submenu."""
         from .styles import theme_manager
 
@@ -695,5 +695,5 @@ class MenuBarMixin:
         from controllers.theme_controller import theme_ctrl
 
         theme_ctrl.set_theme_by_key(key)
-        self._apply_theme()
-        self._refresh_theme_menu()
+        self.apply_theme()
+        self.refresh_theme_menu()

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -89,9 +89,9 @@ class SettingsMixin:
         saved_theme_key = settings.get("view/theme_key")
         if saved_theme_key and saved_theme_key != "light":
             theme_ctrl.set_theme_by_key(saved_theme_key)
-            self._apply_theme()
-            if hasattr(self, "_refresh_theme_menu"):
-                self._refresh_theme_menu()
+            self.apply_theme()
+            if hasattr(self, "refresh_theme_menu"):
+                self.refresh_theme_menu()
         else:
             # Legacy fallback: check old theme name
             saved_theme = settings.get("view/theme")
@@ -100,23 +100,23 @@ class SettingsMixin:
 
         saved_symbol_style = settings.get("view/symbol_style")
         if saved_symbol_style in ("ieee", "iec"):
-            self._set_symbol_style(saved_symbol_style)
+            self.set_symbol_style(saved_symbol_style)
 
         saved_color_mode = settings.get("view/color_mode")
         if saved_color_mode in ("color", "monochrome"):
-            self._set_color_mode(saved_color_mode)
+            self.set_color_mode(saved_color_mode)
 
         saved_wire_thickness = settings.get("view/wire_thickness")
         if saved_wire_thickness in ("thin", "normal", "thick"):
-            self._set_wire_thickness(saved_wire_thickness)
+            self.set_wire_thickness(saved_wire_thickness)
 
         saved_junction_dots = settings.get("view/show_junction_dots")
         if saved_junction_dots is not None:
-            self._set_show_junction_dots(settings.get_bool("view/show_junction_dots"))
+            self.set_show_junction_dots(settings.get_bool("view/show_junction_dots"))
 
         saved_routing_mode = settings.get("view/routing_mode")
         if saved_routing_mode in ("orthogonal", "diagonal"):
-            self._set_routing_mode(saved_routing_mode)
+            self.set_routing_mode(saved_routing_mode)
 
     def closeEvent(self, event):
         """Save settings before closing"""
@@ -124,7 +124,7 @@ class SettingsMixin:
         self.file_ctrl.clear_auto_save()
         super().closeEvent(event)
 
-    def _start_autosave_timer(self):
+    def start_autosave_timer(self):
         """Start or restart the auto-save timer using the configured interval."""
         interval = settings.get_int("autosave/interval", 60)
         enabled = settings.get_bool("autosave/enabled", True)

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -19,11 +19,11 @@ class ViewOperationsMixin:
         else:
             theme_ctrl.set_theme_by_key("light")
             self.light_theme_action.setChecked(True)
-        self._apply_theme()
-        if hasattr(self, "_refresh_theme_menu"):
-            self._refresh_theme_menu()
+        self.apply_theme()
+        if hasattr(self, "refresh_theme_menu"):
+            self.refresh_theme_menu()
 
-    def _apply_theme(self):
+    def apply_theme(self):
         """Apply the current theme to all visual elements."""
         theme = theme_manager.current_theme
         self.setStyleSheet(theme.generate_dark_stylesheet())
@@ -31,7 +31,7 @@ class ViewOperationsMixin:
         # Refresh canvas (grid + components)
         self.canvas.refresh_theme()
 
-    def _set_symbol_style(self, style: str):
+    def set_symbol_style(self, style: str):
         """Switch the component symbol drawing style."""
         theme_ctrl.set_symbol_style(style)
         if style == "iec":
@@ -40,7 +40,7 @@ class ViewOperationsMixin:
             self.ieee_style_action.setChecked(True)
         self.canvas.scene.update()
 
-    def _set_color_mode(self, mode: str):
+    def set_color_mode(self, mode: str):
         """Switch between per-type color and monochrome rendering."""
         theme_ctrl.set_color_mode(mode)
         if mode == "monochrome":
@@ -49,7 +49,7 @@ class ViewOperationsMixin:
             self.color_mode_action.setChecked(True)
         self.canvas.scene.update()
 
-    def _set_wire_thickness(self, thickness: str):
+    def set_wire_thickness(self, thickness: str):
         """Switch wire rendering thickness."""
         theme_ctrl.set_wire_thickness(thickness)
         if hasattr(self, "wire_thickness_actions"):
@@ -57,14 +57,14 @@ class ViewOperationsMixin:
                 action.setChecked(t == thickness)
         self.canvas.scene.update()
 
-    def _set_show_junction_dots(self, show: bool):
+    def set_show_junction_dots(self, show: bool):
         """Toggle junction dot visibility at wire intersections."""
         theme_ctrl.set_show_junction_dots(show)
         if hasattr(self, "show_junction_dots_action"):
             self.show_junction_dots_action.setChecked(show)
         self.canvas.scene.update()
 
-    def _set_routing_mode(self, mode: str):
+    def set_routing_mode(self, mode: str):
         """Switch wire routing mode between orthogonal and diagonal."""
         theme_ctrl.set_routing_mode(mode)
         if hasattr(self, "routing_mode_actions"):

--- a/app/GUI/preferences_dialog.py
+++ b/app/GUI/preferences_dialog.py
@@ -71,15 +71,15 @@ class PreferencesDialog(QDialog):
     def _revert_settings(self):
         """Restore appearance and autosave to snapshot values."""
         theme_ctrl.set_theme(self._snap_theme_obj)
-        self.main_window._apply_theme()
-        self.main_window._set_symbol_style(self._snap_symbol_style)
-        self.main_window._set_color_mode(self._snap_color_mode)
-        self.main_window._set_wire_thickness(self._snap_wire_thickness)
-        self.main_window._set_show_junction_dots(self._snap_show_junction_dots)
+        self.main_window.apply_theme()
+        self.main_window.set_symbol_style(self._snap_symbol_style)
+        self.main_window.set_color_mode(self._snap_color_mode)
+        self.main_window.set_wire_thickness(self._snap_wire_thickness)
+        self.main_window.set_show_junction_dots(self._snap_show_junction_dots)
         settings.set("autosave/enabled", self._snap_autosave_enabled)
         settings.set("autosave/interval", self._snap_autosave_interval)
         settings.set("view/default_zoom", self._snap_default_zoom)
-        self.main_window._start_autosave_timer()
+        self.main_window.start_autosave_timer()
 
     # ---- UI construction --------------------------------------------------
 
@@ -249,23 +249,23 @@ class PreferencesDialog(QDialog):
         if 0 <= index < len(self._theme_keys):
             key = self._theme_keys[index]
             theme_ctrl.set_theme_by_key(key)
-            self.main_window._apply_theme()
+            self.main_window.apply_theme()
             self._update_theme_buttons()
             # Sync the View > Theme menu checkmarks
-            if hasattr(self.main_window, "_refresh_theme_menu"):
-                self.main_window._refresh_theme_menu()
+            if hasattr(self.main_window, "refresh_theme_menu"):
+                self.main_window.refresh_theme_menu()
 
     def _on_style_changed(self, index):
-        self.main_window._set_symbol_style(_STYLE_ITEMS[index][1])
+        self.main_window.set_symbol_style(_STYLE_ITEMS[index][1])
 
     def _on_color_changed(self, index):
-        self.main_window._set_color_mode(_COLOR_ITEMS[index][1])
+        self.main_window.set_color_mode(_COLOR_ITEMS[index][1])
 
     def _on_wire_thickness_changed(self, index):
-        self.main_window._set_wire_thickness(_WIRE_THICKNESS_ITEMS[index][1])
+        self.main_window.set_wire_thickness(_WIRE_THICKNESS_ITEMS[index][1])
 
     def _on_junction_dots_changed(self, checked):
-        self.main_window._set_show_junction_dots(checked)
+        self.main_window.set_show_junction_dots(checked)
 
     # ---- Theme management -------------------------------------------------
 
@@ -282,8 +282,8 @@ class PreferencesDialog(QDialog):
                 if key in self._theme_keys:
                     self.theme_combo.setCurrentIndex(self._theme_keys.index(key))
                 self._update_theme_buttons()
-                if hasattr(self.main_window, "_refresh_theme_menu"):
-                    self.main_window._refresh_theme_menu()
+                if hasattr(self.main_window, "refresh_theme_menu"):
+                    self.main_window.refresh_theme_menu()
 
     def _on_edit_theme(self):
         idx = self.theme_combo.currentIndex()
@@ -314,8 +314,8 @@ class PreferencesDialog(QDialog):
                 if new_key in self._theme_keys:
                     self.theme_combo.setCurrentIndex(self._theme_keys.index(new_key))
                 self._update_theme_buttons()
-                if hasattr(self.main_window, "_refresh_theme_menu"):
-                    self.main_window._refresh_theme_menu()
+                if hasattr(self.main_window, "refresh_theme_menu"):
+                    self.main_window.refresh_theme_menu()
 
     def _on_delete_theme(self):
         idx = self.theme_combo.currentIndex()
@@ -339,12 +339,12 @@ class PreferencesDialog(QDialog):
         theme_store.delete_theme(stem)
         # Switch to Light theme
         theme_ctrl.set_theme_by_key("light")
-        self.main_window._apply_theme()
+        self.main_window.apply_theme()
         self._populate_theme_combo()
         self.theme_combo.setCurrentIndex(0)
         self._update_theme_buttons()
-        if hasattr(self.main_window, "_refresh_theme_menu"):
-            self.main_window._refresh_theme_menu()
+        if hasattr(self.main_window, "refresh_theme_menu"):
+            self.main_window.refresh_theme_menu()
 
     def _on_import_theme(self):
         from pathlib import Path
@@ -359,8 +359,8 @@ class PreferencesDialog(QDialog):
             if key in self._theme_keys:
                 self.theme_combo.setCurrentIndex(self._theme_keys.index(key))
             self._update_theme_buttons()
-            if hasattr(self.main_window, "_refresh_theme_menu"):
-                self.main_window._refresh_theme_menu()
+            if hasattr(self.main_window, "refresh_theme_menu"):
+                self.main_window.refresh_theme_menu()
         else:
             QMessageBox.warning(self, "Import Failed", "Could not import the theme file.")
 
@@ -386,7 +386,7 @@ class PreferencesDialog(QDialog):
         settings.set("autosave/interval", self.autosave_spin.value())
         zoom_index = self.default_zoom_combo.currentIndex()
         settings.set("view/default_zoom", _ZOOM_ITEMS[zoom_index][1])
-        self.main_window._start_autosave_timer()
+        self.main_window.start_autosave_timer()
         # Persist theme key
         settings.set("view/theme_key", theme_manager.get_theme_key())
         settings.set("view/theme", theme_manager.current_theme.name)
@@ -412,4 +412,4 @@ class PreferencesDialog(QDialog):
 
     def _open_keybindings(self):
         """Open the keybindings editor dialog."""
-        self.main_window._open_keybindings_dialog()
+        self.main_window.open_keybindings_dialog()

--- a/app/tests/unit/test_main_window_refactor.py
+++ b/app/tests/unit/test_main_window_refactor.py
@@ -131,7 +131,7 @@ class TestMainWindowHasAllExpectedMethods:
 
         for method in [
             "create_menu_bar",
-            "_open_keybindings_dialog",
+            "open_keybindings_dialog",
             "_apply_keybindings",
         ]:
             assert hasattr(MainWindow, method), f"Missing: {method}"
@@ -196,7 +196,7 @@ class TestMainWindowHasAllExpectedMethods:
 
         methods = [
             "_set_theme",
-            "_apply_theme",
+            "apply_theme",
             "_toggle_statistics_panel",
             "_on_dirty_change",
             "_set_dirty",
@@ -236,7 +236,7 @@ class TestMainWindowHasAllExpectedMethods:
             "_save_settings",
             "_restore_settings",
             "closeEvent",
-            "_start_autosave_timer",
+            "start_autosave_timer",
             "_auto_save",
             "_check_auto_save_recovery",
         ]

--- a/app/tests/unit/test_preferences_dialog.py
+++ b/app/tests/unit/test_preferences_dialog.py
@@ -26,14 +26,14 @@ def mock_main_window():
     """Create a mock MainWindow with the methods PreferencesDialog calls."""
     mw = MagicMock()
     mw._set_theme = MagicMock()
-    mw._apply_theme = MagicMock()
-    mw._set_symbol_style = MagicMock()
-    mw._set_color_mode = MagicMock()
-    mw._set_wire_thickness = MagicMock()
-    mw._set_show_junction_dots = MagicMock()
-    mw._start_autosave_timer = MagicMock()
-    mw._open_keybindings_dialog = MagicMock()
-    mw._refresh_theme_menu = MagicMock()
+    mw.apply_theme = MagicMock()
+    mw.set_symbol_style = MagicMock()
+    mw.set_color_mode = MagicMock()
+    mw.set_wire_thickness = MagicMock()
+    mw.set_show_junction_dots = MagicMock()
+    mw.start_autosave_timer = MagicMock()
+    mw.open_keybindings_dialog = MagicMock()
+    mw.refresh_theme_menu = MagicMock()
     return mw
 
 
@@ -109,20 +109,20 @@ class TestLivePreview:
     """Tests verifying combo changes apply theme immediately."""
 
     def test_theme_combo_dark(self, dialog, mock_main_window):
-        mock_main_window._apply_theme.reset_mock()
+        mock_main_window.apply_theme.reset_mock()
         dialog.theme_combo.setCurrentIndex(1)  # Dark
-        mock_main_window._apply_theme.assert_called()
+        mock_main_window.apply_theme.assert_called()
         assert theme_manager.current_theme.name == "Dark Theme"
 
     def test_symbol_style_combo_live_preview(self, dialog, mock_main_window):
-        mock_main_window._set_symbol_style.reset_mock()
+        mock_main_window.set_symbol_style.reset_mock()
         dialog.style_combo.setCurrentIndex(1)  # IEC
-        mock_main_window._set_symbol_style.assert_called_with("iec")
+        mock_main_window.set_symbol_style.assert_called_with("iec")
 
     def test_color_mode_combo_live_preview(self, dialog, mock_main_window):
-        mock_main_window._set_color_mode.reset_mock()
+        mock_main_window.set_color_mode.reset_mock()
         dialog.color_combo.setCurrentIndex(1)  # Monochrome
-        mock_main_window._set_color_mode.assert_called_with("monochrome")
+        mock_main_window.set_color_mode.assert_called_with("monochrome")
 
 
 class TestCancelRevert:
@@ -137,9 +137,9 @@ class TestCancelRevert:
 
     def test_cancel_reverts_symbol_style(self, dialog, mock_main_window):
         dialog.style_combo.setCurrentIndex(1)
-        mock_main_window._set_symbol_style.reset_mock()
+        mock_main_window.set_symbol_style.reset_mock()
         dialog._on_cancel()
-        mock_main_window._set_symbol_style.assert_called_with("ieee")
+        mock_main_window.set_symbol_style.assert_called_with("ieee")
 
     def test_cancel_reverts_default_zoom(self, dialog, mock_main_window):
         dialog.default_zoom_combo.setCurrentIndex(0)  # 50%
@@ -159,7 +159,7 @@ class TestOkPersist:
 
         assert app_settings.get_int("autosave/interval") == 120
         assert app_settings.get_bool("autosave/enabled") is True
-        mock_main_window._start_autosave_timer.assert_called()
+        mock_main_window.start_autosave_timer.assert_called()
 
     def test_ok_persists_theme_key(self, dialog, mock_main_window):
         dialog._on_ok()
@@ -217,31 +217,31 @@ class TestWireRenderingPreferences:
         assert dialog.junction_dots_checkbox.isChecked()
 
     def test_wire_thickness_live_preview(self, dialog, mock_main_window):
-        mock_main_window._set_wire_thickness.reset_mock()
+        mock_main_window.set_wire_thickness.reset_mock()
         dialog.wire_thickness_combo.setCurrentIndex(0)  # Thin
-        mock_main_window._set_wire_thickness.assert_called_with("thin")
+        mock_main_window.set_wire_thickness.assert_called_with("thin")
 
     def test_wire_thickness_thick_live_preview(self, dialog, mock_main_window):
-        mock_main_window._set_wire_thickness.reset_mock()
+        mock_main_window.set_wire_thickness.reset_mock()
         dialog.wire_thickness_combo.setCurrentIndex(2)  # Thick
-        mock_main_window._set_wire_thickness.assert_called_with("thick")
+        mock_main_window.set_wire_thickness.assert_called_with("thick")
 
     def test_junction_dots_toggle_live_preview(self, dialog, mock_main_window):
-        mock_main_window._set_show_junction_dots.reset_mock()
+        mock_main_window.set_show_junction_dots.reset_mock()
         dialog.junction_dots_checkbox.setChecked(False)
-        mock_main_window._set_show_junction_dots.assert_called_with(False)
+        mock_main_window.set_show_junction_dots.assert_called_with(False)
 
     def test_cancel_reverts_wire_thickness(self, dialog, mock_main_window):
         dialog.wire_thickness_combo.setCurrentIndex(0)  # Change to thin
-        mock_main_window._set_wire_thickness.reset_mock()
+        mock_main_window.set_wire_thickness.reset_mock()
         dialog._on_cancel()
-        mock_main_window._set_wire_thickness.assert_called_with("normal")
+        mock_main_window.set_wire_thickness.assert_called_with("normal")
 
     def test_cancel_reverts_junction_dots(self, dialog, mock_main_window):
         dialog.junction_dots_checkbox.setChecked(False)
-        mock_main_window._set_show_junction_dots.reset_mock()
+        mock_main_window.set_show_junction_dots.reset_mock()
         dialog._on_cancel()
-        mock_main_window._set_show_junction_dots.assert_called_with(True)
+        mock_main_window.set_show_junction_dots.assert_called_with(True)
 
     def test_ok_persists_wire_thickness(self, dialog, mock_main_window):
         dialog.wire_thickness_combo.setCurrentIndex(2)  # Thick
@@ -298,7 +298,7 @@ class TestAutosaveSpinboxState:
         dlg.autosave_checkbox.setChecked(False)
         dlg._on_cancel()
         assert app_settings.get_bool("autosave/enabled") is True
-        mock_main_window._start_autosave_timer.assert_called()
+        mock_main_window.start_autosave_timer.assert_called()
 
     def test_cancel_reverts_autosave_interval(self, dialog, mock_main_window):
         """Cancel should revert auto-save interval to the snapshot value."""


### PR DESCRIPTION
## Summary - Rename 8 private MainWindow mixin methods to public API: apply_theme, set_symbol_style, set_color_mode, set_wire_thickness, set_show_junction_dots, set_routing_mode, start_autosave_timer, refresh_theme_menu, open_keybindings_dialog - PreferencesDialog now calls public methods instead of reaching into private internals (17 call sites updated) - GradingPanel accepts canvas via constructor injection instead of traversing parent().canvas - Update all callers in main_window_menus.py, main_window_settings.py, main_window.py - Update test mocks and method existence assertions ## Test plan - [x] All callers updated consistently across 8 files - [x] No stale private method references remain - [ ] CI passes all existing tests (preferences dialog, main window refactor, grading panel, theme controller tests) - [ ] Manual: Preferences dialog live-previews theme/style/color changes - [ ] Manual: Grading panel highlights components on check selection Closes #585 🤖 Generated with [Claude Code](https://claude.com/claude-code)