### PR TITLE
fix: correct LTspice import/export rotation, positions, and pin offsets (#746, #747)

### DIFF
--- a/app/simulation/asc_exporter.py
+++ b/app/simulation/asc_exporter.py
@@ -29,11 +29,11 @@ _TYPE_TO_SYMBOL = {
     "Waveform Source": "voltage",
 }
 
-# Pin offsets (same as asc_parser._PIN_OFFSETS)
+# Pin offsets (same as asc_parser._PIN_OFFSETS, with corrected pin spacing)
 _PIN_OFFSETS = {
-    "Resistor": [(0, 0), (0, 80)],
+    "Resistor": [(0, 0), (0, 96)],
     "Capacitor": [(0, 0), (0, 64)],
-    "Inductor": [(0, 0), (0, 80)],
+    "Inductor": [(0, 0), (0, 96)],
     "Voltage Source": [(0, 0), (0, 112)],
     "Current Source": [(0, 0), (0, 112)],
     "Waveform Source": [(0, 0), (0, 112)],
@@ -53,11 +53,35 @@ _PIN_OFFSETS = {
 }
 
 
-def _degrees_to_rotation_code(rotation, flip_h=False):
-    """Convert Spice-GUI rotation + flip to LTspice rotation code."""
+def _degrees_to_rotation_code(rotation, flip_h=False, is_bipole=True):
+    """Convert Spice-GUI rotation + flip to LTspice rotation code.
+
+    For 2-terminal (bipole) components, applies the self-inverse transform
+    ``(450 - angle) % 360`` because LTspice R0 is vertical while Spice-GUI
+    0° is horizontal, and they rotate in opposite directions.
+    """
     prefix = "M" if flip_h else "R"
     angle = int(rotation) % 360
+    if is_bipole:
+        angle = (450 - angle) % 360
     return f"{prefix}{angle}"
+
+
+def _center_to_origin(comp_type, rotation, flip_h=False):
+    """Convert Spice-GUI center position back to LTspice SYMBOL origin.
+
+    Returns (dx, dy) to subtract from the Spice-GUI center to get the
+    LTspice SYMBOL position.
+    """
+    offsets = _PIN_OFFSETS.get(comp_type)
+    if not offsets or len(offsets) < 2:
+        return 0, 0
+    avg_x = sum(o[0] for o in offsets) / len(offsets)
+    avg_y = sum(o[1] for o in offsets) / len(offsets)
+    # For bipoles we need the LTspice rotation (reverse of the import transform)
+    is_bipole = len(offsets) == 2
+    lt_angle = (450 - int(rotation)) % 360 if is_bipole else int(rotation) % 360
+    return _transform_pin(avg_x, avg_y, lt_angle, flip_h)
 
 
 def _transform_pin(dx, dy, rotation, flip_h=False):
@@ -127,19 +151,25 @@ def export_asc(model):
         if symbol is None:
             continue
 
-        x = int(comp.position[0])
-        y = int(comp.position[1])
-        rot_code = _degrees_to_rotation_code(comp.rotation, comp.flip_h)
+        offsets = _PIN_OFFSETS.get(comp.component_type, [(0, 0), (0, 80)])
+        is_bipole = len(offsets) == 2
+
+        # Convert Spice-GUI center back to LTspice SYMBOL origin
+        cx, cy = _center_to_origin(comp.component_type, comp.rotation, comp.flip_h)
+        x = int(comp.position[0] - cx)
+        y = int(comp.position[1] - cy)
+        rot_code = _degrees_to_rotation_code(comp.rotation, comp.flip_h, is_bipole=is_bipole)
 
         lines.append(f"SYMBOL {symbol} {x} {y} {rot_code}")
         lines.append(f"SYMATTR InstName {comp_id}")
         if comp.value:
             lines.append(f"SYMATTR Value {comp.value}")
 
-        # Compute pin positions
-        offsets = _PIN_OFFSETS.get(comp.component_type, [(0, 0), (0, 80)])
+        # Compute pin positions using LTspice rotation/flip
+        lt_angle = int(rot_code[1:])
+        lt_flip = rot_code.startswith("M")
         for term_idx, (dx, dy) in enumerate(offsets):
-            tx, ty = _transform_pin(dx, dy, comp.rotation, comp.flip_h)
+            tx, ty = _transform_pin(dx, dy, lt_angle, lt_flip)
             pin_positions[(comp_id, term_idx)] = (x + tx, y + ty)
 
     # Export Ground components as FLAG entries
@@ -160,7 +190,8 @@ def export_asc(model):
         if start_key in pin_positions and end_key in pin_positions:
             x1, y1 = pin_positions[start_key]
             x2, y2 = pin_positions[end_key]
-            lines.append(f"WIRE {x1} {y1} {x2} {y2}")
+            if (x1, y1) != (x2, y2):  # skip zero-length wires
+                lines.append(f"WIRE {x1} {y1} {x2} {y2}")
 
     # Export analysis directive
     if model.analysis_type:

--- a/app/simulation/asc_parser.py
+++ b/app/simulation/asc_parser.py
@@ -66,22 +66,63 @@ _SYMBOL_TO_TYPE = {
     "h2": "CCVS",
 }
 
-# Pin offsets (dx, dy) relative to SYMBOL position for each type (at R0 orientation)
-# LTspice convention: R0 = vertical, pin 1 at top
+# Pin offsets (dx, dy) relative to SYMBOL position for each LTspice symbol
+# at R0 orientation.  Keyed by LTspice symbol name for accuracy; the
+# Spice-GUI component type (used as fallback) may map multiple symbols.
+_SYMBOL_PIN_OFFSETS: dict[str, list[tuple[int, int]]] = {
+    # --- 2-terminal ---
+    "res": [(0, 0), (0, 96)],
+    "res2": [(0, 0), (0, 80)],
+    "cap": [(0, 0), (0, 64)],
+    "cap2": [(0, 0), (0, 64)],
+    "polcap": [(0, 0), (0, 64)],
+    "ind": [(0, 0), (0, 96)],
+    "ind2": [(0, 0), (0, 80)],
+    "voltage": [(0, 0), (0, 112)],
+    "current": [(0, 0), (0, 112)],
+    "diode": [(0, 0), (0, 64)],
+    "schottky": [(0, 0), (0, 64)],
+    "zener": [(0, 0), (0, 64)],
+    "LED": [(0, 0), (0, 64)],
+    "led": [(0, 0), (0, 64)],
+    # --- 3-terminal ---
+    "npn": [(16, 0), (-16, 32), (16, 64)],  # C, B, E
+    "npn2": [(16, 0), (-16, 32), (16, 64)],
+    "pnp": [(16, 64), (-16, 32), (16, 0)],  # C, B, E
+    "pnp2": [(16, 64), (-16, 32), (16, 0)],
+    "nmos": [(16, 0), (-16, 32), (16, 64)],  # D, G, S
+    "nmos3": [(16, 0), (-16, 32), (16, 64)],
+    "pmos": [(16, 64), (-16, 32), (16, 0)],  # D, G, S
+    "pmos3": [(16, 64), (-16, 32), (16, 0)],
+    "opamp": [(-32, 32), (-32, -32), (32, 0)],  # in+, in-, out
+    "Opamps\\\\opamp": [(-32, 32), (-32, -32), (32, 0)],
+    "Opamps\\\\opamp2": [(-32, 32), (-32, -32), (32, 0)],
+    # --- 4-terminal ---
+    "e": [(-32, 32), (-32, -32), (32, -32), (32, 32)],  # VCVS
+    "e2": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
+    "f": [(-32, 32), (-32, -32), (32, -32), (32, 32)],  # CCCS
+    "f2": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
+    "g": [(-32, 32), (-32, -32), (32, -32), (32, 32)],  # VCCS
+    "g2": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
+    "h": [(-32, 32), (-32, -32), (32, -32), (32, 32)],  # CCVS
+    "h2": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
+}
+
+# Fallback offsets keyed by Spice-GUI type (used when LTspice symbol is unknown)
 _PIN_OFFSETS = {
-    "Resistor": [(0, 0), (0, 80)],
+    "Resistor": [(0, 0), (0, 96)],
     "Capacitor": [(0, 0), (0, 64)],
-    "Inductor": [(0, 0), (0, 80)],
+    "Inductor": [(0, 0), (0, 96)],
     "Voltage Source": [(0, 0), (0, 112)],
     "Current Source": [(0, 0), (0, 112)],
     "Diode": [(0, 0), (0, 64)],
     "LED": [(0, 0), (0, 64)],
     "Zener Diode": [(0, 0), (0, 64)],
-    "BJT NPN": [(16, 0), (-16, 32), (16, 64)],  # C, B, E
-    "BJT PNP": [(16, 64), (-16, 32), (16, 0)],  # C, B, E
-    "MOSFET NMOS": [(16, 0), (-16, 32), (16, 64)],  # D, G, S
-    "MOSFET PMOS": [(16, 64), (-16, 32), (16, 0)],  # D, G, S
-    "Op-Amp": [(-32, 32), (-32, -32), (32, 0)],  # in+, in-, out
+    "BJT NPN": [(16, 0), (-16, 32), (16, 64)],
+    "BJT PNP": [(16, 64), (-16, 32), (16, 0)],
+    "MOSFET NMOS": [(16, 0), (-16, 32), (16, 64)],
+    "MOSFET PMOS": [(16, 64), (-16, 32), (16, 0)],
+    "Op-Amp": [(-32, 32), (-32, -32), (32, 0)],
     "VCVS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
     "CCVS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
     "VCCS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
@@ -90,6 +131,26 @@ _PIN_OFFSETS = {
 
 # Coordinate scale factor: LTspice units -> Spice-GUI scene coordinates
 _SCALE = 1.0
+
+
+def _point_on_segment(pt, seg_a, seg_b):
+    """Return True if integer point *pt* lies strictly between *seg_a* and *seg_b*.
+
+    Only checks axis-aligned segments (horizontal or vertical), which is
+    all LTspice wires produce.  The endpoints themselves are already
+    handled by the normal union-find, so this only matches interior points.
+    """
+    px, py = pt
+    ax, ay = seg_a
+    bx, by = seg_b
+
+    if ax == bx == px:  # vertical segment
+        lo, hi = (min(ay, by), max(ay, by))
+        return lo < py < hi
+    if ay == by == py:  # horizontal segment
+        lo, hi = (min(ax, bx), max(ax, bx))
+        return lo < px < hi
+    return False
 
 
 def _transform_pin(dx, dy, rotation_code):
@@ -123,8 +184,13 @@ def _transform_pin(dx, dy, rotation_code):
     return dx, dy
 
 
-def _rotation_to_degrees(rotation_code):
+def _rotation_to_degrees(rotation_code, is_bipole=True):
     """Convert LTspice rotation code to Spice-GUI rotation degrees and flip state.
+
+    Args:
+        rotation_code: LTspice rotation code (R0, R90, R180, R270, M0, etc.)
+        is_bipole: True for 2-terminal components where LTspice R0=vertical
+                   but Spice-GUI 0°=horizontal, requiring a 90° offset.
 
     Returns (rotation_degrees, flip_h).
     """
@@ -132,10 +198,29 @@ def _rotation_to_degrees(rotation_code):
     mirrored = code.startswith("M")
     angle = int(code[1:]) if len(code) > 1 else 0
 
-    # LTspice R0 is vertical, Spice-GUI 0 is horizontal
-    # We use rotation 90 to convert from LTspice vertical to Spice-GUI horizontal
-    # for 2-terminal components. For multi-terminal, keep as-is.
+    if is_bipole:
+        # LTspice R0 is vertical, Spice-GUI 0° is horizontal, and they
+        # rotate in opposite directions (LTspice CW increments map to
+        # Spice-GUI CCW).  The self-inverse transform is:
+        angle = (450 - angle) % 360
+
     return angle, mirrored
+
+
+def _center_offset_from_pins(pin_offsets, rotation_code):
+    """Compute the offset from LTspice SYMBOL origin to Spice-GUI center.
+
+    LTspice positions the SYMBOL origin at pin 1.  Spice-GUI uses the
+    component center.  Returns (dx, dy) to add to the LTspice SYMBOL
+    position to get the Spice-GUI center position.
+    """
+    if not pin_offsets or len(pin_offsets) < 2:
+        return 0, 0
+    # Center = average of all pin offsets (in LTspice space, before rotation)
+    avg_x = sum(o[0] for o in pin_offsets) / len(pin_offsets)
+    avg_y = sum(o[1] for o in pin_offsets) / len(pin_offsets)
+    # Transform the center offset by the LTspice rotation
+    return _transform_pin(avg_x, avg_y, rotation_code)
 
 
 def parse_asc(text):
@@ -388,12 +473,22 @@ def import_asc(text):
                     value = sym["value2"]
                     break
 
-        # Convert position: scale LTspice coords to scene coords
-        pos_x = sym["x"] * _SCALE
-        pos_y = sym["y"] * _SCALE
+        # Look up pin offsets: prefer LTspice symbol name, fall back to type
+        lt_name_lower = lt_name.lower() if lt_name else ""
+        pin_offsets = (
+            _SYMBOL_PIN_OFFSETS.get(lt_name)
+            or _SYMBOL_PIN_OFFSETS.get(lt_name_lower)
+            or _PIN_OFFSETS.get(comp_type, [(0, 0), (0, 96)])
+        )
+        is_bipole = len(pin_offsets) == 2
 
-        # Convert rotation
-        rotation_deg, flip_h = _rotation_to_degrees(sym["rotation"])
+        # Convert position: LTspice SYMBOL origin → Spice-GUI center
+        cx, cy = _center_offset_from_pins(pin_offsets, sym["rotation"])
+        pos_x = (sym["x"] + cx) * _SCALE
+        pos_y = (sym["y"] + cy) * _SCALE
+
+        # Convert rotation (bipoles need +90° offset)
+        rotation_deg, flip_h = _rotation_to_degrees(sym["rotation"], is_bipole=is_bipole)
 
         component = ComponentData(
             component_id=comp_id,
@@ -419,7 +514,7 @@ def import_asc(text):
             model.component_counter[symbol] = max(current, num)
 
         # Calculate absolute pin positions for this component
-        pin_offsets = _PIN_OFFSETS.get(comp_type, [(0, 0), (0, 80)])
+        # (pin_offsets was already resolved above via symbol/type lookup)
         for term_idx, (dx, dy) in enumerate(pin_offsets):
             tx, ty = _transform_pin(dx, dy, sym["rotation"])
             abs_x = sym["x"] + tx

--- a/app/tests/unit/test_asc_exporter.py
+++ b/app/tests/unit/test_asc_exporter.py
@@ -158,6 +158,7 @@ class TestExportAsc:
         assert "Version 4" in content
 
     def test_rotation_code(self):
+        """Spice-GUI 90° (vertical bipole) -> LTspice R0 (vertical)."""
         model = CircuitModel()
         r1 = ComponentData(
             component_id="R1",
@@ -165,6 +166,20 @@ class TestExportAsc:
             value="1k",
             position=(100.0, 100.0),
             rotation=90,
+        )
+        model.add_component(r1)
+        content = export_asc(model)
+        assert "R0" in content
+
+    def test_horizontal_rotation_code(self):
+        """Spice-GUI 0° (horizontal bipole) -> LTspice R90 (horizontal)."""
+        model = CircuitModel()
+        r1 = ComponentData(
+            component_id="R1",
+            component_type="Resistor",
+            value="1k",
+            position=(100.0, 100.0),
+            rotation=0,
         )
         model.add_component(r1)
         content = export_asc(model)
@@ -177,7 +192,7 @@ class TestExportAsc:
             component_type="Resistor",
             value="1k",
             position=(100.0, 100.0),
-            rotation=0,
+            rotation=90,
             flip_h=True,
         )
         model.add_component(r1)

--- a/app/tests/unit/test_asc_parser.py
+++ b/app/tests/unit/test_asc_parser.py
@@ -341,7 +341,10 @@ class TestImportAsc:
 
     def test_rotated_components(self):
         model, _analysis, _warnings = import_asc(ROTATED_COMPONENTS)
-        assert model.components["R1"].rotation == 90
+        # LTspice R90 -> Spice-GUI 0° for bipoles (R0=vertical, 0°=horizontal)
+        assert model.components["R1"].rotation == 0
+        # LTspice M0 -> Spice-GUI 90° with flip_h for bipoles
+        assert model.components["C1"].rotation == 90
         assert model.components["C1"].flip_h is True
 
     def test_multiple_grounds(self):
@@ -386,6 +389,108 @@ class TestTransformPin:
 
     def test_none_defaults_to_r0(self):
         assert _transform_pin(10, 20, None) == (10, 20)
+
+
+class TestRotationMapping:
+    """Tests for the LTspice <-> Spice-GUI rotation conversion."""
+
+    def test_r0_bipole_maps_to_90(self):
+        """LTspice R0 (vertical) -> Spice-GUI 90° (vertical)."""
+        from simulation.asc_parser import _rotation_to_degrees
+
+        deg, flip = _rotation_to_degrees("R0", is_bipole=True)
+        assert deg == 90
+        assert flip is False
+
+    def test_r90_bipole_maps_to_0(self):
+        """LTspice R90 (horizontal) -> Spice-GUI 0° (horizontal)."""
+        from simulation.asc_parser import _rotation_to_degrees
+
+        deg, flip = _rotation_to_degrees("R90", is_bipole=True)
+        assert deg == 0
+        assert flip is False
+
+    def test_r180_bipole_maps_to_270(self):
+        from simulation.asc_parser import _rotation_to_degrees
+
+        deg, flip = _rotation_to_degrees("R180", is_bipole=True)
+        assert deg == 270
+        assert flip is False
+
+    def test_r270_bipole_maps_to_180(self):
+        from simulation.asc_parser import _rotation_to_degrees
+
+        deg, flip = _rotation_to_degrees("R270", is_bipole=True)
+        assert deg == 180
+        assert flip is False
+
+    def test_multipole_no_offset(self):
+        """Multi-terminal components keep rotation angle unchanged."""
+        from simulation.asc_parser import _rotation_to_degrees
+
+        deg, flip = _rotation_to_degrees("R90", is_bipole=False)
+        assert deg == 90
+        assert flip is False
+
+    def test_m0_bipole_mirror(self):
+        """LTspice M0 -> Spice-GUI 90° with flip_h."""
+        from simulation.asc_parser import _rotation_to_degrees
+
+        deg, flip = _rotation_to_degrees("M0", is_bipole=True)
+        assert deg == 90
+        assert flip is True
+
+
+class TestRoundTrip:
+    """Test import then export produces equivalent LTspice data."""
+
+    PROPER_VD = """\
+Version 4
+SHEET 1 880 680
+WIRE 176 64 80 64
+WIRE 176 256 80 256
+WIRE 80 176 80 256
+FLAG 80 256 0
+SYMBOL res 176 64 R0
+SYMATTR InstName R1
+SYMATTR Value 10k
+SYMBOL res 176 160 R0
+SYMATTR InstName R2
+SYMATTR Value 10k
+SYMBOL voltage 80 64 R0
+SYMATTR InstName V1
+SYMATTR Value 5V
+"""
+
+    def test_round_trip_preserves_positions(self):
+        """Import then export should recover the same SYMBOL positions."""
+        from simulation.asc_exporter import export_asc
+
+        model, _analysis, _warnings = import_asc(self.PROPER_VD)
+        exported = export_asc(model)
+
+        # Check key lines are present
+        assert "SYMBOL res 176 64 R0" in exported
+        assert "SYMBOL res 176 160 R0" in exported
+        assert "SYMBOL voltage 80 64 R0" in exported
+
+    def test_round_trip_preserves_connectivity(self):
+        """Import should create the correct wire connections."""
+        model, _analysis, _warnings = import_asc(self.PROPER_VD)
+
+        # R1 top connects to V1 top (same node)
+        wire_pairs = {(w.start_component_id, w.end_component_id) for w in model.wires} | {
+            (w.end_component_id, w.start_component_id) for w in model.wires
+        }
+        assert ("R1", "V1") in wire_pairs
+        assert ("R1", "R2") in wire_pairs
+
+    def test_round_trip_rotation_is_vertical(self):
+        """All R0 bipoles should be imported with rotation=90 (vertical)."""
+        model, _analysis, _warnings = import_asc(self.PROPER_VD)
+        assert model.components["R1"].rotation == 90
+        assert model.components["R2"].rotation == 90
+        assert model.components["V1"].rotation == 90
 
 
 class TestFileControllerIntegration:


### PR DESCRIPTION
## Summary
- Fix rotation mapping: LTspice R0 (vertical) now correctly maps to Spice-GUI 90 degrees (vertical) for bipole components, using the self-inverse transform (450-angle)%360
- Fix position mapping: convert between LTspice SYMBOL origin (pin 1) and Spice-GUI center position
- Fix pin offsets: use per-LTspice-symbol pin offsets instead of per-type. Corrects standard res pin spacing from 80 to 96 units to match actual LTspice symbol definitions
- Skip zero-length wires in export (pins at same position)

Closes #746, Closes #747

## Test plan
- [x] New rotation mapping tests verify all 4 rotation codes + mirror
- [x] Round-trip test verifies import->export preserves SYMBOL positions
- [x] Round-trip test verifies connectivity is preserved
- [x] Existing parser tests updated for new rotation mapping
- [ ] Human testing: import a real LTspice .asc file and verify visual correctness