### PR TITLE
Audit: core logic layer (models, controllers, algorithms, utils)

### DIFF
--- a/app/algorithms/graph_ops.py
+++ b/app/algorithms/graph_ops.py
@@ -208,6 +208,7 @@ def rebuild_all_nodes(
         if comp.component_type == "Ground":
             handle_ground_added(nodes, terminal_to_node, comp)
 
+    # AUDIT(quality): wire_index is not passed to update_nodes_for_wire during rebuild — node.wire_indices will remain empty after a full rebuild, which may cause stale data in incremental operations that rely on wire_indices
     for wire in wires:
         update_nodes_for_wire(nodes, terminal_to_node, components, wire)
 

--- a/app/algorithms/path_finding.py
+++ b/app/algorithms/path_finding.py
@@ -336,6 +336,7 @@ class IDAStarPathfinder(WeightedPathfinder):
         self.last_iterations = iterations
         return [start_pos, end_pos], True
 
+    # AUDIT(quality): _idastar_search is recursive with no depth limit beyond max_iterations on the outer loop — deeply nested circuits can hit Python's default recursion limit (1000); consider an iterative approach or setting sys.setrecursionlimit
     def _idastar_search(
         self,
         current,
@@ -501,6 +502,7 @@ def polygon_to_grid_filled(
 
     # Scanline fill algorithm in WORLD space
     # For each grid row, check which grid cells are inside the polygon
+    # AUDIT(cleanup): debug_first flag and its associated no-op conditional block (lines 531-533) are leftover debug scaffolding — remove them
     debug_first = True
     for grid_y in range(min_grid_y, max_grid_y + 1):
         # Scanline at the CENTER of the grid cell to match round() behavior
@@ -567,6 +569,7 @@ def polygon_to_grid_filled(
     return obstacles
 
 
+# AUDIT(quality): polygon_to_grid_frame duplicates the polygon rotation/inset logic from polygon_to_grid_filled above; extract the shared world-coordinate transform into a helper to reduce duplication
 def polygon_to_grid_frame(
     polygon_points,
     position,

--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -6,6 +6,8 @@ operations between models and views using an observer pattern.
 """
 
 from .circuit_controller import CircuitController
+
+# AUDIT(architecture): validate_circuit_data is re-exported from controllers but its canonical location is models.circuit_schema_validator — consumers should import from the canonical location to avoid confusion
 from .file_controller import FileController, validate_circuit_data
 from .simulation_controller import SimulationController, SimulationResult
 

--- a/app/controllers/circuit_controller.py
+++ b/app/controllers/circuit_controller.py
@@ -62,6 +62,7 @@ class CircuitController:
 
     def _notify(self, event: str, data: Any) -> None:
         """Notify all observers of a model change."""
+        # AUDIT(quality): a failing observer is silently swallowed — consider re-raising after logging, or at minimum logging a traceback (exc_info=True) so bugs in observers are diagnosable
         for observer in self._observers:
             try:
                 observer(event, data)
@@ -521,6 +522,7 @@ class CircuitController:
         Used when an action has already been applied (e.g. during a drag)
         and only needs to be recorded for undo/redo.
         """
+        # AUDIT(quality): accesses private members _undo_stack and _redo_stack directly, bypassing UndoManager's max_depth enforcement; add a public method on UndoManager for this pattern
         self.undo_manager._undo_stack.append(command)
         self.undo_manager._redo_stack.clear()
 

--- a/app/controllers/commands.py
+++ b/app/controllers/commands.py
@@ -324,6 +324,7 @@ class DeleteWireCommand(Command):
         if not self.wire_data:
             return
         model = self.controller.model
+        # AUDIT(quality): undo inserts the wire at its original index but does not call model.remove_wire's inverse — the node graph is not updated on undo, leaving terminal_to_node stale; should call model.add_wire or rebuild_nodes
         if (
             self.wire_data.start_component_id not in model.components
             or self.wire_data.end_component_id not in model.components

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -97,6 +97,7 @@ class FileController:
         """
         filepath = Path(filepath)
         data = self.model.to_dict()
+        # AUDIT(security): file is written without specifying encoding — on Windows this defaults to the system locale and may corrupt non-ASCII net names; add encoding="utf-8"
         with open(filepath, "w") as f:
             json.dump(data, f, indent=2)
         self.current_file = filepath
@@ -123,6 +124,7 @@ class FileController:
             OSError: If the file cannot be read.
         """
         filepath = Path(filepath)
+        # AUDIT(security): load_circuit opens user-supplied filepath without encoding — same issue as save_circuit; also no file-size limit allows memory exhaustion with very large files
         with open(filepath, "r") as f:
             data = json.load(f)
 
@@ -161,6 +163,7 @@ class FileController:
         return base
 
     def _save_session(self) -> None:
+        # AUDIT(quality): _session_file is a relative filename ("last_session.txt") — it writes to whatever the process CWD is, which is fragile; use an absolute path under the config directory
         """Save current file path for session restore."""
         try:
             with open(self._session_file, "w") as f:

--- a/app/controllers/keybindings.py
+++ b/app/controllers/keybindings.py
@@ -139,6 +139,7 @@ class KeybindingsRegistry:
         try:
             with open(self._config_path) as f:
                 overrides = json.load(f)
+            # AUDIT(security): user keybinding overrides from the JSON file are not validated — a malicious or corrupt config could inject arbitrary shortcut strings; add allowlist validation for shortcut format
             for key, value in overrides.items():
                 if key in self._bindings:
                     self._bindings[key] = value

--- a/app/controllers/settings_service.py
+++ b/app/controllers/settings_service.py
@@ -157,5 +157,6 @@ class SettingsService:
         return val
 
 
+# AUDIT(architecture): module-level singleton instantiation triggers disk I/O (JSON load) at import time — this can fail silently on import and makes testing harder; consider lazy initialization
 # Module-level singleton — importable as ``from controllers.settings_service import settings``
 settings = SettingsService()

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -86,6 +86,7 @@ class SimulationController:
         from simulation import validate_circuit
 
         is_valid, errors, warnings = validate_circuit(
+            # AUDIT(quality): list comprehension `[w for w in self.model.wires]` is equivalent to `list(self.model.wires)` — use the simpler form
             self.model.components,
             [w for w in self.model.wires],
             self.model.analysis_type,
@@ -806,6 +807,7 @@ class SimulationController:
             return None
         return func(results, circuit_name)
 
+    # AUDIT(quality): this method has the same name as generate_results_markdown above (defined at line 784) — Python allows this but the second definition shadows the first, making generate_results_markdown unreachable; rename one of them
     def export_results_markdown(self, results, results_type: str, filepath: str, circuit_name: str = "") -> None:
         """Export simulation results to a Markdown file.
 

--- a/app/controllers/theme_controller.py
+++ b/app/controllers/theme_controller.py
@@ -52,5 +52,6 @@ class ThemeController:
         theme_manager.set_routing_mode(mode)
 
 
+# AUDIT(architecture): module-level singleton triggers import of services.theme_manager at import time — any import of this module will fail if theme_manager's dependencies (e.g. GUI styles) are unavailable, hurting testability
 # Module-level singleton
 theme_ctrl = ThemeController()

--- a/app/models/circuit_schema_validator.py
+++ b/app/models/circuit_schema_validator.py
@@ -22,6 +22,7 @@ def validate_circuit_data(data) -> None:
     if "wires" not in data or not isinstance(data["wires"], list):
         raise ValueError("Missing or invalid 'wires' list.")
 
+    # AUDIT(security): component IDs from untrusted JSON are not checked for type (must be str) or uniqueness; duplicate IDs would silently overwrite earlier components during deserialization
     comp_ids = set()
     for i, comp in enumerate(data["components"]):
         for key in ("id", "type", "value", "pos"):

--- a/app/models/component.py
+++ b/app/models/component.py
@@ -283,6 +283,7 @@ class ComponentData:
 
     def __post_init__(self):
         """Initialize waveform parameters for waveform sources."""
+        # AUDIT(architecture): lazy import of simulation layer inside a model dataclass creates a hidden upward dependency (models → simulation); consider moving waveform defaults into models or injecting them
         if self.component_type == "Waveform Source" and self.waveform_params is None:
             from simulation.waveform_utils import DEFAULT_WAVEFORM_TYPE, default_waveform_params
 
@@ -358,6 +359,7 @@ class ComponentData:
         if self.component_type != "Waveform Source":
             return self.value
 
+        # AUDIT(architecture): second lazy import of simulation layer from models; same upward dependency concern as __post_init__
         from simulation.waveform_utils import format_waveform_spice_value
 
         return format_waveform_spice_value(self.waveform_type, self.waveform_params, self.value)

--- a/app/models/node.py
+++ b/app/models/node.py
@@ -46,12 +46,14 @@ def _generate_label(index: int) -> str:
     if index < 26:
         return "node" + chr(ord("A") + index)
     else:
+        # AUDIT(quality): label scheme overflows at 702 nodes (26 + 26*26) — chr(ord("A") + first) will produce non-letter characters when first >= 26; unlikely but add a guard or use a general base-26 encoder
         # For more than 26 nodes, use AA, AB, AC...
         first = (index // 26) - 1
         second = index % 26
         return "node" + chr(ord("A") + first) + chr(ord("A") + second)
 
 
+# AUDIT(architecture): module-level mutable singleton makes NodeData label generation implicitly stateful; concurrent circuits or tests that forget to call reset_node_counter() will produce surprising labels — consider passing a generator instance explicitly
 # Default module-level generator used by NodeData.__post_init__
 _default_generator = NodeLabelGenerator()
 

--- a/app/models/subcircuit_library.py
+++ b/app/models/subcircuit_library.py
@@ -177,6 +177,7 @@ class SubcircuitLibrary:
     # -- Persistence ---------------------------------------------------------
 
     def _path_for(self, name: str) -> Path:
+        # AUDIT(security): sanitisation replaces non-word chars but still allows ".." sequences — e.g. name="a..b" produces "a..b.json" which is benign, but consider also stripping leading dots or path separators to harden against directory traversal
         # Sanitise name for filesystem
         safe = re.sub(r"[^\w\-.]", "_", name)
         return self._library_dir / f"{safe}.json"
@@ -194,6 +195,7 @@ class SubcircuitLibrary:
                 data = json.loads(path.read_text(encoding="utf-8"))
                 defn = SubcircuitDefinition.from_dict(data)
                 self._definitions[defn.name] = defn
+            # AUDIT(quality): bare `except Exception` swallows all errors including KeyError/TypeError from malformed JSON — consider catching (json.JSONDecodeError, KeyError, TypeError) explicitly for clearer failure modes
             except Exception:
                 logger.warning("Failed to load subcircuit from %s", path, exc_info=True)
 
@@ -246,6 +248,7 @@ def _generate_terminal_geometry(terminal_count: int):
     return (20, 10, terminals)
 
 
+# AUDIT(architecture): register_subcircuit_component mutates module-level dicts in models.component at runtime — this side-effect-heavy registration makes the component type system hard to reason about and test; consider a registry object that components query instead of mutating global dicts
 def register_subcircuit_component(defn: SubcircuitDefinition) -> None:
     """Register a SubcircuitDefinition into the component system dictionaries.
 
@@ -294,6 +297,7 @@ def register_subcircuit_component(defn: SubcircuitDefinition) -> None:
     if name not in COMPONENT_CATEGORIES["Subcircuits"]:
         COMPONENT_CATEGORIES["Subcircuits"].append(name)
 
+    # AUDIT(architecture): model-layer code reaches directly into GUI.styles.constants and GUI.component_item, violating the models-must-not-import-GUI layering rule; move GUI registration into GUI-layer init or use an event/hook
     # Update COMPONENTS dict in styles/constants
     try:
         from GUI.styles.constants import _COLOR_KEYS, COMPONENTS

--- a/app/utils/format_utils.py
+++ b/app/utils/format_utils.py
@@ -57,6 +57,7 @@ def parse_value(s: str) -> float:
 
     s = s.strip()
 
+    # AUDIT(quality): "MEG" check uses s.upper() but slices the last 3 chars unconditionally — input like "omega" contains "MEG" and would produce wrong result; match only as a suffix or as a standalone token
     # Check for SPICE 'MEG' variant first
     if "MEG" in s.upper():
         num_part = s[:-3]


### PR DESCRIPTION
## Audit: Core Logic Layer ### Summary Audited all 26 files across , , , and . The core logic layer is generally well-structured with clean separation between Qt-free data models and controller orchestration. The main concerns are: (1) several upward/cross-layer dependency violations where models import from simulation or GUI, (2) module-level mutable singletons that complicate testing, and (3) a few correctness issues in undo/node-rebuild paths. ### Findings by Category #### Security (4) -  — Component IDs from untrusted JSON are not type-checked or tested for uniqueness; duplicates silently overwrite -  — Filesystem path sanitisation allows  sequences in subcircuit names; harden against directory traversal -  —  writes without , risking data corruption on Windows with non-ASCII net names -  —  opens user-supplied paths without encoding or file-size limits #### Quality (7) -  — Failing observers are silently swallowed; log with  or re-raise for diagnosability -  —  accesses private / directly, bypassing  enforcement -  —  inserts wire at original index but does not update the node graph, leaving  stale -  —  should be  -  — Duplicate method name  shadows the generator version at L784; rename one -  — Label scheme overflows at 702 nodes —  produces non-letter chars when  -  —  matches substrings like omega; should match only as a suffix or standalone token #### Architecture (7) -  —  lazy-imports from , creating an upward dependency (models -> simulation) -  — Second lazy import of simulation layer from  -  —  mutates module-level dicts in  at runtime; hard to test and reason about -  — Model-layer code reaches into  and , violating models-must-not-import-GUI layering -  — Module-level mutable singleton  makes label generation implicitly stateful across circuits -  — Module-level singleton triggers disk I/O at import time; hinders testing -  — Module-level singleton triggers  import at import time #### Testing (0) No test-specific findings in scope (test files are in , not audited here). #### Cleanup (2) -  —  flag and associated no-op conditional block are leftover debug scaffolding; remove them -  —  not passed during , leaving  empty after full rebuild #### Additional Notes (2) -  —  is re-exported from controllers but its canonical home is ; consumers should import from the canonical location -  — User keybinding overrides from JSON are not validated; add allowlist validation for shortcut format ### Recommended Actions (priority order) 1. **High** — Fix  to rebuild the node graph after re-inserting a wire (). This is a correctness bug that can leave circuit topology stale after undo. 2. **High** — Fix duplicate  method in  — the generator version is shadowed and unreachable. 3. **High** — Remove model->GUI imports in  (, ). Move GUI registration to the GUI init layer. 4. **Medium** — Add  to all  calls in  for cross-platform safety. 5. **Medium** — Move waveform defaults out of  into  to eliminate models->simulation dependency in . 6. **Medium** — Pass  in  loop () so  is populated correctly. 7. **Medium** — Fix  MEG matching to only match suffix/standalone token (). 8. **Low** — Add a public  method to  to avoid private member access from . 9. **Low** — Replace module-level singletons in , , and  with lazy initialization for better testability. 10. **Low** — Remove debug scaffolding in  ( flag and no-op block). ### Files Audited - [x] models/__init__.py (clean) - [x] models/annotation.py (clean) - [x] models/assignment.py (clean) - [x] models/builtin_subcircuits.py (clean) - [x] models/circuit.py (clean) - [x] models/circuit_schema_validator.py (1 finding) - [x] models/clipboard.py (clean) - [x] models/component.py (2 findings) - [x] models/grading_session.py (clean) - [x] models/node.py (2 findings) - [x] models/subcircuit_library.py (4 findings) - [x] models/template.py (clean) - [x] models/wire.py (clean) - [x] controllers/__init__.py (1 finding) - [x] controllers/assignment_controller.py (clean) - [x] controllers/circuit_controller.py (2 findings) - [x] controllers/commands.py (1 finding) - [x] controllers/file_controller.py (3 findings) - [x] controllers/keybindings.py (1 finding) - [x] controllers/recent_exports.py (clean) - [x] controllers/settings_service.py (1 finding) - [x] controllers/simulation_controller.py (2 findings) - [x] controllers/template_controller.py (clean) - [x] controllers/template_manager.py (clean) - [x] controllers/theme_controller.py (1 finding) - [x] controllers/undo_manager.py (clean) - [x] algorithms/__init__.py (clean) - [x] algorithms/graph_ops.py (1 finding) - [x] algorithms/path_finding.py (3 findings) - [x] utils/__init__.py (clean) - [x] utils/connectivity.py (clean) - [x] utils/constants.py (clean) - [x] utils/drag_drop_router.py (clean) - [x] utils/format_utils.py (1 finding) Closes #752