### PR TITLE
fix: check _dirty flag in _on_new and add utf-8 encoding (#826)

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -21,7 +21,7 @@ class FileOperationsMixin:
 
     def _on_new(self):
         """Create a new circuit"""
-        if len(self.canvas.components) > 0:
+        if len(self.canvas.components) > 0 or self._dirty:
             if not self.dialogs.confirm("New Circuit", "Current circuit will be lost. Continue?"):
                 return
 
@@ -541,7 +541,7 @@ class FileOperationsMixin:
 
         for example_file in example_files:
             try:
-                with open(example_file, "r") as f:
+                with open(example_file, "r", encoding="utf-8") as f:
                     data = json.load(f)
 
                 name = data.get("name", example_file.stem)


### PR DESCRIPTION
## Summary - _on_new now checks self._dirty in addition to component count, so the save prompt appears even when all components have been deleted but the circuit was modified - _populate_examples_menu opens JSON files with encoding=utf-8 to prevent failures on Windows with non-UTF-8 default encoding ## Test plan - [ ] Manual: Delete all components, modify something, click New -- should prompt to save - [ ] Manual: Open example circuits on Windows -- should work without encoding errors Closes #826