### PR TITLE
fix: counter-flip text labels when component is flipped (#810)

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -370,6 +370,9 @@ class ComponentGraphicsItem(QGraphicsItem):
         )
 
         if show_label or show_value:
+            # Counter-flip so text remains readable when component is flipped
+            if sx != 1 or sy != 1:
+                painter.scale(sx, sy)
             painter.setPen(QPen(color))
             if show_label and show_value:
                 painter.drawText(-20, -25, f"{self.component_id} ({self.value})")
@@ -595,6 +598,9 @@ class Ground(ComponentGraphicsItem):
         )
 
         if show_label or show_value:
+            # Counter-flip so text remains readable when component is flipped
+            if sx != 1 or sy != 1:
+                painter.scale(sx, sy)
             painter.setPen(QPen(color))
             if show_label and show_value:
                 painter.drawText(-20, -25, "GND (0V)")

--- a/app/tests/unit/test_component_label_flip.py
+++ b/app/tests/unit/test_component_label_flip.py
@@ -1,0 +1,193 @@
+"""Tests that component text labels are not mirrored when a component is flipped.
+
+Issue #810: When a component is horizontally flipped (F key), the flip
+transform was being applied to the text label, making it unreadable.
+The fix applies a counter-scale before drawing text so labels remain
+in their original orientation regardless of component flip state.
+"""
+
+import ast
+import inspect
+import textwrap
+
+import pytest
+
+
+def _get_paint_source(cls):
+    """Return dedented source of a class's paint method."""
+    return textwrap.dedent(inspect.getsource(cls.paint))
+
+
+def _find_call_indices(source, method_name):
+    """Return line indices where painter.<method_name>(...) appears."""
+    indices = []
+    for i, line in enumerate(source.splitlines()):
+        stripped = line.strip()
+        if f"painter.{method_name}(" in stripped:
+            indices.append(i)
+    return indices
+
+
+class TestLabelCounterFlipStructural:
+    """Structural tests verifying the paint method counter-flips text.
+
+    These parse paint() source code to ensure the counter-scale call
+    appears between the initial flip-scale and drawText.
+    """
+
+    def test_base_paint_applies_counter_scale_before_drawText(self):
+        """ComponentGraphicsItem.paint() must re-apply scale() before drawText()."""
+        from GUI.component_item import ComponentGraphicsItem
+
+        src = _get_paint_source(ComponentGraphicsItem)
+        scale_indices = _find_call_indices(src, "scale")
+        drawtext_indices = _find_call_indices(src, "drawText")
+
+        assert len(scale_indices) >= 2, "Must have initial scale + counter-scale calls"
+        assert len(drawtext_indices) >= 1, "Must have drawText() call"
+        assert scale_indices[1] < drawtext_indices[0], "Counter-scale must come before first drawText"
+
+    def test_ground_paint_applies_counter_scale_before_drawText(self):
+        """Ground.paint() must re-apply scale() before drawText()."""
+        from GUI.component_item import Ground
+
+        src = _get_paint_source(Ground)
+        scale_indices = _find_call_indices(src, "scale")
+        drawtext_indices = _find_call_indices(src, "drawText")
+
+        assert len(scale_indices) >= 2, "Must have initial scale + counter-scale calls"
+        assert len(drawtext_indices) >= 1, "Must have drawText() call"
+        assert scale_indices[1] < drawtext_indices[0], "Counter-scale must come before first drawText"
+
+
+class TestLabelCounterFlipPainter:
+    """Tests using a mock painter to verify counter-flip behaviour."""
+
+    @pytest.fixture
+    def _make_item(self):
+        """Factory for component items with a mock canvas."""
+        from unittest.mock import MagicMock
+
+        from GUI.component_item import ComponentGraphicsItem, Ground
+
+        def factory(cls_or_type, comp_id, **kwargs):
+            if cls_or_type is Ground:
+                item = Ground(comp_id)
+            else:
+                item = ComponentGraphicsItem(comp_id, cls_or_type)
+            # Inject a mock canvas that enables labels
+            mock_canvas = MagicMock()
+            mock_canvas.show_component_labels = True
+            mock_canvas.show_component_values = True
+            item.canvas = mock_canvas
+            for k, v in kwargs.items():
+                setattr(item, k, v)
+            return item
+
+        return factory
+
+    def _collect_scale_calls_around_drawText(self, item, flip_h=False, flip_v=False):
+        """Paint the item with a tracking painter, return scale calls around drawText."""
+        from unittest.mock import MagicMock
+
+        item.model.flip_h = flip_h
+        item.model.flip_v = flip_v
+
+        painter = MagicMock()
+        call_log = []
+
+        def track_scale(*args):
+            call_log.append(("scale", args))
+
+        def track_drawText(*args):
+            call_log.append(("drawText", args))
+
+        painter.scale = track_scale
+        painter.drawText = track_drawText
+
+        item.paint(painter)
+        return call_log
+
+    def test_no_flip_no_counter_scale(self, _make_item):
+        """When not flipped, no scale() should be called."""
+        from GUI.component_item import ComponentGraphicsItem
+
+        item = _make_item(ComponentGraphicsItem, "R1")
+        log = self._collect_scale_calls_around_drawText(item, flip_h=False, flip_v=False)
+        scale_calls = [e for e in log if e[0] == "scale"]
+        assert len(scale_calls) == 0, "No scale calls when component is not flipped"
+
+    def test_flip_h_counter_scale_before_text(self, _make_item):
+        """When flip_h is True, scale(-1,1) must be called twice -- once for the
+        flip transform and once to undo it before drawing text."""
+        from GUI.component_item import ComponentGraphicsItem
+
+        item = _make_item(ComponentGraphicsItem, "R1")
+        log = self._collect_scale_calls_around_drawText(item, flip_h=True)
+
+        scale_calls = [e for e in log if e[0] == "scale"]
+        drawtext_calls = [e for e in log if e[0] == "drawText"]
+
+        assert len(scale_calls) == 2, "Must have flip + counter-flip scale calls"
+        assert len(drawtext_calls) >= 1, "Must draw text"
+
+        # Both scale calls should be (-1, 1)
+        for sc in scale_calls:
+            assert sc[1] == (-1, 1), f"Expected scale(-1, 1), got scale{sc[1]}"
+
+        # Counter-scale must precede drawText
+        scale_indices = [i for i, e in enumerate(log) if e[0] == "scale"]
+        text_indices = [i for i, e in enumerate(log) if e[0] == "drawText"]
+        assert scale_indices[1] < text_indices[0], "Counter-scale must precede drawText"
+
+    def test_flip_v_counter_scale_before_text(self, _make_item):
+        """When flip_v is True, scale(1,-1) is called twice."""
+        from GUI.component_item import ComponentGraphicsItem
+
+        item = _make_item(ComponentGraphicsItem, "R1")
+        log = self._collect_scale_calls_around_drawText(item, flip_v=True)
+
+        scale_calls = [e for e in log if e[0] == "scale"]
+        assert len(scale_calls) == 2
+        for sc in scale_calls:
+            assert sc[1] == (1, -1)
+
+    def test_flip_both_counter_scale_before_text(self, _make_item):
+        """When both flip_h and flip_v are True, scale(-1,-1) is called twice."""
+        from GUI.component_item import ComponentGraphicsItem
+
+        item = _make_item(ComponentGraphicsItem, "R1")
+        log = self._collect_scale_calls_around_drawText(item, flip_h=True, flip_v=True)
+
+        scale_calls = [e for e in log if e[0] == "scale"]
+        assert len(scale_calls) == 2
+        for sc in scale_calls:
+            assert sc[1] == (-1, -1)
+
+    def test_ground_flip_h_counter_scale(self, _make_item):
+        """Ground component also counter-flips text when flip_h is True."""
+        from GUI.component_item import Ground
+
+        item = _make_item(Ground, "GND1")
+        log = self._collect_scale_calls_around_drawText(item, flip_h=True)
+
+        scale_calls = [e for e in log if e[0] == "scale"]
+        drawtext_calls = [e for e in log if e[0] == "drawText"]
+
+        assert len(scale_calls) == 2
+        assert len(drawtext_calls) >= 1
+        scale_indices = [i for i, e in enumerate(log) if e[0] == "scale"]
+        text_indices = [i for i, e in enumerate(log) if e[0] == "drawText"]
+        assert scale_indices[1] < text_indices[0]
+
+    @pytest.mark.parametrize(
+        "comp_type",
+        ["Resistor", "Capacitor", "Inductor", "Voltage Source", "Current Source"],
+    )
+    def test_multiple_component_types_flip_h(self, _make_item, comp_type):
+        """Counter-flip works for various component types (all use base paint)."""
+        item = _make_item(comp_type, "X1")
+        log = self._collect_scale_calls_around_drawText(item, flip_h=True)
+
+        scale_calls = [e for e in log if e[0] == "scale"]
+        assert len(scale_calls) == 2, f"{comp_type} must have counter-flip"

