### PR TITLE
Add ngspice integration test CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,28 @@ jobs:
         working-directory: app
         run: python -m pytest tests/ -v --tb=short --cov=. --cov-report=term-missing
 
+  integration:
+    name: Integration (ngspice)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ngspice libegl1 xvfb
+
+      - name: Install dependencies
+        run: pip install -r app/requirements.txt -r app/requirements-dev.txt
+
+      - name: Run integration tests
+        working-directory: app
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: xvfb-run python -m pytest tests/integration/ -v --tb=short -m ngspice
+
   import-check:
     name: Import Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,11 @@ jobs:
         working-directory: app
         env:
           QT_QPA_PLATFORM: offscreen
-        run: xvfb-run python -m pytest tests/integration/ -v --tb=short -m ngspice
+        run: |
+          rc=0
+          xvfb-run python -m pytest tests/integration/ -v --tb=short -m ngspice || rc=$?
+          # exit code 5 = no tests collected (suite may be empty initially)
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then exit "$rc"; fi
 
   import-check:
     name: Import Check

--- a/app/pytest.ini
+++ b/app/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 testpaths = tests
+markers =
+    ngspice: marks tests that require ngspice (deselect with '-m "not ngspice"')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.pytest.ini_options]
 pythonpath = ["app"]
 testpaths = ["app/tests"]
+markers = [
+    "ngspice: marks tests that require ngspice (deselect with '-m \"not ngspice\"')",
+]


### PR DESCRIPTION
## Summary - Add a new  CI job to  that installs ngspice via apt-get and runs  on ubuntu-latest - Register the  pytest mark in  to avoid warnings - Existing unit test matrix jobs are unchanged Closes #695 ## Test plan - [ ] New  job appears in CI on this PR - [ ] Job installs ngspice successfully - [ ] Job runs (suite can be empty initially — no tests are marked  yet) - [ ] Existing CI jobs (lint, test, security, import-check) remain unchanged and pass 🤖 Generated with [Claude Code](https://claude.com/claude-code)