### PR TITLE
fix: route all GUI mutations through undo/redo command queue (#814)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -617,9 +617,12 @@ class CircuitCanvasView(QGraphicsView):
             grid_x = round(scene_pos.x() / GRID_SIZE) * GRID_SIZE
             grid_y = round(scene_pos.y() / GRID_SIZE) * GRID_SIZE
 
-            # Controller handles component creation, observer creates graphics item
-            component_data = self.controller.add_component(component_type, (grid_x, grid_y))
-            self.componentAdded.emit(component_data.component_id)
+            from controllers.commands import AddComponentCommand
+
+            cmd = AddComponentCommand(self.controller, component_type, (grid_x, grid_y))
+            self.controller.execute_command(cmd)
+            if cmd.component_id:
+                self.componentAdded.emit(cmd.component_id)
 
             event.acceptProposedAction()
 
@@ -639,9 +642,12 @@ class CircuitCanvasView(QGraphicsView):
         grid_x = round(scene_pos.x() / GRID_SIZE) * GRID_SIZE
         grid_y = round(scene_pos.y() / GRID_SIZE) * GRID_SIZE
 
-        # Controller handles component creation, observer creates graphics item
-        component_data = self.controller.add_component(component_type, (grid_x, grid_y))
-        self.componentAdded.emit(component_data.component_id)
+        from controllers.commands import AddComponentCommand
+
+        cmd = AddComponentCommand(self.controller, component_type, (grid_x, grid_y))
+        self.controller.execute_command(cmd)
+        if cmd.component_id:
+            self.componentAdded.emit(cmd.component_id)
 
     def mousePressEvent(self, event):
         """Handle wire drawing, probe mode, and component selection"""
@@ -734,14 +740,18 @@ class CircuitCanvasView(QGraphicsView):
                                         + [(wp.x(), wp.y()) for wp in self._wire_waypoints]
                                         + [(end_pos.x(), end_pos.y())]
                                     )
