### PR TITLE
Wire MainWindow to ProfileManager — panel visibility and menu (#703)

### DIFF
--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from controllers.circuit_controller import CircuitController
 from controllers.file_controller import FileController
 from controllers.keybindings import KeybindingsRegistry
+from controllers.profile_manager import profile_manager
 from controllers.simulation_controller import SimulationController
 from models.circuit import CircuitModel
 from PyQt6.QtCore import Qt, QTimer
@@ -114,6 +115,10 @@ class MainWindow(
         self._autosave_timer = QTimer(self)
         self._autosave_timer.timeout.connect(self._auto_save)
         self.start_autosave_timer()
+
+        # Restore last-used course profile and observe future changes
+        self._restore_course_profile()
+        profile_manager.register_observer(self._on_profile_changed)
 
     # --- ApplicationShellProtocol properties ---
 

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -302,6 +302,11 @@ class MenuBarMixin:
         self.show_statistics_action.triggered.connect(self._toggle_statistics_panel)
         view_menu.addAction(self.show_statistics_action)
 
+        course_profile_action = QAction("Course &Profile...", self)
+        course_profile_action.setToolTip("Select a course profile to customise the interface")
+        course_profile_action.triggered.connect(self._show_course_profile_dialog)
+        view_menu.addAction(course_profile_action)
+
         view_menu.addSeparator()
 
         # Theme submenu (dynamic — includes custom themes)

--- a/app/GUI/main_window_settings.py
+++ b/app/GUI/main_window_settings.py
@@ -1,5 +1,6 @@
 """Settings persistence, autosave, crash recovery, and window lifecycle for MainWindow."""
 
+from controllers.profile_manager import profile_manager
 from controllers.settings_service import settings
 from controllers.theme_controller import theme_ctrl
 from PyQt6.QtWidgets import QMessageBox
@@ -35,6 +36,7 @@ class SettingsMixin:
         settings.set("view/wire_thickness", theme_manager.wire_thickness)
         settings.set("view/show_junction_dots", theme_manager.show_junction_dots)
         settings.set("view/routing_mode", theme_manager.routing_mode)
+        settings.set("course/profile_id", profile_manager.get_profile().id)
 
     def _restore_settings(self):
         """Restore user preferences from the centralized settings service."""

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -1,11 +1,17 @@
 """View operations: theme, visibility toggles, probe tool, zoom, and image export for MainWindow."""
 
+import logging
+
+from controllers.profile_manager import profile_manager
+from controllers.settings_service import settings as app_settings
 from controllers.theme_controller import theme_ctrl
 from PyQt6.QtWidgets import QApplication, QFileDialog, QMessageBox
 
 from .results_plot_dialog import ACSweepPlotDialog, DCSweepPlotDialog
 from .styles import theme_manager
 from .waveform_dialog import WaveformDialog
+
+_logger = logging.getLogger(__name__)
 
 
 class ViewOperationsMixin:
@@ -470,6 +476,38 @@ class ViewOperationsMixin:
                 statusBar.showMessage(f"CircuiTikZ exported to {filename}", 3000)
         except OSError as e:
             QMessageBox.critical(self, "Error", f"Failed to export: {e}")
+
+    # ── Course profile integration ─────────────────────────────────
+
+    def _restore_course_profile(self):
+        """On startup, activate the last-used profile from settings."""
+        saved_id = app_settings.get_str("course/profile_id", "")
+        if saved_id:
+            try:
+                profile_manager.set_profile(saved_id)
+            except KeyError:
+                _logger.warning("Saved profile %r not found, keeping default", saved_id)
+        # Apply panel visibility for the current profile
+        self._apply_profile_panels(profile_manager.get_profile())
+
+    def _on_profile_changed(self, profile):
+        """Observer callback — update UI panels when the active profile changes."""
+        self._apply_profile_panels(profile)
+        self.show_status_message(f"Course profile: {profile.name}", 3000)
+
+    def _apply_profile_panels(self, profile):
+        """Show or hide advanced panels based on the profile's show_advanced_panels flag."""
+        show = profile.show_advanced_panels
+        self.statistics_panel.setVisible(show and self.show_statistics_action.isChecked())
+        self.show_statistics_action.setEnabled(show)
+        self.grading_panel.setVisible(show and self.grading_panel.isVisible())
+
+    def _show_course_profile_dialog(self):
+        """Open the CourseSelectDialog from the View menu."""
+        from .course_select_dialog import CourseSelectDialog
+
+        dialog = CourseSelectDialog(self)
+        dialog.exec()
 
     def copy_circuitikz(self):
         """Copy the CircuiTikZ environment block to the clipboard."""

--- a/app/tests/unit/test_mainwindow_profile_wiring.py
+++ b/app/tests/unit/test_mainwindow_profile_wiring.py
@@ -1,0 +1,199 @@
+"""
+Unit tests for MainWindow ↔ ProfileManager wiring (#703).
+
+Tests profile-driven panel visibility, View > Course Profile menu item,
+startup profile restoration, and settings persistence.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from controllers.profile_manager import ProfileManager, profile_manager
+from controllers.settings_service import settings as app_settings
+from models.course_profile import BUILTIN_PROFILES
+
+
+@pytest.fixture(autouse=True)
+def _reset_profile_manager():
+    """Reset ProfileManager to 'full' profile and clear observers."""
+    profile_manager._profile = BUILTIN_PROFILES["full"]
+    profile_manager._observers.clear()
+    yield
+    profile_manager._profile = BUILTIN_PROFILES["full"]
+    profile_manager._observers.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_course_setting():
+    """Clear course profile setting between tests."""
+    app_settings.set("course/profile_id", None)
+    yield
+    app_settings.set("course/profile_id", None)
+
+
+# ---------------------------------------------------------------------------
+# Helper: lightweight stand-in for MainWindow that mixes in ViewOperationsMixin
+# without needing the full Qt MainWindow + all controllers.
+# ---------------------------------------------------------------------------
+
+
+def _make_stub_window():
+    """Build a minimal stub with the attributes ViewOperationsMixin expects."""
+    from GUI.main_window_view import ViewOperationsMixin
+
+    stub = type("StubWindow", (ViewOperationsMixin,), {})()
+
+    # Minimal widget stand-ins
+    stub.statistics_panel = MagicMock()
+    stub.statistics_panel.isVisible.return_value = False
+    stub.grading_panel = MagicMock()
+    stub.grading_panel.isVisible.return_value = False
+    stub.show_statistics_action = MagicMock()
+    stub.show_statistics_action.isChecked.return_value = True
+
+    stub.statusBar = MagicMock(return_value=MagicMock())
+    stub.show_status_message = MagicMock()
+
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# Panel visibility
+# ---------------------------------------------------------------------------
+
+
+class TestProfilePanelVisibility:
+    """Verify that _apply_profile_panels shows/hides panels correctly."""
+
+    def test_full_profile_enables_advanced_panels(self):
+        stub = _make_stub_window()
+        profile = BUILTIN_PROFILES["full"]
+        stub._apply_profile_panels(profile)
+
+        # show_advanced_panels is True for full
+        stub.show_statistics_action.setEnabled.assert_called_with(True)
+
+    def test_ee120_disables_advanced_panels(self):
+        stub = _make_stub_window()
+        profile = BUILTIN_PROFILES["ee120"]
+        stub._apply_profile_panels(profile)
+
+        # show_advanced_panels is False for ee120
+        stub.show_statistics_action.setEnabled.assert_called_with(False)
+        stub.statistics_panel.setVisible.assert_called_with(False)
+
+    def test_observer_callback_applies_panels(self):
+        stub = _make_stub_window()
+        profile = BUILTIN_PROFILES["ee120"]
+        stub._on_profile_changed(profile)
+
+        stub.show_statistics_action.setEnabled.assert_called_with(False)
+        stub.show_status_message.assert_called_once()
+
+    def test_circuits2_enables_advanced(self):
+        stub = _make_stub_window()
+        profile = BUILTIN_PROFILES["circuits2"]
+        stub._apply_profile_panels(profile)
+
+        stub.show_statistics_action.setEnabled.assert_called_with(True)
+
+
+# ---------------------------------------------------------------------------
+# Startup profile restoration
+# ---------------------------------------------------------------------------
+
+
+class TestStartupProfileRestore:
+    """Verify _restore_course_profile reads from settings and activates."""
+
+    def test_restores_saved_profile(self):
+        stub = _make_stub_window()
+        app_settings.set("course/profile_id", "ee120")
+        stub._restore_course_profile()
+
+        assert profile_manager.get_profile().id == "ee120"
+
+    def test_keeps_default_when_no_saved_profile(self):
+        stub = _make_stub_window()
+        app_settings.set("course/profile_id", None)
+        stub._restore_course_profile()
+
+        assert profile_manager.get_profile().id == "full"
+
+    def test_handles_unknown_profile_gracefully(self):
+        stub = _make_stub_window()
+        app_settings.set("course/profile_id", "nonexistent_profile")
+        # Should not raise — falls back to current profile
+        stub._restore_course_profile()
+        assert profile_manager.get_profile().id == "full"
+
+
+# ---------------------------------------------------------------------------
+# Settings persistence
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsPersistence:
+    """Verify _save_settings persists the active profile id."""
+
+    def test_save_settings_persists_profile(self):
+        from GUI.main_window_settings import SettingsMixin
+
+        stub = type("S", (SettingsMixin,), {})()
+        # Provide minimal attributes the mixin needs
+        stub.saveGeometry = MagicMock(return_value=b"")
+        stub.saveState = MagicMock(return_value=b"")
+        stub.center_splitter = MagicMock()
+        stub.center_splitter.sizes.return_value = [500, 200]
+        stub.model = MagicMock()
+        stub.model.analysis_type = "DC Operating Point"
+        stub.canvas = MagicMock()
+        stub.canvas.show_component_labels = True
+        stub.canvas.show_component_values = True
+        stub.canvas.show_node_labels = True
+        stub.statistics_panel = MagicMock()
+        stub.statistics_panel.isVisible.return_value = False
+
+        profile_manager.set_profile("circuits1")
+        stub._save_settings()
+
+        assert app_settings.get_str("course/profile_id") == "circuits1"
+
+
+# ---------------------------------------------------------------------------
+# Menu item
+# ---------------------------------------------------------------------------
+
+
+class TestCourseProfileMenuItem:
+    """Verify the View > Course Profile menu action exists."""
+
+    def test_menu_action_triggers_dialog(self):
+        stub = _make_stub_window()
+        with patch("GUI.course_select_dialog.CourseSelectDialog") as MockDialog:
+            mock_instance = MagicMock()
+            MockDialog.return_value = mock_instance
+            stub._show_course_profile_dialog()
+            mock_instance.exec.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Observer registration (integration-level)
+# ---------------------------------------------------------------------------
+
+
+class TestObserverRegistration:
+    """Verify ProfileManager observer integration."""
+
+    def test_observer_is_notified_on_set_profile(self):
+        received = []
+        profile_manager.register_observer(lambda p: received.append(p.id))
+        profile_manager.set_profile("me301")
+        assert received == ["me301"]
+
+    def test_observer_not_notified_on_same_profile(self):
+        profile_manager.set_profile("ee120")
+        received = []
+        profile_manager.register_observer(lambda p: received.append(p.id))
+        profile_manager.set_profile("ee120")  # same profile
+        assert received == []


### PR DESCRIPTION
## Summary - MainWindow subscribes to ProfileManager as an observer - On profile change: shows/hides advanced panels (statistics, grading) based on  - Adds **View > Course Profile...** menu item that opens CourseSelectDialog - On startup, restores last-used profile from settings; on close, persists it - 11 new unit tests covering panel visibility, startup restore, settings persistence, menu action, and observer integration ## Test plan - [x] All 3564 unit tests pass (including 11 new profile wiring tests) - [ ] Verify View > Course Profile opens the dialog - [ ] Verify selecting ee120 hides statistics/grading panels - [ ] Verify selecting full/circuits2 re-enables advanced panels - [ ] Verify profile persists across app restarts Closes #703 🤖 Generated with [Claude Code](https://claude.com/claude-code)