### PR TITLE
fix: force scene repaint after wire deletion to remove orphaned node dots (#812)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -316,6 +316,10 @@ class CircuitCanvasView(QGraphicsView):
             # Reroute remaining wires connected to the same components —
             # they may have been routed around the now-deleted wire.
             self._reroute_wires_near_components(affected_components)
+            # Force full repaint so foreground node labels/dots are refreshed.
+            # Without this, stale node annotations remain as ghost artifacts
+            # when the deleted wire's node is removed from the model.
+            self.scene.update()
 
     def _handle_wire_routed(self, data) -> None:
         """Update wire waypoints"""

--- a/app/tests/unit/test_wire_deletion.py
+++ b/app/tests/unit/test_wire_deletion.py
@@ -53,6 +53,16 @@ class TestWireDeletionModelSync:
         for node in model.nodes:
             assert len(node.wires) == 0 or all(w in model.wires for w in node.wires)
 
+    def test_remove_only_wire_leaves_no_nodes(self):
+        """Deleting the only wire should leave no nodes (no orphaned node dots)."""
+        model, ctrl, r1, r2 = _make_circuit_with_wire()
+        assert len(model.nodes) == 1
+
+        ctrl.remove_wire(0)
+
+        assert len(model.nodes) == 0
+        assert len(model.terminal_to_node) == 0
+
 
 class TestWireDeletionUndoRedo:
     """Wire deletion via command must support Ctrl+Z / Ctrl+Y."""
@@ -85,6 +95,34 @@ class TestWireDeletionUndoRedo:
 
         ctrl.redo()
         assert len(model.wires) == 0
+
+    def test_undo_restores_node(self):
+        """Undoing wire deletion should restore the node (no orphaned dots)."""
+        model, ctrl, r1, r2 = _make_circuit_with_wire()
+        assert len(model.nodes) == 1
+
+        cmd = DeleteWireCommand(ctrl, 0)
+        ctrl.execute_command(cmd)
+        assert len(model.nodes) == 0
+
+        ctrl.undo()
+        assert len(model.nodes) == 1
+        # Both terminals should be mapped back to the restored node
+        assert (r1.component_id, 1) in model.terminal_to_node
+        assert (r2.component_id, 0) in model.terminal_to_node
+
+    def test_redo_removes_node_again(self):
+        """Redo of wire deletion should re-remove the node cleanly."""
+        model, ctrl, r1, r2 = _make_circuit_with_wire()
+
+        cmd = DeleteWireCommand(ctrl, 0)
+        ctrl.execute_command(cmd)
+        ctrl.undo()
+        assert len(model.nodes) == 1
+
+        ctrl.redo()
+        assert len(model.nodes) == 0
+        assert len(model.terminal_to_node) == 0
 
     def test_undo_description(self):
         model, ctrl, r1, r2 = _make_circuit_with_wire()


### PR DESCRIPTION
## Summary - Adds  call in  after node sync, ensuring the foreground (node labels/dots) is fully repainted when a wire is deleted - Without this, stale node annotations remained as ghost artifacts because  only calls  when wires are actually rerouted - Adds model-level tests confirming nodes are properly cleaned up on wire deletion and correctly restored/removed on undo/redo ## Test plan - [x] Model tests verify no orphaned nodes remain after wire deletion - [x] Model tests verify undo restores nodes, redo re-removes them - [ ] Manual: connect two components with a wire, delete it, verify no ghost dots remain - [ ] Manual: undo the deletion, verify the node label reappears; redo, verify it disappears Closes #812 🤖 Generated with [Claude Code](https://claude.com/claude-code)