### PR TITLE
Audit: simulation, grading, scripting, services

### DIFF
--- a/app/grading/batch_grader.py
+++ b/app/grading/batch_grader.py
@@ -108,6 +108,7 @@ class BatchGrader:
                 )
                 result.results.append(grade_result)
                 result.successful += 1
+            # AUDIT(quality): broad 'except Exception' swallows all errors including programming bugs; consider catching only expected exceptions (json.JSONDecodeError, ValueError, OSError)
             except Exception as e:
                 logger.warning("Failed to grade %s: %s", filename, e)
                 result.errors.append((filename, str(e)))
@@ -118,6 +119,7 @@ class BatchGrader:
 
         return result
 
+    # AUDIT(security): student submission files are loaded and deserialized from untrusted paths; validate file size before loading to prevent memory exhaustion from very large files
     @staticmethod
     def _load_circuit(filepath: Path) -> CircuitModel:
         """Load a circuit from a .json or .spice-template file."""

--- a/app/grading/circuit_comparer.py
+++ b/app/grading/circuit_comparer.py
@@ -9,7 +9,9 @@ No Qt dependencies — pure Python module.
 from dataclasses import dataclass, field
 
 from models.circuit import CircuitModel
-from simulation.monte_carlo import parse_spice_value
+from simulation.monte_carlo import (
+    parse_spice_value,  # AUDIT(architecture): grading module imports parse_spice_value from simulation.monte_carlo — cross-layer dependency; extract parse_spice_value into a shared utility module
+)
 
 
 @dataclass

--- a/app/grading/grade_exporter.py
+++ b/app/grading/grade_exporter.py
@@ -78,6 +78,7 @@ def export_gradebook_csv(result: BatchGradingResult, filepath: str) -> None:
 
         analytics = compute_check_analytics(result)
         if analytics:
+            # AUDIT(quality): file is opened three times (write, append analytics, append errors) — consolidate into a single write pass for atomicity and performance
             with open(filepath, "a", newline="") as f:
                 writer = csv.writer(f)
                 writer.writerow([])

--- a/app/grading/grader.py
+++ b/app/grading/grader.py
@@ -87,6 +87,7 @@ class CircuitGrader:
         reference: Optional[CircuitModel],
     ) -> CheckGradeResult:
         """Execute a single rubric check and return the graded result."""
