### PR TITLE
Audit: test suite quality and patterns

### DIFF
--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -8,6 +8,7 @@ import os
 import sys
 from pathlib import Path
 
+# AUDIT(architecture): monkeypatching matplotlib.use at conftest import time is a global side effect that could mask real import errors in production; consider using pytest-qt's built-in offscreen handling or a dedicated fixture instead
 # Prevent matplotlib.use("QtAgg") from failing in headless environments.
 # The monte_carlo_results_dialog module calls matplotlib.use("QtAgg") at
 # import time which raises ImportError when Qt's offscreen platform is active.
@@ -69,6 +70,7 @@ def make_wire(start_id, start_term, end_id, end_term):
     )
 
 
+# AUDIT(quality): _build_simple_circuit() / _build_rc_filter() helper functions are duplicated in 15+ test files (test_auto_save, test_file_controller, test_batch_grading, test_grading_panel, test_rubric_grader, test_simulation_controller, etc.); consolidate these into shared conftest fixtures here
 @pytest.fixture
 def simple_resistor_circuit():
     """

--- a/app/tests/integration/conftest.py
+++ b/app/tests/integration/conftest.py
@@ -10,6 +10,7 @@ import shutil
 import pytest
 
 
+# AUDIT(testing): require_ngspice guard also skips test_save_load.py and non-ngspice tests in test_phase4_mvc_integration.py; move those files to unit/ or use per-file skip markers so they run without ngspice
 @pytest.fixture(scope="session", autouse=True)
 def require_ngspice():
     if shutil.which("ngspice") is None:

--- a/app/tests/integration/test_ngspice_workflows.py
+++ b/app/tests/integration/test_ngspice_workflows.py
@@ -99,6 +99,7 @@ class TestDCOperatingPoint:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             sim = SimulationController(model=model, circuit_ctrl=ctrl)
+            # AUDIT(testing): accessing private attribute sim._runner couples tests to internal implementation; inject runner via constructor parameter or public setter instead
             sim._runner = NgspiceRunner(output_dir=tmpdir)
 
             sim.set_analysis("DC Operating Point")
@@ -166,6 +167,7 @@ class TestDCSweep:
 class TestTransientAnalysis:
     """Test transient analysis through the full pipeline."""
 
+    # AUDIT(testing): test builds a resistor divider (no capacitor) but docstring says "RC circuit with step input"; likely copy-paste error—should call _build_rc_circuit() to exercise meaningful transient behavior
     def test_rc_transient_step_response(self):
         """RC circuit with a step input should produce time-domain data."""
         model, ctrl = _build_resistor_divider()
@@ -233,5 +235,6 @@ class TestACSweep:
             assert result.data is not None
             assert isinstance(result.data, dict)
 
+            # AUDIT(testing): DC sweep and AC sweep assertions only check data is non-empty; add value-level checks (e.g., verify passband gain ≈ 1 and stopband attenuation for AC, verify sweep point count for DC) to catch result parser regressions
             # At minimum, the data dict should not be empty
             assert len(result.data) > 0, "AC sweep data is empty"

--- a/app/tests/integration/test_phase4_mvc_integration.py
+++ b/app/tests/integration/test_phase4_mvc_integration.py
@@ -80,6 +80,7 @@ class TestMVCFileOperations:
         assert len(model.wires) == 0
         assert file_ctrl.current_file is None
 
+    # AUDIT(testing): session file uses relative path "test_session.txt" in CWD; use tmp_path fixture to avoid polluting the workspace and ensure CI/parallel-execution safety
     def test_session_persistence(self):
         """Test that session file is saved and restored"""
         # Create model and controller
@@ -168,6 +169,7 @@ class TestMVCSimulationFlow:
             assert model.analysis_params == params
 
 
+# AUDIT(architecture): most tests in this file (TestMVCCircuitOperations, TestMVCDataFlow, TestMVCSimulationFlow) do no I/O or ngspice work but are skipped when ngspice is absent because they are in integration/; move to unit/ or remove from require_ngspice guard
 class TestMVCCircuitOperations:
     """Test circuit operations through CircuitController"""
 
@@ -195,6 +197,7 @@ class TestMVCCircuitOperations:
         # Verify component was removed
         assert "R1" not in model.components
 
+    # AUDIT(testing): test bypasses CircuitController entirely—directly mutates model.components["R1"].value instead of calling ctrl.update_component_value(); rename to test_direct_model_mutation or use the controller API
     def test_update_component_through_controller(self):
         """Test updating component through CircuitController"""
         model = CircuitModel()
@@ -322,6 +325,7 @@ class TestMVCErrorPropagation:
         result = sim_ctrl.run_simulation()
 
         # Verify validation error is reported
+        # AUDIT(testing): 'or' assertion is too permissive—a sim that "succeeds" with errors passes; assert both conditions independently
         assert result.success is False or len(result.errors) > 0
 
 

--- a/app/tests/integration/test_save_load.py
+++ b/app/tests/integration/test_save_load.py
@@ -7,6 +7,9 @@ Tests ComponentData and WireData without any Qt dependencies.
 import json
 
 import pytest
+
+# AUDIT(cleanup): _CLASS_TO_DISPLAY, _DISPLAY_TO_CLASS, and COMPONENT_TYPES are imported but never used; remove dead imports
+# AUDIT(architecture): this file tests pure model serialization (no I/O, no ngspice) but is under integration/ and gets skipped when ngspice is absent; move to unit/
 from models.component import _CLASS_TO_DISPLAY, _DISPLAY_TO_CLASS, COMPONENT_TYPES, DEFAULT_VALUES, ComponentData
 from models.wire import WireData
 from tests.conftest import make_component, make_wire

--- a/app/tests/unit/controllers/test_file_controller_coverage.py
+++ b/app/tests/unit/controllers/test_file_controller_coverage.py
@@ -1,3 +1,5 @@
+# AUDIT(quality): _build_simple_circuit() helper on L30 is duplicated verbatim in test_file_controller.py and 4+ other test files; extract into a shared conftest fixture
+# AUDIT(testing): tests named *_is_logged (L197, L341, L349) assert no exception is raised but never verify the log message via caplog; add caplog assertions to match the test names
 """Tests to increase file_controller.py coverage to 95%+.
 
 Covers:

