### PR TITLE
Replace hardcoded inline stylesheets with theme-aware styling

### DIFF
--- a/app/GUI/analysis_dialog.py
+++ b/app/GUI/analysis_dialog.py
@@ -15,6 +15,7 @@ from PyQt6.QtWidgets import (
 from utils.format_utils import parse_value
 
 from .meas_dialog import MeasurementDialog
+from .styles import theme_manager
 from .validation_helpers import clear_field_error, set_field_error
 
 # Analysis types that support .meas directives
@@ -228,13 +229,13 @@ class AnalysisDialog(QDialog):
         self.meas_btn.clicked.connect(self._open_meas_dialog)
         meas_layout.addWidget(self.meas_btn)
         self.meas_label = QLabel("No measurements configured")
-        self.meas_label.setStyleSheet("color: gray;")
+        self.meas_label.setStyleSheet(theme_manager.stylesheet("status_muted"))
         meas_layout.addWidget(self.meas_label, 1)
         layout.addLayout(meas_layout)
 
         # Error label for validation feedback
         self._error_label = QLabel("")
-        self._error_label.setStyleSheet("color: red; font-size: 9pt;")
+        self._error_label.setStyleSheet(theme_manager.stylesheet("error_label"))
         self._error_label.setWordWrap(True)
         self._error_label.hide()
         layout.addWidget(self._error_label)
@@ -393,7 +394,7 @@ class AnalysisDialog(QDialog):
         count = len(self._measurements)
         if count == 0:
             self.meas_label.setText("No measurements configured")
-            self.meas_label.setStyleSheet("color: gray;")
+            self.meas_label.setStyleSheet(theme_manager.stylesheet("status_muted"))
         elif count == 1:
             self.meas_label.setText("1 measurement configured")
             self.meas_label.setStyleSheet("")

--- a/app/GUI/batch_grading_dialog.py
+++ b/app/GUI/batch_grading_dialog.py
@@ -22,6 +22,8 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
 )
 
+from .styles import theme_manager
+
 if TYPE_CHECKING:
     from grading.batch_grader import BatchGradingResult
     from grading.rubric import Rubric
@@ -109,7 +111,7 @@ class BatchGradingDialog(QDialog):
         # Reference circuit info
         if self._reference_circuit is not None:
             ref_label = QLabel("Reference circuit: current canvas circuit")
-            ref_label.setStyleSheet("color: green;")
+            ref_label.setStyleSheet(theme_manager.stylesheet("ref_info"))
             layout.addWidget(ref_label)
 
         # Grade button

--- a/app/GUI/circuit_statistics_panel.py
+++ b/app/GUI/circuit_statistics_panel.py
@@ -138,10 +138,10 @@ class CircuitStatisticsPanel(QWidget):
             self._ground_label.setStyleSheet("")
         elif has_ground:
             self._ground_label.setText("Yes")
-            self._ground_label.setStyleSheet("QLabel { color: green; }")
+            self._ground_label.setStyleSheet(theme_manager.stylesheet("status_success"))
         else:
             self._ground_label.setText("No (required for simulation)")
-            self._ground_label.setStyleSheet("QLabel { color: red; }")
+            self._ground_label.setStyleSheet(theme_manager.stylesheet("status_error"))
 
     def _update_component_breakdown(self):
         # Clear old rows
@@ -166,11 +166,11 @@ class CircuitStatisticsPanel(QWidget):
         elif floating:
             names = ", ".join(f"{cid}[{tidx}]" for cid, tidx in sorted(floating))
             self._floating_label.setText(f"{len(floating)} terminal(s)")
-            self._floating_label.setStyleSheet("QLabel { color: orange; }")
+            self._floating_label.setStyleSheet(theme_manager.stylesheet("status_warning"))
             self._floating_label.setToolTip(names)
         else:
             self._floating_label.setText("All connected")
-            self._floating_label.setStyleSheet("QLabel { color: green; }")
+            self._floating_label.setStyleSheet(theme_manager.stylesheet("status_success"))
             self._floating_label.setToolTip("")
 
     def _update_netlist_preview(self):

--- a/app/GUI/grading_panel.py
+++ b/app/GUI/grading_panel.py
@@ -24,6 +24,8 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from .styles import theme_manager
+
 if TYPE_CHECKING:
     from grading.grader import GradingResult
     from grading.rubric import Rubric
