### PR TITLE
Add CourseSelectDialog -- startup profile picker (#701)

### DIFF
--- a/app/GUI/course_select_dialog.py
+++ b/app/GUI/course_select_dialog.py
@@ -1,0 +1,101 @@
+"""CourseSelectDialog - Startup / View-menu dialog for picking a course profile.
+
+Users choose from available course profiles to tailor the GUI
+(visible components, analyses, and panels) for their class.
+"""
+
+from __future__ import annotations
+
+from controllers.profile_manager import profile_manager
+from controllers.settings_service import settings
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QDialog, QDialogButtonBox, QLabel, QListWidget, QListWidgetItem, QVBoxLayout
+
+_SETTINGS_KEY = "course/profile_id"
+
+
+class CourseSelectDialog(QDialog):
+    """Modal dialog that lets users pick a course profile."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Select Course Profile")
+        self.setMinimumWidth(420)
+        self._setup_ui()
+        self._populate_profiles()
+        self._select_current_profile()
+
+    # ── UI construction ──────────────────────────────────────────────
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+
+        header = QLabel("Choose a course profile to customise the interface:")
+        header.setWordWrap(True)
+        layout.addWidget(header)
+
+        self._list = QListWidget()
+        self._list.currentRowChanged.connect(self._on_selection_changed)
+        self._list.itemDoubleClicked.connect(self._on_double_click)
+        layout.addWidget(self._list)
+
+        self._desc_label = QLabel()
+        self._desc_label.setWordWrap(True)
+        self._desc_label.setStyleSheet("color: gray;")
+        layout.addWidget(self._desc_label)
+
+        self._buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        self._buttons.accepted.connect(self._on_accept)
+        self._buttons.rejected.connect(self.reject)
+        self._ok_button = self._buttons.button(QDialogButtonBox.StandardButton.Ok)
+        self._ok_button.setEnabled(False)
+        layout.addWidget(self._buttons)
+
+    # ── Data ─────────────────────────────────────────────────────────
+
+    def _populate_profiles(self):
+        self._profiles = profile_manager.list_profiles()
+        for profile in self._profiles:
+            item = QListWidgetItem(profile.name)
+            item.setData(Qt.ItemDataRole.UserRole, profile.id)
+            self._list.addItem(item)
+
+    def _select_current_profile(self):
+        """Pre-select the remembered (or active) profile."""
+        saved_id = settings.get_str(_SETTINGS_KEY, "")
+        current_id = saved_id or profile_manager.get_profile().id
+        for row in range(self._list.count()):
+            item = self._list.item(row)
+            if item and item.data(Qt.ItemDataRole.UserRole) == current_id:
+                self._list.setCurrentRow(row)
+                return
+
+    # ── Slots ────────────────────────────────────────────────────────
+
+    def _on_selection_changed(self, row: int):
+        if row < 0 or row >= len(self._profiles):
+            self._desc_label.setText("")
+            self._ok_button.setEnabled(False)
+            return
+        self._desc_label.setText(self._profiles[row].description)
+        self._ok_button.setEnabled(True)
+
+    def _on_double_click(self, item: QListWidgetItem):
+        self._on_accept()
+
+    def _on_accept(self):
+        profile = self.selected_profile()
+        if profile is None:
+            return
+        profile_manager.set_profile(profile.id)
+        settings.set(_SETTINGS_KEY, profile.id)
+        self.accept()
+
+    # ── Public API ───────────────────────────────────────────────────
+
+    def selected_profile(self):
+        """Return the currently highlighted CourseProfile, or None."""
+        row = self._list.currentRow()
+        if 0 <= row < len(self._profiles):
+            return self._profiles[row]
+        return None

--- a/app/tests/unit/test_course_select_dialog.py
+++ b/app/tests/unit/test_course_select_dialog.py
@@ -1,0 +1,184 @@
+"""Tests for CourseSelectDialog (#701).
+
+Validates profile listing, selection, persistence via settings_service,
+and activation via ProfileManager.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from controllers.profile_manager import ProfileManager
+from models.course_profile import BUILTIN_PROFILES
+from PyQt6.QtCore import Qt
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_profile_manager():
+    """Reset singleton state between tests."""
+    ProfileManager._instance = None
+    yield
+    ProfileManager._instance = None
+
+
+@pytest.fixture()
+def mock_settings():
+    """Patch settings_service so nothing touches disk."""
+    with patch("GUI.course_select_dialog.settings") as s:
+        s.get_str.return_value = ""
+        yield s
+
+
+@pytest.fixture()
+def dialog(qtbot, mock_settings):
+    from GUI.course_select_dialog import CourseSelectDialog
+
+    dlg = CourseSelectDialog()
+    qtbot.addWidget(dlg)
+    return dlg
+
+
+# ── Construction / population ────────────────────────────────────────
+
+
+class TestDialogConstruction:
+    def test_window_title(self, dialog):
+        assert dialog.windowTitle() == "Select Course Profile"
+
+    def test_lists_all_builtin_profiles(self, dialog):
+        assert dialog._list.count() == len(BUILTIN_PROFILES)
+
+    def test_profile_names_displayed(self, dialog):
+        names = {dialog._list.item(i).text() for i in range(dialog._list.count())}
+        expected = {p.name for p in BUILTIN_PROFILES.values()}
+        assert names == expected
+
+    def test_profile_ids_stored_as_user_role(self, dialog):
+        ids = {dialog._list.item(i).data(Qt.ItemDataRole.UserRole) for i in range(dialog._list.count())}
+        expected = set(BUILTIN_PROFILES.keys())
+        assert ids == expected
+
+    def test_ok_button_enabled_after_preselection(self, dialog):
+        """Current profile is pre-selected so OK starts enabled."""
+        assert dialog._ok_button.isEnabled()
+
+
+# ── Pre-selection ────────────────────────────────────────────────────
+
+
+class TestPreSelection:
+    def test_defaults_to_full_when_no_saved_setting(self, dialog):
+        selected = dialog.selected_profile()
+        assert selected is not None
+        assert selected.id == "full"
+
+    def test_restores_saved_profile_from_settings(self, qtbot, mock_settings):
+        from GUI.course_select_dialog import CourseSelectDialog
+
+        mock_settings.get_str.return_value = "ee120"
+        dlg = CourseSelectDialog()
+        qtbot.addWidget(dlg)
+
+        selected = dlg.selected_profile()
+        assert selected is not None
+        assert selected.id == "ee120"
+
+    def test_falls_back_to_active_profile_if_setting_empty(self, qtbot, mock_settings):
+        from controllers.profile_manager import profile_manager
+        from GUI.course_select_dialog import CourseSelectDialog
+
+        profile_manager.set_profile("circuits1")
+        mock_settings.get_str.return_value = ""
+
+        dlg = CourseSelectDialog()
+        qtbot.addWidget(dlg)
+
+        selected = dlg.selected_profile()
+        assert selected is not None
+        assert selected.id == "circuits1"
+
+
+# ── Selection behaviour ─────────────────────────────────────────────
+
+
+class TestSelection:
+    def test_description_updates_on_selection(self, dialog):
+        dialog._list.setCurrentRow(0)
+        profile = dialog._profiles[0]
+        assert dialog._desc_label.text() == profile.description
+
+    def test_ok_disabled_when_no_row(self, dialog):
+        dialog._list.setCurrentRow(-1)
+        assert not dialog._ok_button.isEnabled()
+
+    def test_selected_profile_returns_none_for_no_selection(self, dialog):
+        dialog._list.setCurrentRow(-1)
+        assert dialog.selected_profile() is None
+
+    def test_selected_profile_returns_correct_profile(self, dialog):
+        for row in range(dialog._list.count()):
+            dialog._list.setCurrentRow(row)
+            profile = dialog.selected_profile()
+            assert profile is dialog._profiles[row]
+
+
+# ── Accept / apply ───────────────────────────────────────────────────
+
+
+class TestAccept:
+    def test_accept_sets_profile_on_manager(self, dialog, mock_settings):
+        from controllers.profile_manager import profile_manager
+
+        # Pick a profile that isn't the current one
+        target = next(p for p in dialog._profiles if p.id == "ee120")
+        row = dialog._profiles.index(target)
+        dialog._list.setCurrentRow(row)
+
+        dialog._on_accept()
+
+        assert profile_manager.get_profile().id == "ee120"
+
+    def test_accept_persists_to_settings(self, dialog, mock_settings):
+        target = next(p for p in dialog._profiles if p.id == "circuits1")
+        row = dialog._profiles.index(target)
+        dialog._list.setCurrentRow(row)
+
+        dialog._on_accept()
+
+        mock_settings.set.assert_called_with("course/profile_id", "circuits1")
+
+    def test_accept_noop_when_nothing_selected(self, dialog, mock_settings):
+        dialog._list.setCurrentRow(-1)
+        dialog._on_accept()
+        mock_settings.set.assert_not_called()
+
+    def test_double_click_accepts(self, dialog, mock_settings):
+        from controllers.profile_manager import profile_manager
+
+        target = next(p for p in dialog._profiles if p.id == "me301")
+        row = dialog._profiles.index(target)
+        dialog._list.setCurrentRow(row)
+
+        item = dialog._list.item(row)
+        dialog._on_double_click(item)
+
+        assert profile_manager.get_profile().id == "me301"
+        mock_settings.set.assert_called_with("course/profile_id", "me301")
+
+
+# ── Full profile is always present ───────────────────────────────────
+
+
+class TestFullProfile:
+    def test_full_profile_present(self, dialog):
+        ids = [dialog._list.item(i).data(Qt.ItemDataRole.UserRole) for i in range(dialog._list.count())]
+        assert "full" in ids
+
+    def test_full_profile_enables_everything(self):
+        full = BUILTIN_PROFILES["full"]
+        assert full.show_advanced_panels is True
+        assert len(full.allowed_components) > 0
+        assert len(full.allowed_analyses) > 0


### PR DESCRIPTION
## Summary - Adds CourseSelectDialog (app/GUI/course_select_dialog.py) -- a modal Qt dialog for picking a course profile at startup or from the View menu - Lists all profiles from ProfileManager.list_profiles() with name + description - Applies selection via ProfileManager.set_profile(id) and persists the choice through settings_service under course/profile_id - Pre-selects the saved profile (or falls back to active profile / Full Access default) - Includes 15 unit tests covering construction, pre-selection, accept/cancel behaviour, double-click, and the Full default profile ## Test plan - [ ] Verify dialog opens and lists all 5 built-in profiles - [ ] Verify selecting a profile updates the description label - [ ] Verify clicking OK applies the profile and persists to settings - [ ] Verify double-clicking a profile accepts immediately - [ ] Verify reopening the dialog pre-selects the previously chosen profile - [ ] Run pytest app/tests/unit/test_course_select_dialog.py -v -- all 15 tests pass Closes #701