### PR TITLE
Add profile filtering to ComponentPalette (#702)

### DIFF
--- a/app/GUI/component_palette.py
+++ b/app/GUI/component_palette.py
@@ -1,3 +1,4 @@
+from controllers.profile_manager import profile_manager
 from controllers.settings_service import settings as app_settings
 from models.builtin_subcircuits import register_builtin_subcircuits
 from models.component import COMPONENT_CATEGORIES
@@ -90,6 +91,10 @@ class ComponentPalette(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(4)
 
+        # Profile filtering — set of allowed component names (empty = show all)
+        self._allowed_components: set[str] = set()
+        self._apply_profile(profile_manager.get_profile())
+
         # Search filter
         self.search_input = QLineEdit()
         self.search_input.setPlaceholderText("Filter components...")
@@ -143,6 +148,48 @@ class ComponentPalette(QWidget):
         self.tree_widget.itemExpanded.connect(self._save_expanded_state)
         self.tree_widget.itemCollapsed.connect(self._save_expanded_state)
         layout.addWidget(self.tree_widget)
+
+        # Apply initial profile filter and observe future changes
+        self._apply_profile_filter()
+        profile_manager.register_observer(self._on_profile_changed)
+
+    # ── Profile filtering ────────────────────────────────────────────
+
+    def _apply_profile(self, profile):
+        """Update the allowed-components set from a CourseProfile."""
+        if profile.id == "full":
+            self._allowed_components = set()
+        else:
+            self._allowed_components = set(profile.allowed_components)
+
+    def _on_profile_changed(self, profile):
+        """Observer callback — refresh visibility when the active profile changes."""
+        self._apply_profile(profile)
+        self._apply_profile_filter()
+
+    def _apply_profile_filter(self):
+        """Show/hide component items based on the active profile then re-apply search."""
+        allowed = self._allowed_components
+
+        for category_item in self._category_items.values():
+            for i in range(category_item.childCount()):
+                child = category_item.child(i)
+                hidden_by_profile = bool(allowed) and child.text(0) not in allowed
+                child.setHidden(hidden_by_profile)
+
+            # Hide category entirely when all children are profile-hidden
+            if allowed:
+                any_visible = any(not category_item.child(i).isHidden() for i in range(category_item.childCount()))
+                category_item.setHidden(not any_visible)
+            else:
+                category_item.setHidden(False)
+
+        # Re-apply the current search filter on top of profile filtering
+        self._filter_components(self.search_input.text())
+
+    def _is_hidden_by_profile(self, component_name: str) -> bool:
+        """Return True if the component is excluded by the active profile."""
+        return bool(self._allowed_components) and component_name not in self._allowed_components
 
     def _on_item_double_clicked(self, item, column):
         """Handle double-click on palette item (ignore category headers)."""
@@ -249,6 +296,10 @@ class ComponentPalette(QWidget):
             any_child_visible = False
             for i in range(category_item.childCount()):
                 child = category_item.child(i)
+                # Items hidden by profile stay hidden regardless of search
+                if self._is_hidden_by_profile(child.text(0)):
+                    child.setHidden(True)
+                    continue
                 name = child.text(0).lower()
                 tooltip = (child.toolTip(0) or "").lower()
                 matches = text in name or text in tooltip

--- a/app/tests/unit/test_component_palette.py
+++ b/app/tests/unit/test_component_palette.py
@@ -7,10 +7,12 @@ recommended components, and used-in-file auto-detection.
 """
 
 import pytest
+from controllers.profile_manager import ProfileManager, profile_manager
 from controllers.settings_service import settings as app_settings
 from GUI.component_palette import _RECOMMENDED_CATEGORY, _USED_IN_FILE_CATEGORY, ComponentPalette
 from GUI.styles import COMPONENTS
 from models.component import COMPONENT_CATEGORIES
+from models.course_profile import BUILTIN_PROFILES
 from PyQt6.QtCore import Qt
 
 
@@ -23,6 +25,14 @@ def _clear_palette_settings():
     # Cleanup after test too
     for category_name in COMPONENT_CATEGORIES:
         app_settings.set(f"palette/expanded/{category_name}", None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_profile_manager():
+    """Reset ProfileManager singleton so each test starts with 'full' profile."""
+    ProfileManager._instance = None
+    yield
+    ProfileManager._instance = None
 
 
 @pytest.fixture
@@ -389,3 +399,65 @@ class TestCircuitModelRecommendedPersistence:
         model.recommended_components = ["Resistor"]
         model.clear()
         assert model.recommended_components == []
+
+
+class TestProfileFiltering:
+    """Test profile-based component filtering."""
+
+    def test_full_profile_shows_all(self, palette):
+        """With the default 'full' profile every component should be visible."""
+        visible = _visible_component_names(palette)
+        assert len(visible) == len(COMPONENTS)
+
+    def test_restricted_profile_hides_components(self, qtbot):
+        """Switching to ee120 should hide components not in that profile."""
+        profile_manager.set_profile("ee120")
+        p = ComponentPalette()
+        qtbot.addWidget(p)
+        visible = _visible_component_names(p)
+        ee120 = BUILTIN_PROFILES["ee120"]
+        assert set(visible) == set(ee120.allowed_components)
+
+    def test_observer_updates_on_profile_change(self, palette):
+        """Palette observes ProfileManager and updates when profile changes."""
+        profile_manager.set_profile("ee120")
+        visible = _visible_component_names(palette)
+        ee120 = BUILTIN_PROFILES["ee120"]
+        assert set(visible) == set(ee120.allowed_components)
+
+    def test_switch_back_to_full_restores_all(self, palette):
+        """Switching from restricted back to full should show everything again."""
+        profile_manager.set_profile("ee120")
+        profile_manager.set_profile("full")
+        visible = _visible_component_names(palette)
+        assert len(visible) == len(COMPONENTS)
+
+    def test_hidden_categories_when_no_children_allowed(self, palette):
+        """Categories with no allowed children should be hidden entirely."""
+        profile_manager.set_profile("ee120")
+        # ee120 has no semiconductors
+        assert palette._category_items["Semiconductors"].isHidden()
+        # Passive has Resistor which is in ee120
+        assert not palette._category_items["Passive"].isHidden()
+
+    def test_search_respects_profile_filter(self, palette):
+        """Search should not reveal components hidden by the profile."""
+        profile_manager.set_profile("ee120")
+        palette.search_input.setText("capacitor")
+        visible = _visible_component_names(palette)
+        # Capacitor is not in ee120, so it should stay hidden
+        assert "Capacitor" not in visible
+
+    def test_search_works_within_allowed(self, palette):
+        """Search should find components that are allowed by the profile."""
+        profile_manager.set_profile("ee120")
+        palette.search_input.setText("resistor")
+        visible = _visible_component_names(palette)
+        assert "Resistor" in visible
+
+    def test_circuits2_profile(self, palette):
+        """circuits2 should show op-amp and dependent sources."""
+        profile_manager.set_profile("circuits2")
+        visible = _visible_component_names(palette)
+        circuits2 = BUILTIN_PROFILES["circuits2"]
+        assert set(visible) == set(circuits2.allowed_components)

--- a/app/tests/unit/test_course_select_dialog.py
+++ b/app/tests/unit/test_course_select_dialog.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-from controllers.profile_manager import ProfileManager
+from controllers.profile_manager import ProfileManager, profile_manager
 from models.course_profile import BUILTIN_PROFILES
 from PyQt6.QtCore import Qt
 
@@ -18,10 +18,14 @@ from PyQt6.QtCore import Qt
 
 @pytest.fixture(autouse=True)
 def _reset_profile_manager():
-    """Reset singleton state between tests."""
+    """Reset singleton and module-level instance state between tests."""
     ProfileManager._instance = None
+    profile_manager._profile = BUILTIN_PROFILES["full"]
+    profile_manager._observers.clear()
     yield
     ProfileManager._instance = None
+    profile_manager._profile = BUILTIN_PROFILES["full"]
+    profile_manager._observers.clear()
 
 
 @pytest.fixture()

--- a/app/tests/unit/test_qtbot_widget_interactions.py
+++ b/app/tests/unit/test_qtbot_widget_interactions.py
@@ -13,6 +13,7 @@ Issue: #282
 import pytest
 from controllers.circuit_controller import CircuitController
 from controllers.keybindings import KeybindingsRegistry
+from controllers.profile_manager import profile_manager
 from controllers.simulation_controller import SimulationController
 from GUI.analysis_dialog import AnalysisDialog
 from GUI.component_palette import ComponentPalette
@@ -20,6 +21,7 @@ from GUI.keybindings_dialog import KeybindingsDialog
 from GUI.properties_panel import PropertiesPanel
 from models.circuit import CircuitModel
 from models.component import COMPONENT_TYPES, TERMINAL_COUNTS, ComponentData
+from models.course_profile import BUILTIN_PROFILES
 
 pytest.importorskip("PyQt6")
 
@@ -127,6 +129,13 @@ class TestAnalysisDialogInteractions:
 
 class TestComponentPaletteInteractions:
     """Additional palette tests: search and category filtering."""
+
+    @pytest.fixture(autouse=True)
+    def _full_profile(self):
+        """Ensure the 'full' profile is active so all components are visible."""
+        profile_manager._profile = BUILTIN_PROFILES["full"]
+        yield
+        profile_manager._profile = BUILTIN_PROFILES["full"]
 
     @pytest.fixture
     def palette(self, qtbot):


### PR DESCRIPTION
## Summary - ComponentPalette now observes  for profile changes - Filters displayed components based on the active profile's  list - When profile is , all components are shown (no filtering) - Search filtering respects profile visibility — hidden components cannot be revealed via search - 8 new unit tests covering all filtering scenarios ## Test plan - [x] All 59 palette tests pass (including 8 new profile filtering tests) - [ ] Verify palette updates reactively when profile changes at runtime - [ ] Verify ee120 profile hides semiconductors, op-amps, etc. - [ ] Verify switching back to full restores all components - [ ] Verify search cannot reveal profile-hidden components Closes #702 🤖 Generated with [Claude Code](https://claude.com/claude-code)