### PR TITLE
fix: route properties-panel mutations through undo queue (#819)

### DIFF
--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -371,7 +371,10 @@ class MainWindow(
                 statusBar.showMessage(f"Updated {component_id} value to {new_value}", 2000)
 
         elif property_name == "rotation":
-            self.circuit_ctrl.set_component_rotation(component_id, new_value)
+            from controllers.commands import SetRotationCommand
+
+            cmd = SetRotationCommand(self.circuit_ctrl, component_id, new_value)
+            self.circuit_ctrl.execute_command(cmd)
             statusBar = self.statusBar()
             if statusBar:
                 statusBar.showMessage(f"Rotated {component_id} to {new_value}°", 2000)
@@ -380,8 +383,11 @@ class MainWindow(
                 self.properties_panel.show_component(component)
 
         elif property_name == "waveform":
+            from controllers.commands import UpdateWaveformCommand
+
             waveform_type, params = new_value
-            self.circuit_ctrl.update_component_waveform(component_id, waveform_type, params)
+            cmd = UpdateWaveformCommand(self.circuit_ctrl, component_id, waveform_type, params)
+            self.circuit_ctrl.execute_command(cmd)
             # Refresh properties panel to show updated SPICE value
             component = self.canvas.components.get(component_id)
             if component:
@@ -391,7 +397,10 @@ class MainWindow(
                 statusBar.showMessage(f"Updated {component_id} waveform configuration", 2000)
 
         elif property_name == "initial_condition":
-            self.circuit_ctrl.update_component_initial_condition(component_id, new_value)
+            from controllers.commands import UpdateInitialConditionCommand
+
+            cmd = UpdateInitialConditionCommand(self.circuit_ctrl, component_id, new_value)
+            self.circuit_ctrl.execute_command(cmd)
             ic_display = new_value if new_value else "none"
             statusBar = self.statusBar()
             if statusBar:

--- a/app/controllers/commands.py
+++ b/app/controllers/commands.py
@@ -538,6 +538,124 @@ class EditAnnotationCommand(Command):
         return "Edit annotation"
 
 
+class SetRotationCommand(Command):
+    """Command to set a component's rotation to an exact value."""
+
+    def __init__(self, controller, component_id: str, new_rotation: int):
+        self.controller = controller
+        self.component_id = component_id
+        self.new_rotation = new_rotation % 360
+        self.old_rotation: Optional[int] = None
+
+    def execute(self) -> None:
+        """Set the rotation and store the old value."""
+        component = self.controller.model.components.get(self.component_id)
+        if not component:
+            logger.warning(
+                "SetRotationCommand: component %s not found, skipping",
+                self.component_id,
+            )
+            return
+        self.old_rotation = component.rotation
+        self.controller.set_component_rotation(self.component_id, self.new_rotation)
+
+    def undo(self) -> None:
+        """Restore the old rotation."""
+        if self.old_rotation is None:
+            return
+        if self.component_id not in self.controller.model.components:
+            logger.warning(
+                "SetRotationCommand.undo: component %s not found, skipping",
+                self.component_id,
+            )
+            return
+        self.controller.set_component_rotation(self.component_id, self.old_rotation)
+
+    def get_description(self) -> str:
+        return f"Set {self.component_id} rotation to {self.new_rotation}°"
+
+
+class UpdateWaveformCommand(Command):
+    """Command to update a component's waveform configuration."""
+
+    def __init__(self, controller, component_id: str, waveform_type: str, params: dict):
+        self.controller = controller
+        self.component_id = component_id
+        self.new_waveform_type = waveform_type
+        self.new_params = params
+        self.old_waveform_type: Optional[str] = None
+        self.old_params: Optional[dict] = None
+        self.old_value: Optional[str] = None
+
+    def execute(self) -> None:
+        """Update the waveform and store the old configuration."""
+        component = self.controller.model.components.get(self.component_id)
+        if not component:
+            logger.warning(
+                "UpdateWaveformCommand: component %s not found, skipping",
+                self.component_id,
+            )
+            return
+        self.old_waveform_type = component.waveform_type
+        self.old_params = dict(component.waveform_params) if component.waveform_params else None
+        self.old_value = component.value
+        self.controller.update_component_waveform(self.component_id, self.new_waveform_type, self.new_params)
+
+    def undo(self) -> None:
+        """Restore the old waveform configuration."""
+        if self.old_waveform_type is None:
+            return
+        component = self.controller.model.components.get(self.component_id)
+        if not component:
+            logger.warning(
+                "UpdateWaveformCommand.undo: component %s not found, skipping",
+                self.component_id,
+            )
+            return
+        component.waveform_type = self.old_waveform_type
+        component.waveform_params = dict(self.old_params) if self.old_params else None
+        component.value = self.old_value
+        self.controller._notify("component_value_changed", component)
+
+    def get_description(self) -> str:
+        return f"Update {self.component_id} waveform"
+
+
+class UpdateInitialConditionCommand(Command):
+    """Command to update a component's initial condition."""
+
+    def __init__(self, controller, component_id: str, new_initial_condition: Optional[str]):
+        self.controller = controller
+        self.component_id = component_id
+        self.new_initial_condition = new_initial_condition
+        self.old_initial_condition: Optional[str] = None
+
+    def execute(self) -> None:
+        """Update the initial condition and store the old value."""
+        component = self.controller.model.components.get(self.component_id)
+        if not component:
+            logger.warning(
+                "UpdateInitialConditionCommand: component %s not found, skipping",
+                self.component_id,
+            )
+            return
+        self.old_initial_condition = component.initial_condition
+        self.controller.update_component_initial_condition(self.component_id, self.new_initial_condition)
+
+    def undo(self) -> None:
+        """Restore the old initial condition."""
+        if self.component_id not in self.controller.model.components:
+            logger.warning(
+                "UpdateInitialConditionCommand.undo: component %s not found, skipping",
+                self.component_id,
+            )
+            return
+        self.controller.update_component_initial_condition(self.component_id, self.old_initial_condition)
+
+    def get_description(self) -> str:
+        return f"Update {self.component_id} initial condition"
+
+
 class CompoundCommand(Command):
     """Command that groups multiple commands into a single undo step."""
 

--- a/app/tests/unit/test_undo_redo.py
+++ b/app/tests/unit/test_undo_redo.py
@@ -14,7 +14,10 @@ from controllers.commands import (
     PasteCommand,
     RerouteWireCommand,
     RotateComponentCommand,
+    SetRotationCommand,
     ToggleWireLockCommand,
+    UpdateInitialConditionCommand,
+    UpdateWaveformCommand,
 )
 from controllers.undo_manager import UndoManager
 from models.circuit import CircuitModel
@@ -1000,3 +1003,219 @@ class TestFullUndoRedoWorkflow:
 
         ctrl.undo()  # undo add
         assert len(model.components) == 0
+
+
+# ===========================================================================
+# Properties Panel Undo Commands  (#819)
+# ===========================================================================
+
+
+class TestSetRotationCommand:
+    """Test SetRotationCommand for properties-panel rotation changes."""
+
+    def test_execute_and_undo(self):
+        """Setting rotation to exact value is undoable."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Resistor", (0, 0))
+        comp_id = comp.component_id
+
+        assert model.components[comp_id].rotation == 0
+
+        cmd = SetRotationCommand(ctrl, comp_id, 270)
+        cmd.execute()
+        assert model.components[comp_id].rotation == 270
+
+        cmd.undo()
+        assert model.components[comp_id].rotation == 0
+
+    def test_via_controller_undoable(self):
+        """SetRotationCommand through controller is fully undoable/redoable."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Resistor", (0, 0))
+        comp_id = comp.component_id
+
+        cmd = SetRotationCommand(ctrl, comp_id, 180)
+        ctrl.execute_command(cmd)
+        assert model.components[comp_id].rotation == 180
+        assert ctrl.can_undo()
+
+        ctrl.undo()
+        assert model.components[comp_id].rotation == 0
+
+        ctrl.redo()
+        assert model.components[comp_id].rotation == 180
+
+    def test_normalizes_rotation(self):
+        """Rotation values are normalized mod 360."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Resistor", (0, 0))
+
+        cmd = SetRotationCommand(ctrl, comp.component_id, 450)
+        cmd.execute()
+        assert model.components[comp.component_id].rotation == 90
+
+    def test_missing_component_skips(self):
+        """SetRotationCommand on non-existent component should not crash."""
+        ctrl = CircuitController()
+        cmd = SetRotationCommand(ctrl, "BOGUS", 90)
+        cmd.execute()
+        assert cmd.old_rotation is None
+        cmd.undo()  # should not crash
+
+    def test_undo_missing_component_skips(self):
+        """SetRotationCommand.undo after component deleted should not crash."""
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Resistor", (0, 0))
+        cmd = SetRotationCommand(ctrl, comp.component_id, 90)
+        cmd.execute()
+        ctrl.remove_component(comp.component_id)
+        cmd.undo()  # component gone; should not crash
+
+    def test_description(self):
+        """Command has descriptive get_description."""
+        ctrl = CircuitController()
+        cmd = SetRotationCommand(ctrl, "R1", 270)
+        assert "R1" in cmd.get_description()
+        assert "270" in cmd.get_description()
+
+
+class TestUpdateWaveformCommand:
+    """Test UpdateWaveformCommand for properties-panel waveform changes."""
+
+    def test_execute_and_undo(self):
+        """Updating waveform is undoable."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Waveform Source", (0, 0))
+        comp_id = comp.component_id
+
+        old_type = model.components[comp_id].waveform_type
+        old_value = model.components[comp_id].value
+
+        cmd = UpdateWaveformCommand(ctrl, comp_id, "PULSE", {"v1": "0", "v2": "5"})
+        cmd.execute()
+        assert model.components[comp_id].waveform_type == "PULSE"
+
+        cmd.undo()
+        assert model.components[comp_id].waveform_type == old_type
+        assert model.components[comp_id].value == old_value
+
+    def test_via_controller_undoable(self):
+        """UpdateWaveformCommand through controller is fully undoable/redoable."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Waveform Source", (0, 0))
+        comp_id = comp.component_id
+        old_type = model.components[comp_id].waveform_type
+
+        cmd = UpdateWaveformCommand(ctrl, comp_id, "PULSE", {"v1": "0", "v2": "3.3"})
+        ctrl.execute_command(cmd)
+        assert model.components[comp_id].waveform_type == "PULSE"
+        assert ctrl.can_undo()
+
+        ctrl.undo()
+        assert model.components[comp_id].waveform_type == old_type
+
+        ctrl.redo()
+        assert model.components[comp_id].waveform_type == "PULSE"
+
+    def test_missing_component_skips(self):
+        """UpdateWaveformCommand on non-existent component should not crash."""
+        ctrl = CircuitController()
+        cmd = UpdateWaveformCommand(ctrl, "BOGUS", "SIN", {"amp": "1"})
+        cmd.execute()
+        assert cmd.old_waveform_type is None
+        cmd.undo()
+
+    def test_undo_missing_component_skips(self):
+        """UpdateWaveformCommand.undo after component deleted should not crash."""
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Waveform Source", (0, 0))
+        cmd = UpdateWaveformCommand(ctrl, comp.component_id, "PULSE", {"v1": "0"})
+        cmd.execute()
+        ctrl.remove_component(comp.component_id)
+        cmd.undo()  # should not crash
+
+    def test_description(self):
+        """Command has descriptive get_description."""
+        ctrl = CircuitController()
+        cmd = UpdateWaveformCommand(ctrl, "VW1", "PULSE", {})
+        assert "VW1" in cmd.get_description()
+
+
+class TestUpdateInitialConditionCommand:
+    """Test UpdateInitialConditionCommand for properties-panel IC changes."""
+
+    def test_execute_and_undo(self):
+        """Updating initial condition is undoable."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Capacitor", (0, 0))
+        comp_id = comp.component_id
+
+        assert model.components[comp_id].initial_condition is None
+
+        cmd = UpdateInitialConditionCommand(ctrl, comp_id, "5V")
+        cmd.execute()
+        assert model.components[comp_id].initial_condition == "5V"
+
+        cmd.undo()
+        assert model.components[comp_id].initial_condition is None
+
+    def test_via_controller_undoable(self):
+        """UpdateInitialConditionCommand through controller is fully undoable/redoable."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Capacitor", (0, 0))
+        comp_id = comp.component_id
+
+        cmd = UpdateInitialConditionCommand(ctrl, comp_id, "3.3V")
+        ctrl.execute_command(cmd)
+        assert model.components[comp_id].initial_condition == "3.3V"
+        assert ctrl.can_undo()
+
+        ctrl.undo()
+        assert model.components[comp_id].initial_condition is None
+
+        ctrl.redo()
+        assert model.components[comp_id].initial_condition == "3.3V"
+
+    def test_clear_initial_condition_undoable(self):
+        """Clearing an initial condition (setting to None) is undoable."""
+        model = CircuitModel()
+        ctrl = CircuitController(model)
+        comp = ctrl.add_component("Capacitor", (0, 0))
+        comp_id = comp.component_id
+        model.components[comp_id].initial_condition = "2V"
+
+        cmd = UpdateInitialConditionCommand(ctrl, comp_id, None)
+        ctrl.execute_command(cmd)
+        assert model.components[comp_id].initial_condition is None
+
+        ctrl.undo()
+        assert model.components[comp_id].initial_condition == "2V"
+
+    def test_missing_component_skips(self):
+        """UpdateInitialConditionCommand on non-existent component should not crash."""
+        ctrl = CircuitController()
+        cmd = UpdateInitialConditionCommand(ctrl, "BOGUS", "5V")
+        cmd.execute()
+        cmd.undo()
+
+    def test_undo_missing_component_skips(self):
+        """UpdateInitialConditionCommand.undo after component deleted should not crash."""
+        ctrl = CircuitController()
+        comp = ctrl.add_component("Capacitor", (0, 0))
+        cmd = UpdateInitialConditionCommand(ctrl, comp.component_id, "5V")
+        cmd.execute()
+        ctrl.remove_component(comp.component_id)
+        cmd.undo()  # should not crash
+
+    def test_description(self):
+        """Command has descriptive get_description."""
+        ctrl = CircuitController()
+        cmd = UpdateInitialConditionCommand(ctrl, "C1", "5V")
+        assert "C1" in cmd.get_description()


### PR DESCRIPTION
## Summary - Adds , , and  to the command pattern system in  - Updates  in  to use  for rotation, waveform, and initial-condition changes instead of calling controller methods directly - All three property types are now fully undoable/redoable via Ctrl+Z/Ctrl+Y ## Test plan - [x] Unit tests for all three new commands (execute, undo, redo, missing component safety) - [ ] Manual: Change rotation in properties panel → verify Ctrl+Z reverts it - [ ] Manual: Configure waveform in properties panel → verify Ctrl+Z reverts it - [ ] Manual: Set initial condition in properties panel → verify Ctrl+Z reverts it Closes #819 🤖 Generated with [Claude Code](https://claude.com/claude-code)