-                                # Controller creates wire, observer creates graphics item
-                                self.controller.add_wire(
+
+                                from controllers.commands import AddWireCommand
+
+                                cmd = AddWireCommand(
+                                    self.controller,
                                     self.wire_start_comp.component_id,
                                     self.wire_start_term,
                                     clicked_component.component_id,
                                     target_term,
                                     waypoints=manual_wps,
                                 )
+                                self.controller.execute_command(cmd)
                                 self.wireAdded.emit(
                                     self.wire_start_comp.component_id,
                                     clicked_component.component_id,
@@ -1015,24 +1025,52 @@ class CircuitCanvasView(QGraphicsView):
             menu.exec(self.mapToGlobal(position))
 
     def delete_selected(self):
-        """Delete all selected items"""
+        """Delete all selected items as a single undoable operation."""
         selected_items = self.scene.selectedItems()
         if not selected_items:
             return
+        if not self.controller:
+            return
+
+        from controllers.commands import (
+            CompoundCommand,
+            DeleteAnnotationCommand,
+            DeleteComponentCommand,
+            DeleteWireCommand,
+        )
 
         components_to_delete = [item for item in selected_items if isinstance(item, ComponentGraphicsItem)]
         wires_to_delete = [item for item in selected_items if isinstance(item, WireItem)]
         annotations_to_delete = [item for item in selected_items if isinstance(item, AnnotationItem)]
 
-        for comp in components_to_delete:
-            self.delete_component(comp)
+        # Collect component IDs being deleted so we skip their cascaded wires
+        deleting_comp_ids = {comp.component_id for comp in components_to_delete}
 
+        commands = []
+
+        # Delete standalone wires first (skip wires that will cascade from component deletion)
         for wire in wires_to_delete:
             if wire in self.wires:
-                self.delete_wire(wire)
+                wire_model = self.controller.model.wires[self.wires.index(wire)]
+                if (
+                    wire_model.start_component_id in deleting_comp_ids
+                    or wire_model.end_component_id in deleting_comp_ids
+                ):
+                    continue  # Will be cascade-deleted with the component
+                commands.append(DeleteWireCommand(self.controller, self.wires.index(wire)))
+
+        for comp in components_to_delete:
+            commands.append(DeleteComponentCommand(self.controller, comp.component_id))
 
         for ann in annotations_to_delete:
-            self._delete_annotation(ann)
+            if ann in self.annotations:
+                commands.append(DeleteAnnotationCommand(self.controller, self.annotations.index(ann)))
+
+        if len(commands) == 1:
+            self.controller.execute_command(commands[0])
+        elif commands:
+            compound = CompoundCommand(commands, f"Delete {len(commands)} items")
+            self.controller.execute_command(compound)
 
     def delete_component(self, component):
         """Delete a component and all connected wires via undo/redo command."""
@@ -1114,41 +1152,66 @@ class CircuitCanvasView(QGraphicsView):
             self.controller.execute_command(compound)
 
     def rotate_component(self, component, clockwise=True):
-        """Rotate a single component."""
+        """Rotate a single component via undo/redo command."""
         if component is None or not isinstance(component, ComponentGraphicsItem):
             return
         if not self.controller:
             logger.warning("Cannot rotate component: no controller available")
             return
 
-        # Controller handles rotation, observer updates graphics and wires
-        self.controller.rotate_component(component.component_id, clockwise)
+        from controllers.commands import RotateComponentCommand
+
+        cmd = RotateComponentCommand(self.controller, component.component_id, clockwise)
+        self.controller.execute_command(cmd)
 
     def rotate_selected(self, clockwise=True):
-        """Rotate all selected components"""
+        """Rotate all selected components as a single undoable operation."""
+        if not self.controller:
+            return
         selected_items = self.scene.selectedItems()
         components = [item for item in selected_items if isinstance(item, ComponentGraphicsItem)]
+        if not components:
+            return
 
-        for comp in components:
-            self.rotate_component(comp, clockwise)
+        from controllers.commands import CompoundCommand, RotateComponentCommand
+
+        commands = [RotateComponentCommand(self.controller, comp.component_id, clockwise) for comp in components]
+        if len(commands) == 1:
+            self.controller.execute_command(commands[0])
+        else:
+            compound = CompoundCommand(commands, f"Rotate {len(commands)} components")
+            self.controller.execute_command(compound)
 
     def flip_component(self, component, horizontal=True):
-        """Flip a single component - uses controller"""
+        """Flip a single component via undo/redo command."""
         if component is None or not isinstance(component, ComponentGraphicsItem):
             return
         if not self.controller:
             logger.warning("Cannot flip component: no controller available")
             return
 
-        self.controller.flip_component(component.component_id, horizontal)
+        from controllers.commands import FlipComponentCommand
+
+        cmd = FlipComponentCommand(self.controller, component.component_id, horizontal)
+        self.controller.execute_command(cmd)
 
     def flip_selected(self, horizontal=True):
-        """Flip all selected components"""
+        """Flip all selected components as a single undoable operation."""
+        if not self.controller:
+            return
         selected_items = self.scene.selectedItems()
         components = [item for item in selected_items if isinstance(item, ComponentGraphicsItem)]
+        if not components:
+            return
 
-        for comp in components:
-            self.flip_component(comp, horizontal)
+        from controllers.commands import CompoundCommand, FlipComponentCommand
+
+        commands = [FlipComponentCommand(self.controller, comp.component_id, horizontal) for comp in components]
+        if len(commands) == 1:
+            self.controller.execute_command(commands[0])
+        else:
+            compound = CompoundCommand(commands, f"Flip {len(commands)} components")
+            self.controller.execute_command(compound)
 
     def add_annotation(self, scene_pos=None):
         """Add a text annotation at the given scene position (or viewport center)."""

--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -362,7 +362,10 @@ class MainWindow(
     def on_property_changed(self, component_id, property_name, new_value):
         """Handle property changes from properties panel via controller."""
         if property_name == "value":
-            self.circuit_ctrl.update_component_value(component_id, new_value)
+            from controllers.commands import ChangeValueCommand
+
+            cmd = ChangeValueCommand(self.circuit_ctrl, component_id, new_value)
+            self.circuit_ctrl.execute_command(cmd)
             statusBar = self.statusBar()
             if statusBar:
                 statusBar.showMessage(f"Updated {component_id} value to {new_value}", 2000)

--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -41,22 +41,40 @@ class FileOperationsMixin:
                 statusBar.showMessage(f"Copied {n} component{'s' if n != 1 else ''}", 2000)
 
     def cut_selected(self):
-        """Cut selected components to internal clipboard."""
+        """Cut selected components to internal clipboard (copy + undoable delete)."""
         ids = self.canvas.get_selected_component_ids()
         if ids:
-            self.circuit_ctrl.cut_components(ids)
+            # Copy to clipboard first (non-destructive)
+            self.circuit_ctrl.copy_components(ids)
+
+            # Delete via command so it's undoable
+            from controllers.commands import CompoundCommand, DeleteComponentCommand
+
+            commands = [DeleteComponentCommand(self.circuit_ctrl, comp_id) for comp_id in ids]
+            if len(commands) == 1:
+                self.circuit_ctrl.execute_command(commands[0])
+            else:
+                compound = CompoundCommand(commands, f"Cut {len(commands)} components")
+                self.circuit_ctrl.execute_command(compound)
 
     def paste_components(self):
-        """Paste components from internal clipboard."""
-        new_comps, new_wires = self.circuit_ctrl.paste_components()
-        if new_comps:
+        """Paste components from internal clipboard via undo/redo command."""
+        if not self.circuit_ctrl.has_clipboard_content():
+            return
+
+        from controllers.commands import PasteCommand
+
+        cmd = PasteCommand(self.circuit_ctrl)
+        self.circuit_ctrl.execute_command(cmd)
+
+        if cmd.pasted_component_ids:
             # Select newly pasted items on the canvas
             self.canvas.scene.clearSelection()
-            for comp_data in new_comps:
-                comp_item = self.canvas.components.get(comp_data.component_id)
+            for comp_id in cmd.pasted_component_ids:
+                comp_item = self.canvas.components.get(comp_id)
                 if comp_item is not None:
                     comp_item.setSelected(True)
-            n = len(new_comps)
+            n = len(cmd.pasted_component_ids)
             statusBar = self.statusBar()
             if statusBar:
                 statusBar.showMessage(f"Pasted {n} component{'s' if n != 1 else ''}", 2000)

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -213,7 +213,7 @@ class ViewOperationsMixin:
     # Dirty flag (unsaved changes indicator)
 
     def _on_dirty_change(self, event: str, data) -> None:
-        """Mark circuit as dirty on model-modifying events."""
+        """Mark circuit as dirty on model-modifying events and refresh undo/redo menu."""
         dirty_events = {
             "component_added",
             "component_removed",
@@ -230,6 +230,9 @@ class ViewOperationsMixin:
             self._set_dirty(True)
         elif event in ("circuit_cleared", "model_loaded"):
             self._set_dirty(False)
+
+        if event == "undo_state_changed":
+            self._update_undo_redo_actions()
 
         # Sync palette "Used in File" when components change
         if event in (

--- a/app/controllers/circuit_controller.py
+++ b/app/controllers/circuit_controller.py
@@ -514,6 +514,7 @@ class CircuitController:
             command: A Command instance to execute
         """
         self.undo_manager.execute(command)
+        self._notify("undo_state_changed", None)
 
     def push_already_executed(self, command) -> None:
         """Push a pre-executed command onto the undo stack.
@@ -531,7 +532,10 @@ class CircuitController:
         Returns:
             True if an action was undone, False otherwise
         """
-        return self.undo_manager.undo()
+        result = self.undo_manager.undo()
+        if result:
+            self._notify("undo_state_changed", None)
+        return result
 
     def redo(self) -> bool:
         """
@@ -540,7 +544,10 @@ class CircuitController:
         Returns:
             True if an action was redone, False otherwise
         """
-        return self.undo_manager.redo()
+        result = self.undo_manager.redo()
+        if result:
+            self._notify("undo_state_changed", None)
+        return result
 
     def can_undo(self) -> bool:
         """Return whether there are commands to undo."""

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -94,6 +94,8 @@ class FileController:
         """Clear the circuit and reset file state."""
         self.model.clear()
         self.current_file = None
+        if self.circuit_ctrl:
+            self.circuit_ctrl.clear_undo_history()
 
     def save_circuit(self, filepath) -> None:
         """
@@ -153,6 +155,7 @@ class FileController:
         self.add_recent_file(filepath)
 
         if self.circuit_ctrl:
+            self.circuit_ctrl.clear_undo_history()
             self.circuit_ctrl._notify("model_loaded", None)
 
     def load_from_dict(self, data: dict) -> None:
@@ -165,6 +168,7 @@ class FileController:
         self._replace_model(new_model)
 
         if self.circuit_ctrl:
+            self.circuit_ctrl.clear_undo_history()
             self.circuit_ctrl._notify("model_loaded", None)
 
     def has_file(self) -> bool:

--- a/app/tests/unit/test_annotation_undo.py
+++ b/app/tests/unit/test_annotation_undo.py
@@ -197,8 +197,8 @@ class TestCanvasAnnotationUndoIntegration:
 
         assert _source_uses_name(CircuitCanvasView._delete_annotation, "DeleteAnnotationCommand")
 
-    def test_delete_selected_delegates_to_delete_annotation(self):
-        """delete_selected should call _delete_annotation for annotations."""
+    def test_delete_selected_uses_delete_annotation_command(self):
+        """delete_selected should use DeleteAnnotationCommand for annotations."""
         from GUI.circuit_canvas import CircuitCanvasView
 
-        assert _source_uses_name(CircuitCanvasView.delete_selected, "_delete_annotation")
+        assert _source_uses_name(CircuitCanvasView.delete_selected, "DeleteAnnotationCommand")

--- a/app/tests/unit/test_undo_redo.py
+++ b/app/tests/unit/test_undo_redo.py
@@ -778,3 +778,225 @@ class TestStaleStateValidation:
         cmd = RerouteWireCommand(controller, 99)
         cmd.execute()
         cmd.undo()
+
+
+# ===========================================================================
+# Full Workflow Integration Tests (#814)
+# ===========================================================================
+
+
+class TestFullUndoRedoWorkflow:
+    """Issue #814: verify all model-mutating operations are undoable via controller."""
+
+    def test_add_component_undoable(self):
+        """Adding a component via execute_command is fully undoable."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+
+        cmd = AddComponentCommand(ctrl, "Resistor", (0, 0))
+        ctrl.execute_command(cmd)
+
+        assert len(model.components) == 1
+        assert ctrl.can_undo()
+
+        ctrl.undo()
+        assert len(model.components) == 0
+
+        ctrl.redo()
+        assert len(model.components) == 1
+
+    def test_add_wire_undoable(self):
+        """Adding a wire via execute_command is fully undoable."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        r1 = ctrl.add_component("Resistor", (0, 0))
+        r2 = ctrl.add_component("Resistor", (200, 0))
+
+        cmd = AddWireCommand(ctrl, r1.component_id, 1, r2.component_id, 0)
+        ctrl.execute_command(cmd)
+
+        assert len(model.wires) == 1
+        assert len(model.nodes) == 1
+
+        ctrl.undo()
+        assert len(model.wires) == 0
+        assert len(model.nodes) == 0
+
+        ctrl.redo()
+        assert len(model.wires) == 1
+        assert len(model.nodes) == 1
+
+    def test_add_wire_with_waypoints_undoable(self):
+        """Wire undo must preserve original waypoints on redo."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        r1 = ctrl.add_component("Resistor", (0, 0))
+        r2 = ctrl.add_component("Resistor", (200, 0))
+
+        waypoints = [(0.0, 0.0), (50.0, 50.0), (200.0, 0.0)]
+        cmd = AddWireCommand(ctrl, r1.component_id, 1, r2.component_id, 0, waypoints=waypoints)
+        ctrl.execute_command(cmd)
+
+        assert model.wires[0].waypoints == waypoints
+
+        ctrl.undo()
+        assert len(model.wires) == 0
+
+        ctrl.redo()
+        assert len(model.wires) == 1
+        assert model.wires[0].waypoints == waypoints
+
+    def test_rotate_component_undoable(self):
+        """Rotating a component via execute_command is fully undoable."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Resistor", (0, 0))
+
+        cmd = RotateComponentCommand(ctrl, comp.component_id, clockwise=True)
+        ctrl.execute_command(cmd)
+        assert model.components[comp.component_id].rotation == 90
+
+        ctrl.undo()
+        assert model.components[comp.component_id].rotation == 0
+
+        ctrl.redo()
+        assert model.components[comp.component_id].rotation == 90
+
+    def test_flip_component_undoable(self):
+        """Flipping a component via execute_command is fully undoable."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Resistor", (0, 0))
+
+        cmd = FlipComponentCommand(ctrl, comp.component_id, horizontal=True)
+        ctrl.execute_command(cmd)
+        assert model.components[comp.component_id].flip_h is True
+
+        ctrl.undo()
+        assert model.components[comp.component_id].flip_h is False
+
+        ctrl.redo()
+        assert model.components[comp.component_id].flip_h is True
+
+    def test_change_value_undoable(self):
+        """Changing a value via execute_command is fully undoable."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Resistor", (0, 0))
+        original = comp.value
+
+        cmd = ChangeValueCommand(ctrl, comp.component_id, "47k")
+        ctrl.execute_command(cmd)
+        assert model.components[comp.component_id].value == "47k"
+
+        ctrl.undo()
+        assert model.components[comp.component_id].value == original
+
+        ctrl.redo()
+        assert model.components[comp.component_id].value == "47k"
+
+    def test_paste_undoable(self):
+        """Pasting components via execute_command is fully undoable."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        r1 = ctrl.add_component("Resistor", (0, 0))
+        ctrl.copy_components([r1.component_id])
+
+        cmd = PasteCommand(ctrl, offset=(40, 40))
+        ctrl.execute_command(cmd)
+        assert len(model.components) == 2
+
+        ctrl.undo()
+        assert len(model.components) == 1
+
+        ctrl.redo()
+        assert len(model.components) == 2
+
+    def test_compound_rotate_multiple_undoable(self):
+        """Rotating multiple components in a compound command undoes as one step."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        r1 = ctrl.add_component("Resistor", (0, 0))
+        r2 = ctrl.add_component("Resistor", (200, 0))
+
+        commands = [
+            RotateComponentCommand(ctrl, r1.component_id, clockwise=True),
+            RotateComponentCommand(ctrl, r2.component_id, clockwise=True),
+        ]
+        compound = CompoundCommand(commands, "Rotate 2 components")
+        ctrl.execute_command(compound)
+
+        assert model.components[r1.component_id].rotation == 90
+        assert model.components[r2.component_id].rotation == 90
+
+        ctrl.undo()
+        assert model.components[r1.component_id].rotation == 0
+        assert model.components[r2.component_id].rotation == 0
+
+    def test_compound_delete_undoable(self):
+        """Deleting multiple items in a compound command undoes as one step."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        r1 = ctrl.add_component("Resistor", (0, 0))
+        r2 = ctrl.add_component("Resistor", (200, 0))
+        ctrl.add_wire(r1.component_id, 1, r2.component_id, 0)
+
+        commands = [
+            DeleteComponentCommand(ctrl, r1.component_id),
+            DeleteComponentCommand(ctrl, r2.component_id),
+        ]
+        compound = CompoundCommand(commands, "Delete 2 components")
+        ctrl.execute_command(compound)
+
+        assert len(model.components) == 0
+        assert len(model.wires) == 0
+
+        ctrl.undo()
+        assert len(model.components) == 2
+
+    def test_undo_state_changed_notification(self):
+        """execute_command, undo, and redo all fire undo_state_changed."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        events = []
+        ctrl.add_observer(lambda event, data: events.append(event))
+
+        cmd = AddComponentCommand(ctrl, "Resistor", (0, 0))
+        ctrl.execute_command(cmd)
+        assert "undo_state_changed" in events
+
+        events.clear()
+        ctrl.undo()
+        assert "undo_state_changed" in events
+
+        events.clear()
+        ctrl.redo()
+        assert "undo_state_changed" in events
+
+    def test_mixed_operation_undo_stack_order(self):
+        """Multiple different operations undo in correct LIFO order."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+
+        # 1. Add component
+        cmd1 = AddComponentCommand(ctrl, "Resistor", (0, 0))
+        ctrl.execute_command(cmd1)
+        comp_id = cmd1.component_id
+
+        # 2. Change its value
+        cmd2 = ChangeValueCommand(ctrl, comp_id, "10k")
+        ctrl.execute_command(cmd2)
+
+        # 3. Rotate it
+        cmd3 = RotateComponentCommand(ctrl, comp_id, clockwise=True)
+        ctrl.execute_command(cmd3)
+
+        # Undo in reverse: rotation, value, addition
+        ctrl.undo()  # undo rotate
+        assert model.components[comp_id].rotation == 0
+
+        ctrl.undo()  # undo value change
+        assert model.components[comp_id].value != "10k"
+
+        ctrl.undo()  # undo add
+        assert len(model.components) == 0


### PR DESCRIPTION
## Summary - Routes all model-mutating canvas operations through undoable Command objects, making Ctrl+Z/Ctrl+Y functional for every operation - Previously, add component, add wire, rotate, flip, value edit, paste, and cut all bypassed the command queue - Groups multi-item operations (delete selected, rotate selected, flip selected) into single CompoundCommand undo steps - Clears undo/redo stacks on new file and load operations - Fires undo_state_changed notification so the Edit menu updates after every command ## Operations now covered | Operation | Command | Status | |-----------|---------|--------| | Add component (drop/palette) | AddComponentCommand | NEW | | Add wire | AddWireCommand | NEW | | Rotate component | RotateComponentCommand | NEW | | Flip component | FlipComponentCommand | NEW | | Change value | ChangeValueCommand | NEW | | Paste | PasteCommand | NEW | | Cut | copy + CompoundCommand(Delete) | NEW | | Delete selected | CompoundCommand | IMPROVED (single undo step) | | Delete component | DeleteComponentCommand | Already worked | | Delete wire | DeleteWireCommand | Already worked | | Move component | MoveComponentCommand | Already worked | ## Test plan - [x] 10 model-level integration tests verify undo/redo for all operations - [x] Tests verify LIFO ordering of mixed operations - [x] Tests verify undo_state_changed notification fires correctly - [x] Tests verify wire waypoints are preserved through undo/redo cycles - [x] Format and lint pass - [ ] Manual: add component, Ctrl+Z removes it, Ctrl+Y restores it - [ ] Manual: draw wire, Ctrl+Z removes it - [ ] Manual: rotate/flip component, Ctrl+Z undoes it - [ ] Manual: edit value, Ctrl+Z restores old value - [ ] Manual: paste components, Ctrl+Z removes pasted items - [ ] Manual: select multiple items, Delete, single Ctrl+Z restores all Closes #814, closes #813 🤖 Generated with [Claude Code](https://claude.com/claude-code)