### PR TITLE
Fix _generate_label overflow for >702 nodes

### DIFF
--- a/app/models/node.py
+++ b/app/models/node.py
@@ -35,7 +35,10 @@ class NodeLabelGenerator:
 
 def _generate_label(index: int) -> str:
     """
-    Generate label like nodeA, nodeB, ..., nodeZ, nodeAA, nodeAB...
+    Generate label like nodeA, nodeB, ..., nodeZ, nodeAA, nodeAB, ..., nodeZZ, nodeAAA, ...
+
+    Uses a bijective base-26 encoding so every non-negative index maps to a
+    unique sequence of uppercase letters (A=0 .. Z=25, AA=26 .. AZ=51, ...).
 
     Args:
         index: Zero-based index for the node.
@@ -43,13 +46,14 @@ def _generate_label(index: int) -> str:
     Returns:
         A string label like "nodeA", "nodeB", etc.
     """
-    if index < 26:
-        return "node" + chr(ord("A") + index)
-    else:
-        # For more than 26 nodes, use AA, AB, AC...
-        first = (index // 26) - 1
-        second = index % 26
-        return "node" + chr(ord("A") + first) + chr(ord("A") + second)
+    chars: list[str] = []
+    n = index
+    while True:
+        chars.append(chr(ord("A") + n % 26))
+        n = n // 26 - 1
+        if n < 0:
+            break
+    return "node" + "".join(reversed(chars))
 
 
 # Default module-level generator used by NodeData.__post_init__

--- a/app/tests/unit/test_node.py
+++ b/app/tests/unit/test_node.py
@@ -88,6 +88,27 @@ class TestNodeLabelGenerator:
         assert gen.next_label() == "nodeAB"
 
 
+class TestLabelUniqueness:
+    """Verify label generation produces unique labels for large circuits."""
+
+    def test_labels_unique_up_to_1000(self):
+        labels = [_generate_label(i) for i in range(1000)]
+        assert len(labels) == len(set(labels))
+
+    def test_labels_beyond_702_are_triple_letter(self):
+        """After nodeZZ (index 701), labels should continue with nodeAAA."""
+        assert _generate_label(701) == "nodeZZ"
+        assert _generate_label(702) == "nodeAAA"
+        assert _generate_label(703) == "nodeAAB"
+
+    def test_labels_are_all_alpha(self):
+        """All generated labels should consist of 'node' + uppercase letters."""
+        for i in range(1000):
+            label = _generate_label(i)
+            suffix = label[4:]  # strip 'node' prefix
+            assert suffix.isalpha() and suffix.isupper(), f"Bad label at index {i}: {label}"
+
+
 class TestNodeMerge:
     def test_merge_preserves_custom_label(self):
         node1 = NodeData(auto_label="nodeA")


### PR DESCRIPTION
## Summary - Replace two-tier label scheme (A-Z, AA-ZZ) with bijective base-26 encoding - Labels now scale to any circuit size: nodeA..nodeZ, nodeAA..nodeZZ, nodeAAA... - Previous implementation produced non-letter characters for index >= 702 Closes #763 ## Test plan - [x] Label uniqueness verified up to 1000 nodes - [x] Triple-letter labels start correctly at index 702 - [x] All labels consist of uppercase letters only - [x] Full test suite passes (3652 passed, 56 skipped) 🤖 Generated with [Claude Code](https://claude.com/claude-code)