### PR TITLE
reduce simulation temp file accumulation (#780)

### DIFF
--- a/app/simulation/ngspice_runner.py
+++ b/app/simulation/ngspice_runner.py
@@ -17,10 +17,41 @@ from utils.constants import SIMULATION_TIMEOUT
 class NgspiceRunner:
     """Runs ngspice simulations and manages output files"""
 
+    #: Environment variable that, when set to a truthy value (1/true/yes),
+    #: suppresses automatic cleanup of temp simulation files.  Useful for
+    #: debugging ngspice output by hand.
+    KEEP_FILES_ENV_VAR = "SPICE_KEEP_SIM_OUTPUT"
+
     def __init__(self, output_dir="simulation_output"):
         self.output_dir = validate_output_dir(output_dir)
         os.makedirs(self.output_dir, exist_ok=True)
         self.ngspice_cmd = None
+        # When True, temp files are never deleted (controlled by env var).
+        self._keep_files: bool = os.environ.get(self.KEEP_FILES_ENV_VAR, "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        # Paths written during the most-recently completed run; cleaned up at
+        # the start of the next run so that results remain readable until then.
+        self._prev_run_files: list[str] = []
+
+    def _cleanup_prev_run(self) -> None:
+        """Remove temp files written by the previous simulation run.
+
+        Skipped when *SPICE_KEEP_SIM_OUTPUT* is set.  Uses best-effort
+        deletion: missing or un-deletable files are silently ignored so that
+        a stale path never prevents a new simulation from starting.
+        """
+        if self._keep_files:
+            return
+        for path in self._prev_run_files:
+            try:
+                if os.path.exists(path):
+                    os.remove(path)
+            except OSError:
+                pass
+        self._prev_run_files = []
 
     def find_ngspice(self):
         """Find ngspice executable on the system"""
@@ -68,6 +99,9 @@ class NgspiceRunner:
         Returns:
             tuple: (success: bool, output_file: str, stdout: str, stderr: str)
         """
+        # Clean up temp files from the previous run before starting a new one.
+        self._cleanup_prev_run()
+
         # Find ngspice if not already found
         if self.ngspice_cmd is None:
             ngspice_path = self.find_ngspice()
@@ -97,8 +131,12 @@ class NgspiceRunner:
 
             # Check if output file was created and is non-empty
             if os.path.exists(output_filename) and os.path.getsize(output_filename) > 0:
+                # Track both files so the next run can clean them up.
+                self._prev_run_files = [netlist_filename, output_filename]
                 return True, output_filename, result.stdout, result.stderr
             else:
+                # Track the netlist for cleanup; output was not produced.
+                self._prev_run_files = [netlist_filename]
                 return (
                     False,
                     None,
@@ -107,6 +145,7 @@ class NgspiceRunner:
                 )
 
         except subprocess.TimeoutExpired:
+            self._prev_run_files = [netlist_filename]
             return (
                 False,
                 None,
@@ -114,6 +153,7 @@ class NgspiceRunner:
                 f"Simulation timed out (>{SIMULATION_TIMEOUT} seconds)",
             )
         except (OSError, subprocess.SubprocessError) as e:
+            self._prev_run_files = [netlist_filename]
             return False, None, "", f"Simulation error: {str(e)}"
 
     def read_output(self, output_filename):

--- a/app/tests/unit/test_ngspice_runner.py
+++ b/app/tests/unit/test_ngspice_runner.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -181,3 +182,126 @@ class TestEmptyOutputDetection:
         assert success is False
         assert output_file is None
         assert "no output" in stderr.lower() or "not created" in stderr.lower()
+
+
+# ── Temp-file cleanup (issue #780) ───────────────────────────────────
+
+
+def _fake_run_writing_output(output_content="results\n"):
+    """Return a fake subprocess.run side_effect that writes to the output file."""
+
+    def _inner(cmd, **kwargs):
+        output_path = cmd[4]
+        with open(output_path, "w") as f:
+            f.write(output_content)
+        m = MagicMock()
+        m.stdout = ""
+        m.stderr = ""
+        m.returncode = 0
+        return m
+
+    return _inner
+
+
+class TestTempFileCleanup:
+    """Verify that successive runs do not accumulate stale temp files (#780)."""
+
+    def test_second_run_removes_first_run_files(self, tmp_path):
+        """Files from run 1 must be deleted before run 2 starts."""
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/fake/ngspice"
+
+        # Mock datetime so each call returns a unique timestamp, ensuring
+        # run 1 and run 2 produce differently-named files.
+        ts1 = datetime(2024, 1, 1, 0, 0, 1)
+        ts2 = datetime(2024, 1, 1, 0, 0, 2)
+
+        with patch("simulation.ngspice_runner.datetime") as mock_dt:
+            mock_dt.now.return_value = ts1
+            with patch("simulation.ngspice_runner.subprocess.run", side_effect=_fake_run_writing_output()):
+                runner.run_simulation("netlist 1")
+
+        # After run 1, files still exist (accessible for result reading).
+        first_run_files = {f.name for f in tmp_path.iterdir()}
+        assert any("netlist_" in n for n in first_run_files)
+
+        with patch("simulation.ngspice_runner.datetime") as mock_dt:
+            mock_dt.now.return_value = ts2
+            with patch("simulation.ngspice_runner.subprocess.run", side_effect=_fake_run_writing_output()):
+                runner.run_simulation("netlist 2")
+
+        # Run-1 files must be gone; only run-2 files remain.
+        remaining = {f.name for f in tmp_path.iterdir()}
+        for name in first_run_files:
+            assert name not in remaining, f"Stale file from run 1 still present: {name}"
+
+    def test_keep_files_env_var_prevents_cleanup(self, tmp_path, monkeypatch):
+        """SPICE_KEEP_SIM_OUTPUT=1 must suppress all file deletion."""
+        monkeypatch.setenv("SPICE_KEEP_SIM_OUTPUT", "1")
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/fake/ngspice"
+
+        ts1 = datetime(2024, 1, 1, 0, 0, 1)
+        ts2 = datetime(2024, 1, 1, 0, 0, 2)
+
+        with patch("simulation.ngspice_runner.datetime") as mock_dt:
+            mock_dt.now.return_value = ts1
+            with patch("simulation.ngspice_runner.subprocess.run", side_effect=_fake_run_writing_output()):
+                runner.run_simulation("netlist 1")
+
+        first_run_files = {f.name for f in tmp_path.iterdir()}
+
+        with patch("simulation.ngspice_runner.datetime") as mock_dt:
+            mock_dt.now.return_value = ts2
+            with patch("simulation.ngspice_runner.subprocess.run", side_effect=_fake_run_writing_output()):
+                runner.run_simulation("netlist 2")
+
+        # All files from run 1 must still be present (no cleanup).
+        remaining = {f.name for f in tmp_path.iterdir()}
+        for name in first_run_files:
+            assert name in remaining, f"File was deleted despite SPICE_KEEP_SIM_OUTPUT=1: {name}"
+
+    def test_single_run_files_persist_for_result_reading(self, tmp_path):
+        """Files from the current run must still exist after run_simulation returns."""
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/fake/ngspice"
+
+        with patch("simulation.ngspice_runner.subprocess.run", side_effect=_fake_run_writing_output()):
+            success, output_file, _, _ = runner.run_simulation("netlist")
+
+        assert success is True
+        assert output_file is not None
+        assert os.path.exists(output_file), "Output file must exist after run for result reading"
+
+    def test_failed_run_netlist_cleaned_on_next_run(self, tmp_path):
+        """Even when the run fails (no output), the netlist is cleaned up on the next run."""
+        runner = NgspiceRunner(output_dir=str(tmp_path))
+        runner.ngspice_cmd = "/fake/ngspice"
+
+        ts1 = datetime(2024, 1, 1, 0, 0, 1)
+        ts2 = datetime(2024, 1, 1, 0, 0, 2)
+
+        # First run produces no output file → failure
+        noop_result = MagicMock()
+        noop_result.stdout = ""
+        noop_result.stderr = "error"
+        noop_result.returncode = 1
+        with patch("simulation.ngspice_runner.datetime") as mock_dt:
+            mock_dt.now.return_value = ts1
+            with patch("simulation.ngspice_runner.subprocess.run", return_value=noop_result):
+                success, _, _, _ = runner.run_simulation("bad netlist")
+        assert success is False
+
+        files_after_fail = {f.name for f in tmp_path.iterdir()}
+        assert any("netlist_" in n for n in files_after_fail), "Netlist file should exist after failed run"
+
+        # Second run should clean up the netlist from the failed run.
+        with patch("simulation.ngspice_runner.datetime") as mock_dt:
+            mock_dt.now.return_value = ts2
+            with patch("simulation.ngspice_runner.subprocess.run", side_effect=_fake_run_writing_output()):
+                runner.run_simulation("good netlist")
+
+        remaining = {f.name for f in tmp_path.iterdir()}
+        # The failed run's netlist must be gone.
+        for name in files_after_fail:
+            assert name not in remaining, f"Stale netlist from failed run still present: {name}"


### PR DESCRIPTION
## Summary - Add  tracking to  so each new  call deletes the netlist and output files from the previous run - Add  flag (read from  env var) to suppress cleanup for debugging - Add 4 unit tests covering: normal cleanup, env-var bypass, single-run persistence, and failed-run netlist cleanup ## Test plan - [ ]  — run 1 files are deleted before run 2 - [ ]  —  keeps all files - [ ]  — output file still exists after  returns - [ ]  — netlist from a failed run is cleaned up on next run Closes #780 🤖 Generated with [Claude Code](https://claude.com/claude-code)