### PR TITLE
Add ngspice integration test skeleton (#696)

### DIFF
--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -1,0 +1,16 @@
+"""
+Integration-test fixtures.
+
+The session-scoped ``require_ngspice`` guard automatically skips every test
+in this package when ngspice is not available on the PATH.
+"""
+
+import shutil
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def require_ngspice():
+    if shutil.which("ngspice") is None:
+        pytest.skip("ngspice not installed", allow_module_level=True)

--- a/app/tests/integration/test_ngspice_smoke.py
+++ b/app/tests/integration/test_ngspice_smoke.py
@@ -1,0 +1,24 @@
+"""
+Smoke test: run a trivial DC netlist through NgspiceRunner and verify success.
+"""
+
+import os
+import tempfile
+
+import pytest
+from simulation.ngspice_runner import NgspiceRunner
+
+
+@pytest.mark.ngspice
+class TestNgspiceSmoke:
+    def test_dc_resistor_netlist(self):
+        """NgspiceRunner should complete a simple V-R-GND DC operating-point sim."""
+        netlist = "* DC smoke test\nV1 1 0 DC 5\nR1 1 0 1k\n.op\n.end\n"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner = NgspiceRunner(output_dir=tmpdir)
+            success, output_file, stdout, stderr = runner.run_simulation(netlist)
+
+            assert success, f"ngspice failed: {stderr}"
+            assert output_file is not None
+            assert os.path.isfile(output_file)


### PR DESCRIPTION
## Summary - Add  with a session-scoped  fixture that auto-skips all integration tests when ngspice is not on PATH - Add  with a DC resistor smoke test exercising  end-to-end ## Test plan - [ ] CI  job runs the new smoke test against an ngspice-equipped runner - [ ] Non-ngspice CI jobs skip the integration tests gracefully (marker + fixture guard) Closes #696 🤖 Generated with [Claude Code](https://claude.com/claude-code)