--- a/app/tests/unit/test_component_label_flip.py
+++ b/app/tests/unit/test_component_label_flip.py
@@ -6,7 +6,6 @@ The fix applies a counter-scale before drawing text so labels remain
 in their original orientation regardless of component flip state.
 """
 
-import ast
 import inspect
 import textwrap
 
@@ -110,9 +109,7 @@ class TestLabelCounterFlipPainter:
 
     def test_no_flip_no_counter_scale(self, _make_item):
         """When not flipped, no scale() should be called."""
-        from GUI.component_item import ComponentGraphicsItem
-
-        item = _make_item(ComponentGraphicsItem, "R1")
+        item = _make_item("Resistor", "R1")
         log = self._collect_scale_calls_around_drawText(item, flip_h=False, flip_v=False)
         scale_calls = [e for e in log if e[0] == "scale"]
         assert len(scale_calls) == 0, "No scale calls when component is not flipped"
@@ -120,9 +117,7 @@ class TestLabelCounterFlipPainter:
     def test_flip_h_counter_scale_before_text(self, _make_item):
         """When flip_h is True, scale(-1,1) must be called twice -- once for the
         flip transform and once to undo it before drawing text."""
-        from GUI.component_item import ComponentGraphicsItem
-
-        item = _make_item(ComponentGraphicsItem, "R1")
+        item = _make_item("Resistor", "R1")
         log = self._collect_scale_calls_around_drawText(item, flip_h=True)
 
         scale_calls = [e for e in log if e[0] == "scale"]
@@ -142,9 +137,7 @@ class TestLabelCounterFlipPainter:
 
     def test_flip_v_counter_scale_before_text(self, _make_item):
         """When flip_v is True, scale(1,-1) is called twice."""
-        from GUI.component_item import ComponentGraphicsItem
-
-        item = _make_item(ComponentGraphicsItem, "R1")
+        item = _make_item("Resistor", "R1")
         log = self._collect_scale_calls_around_drawText(item, flip_v=True)
 
         scale_calls = [e for e in log if e[0] == "scale"]
@@ -154,9 +147,7 @@ class TestLabelCounterFlipPainter:
 
     def test_flip_both_counter_scale_before_text(self, _make_item):
         """When both flip_h and flip_v are True, scale(-1,-1) is called twice."""
-        from GUI.component_item import ComponentGraphicsItem
-
-        item = _make_item(ComponentGraphicsItem, "R1")
+        item = _make_item("Resistor", "R1")
         log = self._collect_scale_calls_around_drawText(item, flip_h=True, flip_v=True)
 
         scale_calls = [e for e in log if e[0] == "scale"]


### PR DESCRIPTION
## Summary - When a component is horizontally or vertically flipped (F key), the text label was also being flipped/mirrored, making it unreadable - Fixed by applying a counter-scale transform ( a second time) before drawing text labels, which undoes the flip for text while keeping the component body correctly flipped - Applied the fix to both  and  (the only two paint methods that draw text labels) Closes #810 ## Test plan - [x] Added structural tests verifying the counter-scale call appears before  in both  and  - [x] Added mock painter tests verifying scale is called twice (flip + counter-flip) when flip_h/flip_v is True, and counter-scale precedes text drawing - [x] Parametrized tests across multiple component types (Resistor, Capacitor, Inductor, Voltage Source, Current Source) - [x] Tests cover flip_h only, flip_v only, and both flip_h + flip_v - [ ] Human testing: Open Low Pass Filter example, select voltage source, press F to flip — verify text label remains readable and is not mirrored 🤖 Generated with [Claude Code](https://claude.com/claude-code)