@@ -57,7 +59,7 @@ class GradingPanel(QWidget):
         outer.setContentsMargins(5, 5, 5, 5)
 
         title = QLabel("Instructor Grading")
-        title.setStyleSheet("font-weight: bold; font-size: 14px;")
+        title.setStyleSheet(theme_manager.stylesheet("heading_medium"))
         outer.addWidget(title)
 
         # --- Action buttons ---
@@ -105,7 +107,7 @@ class GradingPanel(QWidget):
 
         # --- Score display ---
         self.score_label = QLabel("")
-        self.score_label.setStyleSheet("font-size: 16px; font-weight: bold;")
+        self.score_label.setStyleSheet(theme_manager.stylesheet("score_bold"))
         self.score_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         outer.addWidget(self.score_label)
 
@@ -120,7 +122,7 @@ class GradingPanel(QWidget):
 
         self.feedback_label = QLabel("")
         self.feedback_label.setWordWrap(True)
-        self.feedback_label.setStyleSheet("padding: 4px;")
+        self.feedback_label.setStyleSheet(theme_manager.stylesheet("label_padded"))
         results_layout.addWidget(self.feedback_label)
 
         outer.addWidget(results_group)
@@ -216,11 +218,11 @@ class GradingPanel(QWidget):
         pct = result.percentage
         self.score_label.setText(f"{result.earned_points}/{result.total_points} — {pct:.0f}%")
         if pct >= 90:
-            self.score_label.setStyleSheet("font-size: 16px; font-weight: bold; color: green;")
+            self.score_label.setStyleSheet(theme_manager.stylesheet("score_success"))
         elif pct >= 70:
-            self.score_label.setStyleSheet("font-size: 16px; font-weight: bold; color: #CC8800;")
+            self.score_label.setStyleSheet(theme_manager.stylesheet("score_warning"))
         else:
-            self.score_label.setStyleSheet("font-size: 16px; font-weight: bold; color: red;")
+            self.score_label.setStyleSheet(theme_manager.stylesheet("score_error"))
 
         # Check results
         for cr in result.check_results:

--- a/app/GUI/meas_dialog.py
+++ b/app/GUI/meas_dialog.py
@@ -32,6 +32,7 @@ build_directive = SimulationController.build_meas_directive
 # Re-export so existing imports from GUI.meas_dialog keep working.
 __all__ = ["ANALYSIS_DOMAIN_MAP", "MEAS_TYPES", "build_directive"]
 
+from .styles import theme_manager
 from .validation_helpers import clear_field_error, set_field_error
 
 
@@ -84,13 +85,13 @@ class MeasurementEntryDialog(QDialog):
         # Preview
         self.preview_label = QLabel()
         self.preview_label.setWordWrap(True)
-        self.preview_label.setStyleSheet("color: gray; font-family: monospace;")
+        self.preview_label.setStyleSheet(theme_manager.stylesheet("preview_monospace"))
         layout.addWidget(QLabel("Directive preview:"))
         layout.addWidget(self.preview_label)
 
         # Error label for validation feedback
         self._error_label = QLabel("")
-        self._error_label.setStyleSheet("color: red; font-size: 9pt;")
+        self._error_label.setStyleSheet(theme_manager.stylesheet("error_label"))
         self._error_label.setWordWrap(True)
         self._error_label.hide()
         layout.addWidget(self._error_label)

--- a/app/GUI/measurement_cursors.py
+++ b/app/GUI/measurement_cursors.py
@@ -9,6 +9,8 @@ import numpy as np
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QGroupBox, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
 
+from .styles import theme_manager
+
 
 class MeasurementCursors:
     """Two draggable vertical cursors on a matplotlib axes.
@@ -23,8 +25,8 @@ class MeasurementCursors:
         Callback ``(cursor_a_x, cursor_b_x)`` called whenever a cursor moves.
     """
 
-    CURSOR_A_COLOR = "#e74c3c"  # red
-    CURSOR_B_COLOR = "#2980b9"  # blue
+    CURSOR_A_COLOR = "#e74c3c"  # red (legacy fallback)
+    CURSOR_B_COLOR = "#2980b9"  # blue (legacy fallback)
 
     def __init__(self, ax, canvas, on_cursor_moved=None):
         self._ax = ax
