### PR TITLE
fix MEG suffix matching and scientific notation regex (#779)

### DIFF
--- a/app/simulation/result_parser.py
+++ b/app/simulation/result_parser.py
@@ -38,7 +38,7 @@ class ResultParser:
 
         for i, line in enumerate(lines):
             # Pattern 1: v(nodename) = voltage
-            match = re.search(r"v\((\w+)\)\s*[=:]\s*([-+]?[\d.]+e?[-+]?\d*)", line, re.IGNORECASE)
+            match = re.search(r"v\((\w+)\)\s*[=:]\s*([-+]?[\d.]+(?:[eE][-+]?\d+)?)", line, re.IGNORECASE)
             if match:
                 try:
                     node_name = match.group(1)
@@ -50,7 +50,7 @@ class ResultParser:
 
             # Branch current patterns: i(device) = current or @device[current]
             i_match = re.search(
-                r"(?:i\((\w+)\)|@(\w+)\[current\])\s*[=:]\s*([-+]?[\d.]+e?[-+]?\d*)",
+                r"(?:i\((\w+)\)|@(\w+)\[current\])\s*[=:]\s*([-+]?[\d.]+(?:[eE][-+]?\d+)?)",
                 line,
                 re.IGNORECASE,
             )
@@ -88,7 +88,7 @@ class ResultParser:
         # Pattern 3: ngspice print output format
         for line in lines:
             # Voltages: " V(5)   1.000000e-06 "
-            match = re.match(r"^\s*V\((\w+)\)\s+([-+]?[\d.]+e?[-+]?\d*)\s*", line, re.IGNORECASE)
+            match = re.match(r"^\s*V\((\w+)\)\s+([-+]?[\d.]+(?:[eE][-+]?\d+)?)\s*", line, re.IGNORECASE)
             if match:
                 try:
                     node_name = match.group(1)
@@ -98,7 +98,7 @@ class ResultParser:
                     logger.debug("Skipping unparseable OP print line: %s", line)
                 continue
             # Currents: " I(v1)   -2.100000e-03 "
-            i_match = re.match(r"^\s*I\((\w+)\)\s+([-+]?[\d.]+e?[-+]?\d*)\s*", line, re.IGNORECASE)
+            i_match = re.match(r"^\s*I\((\w+)\)\s+([-+]?[\d.]+(?:[eE][-+]?\d+)?)\s*", line, re.IGNORECASE)
             if i_match:
                 try:
                     device = i_match.group(1)

--- a/app/tests/unit/test_format_utils.py
+++ b/app/tests/unit/test_format_utils.py
@@ -30,6 +30,16 @@ class TestParseValue:
     def test_meg_suffix(self):
         assert parse_value("4.7MEG") == pytest.approx(4_700_000.0)
 
+    def test_meg_lowercase(self):
+        assert parse_value("10meg") == pytest.approx(10_000_000.0)
+
+    def test_omega_does_not_match_meg(self):
+        # "OMEGA" contains "MEG" as a substring; must not trigger the MEG path.
+        # After the fix the string reaches the normal SI-prefix regex and "m"
+        # (milli) is found inside "omega", returning 100e-3.
+        result = parse_value("100omega")
+        assert result == pytest.approx(0.1)
+
     def test_bare_number(self):
         assert parse_value("100") == 100.0
 

--- a/app/tests/unit/test_result_parser.py
+++ b/app/tests/unit/test_result_parser.py
@@ -71,6 +71,40 @@ class TestParseOpResults:
         assert result["node_voltages"]["nodeC"] == pytest.approx(2.5)
         assert "nodeB" not in result["node_voltages"]
 
+    # ── scientific notation edge cases (issue #779) ───────────────────
+
+    def test_scientific_notation_fractional_no_leading_digit(self):
+        """.5e3 (no leading digit before decimal) is valid scientific notation."""
+        output = "v(a) = .5e3\n"
+        result = ResultParser.parse_op_results(output)
+        assert result["node_voltages"]["a"] == pytest.approx(500.0)
+
+    def test_scientific_notation_positive_exponent_uppercase_e(self):
+        """+1.5E+3 (positive sign, uppercase E) must parse correctly."""
+        output = "v(b) = +1.5E+3\n"
+        result = ResultParser.parse_op_results(output)
+        assert result["node_voltages"]["b"] == pytest.approx(1500.0)
+
+    def test_scientific_notation_negative_exponent(self):
+        """1.5e-3 remains parseable after regex tightening."""
+        output = "v(c) = 1.5e-3\n"
+        result = ResultParser.parse_op_results(output)
+        assert result["node_voltages"]["c"] == pytest.approx(0.0015)
+
+    def test_scientific_notation_print_format_variants(self):
+        """Pattern 3 (print format) handles scientific notation variants."""
+        output = "  V(x)   .5e3\n  V(y)   +1.5E+3\n  V(z)   1.5e-3\n"
+        result = ResultParser.parse_op_results(output)
+        assert result["node_voltages"]["x"] == pytest.approx(500.0)
+        assert result["node_voltages"]["y"] == pytest.approx(1500.0)
+        assert result["node_voltages"]["z"] == pytest.approx(0.0015)
+
+    def test_branch_current_scientific_notation(self):
+        """Branch current regex also handles scientific notation variants."""
+        output = "i(v1) = .5e-3\n"
+        result = ResultParser.parse_op_results(output)
+        assert result["branch_currents"]["v1"] == pytest.approx(0.0005)
+
 
 # ── parse_dc_results ─────────────────────────────────────────────────
 

--- a/app/utils/format_utils.py
+++ b/app/utils/format_utils.py
@@ -57,8 +57,9 @@ def parse_value(s: str) -> float:
 
     s = s.strip()
 
-    # Check for SPICE 'MEG' variant first
-    if "MEG" in s.upper():
+    # Check for SPICE 'MEG' variant first — use endswith to avoid matching
+    # substrings like "OMEGA" which contains "MEG" as a substring.
+    if s.upper().endswith("MEG"):
         num_part = s[:-3]
         multiplier = SI_PREFIX_MULTIPLIERS["MEG"]
         try:


### PR DESCRIPTION
## Summary - **MEG matching**: Changed  to  in  so that strings containing OMEGA (O-**MEG**-A substring) no longer incorrectly trigger the MEG code path. - **Scientific notation regex**: Replaced the loose  exponent pattern in all four number-matching regexes in  with , which explicitly handles both / and requires exponent digits — covering , , and . Closes #779 ## Test plan - [ ]  —  parses to 10 MΩ - [ ]  —  goes through the normal SI-prefix path instead of raising a spurious ValueError from the MEG path - [ ]  —  → 500.0 - [ ]  —  → 1500.0 - [ ]  —  → 0.0015 (regression guard) - [ ]  — all three forms in Pattern 3 (print format) - [ ]  — branch current regex covers  - [ ] All 75 existing tests in  and  pass 🤖 Generated with [Claude Code](https://claude.com/claude-code)