### PR TITLE
Fix NPN/PNP transistor symbols to match IEEE standard (#675)

### DIFF
--- a/app/GUI/renderers.py
+++ b/app/GUI/renderers.py
@@ -274,32 +274,50 @@ class IEEECCCS(ComponentRenderer):
 
 class IEEEBJTNPN(ComponentRenderer):
     def draw(self, painter, component):
-        painter.drawLine(-20, 0, -8, 0)
+        # Enclosing circle (IEEE standard)
+        painter.drawEllipse(-12, -15, 30, 30)
+        # Base lead (left, into circle)
+        painter.drawLine(-20, 0, -6, 0)
+        # Vertical base bar
+        painter.drawLine(-6, -10, -6, 10)
+        # Collector line (base bar to circle edge)
+        painter.drawLine(-6, -6, 8, -12)
+        # Emitter line (base bar to circle edge)
+        painter.drawLine(-6, 6, 8, 12)
+        # Collector lead (circle to terminal)
         painter.drawLine(8, -12, 20, -20)
+        # Emitter lead (circle to terminal)
         painter.drawLine(8, 12, 20, 20)
-        painter.drawLine(-8, -12, -8, 12)
-        painter.drawLine(-8, -6, 8, -12)
-        painter.drawLine(-8, 6, 8, 12)
+        # Arrow on emitter pointing OUTWARD (away from base bar)
         painter.drawLine(8, 12, 4, 7)
         painter.drawLine(8, 12, 3, 12)
 
     def get_obstacle_shape(self, component):
-        return [(-12.0, -15.0), (12.0, -15.0), (12.0, 15.0), (-12.0, 15.0)]
+        return [(-14.0, -17.0), (20.0, -17.0), (20.0, 17.0), (-14.0, 17.0)]
 
 
 class IEEEBJTPNP(ComponentRenderer):
     def draw(self, painter, component):
-        painter.drawLine(-20, 0, -8, 0)
+        # Enclosing circle (IEEE standard)
+        painter.drawEllipse(-12, -15, 30, 30)
+        # Base lead (left, into circle)
+        painter.drawLine(-20, 0, -6, 0)
+        # Vertical base bar
+        painter.drawLine(-6, -10, -6, 10)
+        # Collector line (base bar to circle edge)
+        painter.drawLine(-6, -6, 8, -12)
+        # Emitter line (base bar to circle edge)
+        painter.drawLine(-6, 6, 8, 12)
+        # Collector lead (circle to terminal)
         painter.drawLine(8, -12, 20, -20)
+        # Emitter lead (circle to terminal)
         painter.drawLine(8, 12, 20, 20)
-        painter.drawLine(-8, -12, -8, 12)
-        painter.drawLine(-8, -6, 8, -12)
-        painter.drawLine(-8, 6, 8, 12)
-        painter.drawLine(-8, 6, -3, 2)
-        painter.drawLine(-8, 6, -3, 7)
+        # Arrow on emitter pointing INWARD (toward base bar)
+        painter.drawLine(-6, 6, -1, 2)
+        painter.drawLine(-6, 6, -1, 7)
 
     def get_obstacle_shape(self, component):
-        return [(-12.0, -15.0), (12.0, -15.0), (12.0, 15.0), (-12.0, 15.0)]
+        return [(-14.0, -17.0), (20.0, -17.0), (20.0, 17.0), (-14.0, 17.0)]
 
 
 class IEEEMOSFETNMOS(ComponentRenderer):

--- a/app/tests/unit/test_renderer_symbols.py
+++ b/app/tests/unit/test_renderer_symbols.py
@@ -7,7 +7,16 @@ Structural tests verify that renderers draw the expected primitives
 
 from unittest.mock import MagicMock, call
 
-from GUI.renderers import IEEEMOSFETNMOS, IEEEMOSFETPMOS, IEEECurrentSource, IEEEOpAmp, IEEEVoltageSource, get_renderer
+from GUI.renderers import (
+    IEEEBJTNPN,
+    IEEEBJTPNP,
+    IEEEMOSFETNMOS,
+    IEEEMOSFETPMOS,
+    IEEECurrentSource,
+    IEEEOpAmp,
+    IEEEVoltageSource,
+    get_renderer,
+)
 from PyQt6.QtGui import QColor, QPen
 
 
@@ -225,3 +234,79 @@ class TestRendererRegistration:
                 assert r is not None
             except KeyError:
                 pass
+
+
+class TestBJTStandardSymbol:
+    """#675: BJT NPN/PNP should render with enclosing circle per IEEE standard."""
+
+    def test_npn_has_enclosing_circle(self):
+        renderer = IEEEBJTNPN()
+        painter = _make_mock_painter()
+        comp = _make_mock_component(in_scene=False)
+        renderer.draw(painter, comp)
+        painter.drawEllipse.assert_called_once_with(-12, -15, 30, 30)
+
+    def test_pnp_has_enclosing_circle(self):
+        renderer = IEEEBJTPNP()
+        painter = _make_mock_painter()
+        comp = _make_mock_component(in_scene=False)
+        renderer.draw(painter, comp)
+        painter.drawEllipse.assert_called_once_with(-12, -15, 30, 30)
+
+    def test_npn_has_base_bar(self):
+        renderer = IEEEBJTNPN()
+        painter = _make_mock_painter()
+        comp = _make_mock_component(in_scene=False)
+        renderer.draw(painter, comp)
+        line_calls = painter.drawLine.call_args_list
+        assert call(-6, -10, -6, 10) in line_calls
+
+    def test_pnp_has_base_bar(self):
+        renderer = IEEEBJTPNP()
+        painter = _make_mock_painter()
+        comp = _make_mock_component(in_scene=False)
+        renderer.draw(painter, comp)
+        line_calls = painter.drawLine.call_args_list
+        assert call(-6, -10, -6, 10) in line_calls
+
+    def test_npn_arrow_points_outward(self):
+        """NPN emitter arrow should point away from the base bar."""
+        renderer = IEEEBJTNPN()
+        painter = _make_mock_painter()
+        comp = _make_mock_component(in_scene=False)
+        renderer.draw(painter, comp)
+        line_calls = painter.drawLine.call_args_list
+        # Arrow tip at (8, 12) with barbs at (4, 7) and (3, 12)
+        assert call(8, 12, 4, 7) in line_calls
+        assert call(8, 12, 3, 12) in line_calls
+
+    def test_pnp_arrow_points_inward(self):
+        """PNP emitter arrow should point toward the base bar."""
+        renderer = IEEEBJTPNP()
+        painter = _make_mock_painter()
+        comp = _make_mock_component(in_scene=False)
+        renderer.draw(painter, comp)
+        line_calls = painter.drawLine.call_args_list
+        # Arrow tip at (-6, 6) with barbs at (-1, 2) and (-1, 7)
+        assert call(-6, 6, -1, 2) in line_calls
+        assert call(-6, 6, -1, 7) in line_calls
+
+    def test_npn_has_collector_and_emitter_leads(self):
+        """NPN should have leads connecting circle to terminal positions."""
+        renderer = IEEEBJTNPN()
+        painter = _make_mock_painter()
+        comp = _make_mock_component(in_scene=False)
+        renderer.draw(painter, comp)
+        line_calls = painter.drawLine.call_args_list
+        assert call(8, -12, 20, -20) in line_calls  # Collector lead
+        assert call(8, 12, 20, 20) in line_calls  # Emitter lead
+
+    def test_pnp_has_collector_and_emitter_leads(self):
+        """PNP should have leads connecting circle to terminal positions."""
+        renderer = IEEEBJTPNP()
+        painter = _make_mock_painter()
+        comp = _make_mock_component(in_scene=False)
+        renderer.draw(painter, comp)
+        line_calls = painter.drawLine.call_args_list
+        assert call(8, -12, 20, -20) in line_calls  # Collector lead
+        assert call(8, 12, 20, 20) in line_calls  # Emitter lead


### PR DESCRIPTION
## Summary - Add enclosing circle to both NPN and PNP BJT renderers per IEEE Std 315 - Reposition base bar and collector/emitter lines to fit within the circle - NPN: arrow on emitter points outward (away from base) - PNP: arrow on emitter points inward (toward base) - Update obstacle shapes to account for the larger symbol footprint - Add 8 structural tests verifying circle, base bar, arrow directions, and leads Closes #675 ## Test plan - [x]  and  draw enclosing circle via  - [x] Both renderers draw vertical base bar at x=-6 - [x] NPN arrow barbs point outward from base bar - [x] PNP arrow barbs point inward toward base bar - [x] Collector and emitter leads connect circle to terminal positions - [x] All pre-commit hooks pass (black, isort, ruff) - [ ] Manual visual verification: place NPN and PNP on canvas, confirm standard symbol appearance 🤖 Generated with [Claude Code](https://claude.com/claude-code)