@@ -207,11 +209,11 @@ class CursorReadoutPanel(QWidget):
         # Cursor selector buttons
         btn_row = QHBoxLayout()
         self._btn_a = QPushButton("Place Cursor A")
-        self._btn_a.setStyleSheet(f"color: {MeasurementCursors.CURSOR_A_COLOR};")
+        self._btn_a.setStyleSheet(f"color: {theme_manager.color_hex('cursor_a')};")
         self._btn_a.setCheckable(True)
         self._btn_a.setChecked(True)
         self._btn_b = QPushButton("Place Cursor B")
-        self._btn_b.setStyleSheet(f"color: {MeasurementCursors.CURSOR_B_COLOR};")
+        self._btn_b.setStyleSheet(f"color: {theme_manager.color_hex('cursor_b')};")
         self._btn_b.setCheckable(True)
         self._btn_a.clicked.connect(lambda: self._select_cursor("a"))
         self._btn_b.clicked.connect(lambda: self._select_cursor("b"))
@@ -221,11 +223,11 @@ class CursorReadoutPanel(QWidget):
 
         # Readout labels
         self._label_a = QLabel("Cursor A: —")
-        self._label_a.setStyleSheet(f"color: {MeasurementCursors.CURSOR_A_COLOR};")
+        self._label_a.setStyleSheet(f"color: {theme_manager.color_hex('cursor_a')};")
         self._label_b = QLabel("Cursor B: —")
-        self._label_b.setStyleSheet(f"color: {MeasurementCursors.CURSOR_B_COLOR};")
+        self._label_b.setStyleSheet(f"color: {theme_manager.color_hex('cursor_b')};")
         self._label_delta = QLabel("Delta: —")
-        self._label_delta.setStyleSheet("font-weight: bold;")
+        self._label_delta.setStyleSheet(theme_manager.stylesheet("label_bold"))
 
         layout.addWidget(self._label_a)
         layout.addWidget(self._label_b)

--- a/app/GUI/monte_carlo_dialog.py
+++ b/app/GUI/monte_carlo_dialog.py
@@ -23,6 +23,7 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
 )
 
+from .styles import theme_manager
 from .validation_helpers import clear_field_error, set_field_error
 
 # Base analysis types available for Monte Carlo
@@ -130,7 +131,7 @@ class MonteCarloDialog(QDialog):
 
         # Error label for validation feedback
         self._error_label = QLabel("")
-        self._error_label.setStyleSheet("color: red; font-size: 9pt;")
+        self._error_label.setStyleSheet(theme_manager.stylesheet("error_label"))
         self._error_label.setWordWrap(True)
         self._error_label.hide()
         layout.addWidget(self._error_label)

--- a/app/GUI/netlist_preview.py
+++ b/app/GUI/netlist_preview.py
@@ -8,6 +8,8 @@ import re
 from PyQt6.QtGui import QColor, QFont, QSyntaxHighlighter, QTextCharFormat
 from PyQt6.QtWidgets import QHBoxLayout, QLabel, QPushButton, QTextEdit, QVBoxLayout, QWidget
 
+from .styles import theme_manager
+
 
 class SpiceHighlighter(QSyntaxHighlighter):
     """Syntax highlighter for SPICE netlist text."""
@@ -86,7 +88,7 @@ class NetlistPreviewWidget(QWidget):
 
         # Status label
         self.status_label = QLabel("")
-        self.status_label.setStyleSheet("color: gray; font-size: 9pt;")
+        self.status_label.setStyleSheet(theme_manager.stylesheet("muted_small"))
         layout.addWidget(self.status_label)
 
     def set_netlist(self, netlist_text):

--- a/app/GUI/parameter_sweep_dialog.py
+++ b/app/GUI/parameter_sweep_dialog.py
@@ -16,6 +16,7 @@ from PyQt6.QtWidgets import (
 )
 from utils.format_utils import format_value, parse_value
 
+from .styles import theme_manager
 from .validation_helpers import clear_field_error, set_field_error
 
 # Component types whose primary value can be swept
@@ -121,7 +122,7 @@ class ParameterSweepDialog(QDialog):
 
         # Error label for validation feedback
         self._error_label = QLabel("")
-        self._error_label.setStyleSheet("color: red; font-size: 9pt;")
+        self._error_label.setStyleSheet(theme_manager.stylesheet("error_label"))
         self._error_label.setWordWrap(True)
         self._error_label.hide()
         layout.addWidget(self._error_label)

