### PR TITLE
consolidate duplicated test helpers into shared fixtures (#774)

### DIFF
--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -164,3 +164,92 @@ def resistor_divider_circuit():
     }
 
     return components, wires, nodes, terminal_to_node
+
+
+# ---------------------------------------------------------------------------
+# Shared circuit-model builder
+# ---------------------------------------------------------------------------
+
+
+def build_simple_circuit():
+    """Build a simple V1-R1-GND CircuitModel.
+
+    Creates the canonical 3-component, 3-wire test circuit used across the
+    test suite.  Returns a fully-initialised ``CircuitModel`` with nodes
+    built and ``component_counter`` set.
+
+    Tests that additionally need ``model.analysis_type`` can set it after
+    calling this helper.
+    """
+    from models.circuit import CircuitModel
+
+    model = CircuitModel()
+    model.components["V1"] = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value="5V",
+        position=(0.0, 0.0),
+    )
+    model.components["R1"] = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value="1k",
+        position=(100.0, 0.0),
+    )
+    model.components["GND1"] = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(0.0, 100.0),
+    )
+    model.wires = [
+        WireData(
+            start_component_id="V1",
+            start_terminal=1,
+            end_component_id="R1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="R1",
+            start_terminal=1,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="GND1",
+            end_terminal=0,
+        ),
+    ]
+    model.component_counter = {"V": 1, "R": 1, "GND": 1}
+    model.rebuild_nodes()
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Shared simulation-controller factory
+# ---------------------------------------------------------------------------
+
+
+def make_simulation_controller(model=None, circuit_ctrl=None):
+    """Create a SimulationController with a mocked NgspiceRunner.
+
+    Returns ``(ctrl, runner)`` where ``runner`` is a ``MagicMock`` with
+    ``output_dir`` and ``find_ngspice`` pre-configured.
+
+    Args:
+        model: Optional ``CircuitModel``.  Defaults to an empty model.
+        circuit_ctrl: Optional ``CircuitController`` to pass through.
+    """
+    from unittest.mock import MagicMock
+
+    from controllers.simulation_controller import SimulationController
+    from models.circuit import CircuitModel
+
+    ctrl = SimulationController(model=model or CircuitModel(), circuit_ctrl=circuit_ctrl)
+    runner = MagicMock()
+    runner.output_dir = "/tmp/test_output"
+    runner.find_ngspice.return_value = "/usr/bin/ngspice"
+    ctrl._runner = runner
+    return ctrl, runner

--- a/app/tests/unit/controllers/test_file_controller_coverage.py
+++ b/app/tests/unit/controllers/test_file_controller_coverage.py
@@ -24,54 +24,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from controllers.file_controller import FileController
 from models.circuit import CircuitModel
-from models.component import ComponentData
-from models.wire import WireData
-
-
-def _build_simple_circuit():
-    """Build a simple V1-R1-GND circuit model."""
-    model = CircuitModel()
-    model.components["V1"] = ComponentData(
-        component_id="V1",
-        component_type="Voltage Source",
-        value="5V",
-        position=(0.0, 0.0),
-    )
-    model.components["R1"] = ComponentData(
-        component_id="R1",
-        component_type="Resistor",
-        value="1k",
-        position=(100.0, 0.0),
-    )
-    model.components["GND1"] = ComponentData(
-        component_id="GND1",
-        component_type="Ground",
-        value="0V",
-        position=(0.0, 100.0),
-    )
-    model.wires = [
-        WireData(
-            start_component_id="V1",
-            start_terminal=1,
-            end_component_id="R1",
-            end_terminal=0,
-        ),
-        WireData(
-            start_component_id="R1",
-            start_terminal=1,
-            end_component_id="GND1",
-            end_terminal=0,
-        ),
-        WireData(
-            start_component_id="V1",
-            start_terminal=0,
-            end_component_id="GND1",
-            end_terminal=0,
-        ),
-    ]
-    model.component_counter = {"V": 1, "R": 1, "GND": 1}
-    model.rebuild_nodes()
-    return model
+from tests.conftest import build_simple_circuit
 
 
 class TestLoadFromModel:
@@ -80,7 +33,7 @@ class TestLoadFromModel:
     def test_load_from_model_replaces_data(self):
         """load_from_model should replace the model data in place."""
         ctrl = FileController(CircuitModel())
-        new_model = _build_simple_circuit()
+        new_model = build_simple_circuit()
         ctrl.load_from_model(new_model)
         assert "V1" in ctrl.model.components
         assert "R1" in ctrl.model.components
@@ -89,14 +42,14 @@ class TestLoadFromModel:
         """load_from_model should notify circuit_ctrl when present."""
         mock_ctrl = MagicMock()
         ctrl = FileController(CircuitModel(), circuit_ctrl=mock_ctrl)
-        new_model = _build_simple_circuit()
+        new_model = build_simple_circuit()
         ctrl.load_from_model(new_model)
         mock_ctrl._notify.assert_called_once_with("model_loaded", None)
 
     def test_load_from_model_without_circuit_ctrl(self):
         """load_from_model should work without circuit_ctrl."""
         ctrl = FileController(CircuitModel())
-        new_model = _build_simple_circuit()
+        new_model = build_simple_circuit()
         ctrl.load_from_model(new_model)
         assert "V1" in ctrl.model.components
 
@@ -109,7 +62,7 @@ class TestCircuitCtrlNotifications:
         """save_circuit should notify circuit_ctrl with 'model_saved'."""
         mock_settings.get_list.return_value = []
         mock_ctrl = MagicMock()
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model, circuit_ctrl=mock_ctrl)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
@@ -119,7 +72,7 @@ class TestCircuitCtrlNotifications:
     def test_load_circuit_notifies_circuit_ctrl(self, mock_settings, tmp_path):
         """load_circuit should notify circuit_ctrl with 'model_loaded'."""
         mock_settings.get_list.return_value = []
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
@@ -138,7 +91,7 @@ class TestSaveSessionOSError:
         # Use a session file path in a non-existent directory
         session_file = str(tmp_path / "nonexistent_dir" / "deep" / "session.txt")
         ctrl = FileController(
-            _build_simple_circuit(),
+            build_simple_circuit(),
             session_file=session_file,
         )
         ctrl.current_file = Path("/some/file.json")
@@ -150,7 +103,7 @@ class TestSaveSessionOSError:
         """save_circuit should not fail if session file write raises OSError."""
         mock_settings.get_list.return_value = []
         session_file = str(tmp_path / "no_dir" / "session.txt")
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         filepath = tmp_path / "test.json"
         ctrl = FileController(model, session_file=session_file)
         # Should not raise despite session file being unwritable
@@ -164,7 +117,7 @@ class TestAutoSaveWriting:
     def test_auto_save_writes_file(self, tmp_path):
         """auto_save should write model data to the autosave file."""
         autosave_file = str(tmp_path / ".autosave_recovery.json")
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model, autosave_file=autosave_file)
         ctrl.auto_save()
         autosave_path = ctrl._autosave_file
@@ -176,7 +129,7 @@ class TestAutoSaveWriting:
     def test_auto_save_includes_source_path(self, tmp_path):
         """auto_save should store the current_file as _autosave_source."""
         autosave_file = str(tmp_path / ".autosave_recovery.json")
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model, autosave_file=autosave_file)
         source = tmp_path / "circuit.json"
         ctrl.current_file = source
@@ -187,7 +140,7 @@ class TestAutoSaveWriting:
     def test_auto_save_empty_source_when_no_current_file(self, tmp_path):
         """auto_save should store empty string when no current_file."""
         autosave_file = str(tmp_path / ".autosave_recovery.json")
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model, autosave_file=autosave_file)
         ctrl.auto_save()
         data = json.loads(ctrl._autosave_file.read_text())
@@ -200,7 +153,7 @@ class TestClearAutoSave:
     def test_clear_auto_save_deletes_file(self, tmp_path):
         """clear_auto_save should delete the autosave file."""
         autosave_file = str(tmp_path / ".autosave_recovery.json")
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model, autosave_file=autosave_file)
         ctrl.auto_save()
         assert ctrl._autosave_file.exists()
