### PR TITLE
fix: use ScreenResolution for print/PDF to fix oversized text (#742, #743, #749)

### DIFF
--- a/app/GUI/main_window_print.py
+++ b/app/GUI/main_window_print.py
@@ -75,7 +75,7 @@ class PrintExportMixin:
             QMessageBox.information(self, "Print", "Nothing to print — the canvas is empty.")
             return
 
-        printer = QPrinter(QPrinter.PrinterMode.HighResolution)
+        printer = QPrinter(QPrinter.PrinterMode.ScreenResolution)
         dialog = QPrintDialog(printer, self)
         dialog.setWindowTitle("Print Circuit")
         if dialog.exec() == QPrintDialog.DialogCode.Accepted:
@@ -90,7 +90,7 @@ class PrintExportMixin:
             QMessageBox.information(self, "Print Preview", "Nothing to preview — the canvas is empty.")
             return
 
-        printer = QPrinter(QPrinter.PrinterMode.HighResolution)
+        printer = QPrinter(QPrinter.PrinterMode.ScreenResolution)
         preview = QPrintPreviewDialog(printer, self)
         preview.setWindowTitle("Print Preview — Circuit Schematic")
         preview.paintRequested.connect(self._render_to_printer)
@@ -111,7 +111,7 @@ class PrintExportMixin:
         if not filename.lower().endswith(".pdf"):
             filename += ".pdf"
 
-        printer = QPrinter(QPrinter.PrinterMode.HighResolution)
+        printer = QPrinter(QPrinter.PrinterMode.ScreenResolution)
         printer.setOutputFormat(QPrinter.OutputFormat.PdfFormat)
         printer.setOutputFileName(filename)
 

--- a/app/GUI/report_renderer.py
+++ b/app/GUI/report_renderer.py
@@ -28,7 +28,7 @@ class PDFReportRenderer:
             data: Assembled report content from ReportDataBuilder.
             scene: Optional QGraphicsScene for schematic rendering.
         """
-        printer = QPrinter(QPrinter.PrinterMode.HighResolution)
+        printer = QPrinter(QPrinter.PrinterMode.ScreenResolution)
         printer.setOutputFormat(QPrinter.OutputFormat.PdfFormat)
         printer.setOutputFileName(filepath)
 

--- a/app/tests/unit/test_print_pdf_resolution.py
+++ b/app/tests/unit/test_print_pdf_resolution.py
@@ -1,0 +1,43 @@
+"""Tests for print/PDF/report resolution settings (#742, #743, #749).
+
+QPrinter.PrinterMode.HighResolution causes text rendered via QPainter.drawText
+inside QGraphicsItem.paint() to be double-scaled: once by the scene-to-device
+transform and once by the high-DPI font resolution.  Using ScreenResolution
+ensures text and shapes scale proportionally.
+
+These tests verify the source code uses ScreenResolution, not HighResolution.
+"""
+
+import inspect
+
+
+class TestPrintExportUsesScreenResolution:
+    """Verify that print/PDF export uses ScreenResolution to avoid oversized text."""
+
+    def test_print_preview_uses_screen_resolution(self):
+        from GUI.main_window_print import PrintExportMixin
+
+        source = inspect.getsource(PrintExportMixin._on_print_preview)
+        assert "ScreenResolution" in source
+        assert "HighResolution" not in source
+
+    def test_print_uses_screen_resolution(self):
+        from GUI.main_window_print import PrintExportMixin
+
+        source = inspect.getsource(PrintExportMixin._on_print)
+        assert "ScreenResolution" in source
+        assert "HighResolution" not in source
+
+    def test_export_pdf_uses_screen_resolution(self):
+        from GUI.main_window_print import PrintExportMixin
+
+        source = inspect.getsource(PrintExportMixin._on_export_pdf)
+        assert "ScreenResolution" in source
+        assert "HighResolution" not in source
+
+    def test_report_renderer_uses_screen_resolution(self):
+        from GUI.report_renderer import PDFReportRenderer
+
+        source = inspect.getsource(PDFReportRenderer.render)
+        assert "ScreenResolution" in source
+        assert "HighResolution" not in source


### PR DESCRIPTION
## Summary
- Switch QPrinter from HighResolution to ScreenResolution in print, print preview, PDF export, and report PDF renderer
- HighResolution causes font sizes (in points) to be resolved at the printer's high DPI independently of the scene-to-device transform, making text disproportionately large relative to shapes
- ScreenResolution keeps text and shapes proportional; PDF output remains vector-based and resolution-independent

Closes #742, Closes #743, Closes #749

## Test plan
- [x] Structural tests verify ScreenResolution is used (not HighResolution)
- [ ] Human testing: Print Preview shows correctly sized text relative to components
- [ ] Human testing: Export as PDF produces correctly sized text
- [ ] Human testing: Generate Circuit Report PDF produces readable text without overlap