--- a/app/GUI/properties_panel.py
+++ b/app/GUI/properties_panel.py
@@ -63,7 +63,7 @@ class PropertiesPanel(QWidget):
         # Validation error label
         self.error_label = QLabel("")
         self.error_label.setWordWrap(True)
-        self.error_label.setStyleSheet("QLabel { color: red; font-size: 9pt; }")
+        self.error_label.setStyleSheet(theme_manager.stylesheet("error_label"))
         self.error_label.setVisible(False)
         self.form_layout.addRow("", self.error_label)
 

--- a/app/GUI/rubric_editor_dialog.py
+++ b/app/GUI/rubric_editor_dialog.py
@@ -35,6 +35,8 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from .styles import theme_manager
+
 if TYPE_CHECKING:
     from grading.rubric import Rubric
 
@@ -69,7 +71,7 @@ class RubricEditorDialog(QDialog):
 
         # Points summary
         self.points_label = QLabel("Total Points: 0")
-        self.points_label.setStyleSheet("font-weight: bold;")
+        self.points_label.setStyleSheet(theme_manager.stylesheet("label_bold"))
         layout.addWidget(self.points_label)
 
         # Splitter: check list (left) | check editor (right)
@@ -164,7 +166,7 @@ class RubricEditorDialog(QDialog):
 
         # Validation label
         self.validation_label = QLabel("")
-        self.validation_label.setStyleSheet("color: red;")
+        self.validation_label.setStyleSheet(f"color: {theme_manager.color_hex('error')};")
         self.validation_label.setWordWrap(True)
         layout.addWidget(self.validation_label)
 

--- a/app/GUI/styles/dark_theme.py
+++ b/app/GUI/styles/dark_theme.py
@@ -88,6 +88,17 @@ class DarkTheme(BaseTheme):
             "probe_current": "#66DDAA",  # Light green for probed currents
             "probe_bg": "#3D1E2D",  # Dark pink-tinted background
             "probe_highlight": "#FF66CC",  # Bright pink for probe crosshair
+            # ===== Semantic UI Colors =====
+            "error": "#FF6B6B",  # Light red for dark bg
+            "success": "#66DD66",  # Light green for dark bg
+            "warning": "#FFAA44",  # Light orange for dark bg
+            "info": "#5BC0DE",  # Light teal for dark bg
+            "border_error": "#FF6B6B",  # Red border for invalid inputs
+            "border_light": "#444444",  # Subtle border for dark bg
+            "panel_bg": "#2D2D2D",  # Match background_secondary
+            # ===== Measurement Cursor Colors =====
+            "cursor_a": "#FF6B6B",  # Light red cursor for dark bg
+            "cursor_b": "#5DADE2",  # Light blue cursor for dark bg
         }
 
     def _define_pens(self):
@@ -160,4 +171,31 @@ class DarkTheme(BaseTheme):
             "muted_label": "QLabel { color: #999; }",
             "title_bold": "font-weight: bold; font-size: 12pt; color: #D4D4D4;",
             "metrics_text": "font-family: monospace; font-size: 9pt; color: #D4D4D4;",
+            # --- Semantic UI stylesheets ---
+            "error_label": "color: #FF6B6B; font-size: 9pt;",
+            "error_label_compact": "color: #FF6B6B; font-size: 9pt; margin: 0; padding: 0;",
+            "error_border": "border: 1.5px solid #FF6B6B; border-radius: 3px;",
+            "error_border_thin": "border: 1px solid #FF6B6B;",
+            "status_success": "QLabel { color: #66DD66; }",
+            "status_error": "QLabel { color: #FF6B6B; }",
+            "status_warning": "QLabel { color: #FFAA44; }",
+            "status_muted": "color: #999999;",
+            "muted_italic": "color: #666666; font-style: italic;",
+            "preview_monospace": "color: #666666; font-family: monospace;",
+            "heading_large": "font-weight: bold; font-size: 16px; color: #D4D4D4;",
+            "heading_medium": "font-weight: bold; font-size: 14px; color: #D4D4D4;",
+            "score_bold": "font-size: 16px; font-weight: bold; color: #D4D4D4;",
+            "score_success": "font-size: 16px; font-weight: bold; color: #66DD66;",
+            "score_warning": "font-size: 16px; font-weight: bold; color: #FFAA44;",
+            "score_error": "font-size: 16px; font-weight: bold; color: #FF6B6B;",
+            "label_bold": "font-weight: bold; color: #D4D4D4;",
+            "label_padded": "padding: 4px; color: #D4D4D4;",
+            "help_panel": (
+                "QLabel { background-color: #2D2D2D; padding: 8px; "
+                "border: 1px solid #444444; border-radius: 3px; "
+                "font-size: 9pt; color: #D4D4D4; }"
+            ),
+            "ref_info": "color: #66DD66;",
+            "color_swatch": "border: 1px solid #888888; border-radius: 3px;",
+            "muted_small": "color: #999999; font-size: 9pt;",
         }