@@ -322,7 +275,7 @@ class TestLoadFromDictCtrlNotification:
     def test_load_from_dict_notifies_circuit_ctrl(self):
         """load_from_dict should notify circuit_ctrl with 'model_loaded'."""
         mock_ctrl = MagicMock()
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model, circuit_ctrl=mock_ctrl)
         data = model.to_dict()
         ctrl.load_from_dict(data)
@@ -349,7 +302,7 @@ class TestAutoSaveErrorBranch:
     def test_auto_save_oserror_is_logged(self, tmp_path):
         """auto_save should log a warning on OSError, not raise."""
         autosave_file = str(tmp_path / ".autosave_recovery.json")
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model, autosave_file=autosave_file)
         with patch("builtins.open", side_effect=OSError("disk full")):
             # Should not raise
@@ -362,7 +315,7 @@ class TestHasAutoSave:
     def test_has_auto_save_true(self, tmp_path):
         """has_auto_save should return True when file exists."""
         autosave_file = str(tmp_path / ".autosave_recovery.json")
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model, autosave_file=autosave_file)
         ctrl.auto_save()
         assert ctrl.has_auto_save() is True
@@ -380,7 +333,7 @@ class TestLoadAutoSaveBranches:
     def test_load_auto_save_restores_source_path(self, tmp_path):
         """load_auto_save should restore current_file from _autosave_source."""
         autosave_file = str(tmp_path / ".autosave_recovery.json")
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model, autosave_file=autosave_file)
         original_path = tmp_path / "circuit.json"
         ctrl.current_file = original_path
@@ -394,7 +347,7 @@ class TestLoadAutoSaveBranches:
     def test_load_auto_save_notifies_circuit_ctrl(self, tmp_path):
         """load_auto_save should notify circuit_ctrl with 'model_loaded'."""
         autosave_file = str(tmp_path / ".autosave_recovery.json")
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model, autosave_file=autosave_file)
         ctrl.auto_save()
 

--- a/app/tests/unit/controllers/test_simulation_controller.py
+++ b/app/tests/unit/controllers/test_simulation_controller.py
@@ -12,16 +12,7 @@ from controllers.simulation_controller import SimulationController, SimulationRe
 from models.circuit import CircuitModel
 from models.component import ComponentData
 from models.wire import WireData
-
-
-def _make_controller(model=None, circuit_ctrl=None):
-    """Create a SimulationController with a mocked runner."""
-    ctrl = SimulationController(model=model or CircuitModel(), circuit_ctrl=circuit_ctrl)
-    runner = MagicMock()
-    runner.output_dir = "/tmp/test_output"
-    runner.find_ngspice.return_value = "/usr/bin/ngspice"
-    ctrl._runner = runner
-    return ctrl, runner
+from tests.conftest import make_simulation_controller
 
 
 def _build_circuit(ctrl):
@@ -76,7 +67,7 @@ def _build_circuit(ctrl):
 class TestRunSimulationNetlistError:
     def test_netlist_generation_value_error(self):
         """Lines 152-160: ValueError during netlist generation returns failure."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -91,7 +82,7 @@ class TestRunSimulationNetlistError:
 
     def test_netlist_generation_key_error(self):
         """Lines 152-160: KeyError during netlist generation returns failure."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -105,7 +96,7 @@ class TestRunSimulationNetlistError:
 
     def test_netlist_generation_type_error(self):
         """Lines 152-160: TypeError during netlist generation returns failure."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -120,7 +111,7 @@ class TestRunSimulationNetlistError:
     def test_netlist_error_notifies_circuit_ctrl(self):
         """Lines 158-159: circuit_ctrl notified on netlist failure."""
         cc = MagicMock()
-        ctrl, runner = _make_controller(circuit_ctrl=cc)
+        ctrl, runner = make_simulation_controller(circuit_ctrl=cc)
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -143,7 +134,7 @@ class TestNgspiceNotFoundNotify:
     def test_ngspice_not_found_notifies_circuit_ctrl(self):
         """Line 172: circuit_ctrl notified when ngspice not found."""
         cc = MagicMock()
-        ctrl, runner = _make_controller(circuit_ctrl=cc)
+        ctrl, runner = make_simulation_controller(circuit_ctrl=cc)
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
         runner.find_ngspice.return_value = None
@@ -165,7 +156,7 @@ class TestNgspiceNotFoundNotify:
 class TestRetryNetlistFails:
     def test_retry_netlist_generation_fails(self):
         """Lines 191-192: retry netlist generation raises exception, falls through."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -215,7 +206,7 @@ class TestRetrySuccessNotify:
     def test_convergence_retry_success_notifies_circuit_ctrl(self):
         """Line 207: circuit_ctrl notified after successful convergence retry."""
         cc = MagicMock()
-        ctrl, runner = _make_controller(circuit_ctrl=cc)
+        ctrl, runner = make_simulation_controller(circuit_ctrl=cc)
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -263,7 +254,7 @@ class TestSimFailureNotify:
     def test_simulation_failure_notifies_circuit_ctrl(self):
         """Line 218: circuit_ctrl notified on simulation failure (non-retriable)."""
         cc = MagicMock()
-        ctrl, runner = _make_controller(circuit_ctrl=cc)
+        ctrl, runner = make_simulation_controller(circuit_ctrl=cc)
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -294,7 +285,7 @@ class TestSimFailureNotify:
 class TestParameterSweepComponentNotFound:
     def test_sweep_component_not_found(self):
         """Line 332: component_id not in circuit returns failure."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -319,7 +310,7 @@ class TestParameterSweepComponentNotFound:
 class TestParameterSweepNgspiceNotFound:
     def test_sweep_ngspice_not_found(self):
         """Lines 354-355: ngspice not found restores analysis and returns failure."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("AC Sweep", {"fstart": "1", "fstop": "1Meg"})
         runner.find_ngspice.return_value = None
@@ -348,7 +339,7 @@ class TestParameterSweepNgspiceNotFound:
 class TestParameterSweepCancellation:
     def test_sweep_cancelled_by_callback(self):
         """Lines 375-376: progress_callback returning False cancels sweep."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -374,7 +365,7 @@ class TestParameterSweepCancellation:
 class TestParameterSweepSimFailure:
     def test_sweep_step_sim_failure(self):
         """Lines 394-403: simulation failure at a sweep step records error."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -404,7 +395,7 @@ class TestParameterSweepSimFailure:
 class TestParameterSweepValidationFailure:
     def test_sweep_validation_failure_restores_analysis(self):
         """Lines 348-349: validation failure restores original analysis type."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("AC Sweep", {"fstart": "1", "fstop": "1Meg"})
 
@@ -432,7 +423,7 @@ class TestParameterSweepValidationFailure:
 class TestParameterSweepNetlistFailure:
     def test_sweep_step_netlist_failure(self):
         """Lines 386-389: netlist generation failure at a sweep step."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -460,7 +451,7 @@ class TestParameterSweepNetlistFailure:
 class TestParameterSweepParseFailure:
     def test_sweep_step_parse_failure_records_error(self):
         """Line 416: parse result failure at a sweep step records error."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -493,7 +484,7 @@ class TestParameterSweepParseFailure:
 class TestMonteCarloValidationFailure:
     def test_mc_validation_failure_restores_analysis(self):
         """Lines 483-484: validation failure restores original analysis type."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("AC Sweep", {"fstart": "1", "fstop": "1Meg"})
 