--- a/app/tests/unit/controllers/test_simulation_controller.py
+++ b/app/tests/unit/controllers/test_simulation_controller.py
@@ -14,6 +14,7 @@ from models.component import ComponentData
 from models.wire import WireData
 
 
+# AUDIT(quality): _make_controller() and _build_circuit() are duplicated across 3 simulation controller test files; consolidate into a shared fixture in controllers/conftest.py
 def _make_controller(model=None, circuit_ctrl=None):
     """Create a SimulationController with a mocked runner."""
     ctrl = SimulationController(model=model or CircuitModel(), circuit_ctrl=circuit_ctrl)

--- a/app/tests/unit/test_annotation_undo.py
+++ b/app/tests/unit/test_annotation_undo.py
@@ -155,6 +155,7 @@ class TestEditAnnotationCommand:
         assert "annotation_updated" in events
 
 
+# AUDIT(testing): all tests below use inspect.getsource() to assert on source code strings—these are structural grep tests, not behavioral tests; replace with actual invocation tests or mock-based integration tests
 class TestAnnotationDoubleClickDelegation:
     """mouseDoubleClickEvent should delegate to canvas._edit_annotation."""
 

--- a/app/tests/unit/test_auto_save.py
+++ b/app/tests/unit/test_auto_save.py
@@ -212,6 +212,7 @@ class TestLoadAutoSave:
         assert ctrl2.model.analysis_type == "AC Sweep"
         assert ctrl2.model.analysis_params["fStart"] == 1
 
+    # AUDIT(architecture): test calls private method _notify directly via mock assertion — this couples the test to the controller's internal notification API; prefer asserting on observable state changes
     def test_load_notifies_observers(self, tmp_path):
         from unittest.mock import MagicMock
 

--- a/app/tests/unit/test_batch_reroute.py
+++ b/app/tests/unit/test_batch_reroute.py
@@ -14,6 +14,7 @@ from models.circuit import CircuitModel
 class TestBatchRerouteInfrastructure:
     """Verify batch reroute attributes exist on the canvas class."""
 
+    # AUDIT(testing): inspect.getsource() tests are fragile — they break on refactors that preserve behavior; test observable behavior instead (e.g., instantiate and check attribute exists)
     def test_canvas_has_batch_reroute_timer_attr(self):
         """CircuitCanvasView.__init__ should initialize _batch_reroute_timer."""
         from GUI.circuit_canvas import CircuitCanvasView
