### PR TITLE
Bump vulnerable dependencies (urllib3, pillow, fonttools, pip)

### DIFF
--- a/app/requirements-dev.txt
+++ b/app/requirements-dev.txt
@@ -14,6 +14,10 @@ mypy>=1.13.0
 # Security linting
 bandit>=1.8.0
 
-# Testing (pytest already in main requirements.txt, but adding coverage tools)
+# Testing
+pytest>=8.0.0
 pytest-cov>=6.0.0
 pytest-qt>=4.4.0  # Required for PyQt6 GUI testing
+
+# Build tooling (pin minimum to avoid known CVEs in pip <26.0)
+pip>=26.0

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,14 +3,14 @@ cffi==2.0.0
 charset-normalizer==3.4.3
 contourpy==1.3.3
 cycler==0.12.1
-fonttools==4.60.1
+fonttools==4.60.2
 idna==3.10
 kiwisolver==1.4.9
 matplotlib==3.10.6
 numpy==2.3.3
 openpyxl==3.1.5
 packaging==25.0
-pillow==11.3.0
+pillow==12.1.1
 ply==3.11
 pycparser==2.23
 pyparsing==3.2.5
@@ -23,4 +23,4 @@ PyYAML==6.0.3
 requests==2.32.5
 scipy==1.16.2
 six==1.17.0
-urllib3==2.5.0
+urllib3==2.6.3


### PR DESCRIPTION
## Summary - Bump **fonttools** 4.60.1 → 4.60.2 (CVE-2025-66034) - Bump **urllib3** 2.5.0 → 2.6.3 (CVE-2025-66418, CVE-2025-66471, CVE-2026-21441) - Bump **pillow** 11.3.0 → 12.1.1 (CVE-2025-25990) - Add **pip>=26.0** to dev requirements (CVE-2025-8869, CVE-2026-1703) - Add explicit **pytest>=8.0.0** to  (was only installed transitively via pytest-cov) Closes #750 ## Test plan - [ ] CI passes on all Python versions (3.11, 3.12, 3.13) and platforms (Ubuntu, Windows) - [ ] Verify  no longer reports these CVEs - [ ] Spot-check image rendering paths (pillow major version bump) 🤖 Generated with [Claude Code](https://claude.com/claude-code)