@@ -518,7 +509,7 @@ class TestMonteCarloValidationFailure:
 class TestMonteCarloNgspiceNotFound:
     def test_mc_ngspice_not_found(self):
         """Lines 488-489: ngspice not found restores analysis and returns failure."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("AC Sweep", {"fstart": "1", "fstop": "1Meg"})
         runner.find_ngspice.return_value = None
@@ -544,7 +535,7 @@ class TestMonteCarloNgspiceNotFound:
 class TestMonteCarloCancellation:
     def test_mc_cancelled_by_callback(self):
         """Lines 503-504: progress_callback returning False cancels MC."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -572,7 +563,7 @@ class TestMonteCarloComponentNone:
         R1 passes the invalid_ids filter (line 467) and original_values (line 473),
         then the progress_callback removes it so components.get returns None at line 508.
         """
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -609,7 +600,7 @@ class TestMonteCarloComponentNone:
 class TestMonteCarloNetlistFailure:
     def test_mc_step_netlist_failure(self):
         """Lines 527-530: netlist generation failure at a Monte Carlo step."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -636,7 +627,7 @@ class TestMonteCarloNetlistFailure:
 class TestMonteCarloSimFailure:
     def test_mc_step_simulation_failure(self):
         """Lines 534-542: simulation fails at a Monte Carlo step."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -665,7 +656,7 @@ class TestMonteCarloSimFailure:
 class TestMonteCarloParseFailure:
     def test_mc_step_parse_failure_records_error(self):
         """Line 553: parse result failure in MC step records error."""
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
 
@@ -697,7 +688,7 @@ class TestMonteCarloParseFailure:
 class TestGenerateCircuitikz:
     def test_generate_circuitikz(self):
         """Lines 823-826: generate_circuitikz delegates to exporter."""
-        ctrl, _ = _make_controller()
+        ctrl, _ = make_simulation_controller()
         _build_circuit(ctrl)
 
         with patch(
@@ -743,7 +734,7 @@ class TestCreateBundle:
 class TestPresetManagerLazyInit:
     def test_preset_manager_creates_instance(self):
         """Lines 657-659: preset_manager lazy-creates PresetManager."""
-        ctrl, _ = _make_controller()
+        ctrl, _ = make_simulation_controller()
         assert ctrl._preset_manager is None
         with patch("simulation.preset_manager.PresetManager") as mock_pm_cls:
             mock_pm_cls.return_value = MagicMock()

--- a/app/tests/unit/grading_fakes.py
+++ b/app/tests/unit/grading_fakes.py
@@ -1,0 +1,71 @@
+"""Shared lightweight test doubles for grading-related tests.
+
+Provides fake dataclasses that mirror the grading result types without
+importing the full grading chain.  Used by test_score_histogram.py,
+test_feedback_exporter.py, and test_check_analytics.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FakeCheckResult:
+    check_id: str = "check_1"
+    passed: bool = True
+    points_earned: int = 10
+    points_possible: int = 10
+    feedback: str = ""
+
+
+@dataclass
+class FakeGradingResult:
+    student_file: str = "student.json"
+    rubric_title: str = "Test Rubric"
+    total_points: int = 100
+    earned_points: int = 80
+    check_results: list = field(default_factory=list)
+
+    @property
+    def percentage(self) -> float:
+        if self.total_points == 0:
+            return 0.0
+        return (self.earned_points / self.total_points) * 100.0
+
+
+@dataclass
+class FakeBatchResult:
+    rubric_title: str = "Test"
+    total_students: int = 0
+    successful: int = 0
+    failed: int = 0
+    results: list = field(default_factory=list)
+    errors: list = field(default_factory=list)
+
+    @property
+    def mean_score(self) -> float:
+        if not self.results:
+            return 0.0
+        return sum(r.percentage for r in self.results) / len(self.results)
+
+    @property
+    def median_score(self) -> float:
+        scores = sorted(r.percentage for r in self.results)
+        n = len(scores)
+        if n == 0:
+            return 0.0
+        mid = n // 2
+        return (scores[mid - 1] + scores[mid]) / 2 if n % 2 == 0 else scores[mid]
+
+    @property
+    def min_score(self) -> float:
+        if not self.results:
+            return 0.0
+        return min(r.percentage for r in self.results)
+
+    @property
+    def max_score(self) -> float:
+        if not self.results:
+            return 0.0
+        return max(r.percentage for r in self.results)

--- a/app/tests/unit/test_auto_save.py
+++ b/app/tests/unit/test_auto_save.py
@@ -5,67 +5,19 @@ from pathlib import Path
 
 import pytest
 from controllers.file_controller import FileController