@@ -97,6 +98,7 @@ class TestObserverMoveDedup:
         assert w.start_component_id == r1.component_id
         assert w.end_component_id == r2.component_id
 
+    # AUDIT(testing): source-code string matching is implementation coupling — these tests will break if the variable is renamed even though behavior is unchanged
     def test_do_batch_reroute_clears_pending_set(self):
         """_do_batch_reroute should clear _pending_reroute_components."""
         from GUI.circuit_canvas import CircuitCanvasView

--- a/app/tests/unit/test_check_analytics.py
+++ b/app/tests/unit/test_check_analytics.py
@@ -303,6 +303,7 @@ class TestCsvExportAnalytics:
 # ---------------------------------------------------------------------------
 
 
+# AUDIT(testing): these structural tests read source files as text and grep for string patterns — they will break silently if the attribute is renamed; prefer importing the class and checking with hasattr() or instantiating in a fixture
 class TestBatchGradingDialogAnalytics:
     def test_dialog_has_analytics_table(self):
         source = Path(__file__).parents[2] / "GUI" / "batch_grading_dialog.py"

--- a/app/tests/unit/test_circuit_controller.py
+++ b/app/tests/unit/test_circuit_controller.py
@@ -504,6 +504,8 @@ class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import controllers.circuit_controller as mod
 
+        # AUDIT(security): open() without with-statement leaks file handle; use Path.read_text(encoding="utf-8") instead
+        # AUDIT(testing): source-level substring matching for "PyQt" is brittle (comments/strings trigger false positives); use AST-based import checking as done in test_theme_controller.py
         source = open(mod.__file__).read()
         assert "PyQt" not in source
         assert "QtCore" not in source

--- a/app/tests/unit/test_circuit_model.py
+++ b/app/tests/unit/test_circuit_model.py
@@ -385,6 +385,7 @@ class TestSerialization:
         """Verify CircuitModel has no Qt dependencies."""
         import models.circuit as mod
 
+        # AUDIT(security): open() without with-statement leaks file handle; use Path.read_text(encoding="utf-8")
         source = open(mod.__file__).read()
         assert "PyQt" not in source
         assert "QtCore" not in source

--- a/app/tests/unit/test_copy_paste.py
+++ b/app/tests/unit/test_copy_paste.py
@@ -235,6 +235,7 @@ class TestCutComponents:
         assert len(ctrl.model.wires) == 0
 
 
+# AUDIT(security): open() without with-statement leaks file handles in both tests below; use Path.read_text(encoding="utf-8")
 class TestNoQtDependencies:
     def test_clipboard_no_pyqt(self):
         import models.clipboard as mod

--- a/app/tests/unit/test_data_roundtrips_and_undo.py
+++ b/app/tests/unit/test_data_roundtrips_and_undo.py
@@ -727,6 +727,7 @@ class TestFileControllerOperations:
         filepath = tmp_path / "valid.json"
         ctrl.save_circuit(filepath)
 
+        # AUDIT(quality): open() without explicit encoding="utf-8" may fail on non-UTF-8 default locales
         with open(filepath) as f:
             data = json.load(f)
         assert "components" in data

--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -461,6 +461,7 @@ class TestImportPreservesCircuitOnFailure:
         filepath = tmp_path / "bad.cir"
         filepath.write_text("this is not a valid netlist")
 
+        # AUDIT(testing): catching bare Exception is overly broad; assert the specific exception type (ValueError, ParseError, etc.) raised by import_netlist for invalid input
         with pytest.raises(Exception):
             ctrl.import_netlist(filepath)
 

--- a/app/tests/unit/test_graphics_item_readonly.py
+++ b/app/tests/unit/test_graphics_item_readonly.py
@@ -10,6 +10,7 @@ import sys
 
 import pytest
 
+# AUDIT(cleanup): sys.path.insert is unnecessary — conftest.py already adds app/ to sys.path; remove this line
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 # ---------------------------------------------------------------------------

