### PR TITLE
fix: add Recent Files submenu to File menu (#739)

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -699,6 +699,53 @@ class FileOperationsMixin:
             QMessageBox.critical(self, "Error", f"Failed to load example: {e}")
 
     # ------------------------------------------------------------------
+    # Recent files menu
+    # ------------------------------------------------------------------
+
+    def _populate_recent_files_menu(self):
+        """Rebuild the Recent Files submenu from the file controller."""
+        menu = self._recent_files_menu
+        menu.clear()
+        recent = self.file_ctrl.get_recent_files()
+
+        if not recent:
+            empty = menu.addAction("(no recent files)")
+            empty.setEnabled(False)
+            return
+
+        for filepath_str in recent:
+            label = Path(filepath_str).name
+            action = menu.addAction(label)
+            action.setToolTip(filepath_str)
+            action.triggered.connect(lambda checked=False, p=filepath_str: self._open_recent_file(p))
+
+        menu.addSeparator()
+        clear_action = menu.addAction("Clear Recent Files")
+        clear_action.triggered.connect(self._clear_recent_files)
+
+    def _open_recent_file(self, filepath_str):
+        """Open a file from the Recent Files menu."""
+        path = Path(filepath_str)
+        if not path.exists():
+            QMessageBox.warning(
+                self,
+                "File Not Found",
+                f"The file no longer exists:\n{filepath_str}",
+            )
+            return
+        try:
+            self.file_ctrl.load_circuit(path)
+            self.setWindowTitle(f"Circuit Design GUI - {path}")
+            self._sync_analysis_menu()
+            self._apply_default_zoom()
+        except (OSError, ValueError) as e:
+            QMessageBox.critical(self, "Error", f"Failed to load: {e}")
+
+    def _clear_recent_files(self):
+        """Clear the recent files list."""
+        self.file_ctrl.clear_recent_files()
+
+    # ------------------------------------------------------------------
     # Recent exports tracking and re-export
     # ------------------------------------------------------------------
 

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -129,6 +129,10 @@ class MenuBarMixin:
         re_export_action.triggered.connect(self._on_re_export_last)
         file_menu.addAction(re_export_action)
 
+        self._recent_files_menu = QMenu("Recent &Files", self)
+        file_menu.addMenu(self._recent_files_menu)
+        self._recent_files_menu.aboutToShow.connect(self._populate_recent_files_menu)
+
         self._recent_exports_menu = QMenu("Recent E&xports", self)
         file_menu.addMenu(self._recent_exports_menu)
         self._recent_exports_menu.aboutToShow.connect(self._populate_recent_exports_menu)

--- a/app/tests/unit/test_recent_files_menu.py
+++ b/app/tests/unit/test_recent_files_menu.py
@@ -1,0 +1,107 @@
+"""Tests for the Recent Files menu feature (#739).
+
+These tests verify the backend recent-files logic (no Qt required)
+and structurally confirm the menu wiring in the mixin source code.
+"""
+
+import inspect
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+class TestRecentFilesMenuStructural:
+    """Structural tests confirming the Recent Files menu exists in the mixin code."""
+
+    def test_menu_bar_creates_recent_files_menu(self):
+        """MenuBarMixin.create_menu_bar must reference 'Recent &Files'."""
+        from GUI.main_window_menus import MenuBarMixin
+
+        source = inspect.getsource(MenuBarMixin.create_menu_bar)
+        assert "Recent &Files" in source, "create_menu_bar must create a 'Recent &Files' QMenu"
+
+    def test_menu_bar_stores_recent_files_menu_attr(self):
+        """MenuBarMixin.create_menu_bar must assign self._recent_files_menu."""
+        from GUI.main_window_menus import MenuBarMixin
+
+        source = inspect.getsource(MenuBarMixin.create_menu_bar)
+        assert "_recent_files_menu" in source
+
+    def test_file_ops_has_populate_method(self):
+        """FileOperationsMixin must define _populate_recent_files_menu."""
+        from GUI.main_window_file_ops import FileOperationsMixin
+
+        assert hasattr(FileOperationsMixin, "_populate_recent_files_menu")
+
+    def test_file_ops_has_open_recent_file_method(self):
+        """FileOperationsMixin must define _open_recent_file."""
+        from GUI.main_window_file_ops import FileOperationsMixin
+
+        assert hasattr(FileOperationsMixin, "_open_recent_file")
+
+    def test_file_ops_has_clear_recent_files_method(self):
+        """FileOperationsMixin must define _clear_recent_files."""
+        from GUI.main_window_file_ops import FileOperationsMixin
+
+        assert hasattr(FileOperationsMixin, "_clear_recent_files")
+
+    def test_populate_calls_file_ctrl(self):
+        """_populate_recent_files_menu must call file_ctrl.get_recent_files."""
+        from GUI.main_window_file_ops import FileOperationsMixin
+
+        source = inspect.getsource(FileOperationsMixin._populate_recent_files_menu)
+        assert "get_recent_files" in source
+
+    def test_open_recent_calls_load_circuit(self):
+        """_open_recent_file must call file_ctrl.load_circuit."""
+        from GUI.main_window_file_ops import FileOperationsMixin
+
+        source = inspect.getsource(FileOperationsMixin._open_recent_file)
+        assert "load_circuit" in source
+
+
+class TestRecentFilesBackend:
+    """Tests for the FileController recent files API used by the menu."""
+
+    def test_get_recent_files_empty_initially(self):
+        """A fresh FileController should return no recent files."""
+        from controllers.file_controller import FileController
+
+        with patch("controllers.file_controller.settings") as mock_settings:
+            mock_settings.get_list.return_value = []
+            ctrl = FileController()
+            assert ctrl.get_recent_files() == []
+
+    def test_add_and_get_recent_file(self, tmp_path):
+        """add_recent_file should make the file appear in get_recent_files."""
+        from controllers.file_controller import FileController
+
+        stored = []
+
+        def fake_get_list(key):
+            return list(stored)
+
+        def fake_set(key, val):
+            stored.clear()
+            stored.extend(val)
+
+        with patch("controllers.file_controller.settings") as mock_settings:
+            mock_settings.get_list.side_effect = fake_get_list
+            mock_settings.set.side_effect = fake_set
+
+            ctrl = FileController()
+            test_file = tmp_path / "circuit.json"
+            test_file.touch()
+
+            ctrl.add_recent_file(test_file)
+            recent = ctrl.get_recent_files()
+            assert len(recent) == 1
+            assert str(test_file.absolute()) in recent[0]
+
+    def test_clear_recent_files(self):
+        """clear_recent_files should result in an empty list."""
+        from controllers.file_controller import FileController
+
+        with patch("controllers.file_controller.settings") as mock_settings:
+            ctrl = FileController()
+            ctrl.clear_recent_files()
+            mock_settings.set.assert_called_with("file/recent_files", [])


### PR DESCRIPTION
## Summary
- Add Recent Files submenu to the File menu, wiring up the existing FileController backend
- Menu populates dynamically on show, opens files on click, and supports clearing the list
- Add structural and backend tests for the feature

Closes #739

## Test plan
- [x] Structural tests verify menu creation and method wiring
- [x] Backend tests verify FileController recent files API
- [ ] Human testing: open/save several files, verify they appear in File > Recent Files