-from models.circuit import CircuitModel
-from models.component import ComponentData
-from models.wire import WireData
-
-
-def _build_simple_circuit():
-    """Build a simple V1-R1-GND circuit model."""
-    model = CircuitModel()
-    model.components["V1"] = ComponentData(
-        component_id="V1",
-        component_type="Voltage Source",
-        value="5V",
-        position=(0.0, 0.0),
-    )
-    model.components["R1"] = ComponentData(
-        component_id="R1",
-        component_type="Resistor",
-        value="1k",
-        position=(100.0, 0.0),
-    )
-    model.components["GND1"] = ComponentData(
-        component_id="GND1",
-        component_type="Ground",
-        value="0V",
-        position=(0.0, 100.0),
-    )
-    model.wires = [
-        WireData(
-            start_component_id="V1",
-            start_terminal=1,
-            end_component_id="R1",
-            end_terminal=0,
-        ),
-        WireData(
-            start_component_id="R1",
-            start_terminal=1,
-            end_component_id="GND1",
-            end_terminal=0,
-        ),
-        WireData(
-            start_component_id="V1",
-            start_terminal=0,
-            end_component_id="GND1",
-            end_terminal=0,
-        ),
-    ]
-    model.component_counter = {"V": 1, "R": 1, "GND": 1}
-    model.rebuild_nodes()
-    return model
+from tests.conftest import build_simple_circuit
 
 
 class TestAutoSave:
     def test_auto_save_creates_file(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         ctrl.auto_save()
         assert Path(autosave).exists()
 
     def test_auto_save_writes_valid_json(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         ctrl.auto_save()
         data = json.loads(Path(autosave).read_text())
         assert "components" in data
@@ -73,7 +25,7 @@ class TestAutoSave:
 
     def test_auto_save_includes_source_path(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         source = tmp_path / "my_circuit.json"
         ctrl.current_file = source
         ctrl.auto_save()
@@ -82,21 +34,21 @@ class TestAutoSave:
 
     def test_auto_save_empty_source_when_no_file(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         ctrl.auto_save()
         data = json.loads(Path(autosave).read_text())
         assert data["_autosave_source"] == ""
 
     def test_auto_save_does_not_update_current_file(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         assert ctrl.current_file is None
         ctrl.auto_save()
         assert ctrl.current_file is None
 
     def test_auto_save_preserves_analysis_settings(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         model.analysis_type = "Transient"
         model.analysis_params = {"duration": 0.01, "step": 1e-5}
         ctrl = FileController(model, autosave_file=autosave)
@@ -114,7 +66,7 @@ class TestHasAutoSave:
 
     def test_has_auto_save_true_after_save(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         ctrl.auto_save()
         assert ctrl.has_auto_save()
 
@@ -122,7 +74,7 @@ class TestHasAutoSave:
 class TestClearAutoSave:
     def test_clear_removes_file(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         ctrl.auto_save()
         assert Path(autosave).exists()
         ctrl.clear_auto_save()
@@ -137,7 +89,7 @@ class TestClearAutoSave:
 class TestLoadAutoSave:
     def test_load_restores_components(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         ctrl.auto_save()
 
         # Load into fresh controller
@@ -150,7 +102,7 @@ class TestLoadAutoSave:
 
     def test_load_restores_wires(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         ctrl.auto_save()
 
         ctrl2 = FileController(autosave_file=autosave)
@@ -159,7 +111,7 @@ class TestLoadAutoSave:
 
     def test_load_returns_source_path(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         source_file = tmp_path / "my_circuit.json"
         ctrl.current_file = source_file
         ctrl.auto_save()
@@ -170,7 +122,7 @@ class TestLoadAutoSave:
 
     def test_load_returns_empty_string_for_unsaved(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         ctrl.auto_save()
 
         ctrl2 = FileController(autosave_file=autosave)
@@ -179,7 +131,7 @@ class TestLoadAutoSave:
 
     def test_load_sets_current_file_from_source(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         source_file = tmp_path / "my_circuit.json"
         ctrl.current_file = source_file
         ctrl.auto_save()
@@ -201,7 +153,7 @@ class TestLoadAutoSave:
 
     def test_load_restores_analysis_settings(self, tmp_path):
         autosave = str(tmp_path / "recovery.json")
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         model.analysis_type = "AC Sweep"
         model.analysis_params = {"fStart": 1, "fStop": 1e6}
         ctrl = FileController(model, autosave_file=autosave)
@@ -216,7 +168,7 @@ class TestLoadAutoSave:
         from unittest.mock import MagicMock
 
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         ctrl.auto_save()
 
         ctrl2 = FileController(autosave_file=autosave)
@@ -228,7 +180,7 @@ class TestLoadAutoSave:
     def test_autosave_source_not_in_model_data(self, tmp_path):
         """The _autosave_source metadata should not leak into the model."""
         autosave = str(tmp_path / "recovery.json")
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         ctrl.current_file = tmp_path / "my_circuit.json"
         ctrl.auto_save()
 
@@ -247,7 +199,7 @@ class TestAutoSaveIntegrationWithSave:
         Clearing is MainWindow's responsibility."""
         autosave = str(tmp_path / "recovery.json")
         circuit_file = tmp_path / "circuit.json"
-        ctrl = FileController(_build_simple_circuit(), autosave_file=autosave)
+        ctrl = FileController(build_simple_circuit(), autosave_file=autosave)
         ctrl.auto_save()
         assert ctrl.has_auto_save()
         ctrl.save_circuit(circuit_file)

--- a/app/tests/unit/test_check_analytics.py
+++ b/app/tests/unit/test_check_analytics.py
@@ -11,72 +11,11 @@ from __future__ import annotations
 
 import csv
 import tempfile
-from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
 from grading.check_analytics import CheckAnalytics, compute_check_analytics
-
-# ---------------------------------------------------------------------------
-# Lightweight test doubles
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class _FakeCheckResult:
-    check_id: str = "check_1"
-    passed: bool = True
-    points_earned: int = 10
-    points_possible: int = 10
-    feedback: str = ""
-
-
-@dataclass
-class _FakeGradingResult:
-    student_file: str = "student.json"
-    rubric_title: str = "Test"
-    total_points: int = 100
-    earned_points: int = 80
-    check_results: list = field(default_factory=list)
-
-    @property
-    def percentage(self) -> float:
-        if self.total_points == 0:
-            return 0.0
-        return (self.earned_points / self.total_points) * 100.0
-
-
-@dataclass
-class _FakeBatchResult:
-    rubric_title: str = "Test"
-    total_students: int = 0
-    successful: int = 0
-    failed: int = 0
-    results: list = field(default_factory=list)
-    errors: list = field(default_factory=list)
-
-    @property
-    def mean_score(self):
-        if not self.results:
-            return 0.0
-        return sum(r.percentage for r in self.results) / len(self.results)
-
-    @property
-    def median_score(self):
-        return self.mean_score
-
-    @property
-    def min_score(self):
-        if not self.results:
-            return 0.0
-        return min(r.percentage for r in self.results)
-
-    @property
-    def max_score(self):
-        if not self.results:
-            return 0.0
-        return max(r.percentage for r in self.results)
-
+from tests.unit.grading_fakes import FakeBatchResult, FakeCheckResult, FakeGradingResult
 
 # ---------------------------------------------------------------------------
 # CheckAnalytics
@@ -108,50 +47,50 @@ class TestCheckAnalytics:
 
 class TestComputeCheckAnalytics:
     def test_empty_results(self):
-        result = _FakeBatchResult()
+        result = FakeBatchResult()
         analytics = compute_check_analytics(result)
         assert analytics == []
 
     def test_single_student_all_pass(self):
-        gr = _FakeGradingResult(
+        gr = FakeGradingResult(
             check_results=[
-                _FakeCheckResult(check_id="c1", passed=True),
-                _FakeCheckResult(check_id="c2", passed=True),
+                FakeCheckResult(check_id="c1", passed=True),
+                FakeCheckResult(check_id="c2", passed=True),
             ]
         )
-        result = _FakeBatchResult(results=[gr])
+        result = FakeBatchResult(results=[gr])
         analytics = compute_check_analytics(result)
         assert len(analytics) == 2
         assert all(ca.pass_rate == 100.0 for ca in analytics)
 
     def test_single_student_all_fail(self):
-        gr = _FakeGradingResult(
+        gr = FakeGradingResult(
             check_results=[
-                _FakeCheckResult(check_id="c1", passed=False),
-                _FakeCheckResult(check_id="c2", passed=False),
+                FakeCheckResult(check_id="c1", passed=False),
+                FakeCheckResult(check_id="c2", passed=False),
             ]
         )
-        result = _FakeBatchResult(results=[gr])
+        result = FakeBatchResult(results=[gr])
         analytics = compute_check_analytics(result)
         assert len(analytics) == 2
         assert all(ca.pass_rate == 0.0 for ca in analytics)
 
     def test_multiple_students(self):
-        gr1 = _FakeGradingResult(
+        gr1 = FakeGradingResult(
             student_file="s1.json",
             check_results=[
-                _FakeCheckResult(check_id="c1", passed=True),
-                _FakeCheckResult(check_id="c2", passed=False),
+                FakeCheckResult(check_id="c1", passed=True),
+                FakeCheckResult(check_id="c2", passed=False),
             ],
         )
-        gr2 = _FakeGradingResult(
+        gr2 = FakeGradingResult(
             student_file="s2.json",
             check_results=[
-                _FakeCheckResult(check_id="c1", passed=True),
-                _FakeCheckResult(check_id="c2", passed=True),
+                FakeCheckResult(check_id="c1", passed=True),
+                FakeCheckResult(check_id="c2", passed=True),
             ],
         )
-        result = _FakeBatchResult(results=[gr1, gr2])
+        result = FakeBatchResult(results=[gr1, gr2])
         analytics = compute_check_analytics(result)
 
         # Should be sorted by pass rate (lowest first)
@@ -168,17 +107,17 @@ class TestComputeCheckAnalytics:
         # 3 students, 3 checks with different pass rates
         results = []
         for i in range(3):
-            gr = _FakeGradingResult(
+            gr = FakeGradingResult(
                 student_file=f"s{i}.json",
                 check_results=[
-                    _FakeCheckResult(check_id="easy", passed=True),
-                    _FakeCheckResult(check_id="medium", passed=(i < 2)),
-                    _FakeCheckResult(check_id="hard", passed=(i < 1)),
+                    FakeCheckResult(check_id="easy", passed=True),
+                    FakeCheckResult(check_id="medium", passed=(i < 2)),
+                    FakeCheckResult(check_id="hard", passed=(i < 1)),
                 ],
             )
             results.append(gr)
 
-        result = _FakeBatchResult(results=results)
+        result = FakeBatchResult(results=results)
         analytics = compute_check_analytics(result)
 
         assert analytics[0].check_id == "hard"  # 33% pass rate
@@ -188,15 +127,15 @@ class TestComputeCheckAnalytics:
     def test_check_counts_correct(self):
         results = []
         for i in range(10):
-            gr = _FakeGradingResult(
+            gr = FakeGradingResult(
                 student_file=f"s{i}.json",
                 check_results=[
-                    _FakeCheckResult(check_id="check_a", passed=(i < 8)),
+                    FakeCheckResult(check_id="check_a", passed=(i < 8)),
                 ],
             )
             results.append(gr)
 
-        result = _FakeBatchResult(results=results)
+        result = FakeBatchResult(results=results)
         analytics = compute_check_analytics(result)
         assert len(analytics) == 1
         assert analytics[0].pass_count == 8
@@ -221,14 +160,14 @@ class TestCsvExportAnalytics:
     def test_csv_includes_analytics_section(self):
         from grading.grade_exporter import export_gradebook_csv
 
-        gr1 = _FakeGradingResult(
+        gr1 = FakeGradingResult(
             student_file="s1.json",
             check_results=[
-                _FakeCheckResult(check_id="c1", passed=True, points_earned=10, points_possible=10),
-                _FakeCheckResult(check_id="c2", passed=False, points_earned=0, points_possible=10),
+                FakeCheckResult(check_id="c1", passed=True, points_earned=10, points_possible=10),
+                FakeCheckResult(check_id="c2", passed=False, points_earned=0, points_possible=10),
             ],
         )
-        result = _FakeBatchResult(
+        result = FakeBatchResult(
             total_students=1,
             successful=1,
             failed=0,
@@ -252,21 +191,21 @@ class TestCsvExportAnalytics:
     def test_csv_analytics_sorted_by_pass_rate(self):
         from grading.grade_exporter import export_gradebook_csv
 
-        gr1 = _FakeGradingResult(
+        gr1 = FakeGradingResult(
             student_file="s1.json",
             check_results=[
-                _FakeCheckResult(check_id="easy", passed=True, points_earned=10, points_possible=10),
-                _FakeCheckResult(check_id="hard", passed=False, points_earned=0, points_possible=10),
+                FakeCheckResult(check_id="easy", passed=True, points_earned=10, points_possible=10),
+                FakeCheckResult(check_id="hard", passed=False, points_earned=0, points_possible=10),
             ],
         )
-        gr2 = _FakeGradingResult(
+        gr2 = FakeGradingResult(
             student_file="s2.json",
             check_results=[
-                _FakeCheckResult(check_id="easy", passed=True, points_earned=10, points_possible=10),
-                _FakeCheckResult(check_id="hard", passed=False, points_earned=0, points_possible=10),
+                FakeCheckResult(check_id="easy", passed=True, points_earned=10, points_possible=10),
+                FakeCheckResult(check_id="hard", passed=False, points_earned=0, points_possible=10),
             ],
         )
-        result = _FakeBatchResult(
+        result = FakeBatchResult(
             total_students=2,
             successful=2,
             failed=0,

--- a/app/tests/unit/test_feedback_exporter.py
+++ b/app/tests/unit/test_feedback_exporter.py
@@ -9,50 +9,11 @@ Covers:
 from __future__ import annotations
 
 import tempfile
-from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
 from grading.feedback_exporter import export_student_reports, generate_student_report_html
-
-# ---------------------------------------------------------------------------
-# Lightweight test doubles
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class _FakeCheckResult:
-    check_id: str = "check_1"
-    passed: bool = True
-    points_earned: int = 10
-    points_possible: int = 10
-    feedback: str = ""
-
-
-@dataclass
-class _FakeGradingResult:
-    student_file: str = "student.json"
-    rubric_title: str = "Test Rubric"
-    total_points: int = 100
-    earned_points: int = 80
-    check_results: list = field(default_factory=list)
-
-    @property
-    def percentage(self) -> float:
-        if self.total_points == 0:
-            return 0.0
-        return (self.earned_points / self.total_points) * 100.0
-
-
-@dataclass
-class _FakeBatchResult:
-    rubric_title: str = "Test"
-    total_students: int = 0
-    successful: int = 0
-    failed: int = 0
-    results: list = field(default_factory=list)
-    errors: list = field(default_factory=list)
-
+from tests.unit.grading_fakes import FakeBatchResult, FakeCheckResult, FakeGradingResult
 
 # ---------------------------------------------------------------------------
 # generate_student_report_html
@@ -61,14 +22,14 @@ class _FakeBatchResult:
 
 class TestGenerateStudentReportHtml:
     def test_basic_report(self):
-        result = _FakeGradingResult(
+        result = FakeGradingResult(
             student_file="alice.json",
             rubric_title="Lab 1",
             total_points=100,
             earned_points=85,
             check_results=[
-                _FakeCheckResult(check_id="R1_exists", passed=True, feedback="Found R1"),
-                _FakeCheckResult(
+                FakeCheckResult(check_id="R1_exists", passed=True, feedback="Found R1"),
+                FakeCheckResult(
                     check_id="R1_value",
                     passed=False,
                     points_earned=0,
@@ -87,7 +48,7 @@ class TestGenerateStudentReportHtml:
         assert "Expected 1k, got 2k" in html
 
     def test_html_structure(self):
-        result = _FakeGradingResult()
+        result = FakeGradingResult()
         html = generate_student_report_html(result)
         assert "<!DOCTYPE html>" in html
         assert "<html" in html
@@ -95,10 +56,10 @@ class TestGenerateStudentReportHtml:
         assert "<table>" in html
 
     def test_pass_fail_classes(self):
-        result = _FakeGradingResult(
+        result = FakeGradingResult(
             check_results=[
-                _FakeCheckResult(check_id="c1", passed=True),
-                _FakeCheckResult(check_id="c2", passed=False),
+                FakeCheckResult(check_id="c1", passed=True),
+                FakeCheckResult(check_id="c2", passed=False),
             ]
         )
         html = generate_student_report_html(result)
@@ -108,10 +69,10 @@ class TestGenerateStudentReportHtml:
         assert ">Fail<" in html
 
     def test_html_escapes_special_chars(self):
-        result = _FakeGradingResult(
+        result = FakeGradingResult(
             student_file='<script>alert("xss")</script>.json',
             check_results=[
-                _FakeCheckResult(check_id="check_1", feedback='Value is <b>"wrong"</b> & bad'),
+                FakeCheckResult(check_id="check_1", feedback='Value is <b>"wrong"</b> & bad'),
             ],
         )
         html = generate_student_report_html(result)
@@ -120,19 +81,19 @@ class TestGenerateStudentReportHtml:
         assert "&amp;" in html
 
     def test_empty_check_results(self):
-        result = _FakeGradingResult(check_results=[])
+        result = FakeGradingResult(check_results=[])
         html = generate_student_report_html(result)
         assert "student.json" in html
         assert "<tbody>" in html
 
     def test_zero_total_points(self):
-        result = _FakeGradingResult(total_points=0, earned_points=0)
+        result = FakeGradingResult(total_points=0, earned_points=0)
         html = generate_student_report_html(result)
         assert "0/0" in html
         assert "0.0%" in html
 
     def test_empty_feedback(self):
-        result = _FakeGradingResult(check_results=[_FakeCheckResult(check_id="c1", feedback="")])
+        result = FakeGradingResult(check_results=[FakeCheckResult(check_id="c1", feedback="")])
         html = generate_student_report_html(result)
         assert "c1" in html
 
@@ -145,16 +106,16 @@ class TestGenerateStudentReportHtml:
 class TestExportStudentReports:
     def test_creates_files(self):
         results = [
-            _FakeGradingResult(
+            FakeGradingResult(
                 student_file="alice.json",
-                check_results=[_FakeCheckResult(check_id="c1")],
+                check_results=[FakeCheckResult(check_id="c1")],
             ),
-            _FakeGradingResult(
+            FakeGradingResult(
                 student_file="bob.json",
-                check_results=[_FakeCheckResult(check_id="c1")],
+                check_results=[FakeCheckResult(check_id="c1")],
             ),
         ]
-        batch = _FakeBatchResult(results=results)
+        batch = FakeBatchResult(results=results)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             created = export_student_reports(batch, tmpdir)
@@ -168,17 +129,17 @@ class TestExportStudentReports:
 
     def test_report_content(self):
         results = [
-            _FakeGradingResult(
+            FakeGradingResult(
                 student_file="charlie.json",
                 rubric_title="Final",
                 total_points=50,
                 earned_points=40,
                 check_results=[
-                    _FakeCheckResult(check_id="c1", passed=True, feedback="OK"),
+                    FakeCheckResult(check_id="c1", passed=True, feedback="OK"),
                 ],
             ),
         ]
-        batch = _FakeBatchResult(results=results)
+        batch = FakeBatchResult(results=results)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             created = export_student_reports(batch, tmpdir)
@@ -188,19 +149,19 @@ class TestExportStudentReports:
             assert "40/50" in content
 
     def test_empty_results(self):
-        batch = _FakeBatchResult(results=[])
+        batch = FakeBatchResult(results=[])
         with tempfile.TemporaryDirectory() as tmpdir:
             created = export_student_reports(batch, tmpdir)
             assert created == []
 
     def test_creates_output_dir(self):
         results = [
-            _FakeGradingResult(
+            FakeGradingResult(
                 student_file="test.json",
-                check_results=[_FakeCheckResult()],
+                check_results=[FakeCheckResult()],
             ),
         ]
-        batch = _FakeBatchResult(results=results)
+        batch = FakeBatchResult(results=results)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "reports" / "subdir"
@@ -210,12 +171,12 @@ class TestExportStudentReports:
 
     def test_handles_student_file_with_path(self):
         results = [
-            _FakeGradingResult(
+            FakeGradingResult(
                 student_file="submissions/student1.json",
-                check_results=[_FakeCheckResult()],
+                check_results=[FakeCheckResult()],
             ),
         ]
-        batch = _FakeBatchResult(results=results)
+        batch = FakeBatchResult(results=results)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             created = export_student_reports(batch, tmpdir)

--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -7,72 +7,26 @@ from unittest.mock import MagicMock, patch
 import pytest
 from controllers.file_controller import FileController, validate_circuit_data
 from models.circuit import CircuitModel
-from models.component import ComponentData
 from models.wire import WireData
-
-
-def _build_simple_circuit():
-    """Build a simple V1-R1-GND circuit model."""
-    model = CircuitModel()
-    model.components["V1"] = ComponentData(
-        component_id="V1",
-        component_type="Voltage Source",
-        value="5V",
-        position=(0.0, 0.0),
-    )
-    model.components["R1"] = ComponentData(
-        component_id="R1",
-        component_type="Resistor",
-        value="1k",
-        position=(100.0, 0.0),
-    )
-    model.components["GND1"] = ComponentData(
-        component_id="GND1",
-        component_type="Ground",
-        value="0V",
-        position=(0.0, 100.0),
-    )
-    model.wires = [
-        WireData(
-            start_component_id="V1",
-            start_terminal=1,
-            end_component_id="R1",
-            end_terminal=0,
-        ),
-        WireData(
-            start_component_id="R1",
-            start_terminal=1,
-            end_component_id="GND1",
-            end_terminal=0,
-        ),
-        WireData(
-            start_component_id="V1",
-            start_terminal=0,
-            end_component_id="GND1",
-            end_terminal=0,
-        ),
-    ]
-    model.component_counter = {"V": 1, "R": 1, "GND": 1}
-    model.rebuild_nodes()
-    return model
+from tests.conftest import build_simple_circuit
 
 
 class TestSaveLoad:
     def test_save_creates_file(self, tmp_path):
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
         assert filepath.exists()
 
     def test_save_updates_current_file(self, tmp_path):
-        ctrl = FileController(_build_simple_circuit())
+        ctrl = FileController(build_simple_circuit())
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
         assert ctrl.current_file == filepath
 
     def test_save_writes_valid_json(self, tmp_path):
-        ctrl = FileController(_build_simple_circuit())
+        ctrl = FileController(build_simple_circuit())
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
         data = json.loads(filepath.read_text())
@@ -80,7 +34,7 @@ class TestSaveLoad:
         assert "wires" in data
 
     def test_load_restores_components(self, tmp_path):
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
@@ -93,7 +47,7 @@ class TestSaveLoad:
         assert "GND1" in ctrl2.model.components
 
     def test_load_restores_wires(self, tmp_path):
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
@@ -103,7 +57,7 @@ class TestSaveLoad:
         assert len(ctrl2.model.wires) == 3
 
     def test_load_rebuilds_nodes(self, tmp_path):
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
@@ -113,7 +67,7 @@ class TestSaveLoad:
         assert len(ctrl2.model.nodes) > 0
 
     def test_load_restores_counters(self, tmp_path):
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
@@ -124,7 +78,7 @@ class TestSaveLoad:
         assert ctrl2.model.component_counter.get("R") == 1
 
     def test_round_trip_preserves_data(self, tmp_path):
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
@@ -139,7 +93,7 @@ class TestSaveLoad:
 
     def test_load_updates_model_in_place(self, tmp_path):
         """Loading should update the existing model reference, not replace it."""
-        ctrl = FileController(_build_simple_circuit())
+        ctrl = FileController(build_simple_circuit())
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
 
@@ -149,7 +103,7 @@ class TestSaveLoad:
 
     def test_load_restores_analysis_settings(self, tmp_path):
         """Loading should restore analysis_type and analysis_params from JSON."""
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         model.analysis_type = "Transient"
         model.analysis_params = {"duration": 0.01, "step": 1e-5, "startTime": 0.0}
         ctrl = FileController(model)
@@ -193,7 +147,7 @@ class TestLoadErrors:
 
 class TestNewCircuit:
     def test_new_clears_model(self):
-        ctrl = FileController(_build_simple_circuit())
+        ctrl = FileController(build_simple_circuit())
         ctrl.current_file = Path("some_file.json")
         ctrl.new_circuit()
         assert len(ctrl.model.components) == 0
@@ -204,14 +158,14 @@ class TestNewCircuit:
 class TestSessionPersistence:
     def test_save_creates_session_file(self, tmp_path):
         session_file = str(tmp_path / "session.txt")
-        ctrl = FileController(_build_simple_circuit(), session_file=session_file)
+        ctrl = FileController(build_simple_circuit(), session_file=session_file)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
         assert Path(session_file).exists()
 
     def test_load_last_session_returns_path(self, tmp_path):
         session_file = str(tmp_path / "session.txt")
-        ctrl = FileController(_build_simple_circuit(), session_file=session_file)
+        ctrl = FileController(build_simple_circuit(), session_file=session_file)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
 
@@ -227,7 +181,7 @@ class TestSessionPersistence:
 
     def test_load_last_session_returns_none_when_file_deleted(self, tmp_path):
         session_file = str(tmp_path / "session.txt")
-        ctrl = FileController(_build_simple_circuit(), session_file=session_file)
+        ctrl = FileController(build_simple_circuit(), session_file=session_file)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
         filepath.unlink()  # Delete the circuit file
@@ -242,7 +196,7 @@ class TestWindowTitle:
         assert ctrl.get_window_title() == "Circuit Design GUI"
 
     def test_title_with_file(self, tmp_path):
-        ctrl = FileController(_build_simple_circuit())
+        ctrl = FileController(build_simple_circuit())
         filepath = tmp_path / "my_circuit.json"
         ctrl.save_circuit(filepath)
         assert "my_circuit.json" in ctrl.get_window_title()
@@ -258,7 +212,7 @@ class TestHasFile:
         assert not ctrl.has_file()
 
     def test_has_file_true_after_save(self, tmp_path):
-        ctrl = FileController(_build_simple_circuit())
+        ctrl = FileController(build_simple_circuit())
         ctrl.save_circuit(tmp_path / "test.json")
         assert ctrl.has_file()
 
@@ -397,7 +351,7 @@ class TestRecentFiles:
         """save_circuit should add file to recent files list."""
         mock_settings.get_list.return_value = []
 
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
@@ -410,7 +364,7 @@ class TestRecentFiles:
     def test_load_circuit_updates_recent_files(self, mock_settings, tmp_path):
         """load_circuit should add file to recent files list."""
         # First save a circuit
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         filepath = tmp_path / "test.json"
 
         mock_settings.get_list.return_value = []
@@ -448,13 +402,13 @@ class TestImportPreservesCircuitOnFailure:
         filepath = tmp_path / "valid.json"
         filepath.write_text(json.dumps(bad_data))
 
-        ctrl = FileController(_build_simple_circuit())
+        ctrl = FileController(build_simple_circuit())
         ctrl.load_circuit(filepath)
         assert "R1" in ctrl.model.components
 
     def test_import_netlist_preserves_model_on_parse_error(self, tmp_path):
         """If the parser raises, the original circuit must survive."""
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         original_ids = set(model.components.keys())
 
@@ -469,7 +423,7 @@ class TestImportPreservesCircuitOnFailure:
 
     def test_load_from_dict_skips_corrupt_components(self):
         """load_from_dict must skip corrupt components gracefully (issue #488)."""
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
 
         # A corrupt component dict (missing 'pos') is silently skipped
@@ -485,7 +439,7 @@ class TestImportPreservesCircuitOnFailure:
 
     def test_replace_model_validates_before_clearing(self):
         """_replace_model must validate the new model before touching the old one."""
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         original_ids = set(model.components.keys())
 
@@ -514,7 +468,7 @@ class TestAnnotationsAndRecommendedComponents:
         """Build a circuit with annotations and recommended_components."""
         from models.annotation import AnnotationData
 
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         model.annotations = [
             AnnotationData(
                 text="Test note",
@@ -575,7 +529,7 @@ class TestAnnotationsAndRecommendedComponents:
         """Save and load a model with all fields — nothing should be lost."""
         from models.annotation import AnnotationData
 
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         model.annotations = [
             AnnotationData(text="A", x=10, y=20),
             AnnotationData(text="B", x=30, y=40, bold=True),
@@ -601,7 +555,7 @@ class TestExportBom:
 
     @patch("controllers.file_controller.settings")
     def test_export_bom_csv(self, mock_settings, tmp_path):
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "bom.csv"
         ctrl.export_bom(str(filepath), circuit_name="test")
@@ -611,7 +565,7 @@ class TestExportBom:
 
     @patch("controllers.file_controller.settings")
     def test_export_bom_excel(self, mock_settings, tmp_path):
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "bom.xlsx"
         ctrl.export_bom(str(filepath), circuit_name="test")
@@ -623,7 +577,7 @@ class TestExportAsc:
 
     @patch("controllers.file_controller.settings")
     def test_export_asc_writes_file(self, mock_settings, tmp_path):
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "circuit.asc"
         ctrl.export_asc(str(filepath))
@@ -723,7 +677,7 @@ class TestAtomicWrites:
 
     def test_save_circuit_atomic_no_corruption_on_error(self, tmp_path):
         """If json.dump raises, the original file must remain intact."""
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "circuit.json"
 
@@ -741,7 +695,7 @@ class TestAtomicWrites:
 
     def test_save_circuit_no_temp_files_left(self, tmp_path):
         """After a successful save, no temp files should remain."""
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         filepath = tmp_path / "circuit.json"
 
@@ -754,7 +708,7 @@ class TestAtomicWrites:
 
     def test_auto_save_atomic_no_corruption_on_error(self, tmp_path):
         """If auto_save fails mid-write, the previous auto-save stays intact."""
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         autosave_file = str(tmp_path / ".autosave_recovery.json")
         ctrl = FileController(model, autosave_file=autosave_file)
 
@@ -811,7 +765,7 @@ class TestFileSizeValidation:
 
     def test_load_circuit_with_oversized_file_preserves_model(self, tmp_path):
         """Model should remain intact when oversized file is rejected."""
-        model = _build_simple_circuit()
+        model = build_simple_circuit()
         ctrl = FileController(model)
         original_ids = set(model.components.keys())
 

--- a/app/tests/unit/test_score_histogram.py
+++ b/app/tests/unit/test_score_histogram.py
@@ -10,37 +10,12 @@ Covers:
 from __future__ import annotations
 
 import tempfile
-from dataclasses import dataclass, field
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from grading.histogram import compute_score_bins
-
-# ---------------------------------------------------------------------------
-# Lightweight stand-in so we don't need to import the full grading chain
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class _FakeGradingResult:
-    percentage: float = 0.0
-
-
-@dataclass
-class _FakeBatchResult:
-    results: list = field(default_factory=list)
-    total_students: int = 0
-    successful: int = 0
-    failed: int = 0
-    rubric_title: str = "Test"
-
-    @property
-    def mean_score(self):
-        if not self.results:
-            return 0.0
-        return sum(r.percentage for r in self.results) / len(self.results)
-
+from tests.unit.grading_fakes import FakeBatchResult, FakeGradingResult
 
 # ---------------------------------------------------------------------------
 # compute_score_bins
@@ -51,40 +26,40 @@ class TestComputeScoreBins:
     """Tests for the pure-Python bin computation."""
 
     def test_empty_results(self):
-        result = _FakeBatchResult()
+        result = FakeBatchResult()
         labels, counts = compute_score_bins(result)
         assert len(labels) == 10
         assert all(c == 0 for c in counts)
 
     def test_all_perfect_scores(self):
-        result = _FakeBatchResult(results=[_FakeGradingResult(100.0) for _ in range(5)])
+        result = FakeBatchResult(results=[FakeGradingResult(100.0) for _ in range(5)])
         labels, counts = compute_score_bins(result)
         # 100% should go into the last bin (90-100%)
         assert counts[-1] == 5
         assert sum(counts) == 5
 
     def test_all_zero_scores(self):
-        result = _FakeBatchResult(results=[_FakeGradingResult(0.0) for _ in range(3)])
+        result = FakeBatchResult(results=[FakeGradingResult(0.0) for _ in range(3)])
         labels, counts = compute_score_bins(result)
         assert counts[0] == 3
         assert sum(counts) == 3
 
     def test_spread_across_bins(self):
         scores = [5, 15, 25, 35, 45, 55, 65, 75, 85, 95]
-        result = _FakeBatchResult(results=[_FakeGradingResult(s) for s in scores])
+        result = FakeBatchResult(results=[FakeGradingResult(s) for s in scores])
         labels, counts = compute_score_bins(result)
         # Each bin should have exactly 1 student
         assert counts == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
 
     def test_boundary_values(self):
         """Test bin boundaries: 10 goes into 10-20%, 20 into 20-30%, etc."""
-        result = _FakeBatchResult(
+        result = FakeBatchResult(
             results=[
-                _FakeGradingResult(0.0),
-                _FakeGradingResult(10.0),
-                _FakeGradingResult(50.0),
-                _FakeGradingResult(90.0),
-                _FakeGradingResult(100.0),
+                FakeGradingResult(0.0),
+                FakeGradingResult(10.0),
+                FakeGradingResult(50.0),
+                FakeGradingResult(90.0),
+                FakeGradingResult(100.0),
             ]
         )
         labels, counts = compute_score_bins(result)
@@ -94,7 +69,7 @@ class TestComputeScoreBins:
         assert counts[9] == 2  # 90% and 100%
 
     def test_custom_num_bins(self):
-        result = _FakeBatchResult(results=[_FakeGradingResult(50.0)])
+        result = FakeBatchResult(results=[FakeGradingResult(50.0)])
         labels, counts = compute_score_bins(result, num_bins=5)
         assert len(labels) == 5
         assert len(counts) == 5
@@ -102,26 +77,26 @@ class TestComputeScoreBins:
         assert counts[2] == 1
 
     def test_label_format(self):
-        result = _FakeBatchResult()
+        result = FakeBatchResult()
         labels, _ = compute_score_bins(result)
         assert labels[0] == "0-10%"
         assert labels[4] == "40-50%"
         assert labels[9] == "90-100%"
 
     def test_clamps_negative_scores(self):
-        result = _FakeBatchResult(results=[_FakeGradingResult(-5.0)])
+        result = FakeBatchResult(results=[FakeGradingResult(-5.0)])
         labels, counts = compute_score_bins(result)
         assert counts[0] == 1
 
     def test_clamps_over_100(self):
-        result = _FakeBatchResult(results=[_FakeGradingResult(110.0)])
+        result = FakeBatchResult(results=[FakeGradingResult(110.0)])
         labels, counts = compute_score_bins(result)
         assert counts[9] == 1
 
     def test_realistic_class_distribution(self):
         """Simulate a typical class with various scores."""
         scores = [42, 55, 67, 72, 75, 78, 80, 82, 85, 88, 90, 91, 95, 98, 100]
-        result = _FakeBatchResult(results=[_FakeGradingResult(s) for s in scores])
+        result = FakeBatchResult(results=[FakeGradingResult(s) for s in scores])
         labels, counts = compute_score_bins(result)
         assert sum(counts) == 15
         # Check some bins
@@ -144,7 +119,7 @@ class TestCreateHistogramFigure:
         except ImportError:
             pytest.skip("matplotlib not available")
 
-        result = _FakeBatchResult(results=[_FakeGradingResult(s) for s in [50, 60, 70, 80, 90]])
+        result = FakeBatchResult(results=[FakeGradingResult(s) for s in [50, 60, 70, 80, 90]])
         fig = create_histogram_figure(result)
         assert fig is not None
         # Should have one axes
@@ -156,7 +131,7 @@ class TestCreateHistogramFigure:
         except ImportError:
             pytest.skip("matplotlib not available")
 
-        result = _FakeBatchResult(results=[_FakeGradingResult(75.0)])
+        result = FakeBatchResult(results=[FakeGradingResult(75.0)])
         fig = create_histogram_figure(result)
         ax = fig.axes[0]
         assert ax.get_title() == "Score Distribution"
@@ -167,7 +142,7 @@ class TestCreateHistogramFigure:
         except ImportError:
             pytest.skip("matplotlib not available")
 
-        result = _FakeBatchResult(results=[_FakeGradingResult(50.0)])
+        result = FakeBatchResult(results=[FakeGradingResult(50.0)])
         fig = create_histogram_figure(result, num_bins=10)
         ax = fig.axes[0]
         # Should have 10 bar patches
@@ -188,7 +163,7 @@ class TestSaveHistogramPng:
         except ImportError:
             pytest.skip("matplotlib not available")
 
-        result = _FakeBatchResult(results=[_FakeGradingResult(s) for s in [50, 60, 70]])
+        result = FakeBatchResult(results=[FakeGradingResult(s) for s in [50, 60, 70]])
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
             filepath = Path(f.name)
         try:

--- a/app/tests/unit/test_score_histogram.py
+++ b/app/tests/unit/test_score_histogram.py
@@ -10,12 +10,33 @@ Covers:
 from __future__ import annotations
 
 import tempfile
+from dataclasses import dataclass, field
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from grading.histogram import compute_score_bins
-from tests.unit.grading_fakes import FakeBatchResult, FakeGradingResult
+
+
+@dataclass
+class FakeGradingResult:
+    percentage: float = 0.0
+
+
+@dataclass
+class FakeBatchResult:
+    results: list = field(default_factory=list)
+    total_students: int = 0
+    successful: int = 0
+    failed: int = 0
+    rubric_title: str = "Test"
+
+    @property
+    def mean_score(self):
+        if not self.results:
+            return 0.0
+        return sum(r.percentage for r in self.results) / len(self.results)
+
 
 # ---------------------------------------------------------------------------
 # compute_score_bins

--- a/app/tests/unit/test_simulation_controller_coverage.py
+++ b/app/tests/unit/test_simulation_controller_coverage.py
@@ -9,16 +9,7 @@ from unittest.mock import MagicMock, patch
 
 from controllers.simulation_controller import SimulationController, SimulationResult
 from models.circuit import CircuitModel
-
-
-def _make_controller(model=None):
-    """Create a SimulationController with a mocked runner."""
-    ctrl = SimulationController(model=model or CircuitModel())
-    runner = MagicMock()
-    runner.output_dir = "/tmp/test_output"
-    runner.find_ngspice.return_value = "/usr/bin/ngspice"
-    ctrl._runner = runner
-    return ctrl, runner
+from tests.conftest import make_simulation_controller
 
 
 def _build_simple_circuit(ctrl):
@@ -94,19 +85,19 @@ class TestSimulationResult:
 
 class TestAnalysisConfig:
     def test_set_and_get_analysis(self):
-        ctrl, _ = _make_controller()
+        ctrl, _ = make_simulation_controller()
         ctrl.set_analysis("Transient", {"tstep": "1u", "tstop": "1m"})
         assert ctrl.get_analysis_type() == "Transient"
         params = ctrl.get_analysis_params()
         assert params["tstep"] == "1u"
 
     def test_set_analysis_none_params(self):
-        ctrl, _ = _make_controller()
+        ctrl, _ = make_simulation_controller()
         ctrl.set_analysis("DC Operating Point", None)
         assert ctrl.get_analysis_params() == {}
 
     def test_get_params_returns_copy(self):
-        ctrl, _ = _make_controller()
+        ctrl, _ = make_simulation_controller()
         ctrl.set_analysis("AC Sweep", {"fstart": "1", "fstop": "1Meg"})
         p1 = ctrl.get_analysis_params()
         p1["extra"] = "X"
@@ -115,7 +106,7 @@ class TestAnalysisConfig:
 
 class TestRunSimulationNgspiceNotFound:
     def test_ngspice_not_found(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_simple_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
         runner.find_ngspice.return_value = None
@@ -128,7 +119,7 @@ class TestRunSimulationNgspiceNotFound:
 
 class TestRunSimulationValidationFailure:
     def test_validation_failure_returns_errors(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         ctrl.set_analysis("DC Operating Point")
 
         with patch("simulation.validate_circuit", return_value=(False, ["No ground"], ["warn"])):
@@ -139,7 +130,7 @@ class TestRunSimulationValidationFailure:
 
 class TestRunSimulationNotify:
     def test_notifies_on_start_and_complete(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_simple_circuit(ctrl)
         ctrl.set_analysis("DC Operating Point")
         cc = MagicMock()
@@ -159,7 +150,7 @@ class TestRunSimulationNotify:
         cc._notify.assert_any_call("simulation_started", None)
 
     def test_notifies_on_validation_failure(self):
-        ctrl, _ = _make_controller()
+        ctrl, _ = make_simulation_controller()
         ctrl.set_analysis("DC Operating Point")
         cc = MagicMock()
         ctrl.circuit_ctrl = cc
@@ -171,7 +162,7 @@ class TestRunSimulationNotify:
 
 class TestRunSimulationConvergenceRetry:
     def test_retry_with_relaxed_tolerances(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         _build_simple_circuit(ctrl)
         ctrl.set_analysis("Transient", {"tstep": "1u", "tstop": "1m"})
 
@@ -236,58 +227,58 @@ class TestParseResultsBranches:
                 )
 
     def test_dc_op(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         result = self._run_parse(ctrl, runner, "DC Operating Point")
         assert result.success is True
 
     def test_dc_sweep(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         result = self._run_parse(ctrl, runner, "DC Sweep")
         assert result.success is True
 
     def test_ac_sweep(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         result = self._run_parse(ctrl, runner, "AC Sweep")
         assert result.success is True
 
     def test_transient(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         result = self._run_parse(ctrl, runner, "Transient")
         assert result.success is True
 
     def test_temperature_sweep(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         result = self._run_parse(ctrl, runner, "Temperature Sweep")
         assert result.success is True
 
     def test_noise(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         result = self._run_parse(ctrl, runner, "Noise")
         assert result.success is True
 
     def test_sensitivity(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         result = self._run_parse(ctrl, runner, "Sensitivity")
         assert result.success is True
 
     def test_transfer_function(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         result = self._run_parse(ctrl, runner, "Transfer Function")
         assert result.success is True
 
     def test_pole_zero(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         result = self._run_parse(ctrl, runner, "Pole-Zero")
         assert result.success is True
 
     def test_unknown_type(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         result = self._run_parse(ctrl, runner, "UnknownAnalysis")
         assert result.success is False
         assert "Unknown" in result.error
 
     def test_parse_error_handled(self):
-        ctrl, runner = _make_controller()
+        ctrl, runner = make_simulation_controller()
         ctrl.model.analysis_type = "DC Operating Point"
         runner.read_output.return_value = "output"
 
@@ -338,13 +329,13 @@ class TestStaticHelpers:
 
 class TestPresetManagement:
     def test_preset_manager_lazy(self):
-        ctrl, _ = _make_controller()
+        ctrl, _ = make_simulation_controller()
         mock_pm = MagicMock()
         ctrl._preset_manager = mock_pm
         assert ctrl.preset_manager is mock_pm
 
     def test_get_presets(self):
-        ctrl, _ = _make_controller()
+        ctrl, _ = make_simulation_controller()
         mock_pm = MagicMock()
         mock_pm.get_presets.return_value = [{"name": "default"}]
         ctrl._preset_manager = mock_pm
@@ -352,21 +343,21 @@ class TestPresetManagement:
         mock_pm.get_presets.assert_called_once_with("Transient")
 
     def test_get_preset_by_name(self):
-        ctrl, _ = _make_controller()
+        ctrl, _ = make_simulation_controller()
         mock_pm = MagicMock()
         ctrl._preset_manager = mock_pm
         ctrl.get_preset_by_name("fast", "Transient")
         mock_pm.get_preset_by_name.assert_called_once_with("fast", "Transient")
 
     def test_save_preset(self):
-        ctrl, _ = _make_controller()
+        ctrl, _ = make_simulation_controller()
         mock_pm = MagicMock()
         ctrl._preset_manager = mock_pm
         ctrl.save_preset("my_preset", "AC Sweep", {"fstart": "1"})
         mock_pm.save_preset.assert_called_once()
 
     def test_delete_preset(self):
-        ctrl, _ = _make_controller()
+        ctrl, _ = make_simulation_controller()
         mock_pm = MagicMock()
         ctrl._preset_manager = mock_pm
         ctrl.delete_preset("old_preset")
@@ -414,6 +405,6 @@ class TestExportHelpers:
                 assert summary == ""
 
     def test_generate_results_csv_unknown_type(self):
-        ctrl, _ = _make_controller()
+        ctrl, _ = make_simulation_controller()
         result = ctrl.generate_results_csv({"data": 1}, "Unknown Type", "test")
         assert result is None


### PR DESCRIPTION
Adds build_simple_circuit() and make_simulation_controller() to conftest.py, and creates grading_fakes.py. Removes ~195 lines of duplicated test code across 8 files. Closes #774