--- a/app/GUI/styles/light_theme.py
+++ b/app/GUI/styles/light_theme.py
@@ -85,6 +85,17 @@ class LightTheme(BaseTheme):
             "probe_current": "#006633",  # Dark green for probed currents
             "probe_bg": "#FFE0F0",  # Light pink background
             "probe_highlight": "#FF3399",  # Bright pink for probe crosshair
+            # ===== Semantic UI Colors =====
+            "error": "#DC3545",  # Red for errors/failures
+            "success": "#28A745",  # Green for success/valid
+            "warning": "#CC8800",  # Orange for warnings
+            "info": "#17A2B8",  # Teal for informational
+            "border_error": "#DC3545",  # Red border for invalid inputs
+            "border_light": "#DDDDDD",  # Light border for panels
+            "panel_bg": "#F9F9F9",  # Light panel background
+            # ===== Measurement Cursor Colors =====
+            "cursor_a": "#E74C3C",  # Red cursor
+            "cursor_b": "#2980B9",  # Blue cursor
         }
 
     def _define_pens(self):
@@ -156,4 +167,30 @@ class LightTheme(BaseTheme):
             "muted_label": "QLabel { color: #666; }",
             "title_bold": "font-weight: bold; font-size: 12pt;",
             "metrics_text": "font-family: monospace; font-size: 9pt;",
+            # --- Semantic UI stylesheets ---
+            "error_label": "color: #DC3545; font-size: 9pt;",
+            "error_label_compact": "color: #DC3545; font-size: 9pt; margin: 0; padding: 0;",
+            "error_border": "border: 1.5px solid #DC3545; border-radius: 3px;",
+            "error_border_thin": "border: 1px solid #DC3545;",
+            "status_success": "QLabel { color: #28A745; }",
+            "status_error": "QLabel { color: #DC3545; }",
+            "status_warning": "QLabel { color: #CC8800; }",
+            "status_muted": "color: gray;",
+            "muted_italic": "color: #999999; font-style: italic;",
+            "preview_monospace": "color: #999999; font-family: monospace;",
+            "heading_large": "font-weight: bold; font-size: 16px;",
+            "heading_medium": "font-weight: bold; font-size: 14px;",
+            "score_bold": "font-size: 16px; font-weight: bold;",
+            "score_success": "font-size: 16px; font-weight: bold; color: #28A745;",
+            "score_warning": "font-size: 16px; font-weight: bold; color: #CC8800;",
+            "score_error": "font-size: 16px; font-weight: bold; color: #DC3545;",
+            "label_bold": "font-weight: bold;",
+            "label_padded": "padding: 4px;",
+            "help_panel": (
+                "QLabel { background-color: #F9F9F9; padding: 8px; "
+                "border: 1px solid #DDDDDD; border-radius: 3px; font-size: 9pt; }"
+            ),
+            "ref_info": "color: #28A745;",
+            "color_swatch": "border: 1px solid #888888; border-radius: 3px;",
+            "muted_small": "color: #999999; font-size: 9pt;",
         }

--- a/app/GUI/template_dialog.py
+++ b/app/GUI/template_dialog.py
@@ -20,6 +20,8 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
 )
 
