### PR TITLE
Fix noisy warning traceback on first run (#718)

### DIFF
--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -175,6 +175,8 @@ class FileController:
         Returns:
             Path to the last opened file, or None.
         """
+        if not self._session_file.exists():
+            return None
         try:
             with open(self._session_file, "r") as f:
                 path_str = f.read().strip()

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -175,7 +175,7 @@ class FileController:
         Returns:
             Path to the last opened file, or None.
         """
-        if not self._session_file.exists():
+        if not os.path.exists(self._session_file):
             return None
         try:
             with open(self._session_file, "r") as f:


### PR DESCRIPTION
## Summary - Add file existence check in  before attempting , so a missing  on first run returns  silently instead of logging a full traceback via  - The  catch with  is preserved for genuine read failures (permissions, corrupt data) Fixes #718 ## Test plan - [ ] First run with no  — should return  with no warning logged - [ ] Existing  with valid path — should return the path as before - [ ] Existing  with read permission denied — should log warning with traceback 🤖 Generated with [Claude Code](https://claude.com/claude-code)