### PR TITLE
fix: extract shared _draw_label_text() to deduplicate flip label logic (#825)

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -370,16 +370,7 @@ class ComponentGraphicsItem(QGraphicsItem):
         )
 
         if show_label or show_value:
-            # Counter-flip so text remains readable when component is flipped
-            if sx != 1 or sy != 1:
-                painter.scale(sx, sy)
-            painter.setPen(QPen(color))
-            if show_label and show_value:
-                painter.drawText(-20, -25, f"{self.component_id} ({self.value})")
-            elif show_label:
-                painter.drawText(-20, -25, self.component_id)
-            elif show_value:
-                painter.drawText(-20, -25, f"({self.value})")
+            self._draw_label_text(painter, color, sx, sy, show_label, show_value, self.component_id, self.value)
 
         # Restore painter state
         painter.restore()
@@ -388,6 +379,22 @@ class ComponentGraphicsItem(QGraphicsItem):
         painter.setPen(theme_manager.pen("terminal"))
         for terminal in self.terminals:
             painter.drawEllipse(terminal, 3, 3)
+
+    def _draw_label_text(self, painter, color, sx, sy, show_label, show_value, label, value):
+        """Draw counter-flipped label text above the component.
+
+        Shared by ComponentGraphicsItem.paint() and Ground.paint() to avoid
+        duplicating the counter-flip correction logic.
+        """
+        if sx != 1 or sy != 1:
+            painter.scale(sx, sy)
+        painter.setPen(QPen(color))
+        if show_label and show_value:
+            painter.drawText(-20, -25, f"{label} ({value})")
+        elif show_label:
+            painter.drawText(-20, -25, label)
+        elif show_value:
+            painter.drawText(-20, -25, f"({value})")
 
     def itemChange(self, change, value):
         if change == QGraphicsItem.GraphicsItemChange.ItemPositionChange and self.scene():
@@ -598,16 +605,7 @@ class Ground(ComponentGraphicsItem):
         )
 
         if show_label or show_value:
-            # Counter-flip so text remains readable when component is flipped
-            if sx != 1 or sy != 1:
-                painter.scale(sx, sy)
-            painter.setPen(QPen(color))
-            if show_label and show_value:
-                painter.drawText(-20, -25, "GND (0V)")
-            elif show_label:
-                painter.drawText(-20, -25, "GND")
-            elif show_value:
-                painter.drawText(-20, -25, "(0V)")
+            self._draw_label_text(painter, color, sx, sy, show_label, show_value, "GND", "0V")
 
         painter.restore()
 

--- a/app/tests/unit/test_component_label_flip.py
+++ b/app/tests/unit/test_component_label_flip.py
@@ -30,33 +30,37 @@ def _find_call_indices(source, method_name):
 class TestLabelCounterFlipStructural:
     """Structural tests verifying the paint method counter-flips text.
 
-    These parse paint() source code to ensure the counter-scale call
-    appears between the initial flip-scale and drawText.
+    The counter-scale and drawText logic lives in the shared
+    _draw_label_text() helper.  paint() delegates to it, so we verify:
+    1. paint() calls _draw_label_text
+    2. _draw_label_text contains scale() before drawText()
     """
 
-    def test_base_paint_applies_counter_scale_before_drawText(self):
-        """ComponentGraphicsItem.paint() must re-apply scale() before drawText()."""
+    def test_base_paint_delegates_to_draw_label_text(self):
+        """ComponentGraphicsItem.paint() must call _draw_label_text()."""
         from GUI.component_item import ComponentGraphicsItem
 
         src = _get_paint_source(ComponentGraphicsItem)
-        scale_indices = _find_call_indices(src, "scale")
-        drawtext_indices = _find_call_indices(src, "drawText")
+        assert "_draw_label_text(" in src, "paint() must delegate to _draw_label_text()"
 
-        assert len(scale_indices) >= 2, "Must have initial scale + counter-scale calls"
-        assert len(drawtext_indices) >= 1, "Must have drawText() call"
-        assert scale_indices[1] < drawtext_indices[0], "Counter-scale must come before first drawText"
-
-    def test_ground_paint_applies_counter_scale_before_drawText(self):
-        """Ground.paint() must re-apply scale() before drawText()."""
+    def test_ground_paint_delegates_to_draw_label_text(self):
+        """Ground.paint() must call _draw_label_text()."""
         from GUI.component_item import Ground
 
         src = _get_paint_source(Ground)
+        assert "_draw_label_text(" in src, "paint() must delegate to _draw_label_text()"
+
+    def test_draw_label_text_applies_counter_scale_before_drawText(self):
+        """_draw_label_text() must call scale() before drawText()."""
+        from GUI.component_item import ComponentGraphicsItem
+
+        src = textwrap.dedent(inspect.getsource(ComponentGraphicsItem._draw_label_text))
         scale_indices = _find_call_indices(src, "scale")
         drawtext_indices = _find_call_indices(src, "drawText")
 
-        assert len(scale_indices) >= 2, "Must have initial scale + counter-scale calls"
+        assert len(scale_indices) >= 1, "Must have counter-scale call"
         assert len(drawtext_indices) >= 1, "Must have drawText() call"
-        assert scale_indices[1] < drawtext_indices[0], "Counter-scale must come before first drawText"
+        assert scale_indices[0] < drawtext_indices[0], "Counter-scale must come before first drawText"
 
 
 class TestLabelCounterFlipPainter:


### PR DESCRIPTION
## Summary - Extracts counter-flip label drawing logic into a shared _draw_label_text() method on ComponentGraphicsItem - Both ComponentGraphicsItem.paint() and Ground.paint() now call the shared method - Future label fixes only need one change instead of two ## Test plan - [ ] Manual: Verify component labels render correctly for normal, flipped, and rotated components - [ ] Manual: Verify Ground label renders correctly when flipped Closes #825