+from .styles import theme_manager
+
 
 class NewFromTemplateDialog(QDialog):
     """Dialog for creating a new circuit from a template.
@@ -69,12 +71,12 @@ class NewFromTemplateDialog(QDialog):
         right.addWidget(QLabel("Details:"))
 
         self.name_label = QLabel("")
-        self.name_label.setStyleSheet("font-weight: bold; font-size: 14px;")
+        self.name_label.setStyleSheet(theme_manager.stylesheet("heading_medium"))
         self.name_label.setWordWrap(True)
         right.addWidget(self.name_label)
 
         self.category_label = QLabel("")
-        self.category_label.setStyleSheet("color: gray;")
+        self.category_label.setStyleSheet(theme_manager.stylesheet("status_muted"))
         right.addWidget(self.category_label)
 
         self.description_label = QLabel("")

--- a/app/GUI/template_metadata_dialog.py
+++ b/app/GUI/template_metadata_dialog.py
@@ -3,6 +3,8 @@
 from models.template import TemplateMetadata
 from PyQt6.QtWidgets import QDialog, QDialogButtonBox, QFormLayout, QLineEdit, QPlainTextEdit, QVBoxLayout
 
+from .styles import theme_manager
+
 
 class TemplateMetadataDialog(QDialog):
     """Dialog for entering assignment template metadata.
@@ -53,7 +55,7 @@ class TemplateMetadataDialog(QDialog):
     def _on_accept(self):
         if not self.title_edit.text().strip():
             self.title_edit.setFocus()
-            self.title_edit.setStyleSheet("border: 1px solid red;")
+            self.title_edit.setStyleSheet(theme_manager.stylesheet("error_border_thin"))
             return
         self.accept()
 

--- a/app/GUI/template_preview_dialog.py
+++ b/app/GUI/template_preview_dialog.py
@@ -15,6 +15,8 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
 )
 
+from .styles import theme_manager
+
 
 class TemplatePreviewDialog(QDialog):
     """Dialog to preview a template before loading it.
@@ -40,16 +42,16 @@ class TemplatePreviewDialog(QDialog):
         meta_layout = QVBoxLayout(meta_group)
 
         self.title_label = QLabel()
-        self.title_label.setStyleSheet("font-weight: bold; font-size: 16px;")
+        self.title_label.setStyleSheet(theme_manager.stylesheet("heading_large"))
         self.title_label.setWordWrap(True)
         meta_layout.addWidget(self.title_label)
 
         info_row = QHBoxLayout()
         self.author_label = QLabel()
-        self.author_label.setStyleSheet("color: gray;")
+        self.author_label.setStyleSheet(theme_manager.stylesheet("status_muted"))
         info_row.addWidget(self.author_label)
         self.date_label = QLabel()
-        self.date_label.setStyleSheet("color: gray;")
+        self.date_label.setStyleSheet(theme_manager.stylesheet("status_muted"))
         info_row.addWidget(self.date_label)
         info_row.addStretch()
         meta_layout.addLayout(info_row)
@@ -86,7 +88,7 @@ class TemplatePreviewDialog(QDialog):
         circuit_layout.addWidget(self.circuit_tree)
 
         self.circuit_summary = QLabel()
-        self.circuit_summary.setStyleSheet("color: gray; font-style: italic;")
+        self.circuit_summary.setStyleSheet(theme_manager.stylesheet("muted_italic"))
         circuit_layout.addWidget(self.circuit_summary)
 
         layout.addWidget(circuit_group)

--- a/app/GUI/theme_editor_dialog.py
+++ b/app/GUI/theme_editor_dialog.py
@@ -167,7 +167,10 @@ class ThemeEditorDialog(QDialog):
         layout.addLayout(btn_layout)
 
     def _update_swatch(self, btn, hex_color):
-        btn.setStyleSheet(f"background-color: {hex_color}; border: 1px solid #888; border-radius: 3px;")
+        from .styles import theme_manager
+
+        base = theme_manager.stylesheet("color_swatch")
+        btn.setStyleSheet(f"background-color: {hex_color}; {base}")
 
     def _pick_color(self, key):
         current = QColor(self._colors.get(key, "#FF00FF"))

--- a/app/GUI/validation_helpers.py
+++ b/app/GUI/validation_helpers.py
@@ -6,8 +6,8 @@ display an error label, plus a function to clear the error state.
 
 from PyQt6.QtWidgets import QLabel, QLineEdit, QWidget
 
-# Stylesheet applied to fields with validation errors
-_ERROR_STYLE = "border: 1.5px solid red; border-radius: 3px;"
+from .styles import theme_manager
+
 _NORMAL_STYLE = ""
 
 # Object name used to locate dynamically-created error labels
@@ -20,7 +20,7 @@ def set_field_error(widget: QLineEdit, message: str) -> None:
     If an error label already exists for this widget it is updated rather
     than duplicated.
     """
