### PR TITLE
fix: emit vp() phase variables in AC Sweep print commands

### DIFF
--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -533,11 +533,19 @@ class NetlistGenerator:
             nodes_to_print.discard(0)
             labeled_nodes_to_print = {num: label for num, label in node_labels.items() if num != 0}
 
+            is_ac = self.analysis_type == "AC Sweep"
+
             all_print_vars = []
             if labeled_nodes_to_print:
-                all_print_vars.extend([f"v({label})" for label in sorted(labeled_nodes_to_print.values())])
+                for label in sorted(labeled_nodes_to_print.values()):
+                    all_print_vars.append(f"v({label})")
+                    if is_ac:
+                        all_print_vars.append(f"vp({label})")
             elif nodes_to_print:
-                all_print_vars.extend([f"v({node})" for node in sorted(list(nodes_to_print))])
+                for node in sorted(list(nodes_to_print)):
+                    all_print_vars.append(f"v({node})")
+                    if is_ac:
+                        all_print_vars.append(f"vp({node})")
 
             # Add resistor voltages to the print list
             all_print_vars.extend(resistor_voltages_print)

--- a/app/tests/unit/test_netlist_generator.py
+++ b/app/tests/unit/test_netlist_generator.py
@@ -220,6 +220,66 @@ class TestAnalysisCommands:
         )
         assert ".ac" in netlist
 
+    def test_ac_sweep_includes_phase_variables(self, simple_resistor_circuit):
+        """AC Sweep print commands must include vp() for phase data (#738)."""
+        components, wires, nodes, t2n = simple_resistor_circuit
+        netlist = _generate(
+            components,
+            wires,
+            nodes,
+            t2n,
+            analysis_type="AC Sweep",
+            analysis_params={
+                "sweep_type": "dec",
+                "points": "10",
+                "fStart": "1",
+                "fStop": "1MEG",
+            },
+        )
+        assert "vp(" in netlist, "AC Sweep netlist must include vp() phase variables"
+
+    def test_ac_sweep_pairs_v_and_vp(self, simple_resistor_circuit):
+        """Each v(node) in AC Sweep must have a matching vp(node) (#738)."""
+        import re
+
+        components, wires, nodes, t2n = simple_resistor_circuit
+        netlist = _generate(
+            components,
+            wires,
+            nodes,
+            t2n,
+            analysis_type="AC Sweep",
+            analysis_params={
+                "sweep_type": "dec",
+                "points": "10",
+                "fStart": "1",
+                "fStop": "1MEG",
+            },
+        )
+        # Extract print line
+        for line in netlist.splitlines():
+            if line.strip().startswith("print "):
+                # Find all v(X) tokens that are NOT preceded by a letter
+                # (i.e. standalone v(), not vp())
+                v_nodes = set(re.findall(r"(?<![a-zA-Z])v\(([^)]+)\)", line))
+                vp_nodes = set(re.findall(r"\bvp\(([^)]+)\)", line))
+                assert v_nodes, "No v() variables found in print line"
+                assert vp_nodes, "No vp() variables found in print line"
+                assert v_nodes == vp_nodes, f"Mismatched v/vp nodes: v={v_nodes}, vp={vp_nodes}"
+                break
+
+    def test_non_ac_sweep_excludes_vp(self, simple_resistor_circuit):
+        """Non-AC analysis types must NOT include vp() variables."""
+        components, wires, nodes, t2n = simple_resistor_circuit
+        netlist = _generate(
+            components,
+            wires,
+            nodes,
+            t2n,
+            analysis_type="DC Operating Point",
+        )
+        assert "vp(" not in netlist
+
     def test_transient(self, simple_resistor_circuit):
         components, wires, nodes, t2n = simple_resistor_circuit
         netlist = _generate(


### PR DESCRIPTION
## Summary - Fixes #738: AC Sweep netlists now include  phase variables alongside  magnitude variables in both  and  commands - The result parser already expected both  and  columns but never received phase data, causing incomplete AC sweep results - Non-AC analysis types are unaffected — only AC Sweep generates the additional  entries ## Test plan - [x] 3 new unit tests verify:  presence in AC netlists, v/vp node pairing, and absence of  in non-AC netlists - [x] All 3927 existing tests pass (0 failures) - [x] Pre-commit hooks (ruff, isort, black) pass - [ ] Human testing: build a circuit, run AC Sweep, verify Bode plot shows both magnitude and phase 🤖 Generated with [Claude Code](https://claude.com/claude-code)