### PR TITLE
fix file handle leaks and missing encoding (#775)

### DIFF
--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -110,7 +110,7 @@ class FileController:
         data = self.model.to_dict()
         fd, tmp = tempfile.mkstemp(dir=filepath.parent, suffix=".tmp")
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)
             os.replace(tmp, filepath)
         except BaseException:
@@ -141,7 +141,7 @@ class FileController:
         """
         filepath = Path(filepath)
         check_file_size(filepath)
-        with open(filepath, "r") as f:
+        with open(filepath, "r", encoding="utf-8") as f:
             data = json.load(f)
 
         validate_circuit_data(data)
@@ -185,7 +185,7 @@ class FileController:
             content = os.path.abspath(str(self.current_file)) if self.current_file else ""
             fd, tmp = tempfile.mkstemp(dir=session_path.parent, suffix=".tmp")
             try:
-                with os.fdopen(fd, "w") as f:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
                     f.write(content)
                 os.replace(tmp, session_path)
             except BaseException:
@@ -204,7 +204,7 @@ class FileController:
         if not os.path.exists(self._session_file):
             return None
         try:
-            with open(self._session_file, "r") as f:
+            with open(self._session_file, "r", encoding="utf-8") as f:
                 path_str = f.read().strip()
                 if path_str:
                     path = Path(path_str)
@@ -274,7 +274,7 @@ class FileController:
             data["_autosave_source"] = str(self.current_file) if self.current_file else ""
             fd, tmp = tempfile.mkstemp(dir=self._autosave_file.parent, suffix=".tmp")
             try:
-                with os.fdopen(fd, "w") as f:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
                     json.dump(data, f, indent=2)
                 os.replace(tmp, self._autosave_file)
             except BaseException:
@@ -296,7 +296,7 @@ class FileController:
             on failure.
         """
         try:
-            with open(self._autosave_file, "r") as f:
+            with open(self._autosave_file, "r", encoding="utf-8") as f:
                 data = json.load(f)
 
             source_path = data.pop("_autosave_source", "")
@@ -334,7 +334,7 @@ class FileController:
 
         filepath = Path(filepath)
         check_file_size(filepath)
-        with open(filepath, "r") as f:
+        with open(filepath, "r", encoding="utf-8") as f:
             text = f.read()
 
         new_model, analysis = import_netlist(text)
@@ -372,7 +372,7 @@ class FileController:
 
         filepath = Path(filepath)
         check_file_size(filepath)
-        with open(filepath, "r") as f:
+        with open(filepath, "r", encoding="utf-8") as f:
             text = f.read()
 
         new_model, analysis, warnings = import_asc(text)
@@ -412,7 +412,7 @@ class FileController:
 
         filepath = Path(filepath)
         check_file_size(filepath)
-        with open(filepath, "r") as f:
+        with open(filepath, "r", encoding="utf-8") as f:
             text = f.read()
 
         new_model, warnings = import_circuitikz(text)

--- a/app/tests/unit/test_asc_exporter.py
+++ b/app/tests/unit/test_asc_exporter.py
@@ -1,5 +1,7 @@
 """Tests for LTspice .asc schematic export."""
 
+from pathlib import Path
+
 import pytest
 from models.circuit import CircuitModel
 from models.component import ComponentData
@@ -242,6 +244,6 @@ class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import simulation.asc_exporter as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source

--- a/app/tests/unit/test_bom_exporter.py
+++ b/app/tests/unit/test_bom_exporter.py
@@ -2,6 +2,7 @@
 
 import csv
 import io
+from pathlib import Path
 
 import pytest
 from openpyxl import load_workbook
@@ -205,7 +206,7 @@ class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import simulation.bom_exporter as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source
         assert "QtWidgets" not in source

--- a/app/tests/unit/test_bundle_exporter.py
+++ b/app/tests/unit/test_bundle_exporter.py
@@ -2,6 +2,7 @@
 
 import json
 import zipfile
+from pathlib import Path
 
 from simulation.bundle_exporter import create_bundle, suggest_bundle_name
 
@@ -123,7 +124,7 @@ class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import simulation.bundle_exporter as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source
         assert "QtWidgets" not in source

--- a/app/tests/unit/test_circuit_controller.py
+++ b/app/tests/unit/test_circuit_controller.py
@@ -1,5 +1,7 @@
 """Tests for CircuitController."""
 
+from pathlib import Path
+
 import pytest
 from controllers.circuit_controller import CircuitController
 from models.circuit import CircuitModel
@@ -504,7 +506,7 @@ class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import controllers.circuit_controller as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source
         assert "QtWidgets" not in source

--- a/app/tests/unit/test_circuit_model.py
+++ b/app/tests/unit/test_circuit_model.py
@@ -1,5 +1,7 @@
 """Tests for CircuitModel central data store."""
 
+from pathlib import Path
+
 import pytest
 from models.circuit import CircuitModel
 from models.component import ComponentData
@@ -385,7 +387,7 @@ class TestSerialization:
         """Verify CircuitModel has no Qt dependencies."""
         import models.circuit as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source
         assert "QtWidgets" not in source

--- a/app/tests/unit/test_circuitikz_parser.py
+++ b/app/tests/unit/test_circuitikz_parser.py
@@ -1,5 +1,7 @@
 """Tests for CircuiTikZ LaTeX parser."""
 
+from pathlib import Path
+
 import pytest
 from simulation.circuitikz_parser import CircuitikzParseError, import_circuitikz
 