--- a/app/tests/unit/test_grid_snap_group_drag.py
+++ b/app/tests/unit/test_grid_snap_group_drag.py
@@ -28,6 +28,7 @@ def _add_resistor(scene, comp_id, x, y):
 class TestRawDeltaSourceInspection:
     """Verify the itemChange source uses raw delta, not snapped delta."""
 
+    # AUDIT(testing): all three tests below use inspect.getsource() string matching — they test implementation details (variable names) rather than behavior; replace with functional tests that verify group drag snap correctness
     def test_itemchange_uses_raw_delta(self):
         """itemChange should compute raw_delta from new_pos, not snapped_pos."""
         source = inspect.getsource(ComponentGraphicsItem.itemChange)

--- a/app/tests/unit/test_model_layer_coverage.py
+++ b/app/tests/unit/test_model_layer_coverage.py
@@ -1,3 +1,4 @@
+# AUDIT(quality): file name "model_layer_coverage" is misleading—it also tests controllers (circuit_controller.py, keybindings.py, recent_exports.py); rename to reflect actual scope
 """Tests closing remaining model-layer coverage gaps.
 
 Covers missing lines in circuit_controller.py, node.py, wire.py,

--- a/app/tests/unit/test_multiselect_tearing.py
+++ b/app/tests/unit/test_multiselect_tearing.py
@@ -25,6 +25,7 @@ def _add_resistor(scene, comp_id, x, y):
 class TestWirePreviewSuppression:
     """Verify that followers skip wire preview during group drag (#442)."""
 
+    # AUDIT(testing): inspect.getsource() string matching on itemChange is an implementation test — tests will break on variable rename even if behavior is correct
     def test_group_moving_guard_in_position_has_changed(self):
         """ItemPositionHasChanged handler must check _group_moving before wire preview."""
         source = inspect.getsource(ComponentGraphicsItem.itemChange)

--- a/app/tests/unit/test_new_components.py
+++ b/app/tests/unit/test_new_components.py
@@ -526,6 +526,7 @@ class TestDiodeModelDeduplication:
         assert "D3 nodeC 0 D_Ideal" in netlist
 
         # Only one model directive
+        # AUDIT(cleanup): variable name `l` shadows built-in; rename to `line` per PEP 8 (also at L576, L594, L618)
         model_lines = [l for l in netlist.split("\n") if l.startswith(".model D_Ideal")]
         assert len(model_lines) == 1
         assert model_lines[0] == ".model D_Ideal D(IS=1e-14 N=1)"

--- a/app/tests/unit/test_node.py
+++ b/app/tests/unit/test_node.py
@@ -329,6 +329,8 @@ class TestSetNetNamePublicAPI:
         assert node.custom_label is None
         assert node.get_label() == "nodeA"
 
+    # AUDIT(testing): inspect.getsource() string match for "_notify" is fragile—any variable or comment containing "_notify" triggers a false positive; use a mock-based behavioral test instead
+    # AUDIT(architecture): this test verifies canvas behavior and belongs in a canvas or integration test file, not test_node.py
     def test_canvas_does_not_call_private_notify(self):
         """Verify the canvas code no longer calls controller._notify directly."""
         import inspect

--- a/app/tests/unit/test_renderer_symbols.py
+++ b/app/tests/unit/test_renderer_symbols.py
@@ -1,3 +1,4 @@
+# AUDIT(testing): pixel-level draw call assertions (e.g., call(5, -4, 8, 0)) are extremely brittle — any coordinate tweak breaks tests even if visual output is correct; consider snapshot/image-diff testing instead
 """
 Tests for renderer symbol correctness (#431, #433).
 

--- a/app/tests/unit/test_scene_item_decoupling.py
+++ b/app/tests/unit/test_scene_item_decoupling.py
@@ -63,6 +63,7 @@ class TestComponentItemCanvasInjection:
         # Should have synced position via canvas.controller
         mock_controller.model.components["R1"].__setattr__("position", (100, 200))
 
+    # AUDIT(testing): negative source-code grep assertions are brittle and do not test behavior; consider integration tests that verify the canvas reference is used correctly instead
     def test_no_hierarchy_climbing_in_source(self):
         """Verify no scene().views()[0] patterns remain in component_item.py."""
         import inspect

--- a/app/tests/unit/test_score_histogram.py
+++ b/app/tests/unit/test_score_histogram.py
@@ -22,6 +22,7 @@ from grading.histogram import compute_score_bins
 # ---------------------------------------------------------------------------
 
 
+# AUDIT(quality): _FakeGradingResult and _FakeBatchResult are duplicated in test_check_analytics.py and test_feedback_exporter.py; extract shared test doubles into conftest.py or a tests/helpers module
 @dataclass
 class _FakeGradingResult:
     percentage: float = 0.0
@@ -207,6 +208,7 @@ class TestSaveHistogramPng:
 class TestBatchGradingDialogHistogram:
     """Structural tests for histogram integration in the dialog."""
 
+    # AUDIT(testing): reading production source files as text and asserting string presence is fragile and tests implementation, not behavior; prefer importing the class and using hasattr() or instantiation
     def test_dialog_has_histogram_canvas_attr(self):
         """Verify the dialog stores a histogram canvas reference."""
         source = Path(__file__).parents[2] / "GUI" / "batch_grading_dialog.py"

--- a/app/tests/unit/test_settings_service.py
+++ b/app/tests/unit/test_settings_service.py
@@ -14,6 +14,7 @@ import pytest
 from controllers.settings_service import SettingsService, settings
 
 
+# AUDIT(testing): _clean fixture uses the real global settings singleton, which modifies process-wide state; use an isolated SettingsService(path=tmp_path/...) instance per test to avoid cross-test contamination
 class TestSettingsServiceTypedHelpers:
     """Test the typed helper methods."""
 

--- a/app/tests/unit/test_simulation_controller.py
+++ b/app/tests/unit/test_simulation_controller.py
@@ -244,6 +244,7 @@ class TestExportNetlist:
 
 
 class TestExportResultsCSV:
+    # AUDIT(testing): 'or' assertion is too permissive—passes if only one substring appears even if CSV format is broken; assert both or check CSV structure
     def test_generate_results_csv_returns_content_for_op(self):
         ctrl = SimulationController()
         op_results = {"v(1)": 5.0, "v(2)": 3.3}

--- a/app/tests/unit/test_simulation_controller_coverage.py
+++ b/app/tests/unit/test_simulation_controller_coverage.py
@@ -11,6 +11,8 @@ from controllers.simulation_controller import SimulationController, SimulationRe
 from models.circuit import CircuitModel
 
 
+# AUDIT(quality): _make_controller() and _build_simple_circuit() are duplicated from controllers/test_simulation_controller.py; consolidate into shared conftest
+# AUDIT(testing): TestRunSimulationConvergenceRetry.test_retry_with_relaxed_tolerances has 9 levels of nested `with patch(...)` context managers; refactor to @patch decorators or mock.patch.multiple for readability
 def _make_controller(model=None):
     """Create a SimulationController with a mocked runner."""
     ctrl = SimulationController(model=model or CircuitModel())

--- a/app/tests/unit/test_subcircuit_library.py
+++ b/app/tests/unit/test_subcircuit_library.py
@@ -195,6 +195,7 @@ class TestSubcircuitLibrary:
 # ---------------------------------------------------------------------------
 
 
+# AUDIT(testing): test_register_adds_to_component_system and test_register_idempotent modify global mutable state (COMPONENT_TYPES, SPICE_SYMBOLS, etc.) without teardown; add setup/teardown to save and restore global dicts as done in test_subcircuit_library_coverage.py
 class TestSubcircuitRegistration:
     def test_register_adds_to_component_system(self, tmp_path):
         from models.component import (

--- a/app/tests/unit/test_svg_export.py
+++ b/app/tests/unit/test_svg_export.py
@@ -16,6 +16,7 @@ from PyQt6.QtWidgets import QGraphicsScene
 class TestSVGExportInfrastructure:
     """Verify SVG export infrastructure is in place."""
 
+    # AUDIT(testing): inspect.getsource() string matching is fragile — tests will break on rename/refactor even if behavior is preserved; prefer functional tests or mock-based verification
     def test_export_image_dialog_offers_svg(self):
         """Export image dialog should include SVG as a format option."""
         from GUI.main_window_view import ViewOperationsMixin

--- a/app/tests/unit/test_template_dialog.py
+++ b/app/tests/unit/test_template_dialog.py
@@ -128,6 +128,7 @@ class TestNewFromTemplateDialogDelete:
         dlg.template_list.setCurrentRow(4)
 
         # Monkeypatch QMessageBox to auto-confirm
+        # AUDIT(quality): QMessageBox.question is monkeypatched twice redundantly — remove the first patch or the duplicate below
         monkeypatch.setattr(
             "GUI.template_dialog.QMessageBox.question",
             lambda *a, **kw: QMessageBox.StandardButton.Yes,

--- a/app/tests/unit/test_theme_controller_coverage.py
+++ b/app/tests/unit/test_theme_controller_coverage.py
@@ -44,6 +44,7 @@ except (ImportError, RuntimeError):
     import controllers.theme_controller as _tc_mod  # noqa: E402
 
 
+# AUDIT(quality): TestThemeControllerDelegation is nearly identical to TestThemeControllerWrappers in test_theme_controller.py; remove the duplicate and keep only the one with proper stub handling
 class TestThemeControllerDelegation:
     """Verify every ThemeController method delegates to theme_manager."""
 

--- a/app/tests/unit/test_theme_manager_coverage.py
+++ b/app/tests/unit/test_theme_manager_coverage.py
@@ -38,6 +38,7 @@ def _make_mock_theme(name="Mock Theme"):
 # Try the real import first.  Only seed stubs when Qt is unavailable.
 # This avoids contaminating sys.modules for other test files in CI.
 # ---------------------------------------------------------------------------
+# AUDIT(quality): complex sys.modules patching (50+ lines) duplicates functionality already present in test_symbol_style.py autouse fixture; extract shared theme/Qt mocking infrastructure into a conftest fixture
 try:
     import services.theme_manager as _tm_mod  # works when Qt is available
 except (ImportError, RuntimeError):

--- a/app/tests/unit/test_theme_store.py
+++ b/app/tests/unit/test_theme_store.py
@@ -124,12 +124,14 @@ class TestCanonicalLocation:
 
         assert "services" in tm.__file__
 
+    # AUDIT(security): open(ts.__file__).read() leaks a file handle — use 'with open(...) as f:' or Path.read_text() instead
     def test_theme_store_no_qt_imports(self):
         import services.theme_store as ts
 
         source = open(ts.__file__).read()
         assert "PyQt" not in source
 
+    # AUDIT(security): open(ts.__file__).read() leaks a file handle — use 'with open(...) as f:' or Path.read_text() instead
     def test_theme_manager_no_qt_imports(self):
         import services.theme_manager as ts
 

--- a/app/tests/unit/test_theme_store_coverage.py
+++ b/app/tests/unit/test_theme_store_coverage.py
@@ -27,6 +27,7 @@ def _make_custom_theme(name="Test Theme", base="light", colors=None, is_dark=Fal
 # ---- _filename_safe ----
 
 
+# AUDIT(quality): TestFilenameSafe is fully duplicated in test_theme_store.py; consolidate into one location to reduce maintenance burden
 class TestFilenameSafe:
     def test_basic(self):
         assert _filename_safe("My Theme") == "my-theme"

--- a/app/tests/unit/test_wire_preview_cleanup.py
+++ b/app/tests/unit/test_wire_preview_cleanup.py
@@ -95,7 +95,7 @@ class TestFocusOutCancelsWireDrawing:
         # The focusOutEvent method should exist
         assert hasattr(CircuitCanvasView, "focusOutEvent")
 
-        # Verify it calls cancel_wire_drawing (source inspection)
+        # AUDIT(testing): source inspection is fragile — use a mock-based test that simulates focusOutEvent and asserts cancel_wire_drawing was called
         import inspect
 
         source = inspect.getsource(CircuitCanvasView.focusOutEvent)

--- a/app/tests/unit/test_wire_reroute_after_delete.py
+++ b/app/tests/unit/test_wire_reroute_after_delete.py
@@ -12,6 +12,7 @@ import pytest
 class TestRerouteWiresNearComponents:
     """_reroute_wires_near_components should reroute affected wires only."""
 
+    # AUDIT(testing): binding a real unbound method onto a MagicMock is fragile — any change to _reroute_wires_near_components signature or self-references may silently break the test; prefer creating a minimal real instance or using spec= with patch
     def _make_canvas(self):
         """Create a minimal mock canvas with the real _reroute method."""
         from GUI.circuit_canvas import CircuitCanvasView

--- a/app/tests/unit/test_wire_reroute_dedup.py
+++ b/app/tests/unit/test_wire_reroute_dedup.py
@@ -65,6 +65,7 @@ class TestTimerPathRemoved:
 
         assert not hasattr(ComponentGraphicsItem, "update_wires_after_drag")
 
+    # AUDIT(testing): negative string assertions on source code are fragile; use hasattr(instance, 'update_timer') after construction instead
     def test_no_wire_update_timer_attribute(self):
         """ComponentGraphicsItem should not have self.update_timer in init."""
         import inspect


### PR DESCRIPTION
## Audit: Test Suite

### Summary
Audited all 140+ test files in `app/tests/` (unit + integration, ~38,000 lines) and cross-referenced against all source modules in `app/`. The test suite is generally well-structured with good use of pytest fixtures, parametrize, and thorough coverage of core model/controller logic. However, several systemic anti-patterns affect maintainability: widespread use of `inspect.getsource()` for structural assertions instead of behavioral tests, significant helper function duplication across 15+ files, integration tests misplaced under the `require_ngspice` guard (causing silent skips), and file handle leaks in Qt-dependency checks.

### Findings by Category

#### Security (5)
- `test_circuit_controller.py:L507` — `open(mod.__file__).read()` leaks file handle; use `Path.read_text(encoding="utf-8")`
- `test_circuit_model.py:L388` — same file handle leak pattern
- `test_copy_paste.py:L242` — same file handle leak in two Qt-dependency tests
- `test_theme_store.py:L127,L133` — same file handle leak pattern (2 occurrences)
- `test_phase4_mvc_integration.py:L87` — session file written to CWD using relative path, polluting workspace

#### Quality (14)
- `conftest.py:L73` — `_build_simple_circuit()` helper duplicated in 15+ test files with subtle differences; consolidate into shared conftest fixtures
- `controllers/test_simulation_controller.py:L17` — `_make_controller()` / `_build_circuit()` duplicated across 3 simulation controller test files
- `test_simulation_controller_coverage.py:L14` — same duplication of `_make_controller()` and `_build_simple_circuit()`
- `controllers/test_file_controller_coverage.py:L14` — `_build_simple_circuit()` is exact duplicate of `test_file_controller.py:L14`
- `test_theme_controller_coverage.py:L47` — `TestThemeControllerDelegation` is near-identical duplicate; remove one
- `test_theme_store_coverage.py:L30` — `TestFilenameSafe` fully duplicated from `test_theme_store.py`
- `test_score_histogram.py:L26` — test doubles duplicated across 3 files
- `test_template_dialog.py:L131` — `QMessageBox.question` monkeypatched twice redundantly
- `test_theme_manager_coverage.py:L41` — 50+ lines of `sys.modules` patching; extract into shared fixture
- `test_model_layer_coverage.py:L1` — file name misleading—tests controllers too
- `test_data_roundtrips_and_undo.py:L730` — `open()` without explicit encoding
- `test_new_components.py:L529` — variable `l` shadows built-in; rename to `line`
- `test_simulation_controller_coverage.py:L137` — 9 levels of nested `with patch(...)` context managers
- `conftest.py:L11` — matplotlib monkeypatch ordering fragile relative to `QT_QPA_PLATFORM` setdefault

#### Architecture (5)
- `test_phase4_mvc_integration.py:L172` — most test classes do no ngspice work but are skipped when ngspice is absent; move to `unit/`
- `test_save_load.py:L10` — pure model serialization tests in `integration/`; skipped unnecessarily
- `conftest.py:L34` — QApplication created at module scope forces Qt dependency on pure-model tests
- `test_node.py:L332` — canvas behavior test in a node unit test file; move to integration tests
- `test_auto_save.py:L226` — asserts on private `_notify()` method via mock

#### Testing (25)
- `integration/conftest.py:L13` — `require_ngspice` guard skips non-ngspice tests
- `test_ngspice_workflows.py:L102` — accesses private `sim._runner` (4 occurrences)
- `test_ngspice_workflows.py:L169` — transient test builds wrong circuit (copy-paste error)
- `test_ngspice_workflows.py:L237` — DC/AC sweep assertions only check non-empty
- `test_phase4_mvc_integration.py:L198` — bypasses controller entirely
- `test_phase4_mvc_integration.py:L325` — `or` assertion too permissive
- `test_file_controller.py:L464` — `pytest.raises(Exception)` too broad
- `controllers/test_file_controller_coverage.py:L197` — `*_is_logged` tests never verify log messages
- `test_simulation_controller.py:L252` — `or`-based CSV assertion too permissive
- `test_circuit_controller.py:L507` — source substring matching; use AST checking
- `test_annotation_undo.py:L158` — 6 `inspect.getsource()` structural tests
- `test_batch_reroute.py:L17` — 6 `inspect.getsource()` structural tests
- `test_svg_export.py:L19` — 5 source string matching tests
- `test_scene_item_decoupling.py:L66` — negative source-code grep
- `test_grid_snap_group_drag.py:L31` — source variable name matching
- `test_multiselect_tearing.py:L28` — source inspection on `itemChange`
- `test_wire_reroute_dedup.py:L69` — 4 negative source assertions
- `test_wire_preview_cleanup.py:L99` — `inspect.getsource()` for `focusOutEvent`
- `test_check_analytics.py:L307` — 3 tests read source files as text
- `test_score_histogram.py:L210` — 4 tests read source files as text
- `test_node.py:L338` — fragile `_notify` string match
- `test_subcircuit_library.py:L199` — global state modified without teardown
- `test_settings_service.py:L17` — uses real global settings singleton
- `test_renderer_symbols.py:L1` — pixel-level draw call assertions
- `test_wire_reroute_after_delete.py:L16` — fragile mock pattern

#### Cleanup (3)
- `test_save_load.py:L10` — unused imports (`_CLASS_TO_DISPLAY`, `_DISPLAY_TO_CLASS`, `COMPONENT_TYPES`)
- `test_graphics_item_readonly.py:L13` — redundant `sys.path.insert`
- `test_new_components.py:L529` — variable name `l` shadows built-in (4 occurrences)

### Source Modules Without Test Coverage

**Controllers:** `assignment_controller.py` (84 lines, entirely untested)

**Simulation:** `circuit_semantic_validator.py`, `measurement_builder.py`

**GUI (20+):** `canvas_context_menu.py`, `circuit_canvas.py`, `circuit_canvas_rebuild.py`, `circuitikz_options_dialog.py`, `component_item.py`, `dialog_provider.py`, `main_window.py` + 8 mixins, `monte_carlo_dialog.py`, `monte_carlo_results_dialog.py`, `parameter_sweep_dialog.py`, `parameter_sweep_plot_dialog.py`, `recommended_components_dialog.py`, `report_dialog.py`, `results_panel.py`, `subcircuit_dialog.py`, `template_metadata_dialog.py`, `validation_helpers.py`, `waveform_dialog.py`, `wire_item.py`

**Styles:** `constants.py`, `light_theme.py`, `theme.py`

**Grading:** `component_mapper.py`, `rubric_validator.py`, `session_persistence.py`

**Models:** `template.py` (no dedicated test), `circuit_schema_validator.py` (position validation untested)

**Other:** `app/protocols/` (all), `app/utils/constants.py`, `app/utils/drag_drop_router.py`, `app/ComponentPalette.py`, `app/MainWindow.py`, `app/PropertiesPanel.py`, `app/main.py`

### Recommended Actions (priority order)
1. **High** — Move `test_save_load.py` and non-ngspice tests out of `integration/` so they run without ngspice
2. **High** — Extract duplicated helpers into shared conftest fixtures (15+ files, ~300 lines)
3. **High** — Replace `inspect.getsource()` structural tests with behavioral tests (10+ files, ~30 tests)
4. **High** — Add test coverage for `assignment_controller.py` and `circuit_semantic_validator.py`
5. **Medium** — Fix file handle leaks: `open(mod.__file__).read()` → `Path.read_text()` (5+ files)
6. **Medium** — Strengthen weak assertions: replace `or`-based and `pytest.raises(Exception)` patterns
7. **Medium** — Fix transient test copy-paste error in `test_ngspice_workflows.py`
8. **Low** — Remove dead imports, redundant `sys.path.insert`, rename `l` variables
9. **Low** — Consider moving QApplication creation to session-scoped fixture for GUI tests only

### Files Audited
All 140+ test files in `app/tests/` were read and audited. 52 findings across 38 files with findings; remaining files clean.