+        # AUDIT(quality): _CHECK_HANDLERS is a module-level dict mapping strings to unbound methods; consider using a registry pattern or @singledispatch for extensibility
         handler = _CHECK_HANDLERS.get(check.check_type)
         if handler is None:
             return CheckGradeResult(

--- a/app/grading/rubric.py
+++ b/app/grading/rubric.py
@@ -128,6 +128,7 @@ def validate_rubric(data: dict) -> None:
         raise ValueError(f"Check points sum to {points_sum}, but total_points is {data['total_points']}.")
 
 
+# AUDIT(security): file path is not validated before writing; ensure callers pass sanitized paths to prevent path traversal
 def save_rubric(rubric: Rubric, filepath) -> None:
     """Save a rubric to a .spice-rubric JSON file."""
     filepath = Path(filepath)
@@ -135,6 +136,7 @@ def save_rubric(rubric: Rubric, filepath) -> None:
         json.dump(rubric.to_dict(), f, indent=2)
 
 
+# AUDIT(security): rubric JSON is loaded from an arbitrary file path; malformed JSON could cause crashes — consider wrapping in try/except at call sites
 def load_rubric(filepath) -> Rubric:
     """Load and validate a rubric from a .spice-rubric JSON file.
 

--- a/app/grading/session_persistence.py
+++ b/app/grading/session_persistence.py
@@ -142,6 +142,7 @@ def batch_result_to_session(
 # ---------------------------------------------------------------------------
 
 
+# AUDIT(quality): no atomic write (write-to-temp-then-rename); a crash mid-write could corrupt the session file
 def save_grading_session(filepath, session: GradingSessionData) -> None:
     """Save a grading session to a .spice-grades JSON file.
 

--- a/app/scripting/circuit.py
+++ b/app/scripting/circuit.py
@@ -49,9 +49,11 @@ class Circuit:
             ValueError: If the JSON structure is invalid.
         """
         path = Path(path)
+        # AUDIT(security): file loaded from user-supplied path without size validation; very large files could exhaust memory
         with open(path, "r") as f:
             data = json.load(f)
 
+        # AUDIT(architecture): lazy import from controllers layer inside a scripting module; this creates an implicit dependency that could break if controllers are refactored
         from controllers.file_controller import validate_circuit_data
 
         validate_circuit_data(data)
@@ -230,6 +232,7 @@ class Circuit:
         path = Path(path)
         data = self._model.to_dict()
         with open(path, "w") as f:
+            # AUDIT(quality): no atomic write (write-to-temp-then-rename); a crash mid-write could corrupt the saved circuit file
             json.dump(data, f, indent=2)
 
     # --- Properties ---

--- a/app/scripting/jupyter.py
+++ b/app/scripting/jupyter.py
@@ -189,6 +189,7 @@ def plot_result(result, title: Optional[str] = None):
         or the result has no plottable data.
     """
     try:
+        # AUDIT(quality): matplotlib.pyplot is stateful and can cause issues in non-interactive environments; consider using the object-oriented API (matplotlib.figure.Figure) consistently
         import matplotlib.pyplot as plt
     except ImportError:
         return None

--- a/app/services/theme_manager.py
+++ b/app/services/theme_manager.py
@@ -80,6 +80,7 @@ class ThemeManager:
     _show_junction_dots: bool
     _routing_mode: str
 
+    # AUDIT(architecture): singleton via __new__ makes testing difficult — consider using a module-level instance with a reset method for test isolation
     def __new__(cls) -> "ThemeManager":
         if cls._instance is None:
             cls._instance = super().__new__(cls)
@@ -224,6 +225,7 @@ class ThemeManager:
             try:
                 callback(self._theme)
             except (TypeError, AttributeError, RuntimeError) as e:
+                # AUDIT(quality): silently catching and logging listener errors could mask bugs; consider re-raising after logging in debug mode
                 logger.error("Error notifying theme listener: %s", e)
 
     # ===== Custom theme support =====
@@ -266,6 +268,7 @@ class ThemeManager:
 
         theme = self._theme
         if isinstance(theme, CustomTheme):
+            # AUDIT(quality): accessing private function _filename_safe from theme_store breaks encapsulation; make it public or add a public accessor
             stem = theme_store._filename_safe(theme.name)
             return f"custom:{stem}"
         elif theme.name == "Dark Theme":

--- a/app/services/theme_store.py
+++ b/app/services/theme_store.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# AUDIT(quality): hardcoded home directory path; consider using XDG_CONFIG_HOME on Linux or platformdirs for cross-platform config directory conventions
 _THEMES_DIR = Path.home() / ".spice-gui" / "themes"
 _SCHEMA_VERSION = 1
 

--- a/app/simulation/bundle_exporter.py
+++ b/app/simulation/bundle_exporter.py
@@ -39,6 +39,7 @@ def create_bundle(
     """
     included = []
 
+    # AUDIT(security): zip archive creation does not set a maximum size limit; large simulation outputs could create unexpectedly large archives
     with zipfile.ZipFile(filepath, "w", zipfile.ZIP_DEFLATED) as zf:
         # Circuit JSON (native format for re-import)
         if circuit_json is not None:

--- a/app/simulation/excel_exporter.py
+++ b/app/simulation/excel_exporter.py
@@ -7,6 +7,7 @@ No Qt dependencies — file dialog is the view's responsibility.
 
 from datetime import datetime
 
+# AUDIT(quality): openpyxl import failure produces a generic error message; consider checking for ImportError explicitly and suggesting 'pip install openpyxl'
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Font, PatternFill
 

--- a/app/simulation/fft_analysis.py
+++ b/app/simulation/fft_analysis.py
@@ -7,6 +7,7 @@ Includes magnitude/phase spectrum computation, windowing, and THD calculation.
 
 from typing import Optional
 
+# AUDIT(architecture): numpy and scipy imported eagerly; consider lazy import since FFT analysis is an optional feature
 import numpy as np
 
 

--- a/app/simulation/monte_carlo.py
+++ b/app/simulation/monte_carlo.py
@@ -7,6 +7,7 @@ No Qt dependencies — pure computation module.
 
 import logging
 
+# AUDIT(architecture): numpy is a heavy dependency imported at module level; consider lazy import since monte_carlo is only used on-demand
 import numpy as np
 
 logger = logging.getLogger(__name__)

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -32,6 +32,7 @@ def generate_analysis_command(analysis_type: str, params: dict) -> str:
         start = params.get("min", 0)
         stop = params.get("max", 10)
         step = params.get("step", 0.1)
+        # AUDIT(security): component values and source names are interpolated into SPICE directives without sanitization; malicious values could inject SPICE commands
         return f".dc {source} {start} {stop} {step}"
 
     if analysis_type == "AC Sweep":
@@ -129,6 +130,7 @@ class NetlistGenerator:
         lines = ["My Test Circuit", "* Generated netlist", ""]
 
         # Add op-amp subcircuit definitions for each model used
+        # AUDIT(quality): lazy import inside method body; move to module-level or __init__ to improve clarity and catch import errors early
         from models.component import OPAMP_SUBCIRCUITS
 
         opamp_models_used = set()
@@ -216,6 +218,7 @@ class NetlistGenerator:
                 continue
 
             comp_id = comp.component_id
+            # AUDIT(quality): local variable 'nodes' shadows self.nodes attribute — rename to 'comp_nodes' or 'terminal_nodes' for clarity
             nodes = []
             for i in range(comp.get_terminal_count()):
                 key = (comp_id, i)
@@ -227,6 +230,7 @@ class NetlistGenerator:
                 node_str = node_labels.get(node_num, str(node_num))
                 nodes.append(node_str)
 
+            # AUDIT(quality): long elif chain (~90 lines) mapping component types to netlist lines; refactor into a dispatch dict or visitor pattern for maintainability
             if comp.component_type == "Resistor":
                 lines.append(f"{comp_id} {' '.join(nodes)} {comp.value}")
             elif comp.component_type == "Capacitor":
@@ -505,6 +509,7 @@ class NetlistGenerator:
             lines.append("* Save to file (for backup)")
             lines.append("set wr_vecnames")
             lines.append("set wr_singlescale")
+            # AUDIT(security): wrdata_filepath is interpolated into ngspice control block without sanitization; a crafted filepath could inject ngspice commands
             wrdata_path = self.wrdata_filepath.replace("\\", "/")
             lines.append(f"wrdata {wrdata_path} onoise_spectrum inoise_spectrum")
         else:

--- a/app/simulation/netlist_parser.py
+++ b/app/simulation/netlist_parser.py
@@ -157,6 +157,7 @@ def _parse_component_line(line, models):
         subckt_name = tokens[-1].upper()
         node_names = tokens[1:-1]
         comp_type = "Op-Amp" if "OPAMP" in subckt_name else None
+        # AUDIT(quality): unknown subcircuit types are silently skipped with only a warning log; consider collecting unrecognized subcircuits for user feedback
         if comp_type is None:
             logger.warning("Unknown subcircuit '%s' - skipping %s", subckt_name, comp_id)
             return None

--- a/app/simulation/ngspice_runner.py
+++ b/app/simulation/ngspice_runner.py
@@ -16,6 +16,7 @@ from utils.constants import SIMULATION_TIMEOUT
 class NgspiceRunner:
     """Runs ngspice simulations and manages output files"""
 
+    # AUDIT(security): output_dir is caller-controlled with no path traversal validation; ensure callers pass safe paths
     def __init__(self, output_dir="simulation_output"):
         self.output_dir = output_dir
         os.makedirs(self.output_dir, exist_ok=True)
@@ -74,6 +75,7 @@ class NgspiceRunner:
                 return False, None, "", "ngspice executable not found"
 
         # Create timestamped filenames
+        # AUDIT(quality): simulation files accumulate in output_dir with no cleanup mechanism; add a max-age or max-count purge strategy
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         netlist_filename = os.path.join(self.output_dir, f"netlist_{timestamp}.cir")
         output_filename = os.path.join(self.output_dir, f"output_{timestamp}.txt")
@@ -87,6 +89,7 @@ class NgspiceRunner:
 
         # Run ngspice
         try:
+            # AUDIT(security): netlist_content is written to disk and executed by ngspice without sanitization; a malicious netlist could embed shell commands via .system directive
             result = subprocess.run(
                 [self.ngspice_cmd, "-b", netlist_filename, "-o", output_filename],
                 capture_output=True,

--- a/app/simulation/preset_manager.py
+++ b/app/simulation/preset_manager.py
@@ -145,6 +145,7 @@ class PresetManager:
 
     # --- Persistence ---
 
+    # AUDIT(security): user preset file path is derived from Path.home() which is safe, but loaded JSON is not schema-validated; malformed presets could cause runtime errors
     def _load(self):
         """Load user presets from disk."""
         if not self._preset_file.exists():

--- a/app/simulation/result_parser.py
+++ b/app/simulation/result_parser.py
@@ -38,6 +38,7 @@ class ResultParser:
 
         for i, line in enumerate(lines):
             # Pattern 1: v(nodename) = voltage
+            # AUDIT(quality): regex pattern does not match all valid scientific notation forms (e.g. '1.5E+03'); consider using a more robust numeric pattern like r'[-+]?[\d.]+(?:[eE][-+]?\d+)?'
             match = re.search(r"v\((\w+)\)\s*[=:]\s*([-+]?[\d.]+e?[-+]?\d*)", line, re.IGNORECASE)
             if match:
                 try:
@@ -65,6 +66,7 @@ class ResultParser:
 
             # Pattern 2: Node/Voltage table
             if "node" in line.lower() and "voltage" in line.lower():
+                # AUDIT(quality): hard-coded 50-line lookahead window for voltage table parsing could miss data in large outputs; consider scanning until a clear terminator
                 for j in range(i + 1, min(i + 50, len(lines))):
                     result_line = lines[j].strip()
                     if not result_line or result_line.startswith("-"):
@@ -429,6 +431,7 @@ class ResultParser:
         except (ValueError, IndexError, AttributeError) as e:
             raise ResultParseError(f"Error parsing PZ results: {e}") from e
 
+    # AUDIT(architecture): parse_transient_results reads from a file path while all other parse methods accept string input — inconsistent interface
     @staticmethod
     def parse_transient_results(filepath):
         """


### PR DESCRIPTION
## Audit: simulation, grading, scripting, services ### Summary Audited all 43 Python files across  (24 files),  (13 files),  (3 files), and  (3 files). The codebase is generally well-structured with clean separation of concerns. Key areas of concern are: unsanitized interpolation of user values into SPICE commands (security), lack of atomic file writes across multiple persistence points (quality), and cross-layer import dependencies between grading and simulation (architecture). ### Findings by Category #### Security (8) -  — output_dir is caller-controlled with no path traversal validation -  — netlist_content written to disk and executed by ngspice without sanitization; malicious netlist could embed shell commands via .system directive -  — component values and source names interpolated into SPICE directives without sanitization -  — wrdata_filepath interpolated into ngspice control block without sanitization -  — loaded JSON is not schema-validated; malformed presets could cause runtime errors -  — file path not validated before writing; callers must pass sanitized paths -  — student submission files loaded from untrusted paths without file size validation -  — file loaded from user-supplied path without size validation #### Quality (13) -  — simulation files accumulate with no cleanup mechanism -  — lazy import inside method body; move to module-level -  — local variable 'nodes' shadows self.nodes attribute -  — long elif chain (~90 lines) for component type mapping; use dispatch dict -  — unknown subcircuit types silently skipped -  — regex pattern doesn't match all valid scientific notation forms -  — hard-coded 50-line lookahead window for voltage table parsing -  — openpyxl import failure produces generic error; suggest pip install -  — _CHECK_HANDLERS dict could use registry pattern for extensibility -  — broad 'except Exception' swallows programming bugs -  — file opened three times; consolidate into single write pass -  — no atomic write for session file -  — no atomic write for saved circuit file -  — matplotlib.pyplot stateful API; prefer OO API -  — silently catching listener errors could mask bugs -  — accessing private _filename_safe breaks encapsulation -  — hardcoded home directory path; use platformdirs -  — zip archive creation has no maximum size limit #### Architecture (5) -  — parse_transient_results reads from file path while others accept strings -  — numpy imported eagerly; consider lazy import -  — numpy/scipy imported eagerly for optional feature -  — grading imports parse_spice_value from simulation.monte_carlo; extract to shared utility -  — lazy import from controllers layer creates implicit cross-layer dependency -  — singleton via __new__ makes test isolation difficult #### Testing (0) No test-specific findings in audited scope (tests live under app/tests/). #### Cleanup (0) No stale imports, dead code, or TODO items found. ### Recommended Actions (priority order) 1. **High** — Sanitize user-supplied values before interpolation into SPICE netlists and ngspice control blocks (, ). A malicious  directive in a netlist could execute arbitrary shell commands. 2. **High** — Add file size validation before loading untrusted circuit/rubric files (, ) to prevent memory exhaustion attacks. 3. **Medium** — Implement atomic writes (write-to-temp-then-rename) for all persistence points (, , ) to prevent data corruption on crash. 4. **Medium** — Extract  from  into a shared utility module to eliminate the cross-layer dependency from grading to simulation. 5. **Medium** — Narrow the broad  in  to only expected exception types. 6. **Low** — Refactor the ~90-line elif chain in  into a dispatch dict for maintainability. 7. **Low** — Make numpy/scipy imports lazy in  and  to reduce startup time. 8. **Low** — Use  or XDG conventions for config directory in . ### Files Audited - [x] simulation/__init__.py (clean) - [x] simulation/ngspice_runner.py (3 findings) - [x] simulation/netlist_generator.py (5 findings) - [x] simulation/netlist_parser.py (1 finding) - [x] simulation/result_parser.py (3 findings) - [x] simulation/asc_parser.py (clean) - [x] simulation/asc_exporter.py (clean) - [x] simulation/monte_carlo.py (1 finding) - [x] simulation/preset_manager.py (1 finding) - [x] simulation/convergence.py (clean) - [x] simulation/fft_analysis.py (1 finding) - [x] simulation/circuitikz_parser.py (clean) - [x] simulation/circuitikz_exporter.py (clean) - [x] simulation/power_calculator.py (clean) - [x] simulation/power_metrics.py (clean) - [x] simulation/waveform_utils.py (clean) - [x] simulation/measurement_builder.py (clean) - [x] simulation/freq_markers.py (clean) - [x] simulation/markdown_exporter.py (clean) - [x] simulation/bom_exporter.py (clean) - [x] simulation/excel_exporter.py (1 finding) - [x] simulation/csv_exporter.py (clean) - [x] simulation/bundle_exporter.py (1 finding) - [x] simulation/circuit_semantic_validator.py (clean) - [x] grading/__init__.py (clean) - [x] grading/rubric.py (2 findings) - [x] grading/grader.py (1 finding) - [x] grading/batch_grader.py (2 findings) - [x] grading/rubric_validator.py (clean) - [x] grading/rubric_generator.py (clean) - [x] grading/circuit_comparer.py (1 finding) - [x] grading/component_mapper.py (clean) - [x] grading/histogram.py (clean) - [x] grading/feedback_exporter.py (clean) - [x] grading/grade_exporter.py (1 finding) - [x] grading/session_persistence.py (1 finding) - [x] grading/check_analytics.py (clean) - [x] scripting/__init__.py (clean) - [x] scripting/circuit.py (3 findings) - [x] scripting/jupyter.py (1 finding) - [x] services/__init__.py (clean) - [x] services/report_generator.py (clean) - [x] services/theme_manager.py (3 findings) - [x] services/theme_store.py (1 finding)