### PR TITLE
Fix grid lines rendering over components (#722)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -504,6 +504,7 @@ class CircuitCanvasView(QGraphicsView):
             is_major = x % MAJOR_GRID_INTERVAL == 0
             pen = major_pen if is_major else minor_pen
             line = self.scene.addLine(x, -GRID_EXTENT, x, GRID_EXTENT, pen)
+            line.setZValue(-1)
             self._grid_items.append(line)
 
             # Add label for major grid lines
@@ -521,6 +522,7 @@ class CircuitCanvasView(QGraphicsView):
             is_major = y % MAJOR_GRID_INTERVAL == 0
             pen = major_pen if is_major else minor_pen
             line = self.scene.addLine(-GRID_EXTENT, y, GRID_EXTENT, y, pen)
+            line.setZValue(-1)
             self._grid_items.append(line)
 
             # Add label for major grid lines


### PR DESCRIPTION
## Summary

Grid line `QGraphicsLineItem` objects were defaulting to `z=0`, the same as components, causing them to render on top of component symbols. Grid labels already had `setZValue(-1)` — this fix applies the same to the line items.

## Change

Two lines added in `draw_grid()` in `app/GUI/circuit_canvas.py`:

```python
line.setZValue(-1)  # added for both vertical and horizontal lines
```

## Z-order after fix

| Layer | z-value |
|---|---|
| Grid lines + labels | -1 |
| Components | 0 |
| Wires | 1 |
| Annotations | 90 |
| Waypoint handles | 200 |

## Test plan

- [x] `python -m pytest app/tests/ -x -q` — 3556 passed
- [ ] Visual smoke test: place components on grid, confirm no grid lines visible through symbols

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)