@@ -399,7 +401,7 @@ class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import simulation.circuitikz_parser as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source
         assert "QtWidgets" not in source

--- a/app/tests/unit/test_copy_paste.py
+++ b/app/tests/unit/test_copy_paste.py
@@ -1,5 +1,7 @@
 """Tests for copy/paste/cut functionality in CircuitController."""
 
+from pathlib import Path
+
 import pytest
 from controllers.circuit_controller import CircuitController
 from models.clipboard import ClipboardData
@@ -239,13 +241,13 @@ class TestNoQtDependencies:
     def test_clipboard_no_pyqt(self):
         import models.clipboard as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source
 
     def test_controller_no_pyqt(self):
         import controllers.circuit_controller as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source

--- a/app/tests/unit/test_csv_exporter.py
+++ b/app/tests/unit/test_csv_exporter.py
@@ -2,6 +2,7 @@
 
 import csv
 import io
+from pathlib import Path
 
 import pytest
 from simulation.csv_exporter import (
@@ -176,7 +177,7 @@ class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import simulation.csv_exporter as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source
         assert "QtWidgets" not in source

--- a/app/tests/unit/test_data_roundtrips_and_undo.py
+++ b/app/tests/unit/test_data_roundtrips_and_undo.py
@@ -727,7 +727,7 @@ class TestFileControllerOperations:
         filepath = tmp_path / "valid.json"
         ctrl.save_circuit(filepath)
 
-        with open(filepath) as f:
+        with open(filepath, encoding="utf-8") as f:
             data = json.load(f)
         assert "components" in data
         assert "wires" in data

--- a/app/tests/unit/test_drag_drop.py
+++ b/app/tests/unit/test_drag_drop.py
@@ -1,5 +1,7 @@
 """Tests for drag-and-drop file import routing logic."""
 
+from pathlib import Path
+
 import pytest
 from utils.drag_drop_router import EXTENSION_ROUTES, route_dropped_file
 
@@ -57,7 +59,7 @@ class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import utils.drag_drop_router as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source
         assert "QtWidgets" not in source

--- a/app/tests/unit/test_excel_exporter.py
+++ b/app/tests/unit/test_excel_exporter.py
@@ -1,5 +1,7 @@
 """Tests for Excel (.xlsx) export functionality."""
 
+from pathlib import Path
+
 import pytest
 from openpyxl import load_workbook
 from simulation.excel_exporter import export_to_excel
@@ -219,7 +221,7 @@ class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import simulation.excel_exporter as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source
         assert "QtWidgets" not in source

--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -664,7 +664,7 @@ class TestQtDependencies:
         """FileController uses centralized SettingsService for persistence (#598)."""
         import controllers.file_controller as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         # Should use centralized settings service, not QSettings directly
         assert "settings_service" in source
         assert "QSettings" not in source

--- a/app/tests/unit/test_markdown_exporter.py
+++ b/app/tests/unit/test_markdown_exporter.py
@@ -1,5 +1,7 @@
 """Tests for Markdown table export of simulation results."""
 
+from pathlib import Path
+
 from simulation.markdown_exporter import (
     export_ac_results,
     export_dc_sweep_results,
@@ -168,7 +170,7 @@ class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import simulation.markdown_exporter as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source
         assert "QtWidgets" not in source

--- a/app/tests/unit/test_monte_carlo.py
+++ b/app/tests/unit/test_monte_carlo.py
@@ -1,5 +1,6 @@
 """Tests for Monte Carlo simulation module and controller integration."""
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -315,7 +316,7 @@ class TestNoQtInMonteCarloModule:
     def test_no_pyqt_imports(self):
         import simulation.monte_carlo as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source
         assert "QtWidgets" not in source

--- a/app/tests/unit/test_parameter_sweep.py
+++ b/app/tests/unit/test_parameter_sweep.py
@@ -1,5 +1,6 @@
 """Tests for parameter sweep functionality."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -403,7 +404,7 @@ class TestNoQtDependenciesInController:
     def test_no_pyqt_imports(self):
         import controllers.simulation_controller as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source
         assert "QtWidgets" not in source

--- a/app/tests/unit/test_simulation_controller.py
+++ b/app/tests/unit/test_simulation_controller.py
@@ -1,5 +1,6 @@
 """Tests for SimulationController."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -304,7 +305,7 @@ class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import controllers.simulation_controller as mod
 
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
         assert "QtCore" not in source
         assert "QtWidgets" not in source

--- a/app/tests/unit/test_theme_store.py
+++ b/app/tests/unit/test_theme_store.py
@@ -1,6 +1,7 @@
 """Tests for ThemeStore persistence layer."""
 
 import json
+from pathlib import Path
 
 import pytest
 from GUI.styles.custom_theme import CustomTheme
@@ -127,13 +128,13 @@ class TestCanonicalLocation:
     def test_theme_store_no_qt_imports(self):
         import services.theme_store as ts
 
-        source = open(ts.__file__).read()
+        source = Path(ts.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
 
     def test_theme_manager_no_qt_imports(self):
         import services.theme_manager as ts
 
-        source = open(ts.__file__).read()
+        source = Path(ts.__file__).read_text(encoding="utf-8")
         assert "PyQt" not in source
 
     def test_backward_compat_reexport(self):


### PR DESCRIPTION
Fixes #775. Replace bare open(mod.__file__).read() with Path(...).read_text(encoding='utf-8') in 17 test files, and add encoding='utf-8' to all open/os.fdopen calls in file_controller.py.