-    widget.setStyleSheet(_ERROR_STYLE)
+    widget.setStyleSheet(theme_manager.stylesheet("error_border"))
 
     parent: QWidget | None = widget.parentWidget()
     if parent is None:
@@ -35,7 +35,7 @@ def set_field_error(widget: QLineEdit, message: str) -> None:
 
     # Create a new error label and insert it right after the widget
     label = QLabel(message, parent)
-    label.setStyleSheet("color: red; font-size: 9pt; margin: 0; padding: 0;")
+    label.setStyleSheet(theme_manager.stylesheet("error_label_compact"))
     label.setWordWrap(True)
     label.setObjectName(_ERROR_LABEL_NAME)
     widget.setProperty(_ERROR_LABEL_NAME, label)

--- a/app/GUI/waveform_config_dialog.py
+++ b/app/GUI/waveform_config_dialog.py
@@ -11,6 +11,7 @@ from PyQt6.QtWidgets import (
 )
 from utils.format_utils import parse_value
 
+from .styles import theme_manager
 from .validation_helpers import clear_field_error, set_field_error
 
 
@@ -56,10 +57,7 @@ class WaveformConfigDialog(QDialog):
         # Help text (must be created before on_type_changed which calls update_help_text)
         self.help_label = QLabel()
         self.help_label.setWordWrap(True)
-        self.help_label.setStyleSheet(
-            "QLabel { background-color: #f9f9f9; padding: 8px; "
-            "border: 1px solid #ddd; border-radius: 3px; font-size: 9pt; }"
-        )
+        self.help_label.setStyleSheet(theme_manager.stylesheet("help_panel"))
         layout.addWidget(self.help_label)
 
         # Update display for current waveform type
@@ -67,7 +65,7 @@ class WaveformConfigDialog(QDialog):
 
         # Error label for validation feedback
         self._error_label = QLabel("")
-        self._error_label.setStyleSheet("color: red; font-size: 9pt;")
+        self._error_label.setStyleSheet(theme_manager.stylesheet("error_label"))
         self._error_label.setWordWrap(True)
         self._error_label.hide()
         layout.addWidget(self._error_label)

--- a/app/GUI/waveform_dialog.py
+++ b/app/GUI/waveform_dialog.py
@@ -219,7 +219,7 @@ class WaveformDialog(QDialog):
         scroll_layout = self._toggle_scroll_content.layout()
 
         separator = QLabel(f"── {label} ──")
-        separator.setStyleSheet("color: gray; font-style: italic;")
+        separator.setStyleSheet(theme_manager.stylesheet("muted_italic"))
         scroll_layout.addWidget(separator)
 
         for key in overlay_keys:

--- a/app/tests/unit/test_dialog_validation_feedback.py
+++ b/app/tests/unit/test_dialog_validation_feedback.py
@@ -31,7 +31,7 @@ class TestValidationHelpers:
         qtbot.addWidget(parent)
 
         set_field_error(field, "bad value")
-        assert "red" in field.styleSheet()
+        assert "border" in field.styleSheet()
 
     def test_clear_field_error_removes_border(self, qtbot):
         from PyQt6.QtWidgets import QLineEdit, QVBoxLayout, QWidget
@@ -44,7 +44,7 @@ class TestValidationHelpers:
 
         set_field_error(field, "bad value")
         clear_field_error(field)
-        assert "red" not in field.styleSheet()
+        assert "border" not in field.styleSheet()
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary - Replaces ~40 hardcoded  calls across 16 GUI files with  and  lookups, so all colors now adapt to the active theme (light, dark, or custom) - Adds semantic color keys (, , , , , , , , etc.) to both  and  - Adds 22 predefined stylesheet entries (, , , , , , etc.) to both themes with appropriate color values for each - Updates one test that was asserting on the literal string red to instead check for border (theme-aware equivalent) ### Files changed (21) **Theme definitions:** ,  **GUI files (16):** , , , , , , , , , , , , , , , , ,  **Tests:**  Closes #768 ## Test plan - [x] , , ,  all pass - [x] Pre-commit hooks pass - [x] Full test suite: 3649 passed, 56 skipped, 0 failures - [ ] Manual verification: switch between Light and Dark themes and confirm all error labels, status indicators, score displays, and help panels render correctly in both 🤖 Generated with [Claude Code](https://claude.com/claude-code)