### PR TITLE
fix: shareable SVG export/import and fix SVG rendering (#748)

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -260,6 +260,30 @@ class FileOperationsMixin:
             except (OSError, ValueError) as e:
                 QMessageBox.critical(self, "Import Error", f"Failed to import CircuiTikZ LaTeX:\n{e}")
 
+    def _on_import_svg(self):
+        """Import a shareable SVG file containing embedded circuit data."""
+        filename, _ = QFileDialog.getOpenFileName(
+            self,
+            "Import Shareable SVG",
+            "",
+            "SVG Files (*.svg);;All Files (*)",
+        )
+        if filename:
+            try:
+                self.file_ctrl.import_svg(filename)
+                self.setWindowTitle(f"Circuit Design GUI - {Path(filename).name} (imported)")
+                self._sync_analysis_menu()
+                self._set_dirty(True)
+                num_components = len(self.model.components)
+                num_wires = len(self.model.wires)
+                QMessageBox.information(
+                    self,
+                    "Import Successful",
+                    f"Imported {num_components} components and {num_wires} wires from {Path(filename).name}.",
+                )
+            except (OSError, ValueError) as e:
+                QMessageBox.critical(self, "Import Error", f"Failed to import SVG:\n{e}")
+
     def _on_export_bom(self):
         """Export a Bill of Materials (BOM) as CSV or Excel."""
         if not self.model.components:

--- a/app/GUI/main_window_menus.py
+++ b/app/GUI/main_window_menus.py
@@ -77,6 +77,11 @@ class MenuBarMixin:
         import_tikz_action.triggered.connect(self._on_import_circuitikz)
         file_menu.addAction(import_tikz_action)
 
+        import_svg_action = QAction("Import from &SVG...", self)
+        import_svg_action.setToolTip("Import a circuit from a shareable SVG file")
+        import_svg_action.triggered.connect(self._on_import_svg)
+        file_menu.addAction(import_svg_action)
+
         export_netlist_action = QAction("Export &Netlist...", self)
         export_netlist_action.setShortcut(kb.get("file.export_netlist"))
         export_netlist_action.setToolTip("Export the generated SPICE netlist to a .cir file")

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -381,20 +381,29 @@ class ViewOperationsMixin:
         source_rect.adjust(-padding, -padding, padding, padding)
 
         if filename.lower().endswith(".svg"):
-            from PyQt6.QtCore import QSize
+            from PyQt6.QtCore import QRect, QRectF, QSize
             from PyQt6.QtSvg import QSvgGenerator
+
+            width = int(source_rect.width())
+            height = int(source_rect.height())
 
             generator = QSvgGenerator()
             generator.setFileName(filename)
-            generator.setSize(QSize(int(source_rect.width()), int(source_rect.height())))
-            generator.setViewBox(source_rect)
+            generator.setSize(QSize(width, height))
+            generator.setViewBox(QRect(0, 0, width, height))
             generator.setTitle("SDM Spice Circuit")
 
             from PyQt6.QtGui import QPainter
 
             painter = QPainter(generator)
-            scene.render(painter, source=source_rect)
+            painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+            scene.render(painter, QRectF(0, 0, width, height), source_rect)
             painter.end()
+
+            # Embed circuit data in the SVG for shareable round-trip import
+            from simulation.svg_shareable import embed_circuit_data
+
+            embed_circuit_data(filename, self.model)
         else:
             # PNG
             from PyQt6.QtCore import QRectF, Qt

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -441,6 +441,42 @@ class FileController:
             content = export_bom_csv(self.model.components, circuit_name=circuit_name)
             write_bom_csv(content, filepath)
 
+    def import_svg(self, filepath) -> None:
+        """Import a shareable SVG file that contains embedded circuit data.
+
+        Extracts the circuit JSON from the SVG metadata and replaces
+        the current model.
+
+        Args:
+            filepath: Path or string to the .svg file.
+
+        Raises:
+            OSError: If the file cannot be read.
+            ValueError: If the SVG contains no embedded circuit data
+                or the data is corrupt.
+        """
+        from simulation.svg_shareable import extract_circuit_data
+
+        filepath = Path(filepath)
+        check_file_size(filepath)
+
+        data = extract_circuit_data(filepath)
+        if data is None:
+            raise ValueError(
+                "This SVG file does not contain embedded circuit data.\n"
+                "Only SVGs exported with 'Export Image' (SVG format) from Spice-GUI can be imported."
+            )
+
+        validate_circuit_data(data)
+        new_model = CircuitModel.from_dict(data)
+        self._replace_model(new_model)
+
+        self.current_file = None
+        self.add_recent_file(filepath)
+
+        if self.circuit_ctrl:
+            self.circuit_ctrl._notify("model_loaded", None)
+
     def export_asc(self, filepath: str) -> None:
         """Export the circuit as an LTspice .asc schematic.
 

--- a/app/simulation/svg_shareable.py
+++ b/app/simulation/svg_shareable.py
@@ -1,0 +1,106 @@
+"""
+simulation/svg_shareable.py
+
+Embed and extract Spice-GUI circuit JSON in SVG files for shareable
+round-trip export/import.  Circuit data is stored inside an SVG
+``<metadata>`` block using a dedicated XML namespace so it does not
+interfere with standard SVG rendering.
+
+No Qt dependencies.
+"""
+
+import base64
+import json
+import logging
+import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_NS = "https://spice-gui.github.io/schema/circuit"
+_TAG_PREFIX = "spice-gui"
+_MARKER = f"<!-- {_TAG_PREFIX}-circuit-data: "
+_MARKER_END = " -->"
+
+
+def embed_circuit_data(svg_path, model):
+    """Post-process an SVG file to embed circuit JSON data.
+
+    Inserts a ``<metadata>`` block containing the circuit model
+    serialised as base64-encoded JSON.  If the SVG already has a
+    ``<metadata>`` section it is left intact and the circuit block is
+    appended.
+
+    Args:
+        svg_path: Path to the SVG file (modified in place).
+        model: CircuitModel instance whose ``to_dict()`` output will
+            be embedded.
+    """
+    svg_path = Path(svg_path)
+    svg_text = svg_path.read_text(encoding="utf-8")
+
+    circuit_dict = model.to_dict()
+    json_bytes = json.dumps(circuit_dict, separators=(",", ":")).encode("utf-8")
+    b64 = base64.b64encode(json_bytes).decode("ascii")
+
+    # Build the metadata snippet to inject
+    metadata_block = (
+        f'<metadata xmlns:{_TAG_PREFIX}="{_NS}"><{_TAG_PREFIX}:circuit>{b64}</{_TAG_PREFIX}:circuit></metadata>'
+    )
+
+    # Insert right after the opening <svg ...> tag
+    # Use a regex to find the end of the <svg> opening tag
+    match = re.search(r"(<svg[^>]*>)", svg_text, re.IGNORECASE | re.DOTALL)
+    if match:
+        insert_pos = match.end()
+        svg_text = svg_text[:insert_pos] + "\n" + metadata_block + "\n" + svg_text[insert_pos:]
+    else:
+        logger.warning("Could not find <svg> tag in %s; skipping circuit data embedding", svg_path)
+        return
+
+    svg_path.write_text(svg_text, encoding="utf-8")
+
+
+def extract_circuit_data(svg_path):
+    """Extract embedded circuit JSON from an SVG file.
+
+    Returns:
+        dict: The circuit data dictionary (suitable for
+            ``CircuitModel.from_dict()``), or ``None`` if no embedded
+            data is found.
+
+    Raises:
+        OSError: If the file cannot be read.
+        ValueError: If the embedded data is corrupt.
+    """
+    svg_path = Path(svg_path)
+    svg_text = svg_path.read_text(encoding="utf-8")
+
+    return extract_circuit_data_from_string(svg_text)
+
+
+def extract_circuit_data_from_string(svg_text):
+    """Extract embedded circuit JSON from SVG text content.
+
+    Returns:
+        dict or None: The circuit data dictionary, or ``None`` if no
+            embedded data is found.
+
+    Raises:
+        ValueError: If the embedded data is corrupt.
+    """
+    # Look for the <spice-gui:circuit> element containing base64 data
+    pattern = re.compile(
+        rf"<{_TAG_PREFIX}:circuit[^>]*>(.*?)</{_TAG_PREFIX}:circuit>",
+        re.DOTALL,
+    )
+    match = pattern.search(svg_text)
+    if not match:
+        return None
+
+    b64_data = match.group(1).strip()
+    try:
+        json_bytes = base64.b64decode(b64_data)
+        return json.loads(json_bytes)
+    except Exception as exc:
+        raise ValueError(f"Corrupt circuit data in SVG: {exc}") from exc

--- a/app/tests/unit/test_svg_shareable.py
+++ b/app/tests/unit/test_svg_shareable.py
@@ -1,0 +1,252 @@
+"""Tests for shareable SVG export/import (#748).
+
+Verifies that circuit data can be embedded in SVG files and extracted
+back, and that the UI wiring for SVG import is in place.
+"""
+
+import inspect
+import json
+import textwrap
+
+import pytest
+from models.circuit import CircuitModel
+from models.component import ComponentData
+from models.wire import WireData
+from simulation.svg_shareable import embed_circuit_data, extract_circuit_data, extract_circuit_data_from_string
+
+
+def _make_simple_circuit():
+    """Build a simple circuit for round-trip testing."""
+    model = CircuitModel()
+    r1 = ComponentData(
+        component_id="R1",
+        component_type="Resistor",
+        value="1k",
+        position=(100.0, 100.0),
+        rotation=0,
+    )
+    v1 = ComponentData(
+        component_id="V1",
+        component_type="Voltage Source",
+        value="5",
+        position=(0.0, 100.0),
+        rotation=0,
+    )
+    gnd = ComponentData(
+        component_id="GND1",
+        component_type="Ground",
+        value="0V",
+        position=(0.0, 300.0),
+    )
+    model.add_component(r1)
+    model.add_component(v1)
+    model.add_component(gnd)
+    model.add_wire(
+        WireData(
+            start_component_id="V1",
+            start_terminal=0,
+            end_component_id="R1",
+            end_terminal=0,
+        )
+    )
+    model.analysis_type = "Transient"
+    model.analysis_params = {"duration": "10m", "step": "10u"}
+    return model
+
+
+_MINIMAL_SVG = textwrap.dedent(
+    """\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+    <rect x="10" y="10" width="100" height="80" fill="none" stroke="black"/>
+    </svg>
+"""
+)
+
+
+class TestEmbedCircuitData:
+    """Test embedding circuit data into SVG files."""
+
+    def test_embed_creates_metadata(self, tmp_path):
+        svg_file = tmp_path / "test.svg"
+        svg_file.write_text(_MINIMAL_SVG, encoding="utf-8")
+
+        model = _make_simple_circuit()
+        embed_circuit_data(svg_file, model)
+
+        content = svg_file.read_text(encoding="utf-8")
+        assert "<metadata" in content
+        assert "spice-gui:circuit" in content
+
+    def test_embed_preserves_svg_structure(self, tmp_path):
+        svg_file = tmp_path / "test.svg"
+        svg_file.write_text(_MINIMAL_SVG, encoding="utf-8")
+
+        model = _make_simple_circuit()
+        embed_circuit_data(svg_file, model)
+
+        content = svg_file.read_text(encoding="utf-8")
+        # Original SVG content should still be present
+        assert "<rect" in content
+        assert "</svg>" in content
+
+    def test_embed_is_valid_xml(self, tmp_path):
+        import xml.etree.ElementTree as ET
+
+        svg_file = tmp_path / "test.svg"
+        svg_file.write_text(_MINIMAL_SVG, encoding="utf-8")
+
+        model = _make_simple_circuit()
+        embed_circuit_data(svg_file, model)
+
+        content = svg_file.read_text(encoding="utf-8")
+        # Should parse without error
+        root = ET.fromstring(content)
+        assert root.tag.endswith("svg")
+
+
+class TestExtractCircuitData:
+    """Test extracting circuit data from SVG files."""
+
+    def test_round_trip_preserves_components(self, tmp_path):
+        svg_file = tmp_path / "test.svg"
+        svg_file.write_text(_MINIMAL_SVG, encoding="utf-8")
+
+        model = _make_simple_circuit()
+        embed_circuit_data(svg_file, model)
+
+        data = extract_circuit_data(svg_file)
+        assert data is not None
+        reimported = CircuitModel.from_dict(data)
+
+        original_ids = set(model.components.keys())
+        reimported_ids = set(reimported.components.keys())
+        assert original_ids == reimported_ids
+
+    def test_round_trip_preserves_values(self, tmp_path):
+        svg_file = tmp_path / "test.svg"
+        svg_file.write_text(_MINIMAL_SVG, encoding="utf-8")
+
+        model = _make_simple_circuit()
+        embed_circuit_data(svg_file, model)
+
+        data = extract_circuit_data(svg_file)
+        reimported = CircuitModel.from_dict(data)
+
+        assert reimported.components["R1"].value == "1k"
+        assert reimported.components["V1"].value == "5"
+
+    def test_round_trip_preserves_wires(self, tmp_path):
+        svg_file = tmp_path / "test.svg"
+        svg_file.write_text(_MINIMAL_SVG, encoding="utf-8")
+
+        model = _make_simple_circuit()
+        embed_circuit_data(svg_file, model)
+
+        data = extract_circuit_data(svg_file)
+        reimported = CircuitModel.from_dict(data)
+
+        assert len(reimported.wires) == len(model.wires)
+
+    def test_round_trip_preserves_analysis(self, tmp_path):
+        svg_file = tmp_path / "test.svg"
+        svg_file.write_text(_MINIMAL_SVG, encoding="utf-8")
+
+        model = _make_simple_circuit()
+        embed_circuit_data(svg_file, model)
+
+        data = extract_circuit_data(svg_file)
+        assert data["analysis_type"] == "Transient"
+        assert data["analysis_params"]["duration"] == "10m"
+
+    def test_extract_returns_none_for_plain_svg(self, tmp_path):
+        svg_file = tmp_path / "plain.svg"
+        svg_file.write_text(_MINIMAL_SVG, encoding="utf-8")
+
+        data = extract_circuit_data(svg_file)
+        assert data is None
+
+    def test_extract_from_string(self):
+        model = _make_simple_circuit()
+        circuit_dict = model.to_dict()
+
+        import base64
+
+        json_bytes = json.dumps(circuit_dict, separators=(",", ":")).encode("utf-8")
+        b64 = base64.b64encode(json_bytes).decode("ascii")
+
+        svg_with_data = _MINIMAL_SVG.replace(
+            "<rect",
+            f'<metadata xmlns:spice-gui="https://spice-gui.github.io/schema/circuit">'
+            f"<spice-gui:circuit>{b64}</spice-gui:circuit>"
+            f"</metadata>\n<rect",
+        )
+
+        data = extract_circuit_data_from_string(svg_with_data)
+        assert data is not None
+        assert "components" in data
+
+    def test_extract_raises_on_corrupt_data(self, tmp_path):
+        svg_file = tmp_path / "corrupt.svg"
+        corrupt_svg = _MINIMAL_SVG.replace(
+            "<rect",
+            '<metadata xmlns:spice-gui="https://spice-gui.github.io/schema/circuit">'
+            "<spice-gui:circuit>NOT-VALID-BASE64!!!</spice-gui:circuit>"
+            "</metadata>\n<rect",
+        )
+        svg_file.write_text(corrupt_svg, encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Corrupt circuit data"):
+            extract_circuit_data(svg_file)
+
+
+class TestSVGShareableInfrastructure:
+    """Structural tests verifying the SVG export embeds data and import menu exists."""
+
+    def test_export_image_calls_embed(self):
+        """export_image in ViewOperationsMixin should call embed_circuit_data for SVG."""
+        from GUI.main_window_view import ViewOperationsMixin
+
+        source = inspect.getsource(ViewOperationsMixin.export_image)
+        assert "embed_circuit_data" in source
+
+    def test_import_svg_menu_exists(self):
+        """Menu bar should include an 'Import from SVG' action."""
+        from GUI.main_window_menus import MenuBarMixin
+
+        source = inspect.getsource(MenuBarMixin.create_menu_bar)
+        assert "Import from" in source
+        assert "_on_import_svg" in source
+
+    def test_import_svg_handler_exists(self):
+        """FileOperationsMixin should have _on_import_svg method."""
+        from GUI.main_window_file_ops import FileOperationsMixin
+
+        assert hasattr(FileOperationsMixin, "_on_import_svg")
+
+    def test_file_controller_has_import_svg(self):
+        """FileController should have import_svg method."""
+        from controllers.file_controller import FileController
+
+        assert hasattr(FileController, "import_svg")
+
+    def test_svg_viewbox_uses_zero_origin(self):
+        """SVG export should use a zero-origin viewBox for correct rendering."""
+        from GUI.main_window_view import ViewOperationsMixin
+
+        source = inspect.getsource(ViewOperationsMixin.export_image)
+        # Should use QRect(0, 0, ...) not source_rect for viewBox
+        assert "QRect(0, 0," in source
+
+
+class TestNoQtDependencies:
+    """Ensure svg_shareable.py has no Qt imports."""
+
+    def test_no_pyqt_imports(self):
+        from pathlib import Path
+
+        import simulation.svg_shareable as mod
+
+        source = Path(mod.__file__).read_text(encoding="utf-8")
+        assert "PyQt" not in source
+        assert "QtCore" not in source

--- a/app/tests/unit/test_svg_shareable.py
+++ b/app/tests/unit/test_svg_shareable.py
@@ -6,7 +6,6 @@ back, and that the UI wiring for SVG import is in place.
 
 import inspect
 import json
-import textwrap
 
 import pytest
 from models.circuit import CircuitModel
@@ -54,13 +53,11 @@ def _make_simple_circuit():
     return model
 
 
-_MINIMAL_SVG = textwrap.dedent(
-    """\
-    <?xml version="1.0" encoding="UTF-8"?>
-    <svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
-    <rect x="10" y="10" width="100" height="80" fill="none" stroke="black"/>
-    </svg>
-"""
+_MINIMAL_SVG = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">\n'
+    '<rect x="10" y="10" width="100" height="80" fill="none" stroke="black"/>\n'
+    "</svg>\n"
 )
 
 


### PR DESCRIPTION
## Summary
- **Fix SVG export rendering**: Changed viewBox to use zero-origin coordinates (`QRect(0, 0, w, h)`) instead of scene coordinates, and added explicit source→target mapping in `scene.render()`. This fixes the misaligned/improper SVG output reported in the issue.
- **Add shareable SVG export**: SVG exports now embed circuit JSON data (base64-encoded) inside an SVG `<metadata>` element using a custom XML namespace. This enables round-trip import.
- **Add SVG import**: New "Import from SVG..." menu item extracts embedded circuit data from shareable SVGs and loads the circuit.

## Changes
- `app/GUI/main_window_view.py`: Fix SVG viewBox, add antialiasing, embed circuit data after export
- `app/simulation/svg_shareable.py`: New pure-Python module for embedding/extracting circuit JSON in SVG (no Qt dependency)
- `app/controllers/file_controller.py`: Add `import_svg()` method
- `app/GUI/main_window_file_ops.py`: Add `_on_import_svg()` handler
- `app/GUI/main_window_menus.py`: Add "Import from SVG..." menu action
- `app/tests/unit/test_svg_shareable.py`: Comprehensive tests for embed/extract round-trip, structural checks

## Test plan
- [ ] Verify SVG export produces visually correct output (matches PNG export)
- [ ] Verify exported SVG can be re-imported via "Import from SVG..." menu
- [ ] Verify importing a plain SVG (without embedded data) shows an appropriate error message
- [ ] Verify round-trip preserves component IDs, values, wires, and analysis settings
- [ ] Run `pytest` — all existing and new tests should pass

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)