### PR TITLE
refactor: encapsulation cleanup -- public APIs, rename, lazy logging (#827)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -164,9 +164,9 @@ class CircuitCanvasView(QGraphicsView):
             try:
                 handler(data)
             except (AttributeError, KeyError, TypeError) as e:
-                logger.error(f"Error handling event '{event}': {e}")
+                logger.error("Error handling event '%s': %s", event, e)
         else:
-            logger.debug(f"Unhandled observer event: {event}")
+            logger.debug("Unhandled observer event: %s", event)
 
         # Clear stale OP annotations when circuit is modified
         _stale_events = {

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -26,7 +26,7 @@ class ViewOperationsMixin:
     def apply_theme(self):
         """Apply the current theme to all visual elements."""
         theme = theme_manager.current_theme
-        self.setStyleSheet(theme.generate_dark_stylesheet())
+        self.setStyleSheet(theme.generate_stylesheet())
 
         # Refresh canvas (grid + components)
         self.canvas.refresh_theme()

--- a/app/GUI/styles/theme.py
+++ b/app/GUI/styles/theme.py
@@ -163,8 +163,8 @@ class BaseTheme:
         color = self.get_component_color(component_type)
         return QBrush(color.lighter(150))
 
-    def generate_dark_stylesheet(self) -> str:
-        """Generate a global dark stylesheet from theme colors.
+    def generate_stylesheet(self) -> str:
+        """Generate a global stylesheet from theme colors.
 
         Returns an empty string for light themes.
         """

--- a/app/controllers/circuit_controller.py
+++ b/app/controllers/circuit_controller.py
@@ -60,13 +60,20 @@ class CircuitController:
         if callback in self._observers:
             self._observers.remove(callback)
 
-    def _notify(self, event: str, data: Any) -> None:
-        """Notify all observers of a model change."""
+    def notify(self, event: str, data: Any = None) -> None:
+        """Notify all observers of a model change.
+
+        Public API for use by collaborating controllers (e.g. FileController).
+        """
         for observer in self._observers:
             try:
                 observer(event, data)
             except (TypeError, AttributeError, RuntimeError) as e:
                 logger.error("Error notifying observer: %s", e)
+
+    def _notify(self, event: str, data: Any) -> None:
+        """Notify all observers of a model change."""
+        self.notify(event, data)
 
     # --- Component operations ---
 
@@ -522,8 +529,7 @@ class CircuitController:
         Used when an action has already been applied (e.g. during a drag)
         and only needs to be recorded for undo/redo.
         """
-        self.undo_manager._undo_stack.append(command)
-        self.undo_manager._redo_stack.clear()
+        self.undo_manager.push_already_executed(command)
 
     def undo(self) -> bool:
         """

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -89,7 +89,7 @@ class FileController:
         self._replace_model(new_model)
         if self.circuit_ctrl:
             self.circuit_ctrl.clear_undo_history()
-            self.circuit_ctrl._notify("model_loaded", None)
+            self.circuit_ctrl.notify("model_loaded", None)
 
     def new_circuit(self) -> None:
         """Clear the circuit and reset file state."""
@@ -124,7 +124,7 @@ class FileController:
         self.add_recent_file(filepath)  # Track in recent files
 
         if self.circuit_ctrl:
-            self.circuit_ctrl._notify("model_saved", None)
+            self.circuit_ctrl.notify("model_saved", None)
 
     def load_circuit(self, filepath) -> None:
         """
@@ -157,7 +157,7 @@ class FileController:
 
         if self.circuit_ctrl:
             self.circuit_ctrl.clear_undo_history()
-            self.circuit_ctrl._notify("model_loaded", None)
+            self.circuit_ctrl.notify("model_loaded", None)
 
     def load_from_dict(self, data: dict) -> None:
         """Load circuit from a pre-validated dict (e.g. from clipboard).
@@ -170,7 +170,7 @@ class FileController:
 
         if self.circuit_ctrl:
             self.circuit_ctrl.clear_undo_history()
-            self.circuit_ctrl._notify("model_loaded", None)
+            self.circuit_ctrl.notify("model_loaded", None)
 
     def has_file(self) -> bool:
         """Return whether a current file path is set (for quick-save)."""
@@ -313,7 +313,7 @@ class FileController:
                 self.current_file = Path(source_path)
 
             if self.circuit_ctrl:
-                self.circuit_ctrl._notify("model_loaded", None)
+                self.circuit_ctrl.notify("model_loaded", None)
 
             return source_path
         except (OSError, json.JSONDecodeError, ValueError):
@@ -353,7 +353,7 @@ class FileController:
         self.add_recent_file(filepath)
 
         if self.circuit_ctrl:
-            self.circuit_ctrl._notify("model_loaded", None)
+            self.circuit_ctrl.notify("model_loaded", None)
 
     def import_asc(self, filepath) -> list[str]:
         """Import an LTspice .asc schematic file into the current model.
@@ -391,7 +391,7 @@ class FileController:
         self.add_recent_file(filepath)
 
         if self.circuit_ctrl:
-            self.circuit_ctrl._notify("model_loaded", None)
+            self.circuit_ctrl.notify("model_loaded", None)
 
         return warnings
 
@@ -426,7 +426,7 @@ class FileController:
         self.add_recent_file(filepath)
 
         if self.circuit_ctrl:
-            self.circuit_ctrl._notify("model_loaded", None)
+            self.circuit_ctrl.notify("model_loaded", None)
 
         return warnings
 
@@ -480,7 +480,7 @@ class FileController:
         self.add_recent_file(filepath)
 
         if self.circuit_ctrl:
-            self.circuit_ctrl._notify("model_loaded", None)
+            self.circuit_ctrl.notify("model_loaded", None)
 
     def export_asc(self, filepath: str) -> None:
         """Export the circuit as an LTspice .asc schematic.

--- a/app/controllers/undo_manager.py
+++ b/app/controllers/undo_manager.py
@@ -112,6 +112,20 @@ class UndoManager:
             return self._redo_stack[-1].get_description()
         return None
 
+    def push_already_executed(self, command: Command) -> None:
+        """Push a pre-executed command onto the undo stack.
+
+        Used when an action has already been applied (e.g. during a drag)
+        and only needs to be recorded for undo/redo.
+
+        Args:
+            command: The already-executed command to record
+        """
+        self._undo_stack.append(command)
+        if len(self._undo_stack) > self.max_depth:
+            self._undo_stack.pop(0)
+        self._redo_stack.clear()
+
     def clear(self) -> None:
         """Clear both undo and redo stacks."""
         self._undo_stack.clear()

--- a/app/tests/unit/controllers/test_file_controller_coverage.py
+++ b/app/tests/unit/controllers/test_file_controller_coverage.py
@@ -44,7 +44,7 @@ class TestLoadFromModel:
         ctrl = FileController(CircuitModel(), circuit_ctrl=mock_ctrl)
         new_model = build_simple_circuit()
         ctrl.load_from_model(new_model)
-        mock_ctrl._notify.assert_called_once_with("model_loaded", None)
+        mock_ctrl.notify.assert_called_once_with("model_loaded", None)
 
     def test_load_from_model_without_circuit_ctrl(self):
         """load_from_model should work without circuit_ctrl."""
@@ -66,7 +66,7 @@ class TestCircuitCtrlNotifications:
         ctrl = FileController(model, circuit_ctrl=mock_ctrl)
         filepath = tmp_path / "test.json"
         ctrl.save_circuit(filepath)
-        mock_ctrl._notify.assert_called_with("model_saved", None)
+        mock_ctrl.notify.assert_called_with("model_saved", None)
 
     @patch("controllers.file_controller.settings")
     def test_load_circuit_notifies_circuit_ctrl(self, mock_settings, tmp_path):
@@ -80,7 +80,7 @@ class TestCircuitCtrlNotifications:
         mock_ctrl = MagicMock()
         ctrl2 = FileController(circuit_ctrl=mock_ctrl)
         ctrl2.load_circuit(filepath)
-        mock_ctrl._notify.assert_called_with("model_loaded", None)
+        mock_ctrl.notify.assert_called_with("model_loaded", None)
 
 
 class TestSaveSessionOSError:
@@ -188,7 +188,7 @@ class TestImportNetlistCtrlNotification:
         netlist.write_text("Test Circuit\nV1 1 0 DC 5V\nR1 1 0 1k\n.op\n.end\n")
         ctrl = FileController(CircuitModel(), circuit_ctrl=mock_ctrl)
         ctrl.import_netlist(netlist)
-        mock_ctrl._notify.assert_called_with("model_loaded", None)
+        mock_ctrl.notify.assert_called_with("model_loaded", None)
 
 
 class TestImportAscAnalysisAndNotification:
@@ -229,7 +229,7 @@ class TestImportAscAnalysisAndNotification:
         )
         ctrl = FileController(CircuitModel(), circuit_ctrl=mock_ctrl)
         ctrl.import_asc(asc)
-        mock_ctrl._notify.assert_called_with("model_loaded", None)
+        mock_ctrl.notify.assert_called_with("model_loaded", None)
 
 
 class TestImportCircuitikzCoverage:
@@ -255,7 +255,7 @@ class TestImportCircuitikzCoverage:
         tex.write_text("\\begin{circuitikz}\n\\draw (0,0) to[R, l=$R_1$] (2,0);\n\\end{circuitikz}\n")
         ctrl = FileController(CircuitModel(), circuit_ctrl=mock_ctrl)
         ctrl.import_circuitikz(tex)
-        mock_ctrl._notify.assert_called_with("model_loaded", None)
+        mock_ctrl.notify.assert_called_with("model_loaded", None)
 
     @patch("controllers.file_controller.settings")
     def test_import_circuitikz_adds_to_recent(self, mock_settings, tmp_path):
@@ -279,7 +279,7 @@ class TestLoadFromDictCtrlNotification:
         ctrl = FileController(model, circuit_ctrl=mock_ctrl)
         data = model.to_dict()
         ctrl.load_from_dict(data)
-        mock_ctrl._notify.assert_called_with("model_loaded", None)
+        mock_ctrl.notify.assert_called_with("model_loaded", None)
 
 
 class TestLoadLastSessionOSError:
@@ -354,7 +354,7 @@ class TestLoadAutoSaveBranches:
         mock_ctrl = MagicMock()
         ctrl2 = FileController(autosave_file=autosave_file, circuit_ctrl=mock_ctrl)
         ctrl2.load_auto_save()
-        mock_ctrl._notify.assert_called_with("model_loaded", None)
+        mock_ctrl.notify.assert_called_with("model_loaded", None)
 
     def test_load_auto_save_returns_none_on_oserror(self, tmp_path):
         """load_auto_save should return None on OSError."""

--- a/app/tests/unit/test_auto_save.py
+++ b/app/tests/unit/test_auto_save.py
@@ -175,7 +175,7 @@ class TestLoadAutoSave:
         mock_ctrl = MagicMock()
         ctrl2.circuit_ctrl = mock_ctrl
         ctrl2.load_auto_save()
-        mock_ctrl._notify.assert_called_once_with("model_loaded", None)
+        mock_ctrl.notify.assert_called_once_with("model_loaded", None)
 
     def test_autosave_source_not_in_model_data(self, tmp_path):
         """The _autosave_source metadata should not leak into the model."""

--- a/app/tests/unit/test_custom_theme.py
+++ b/app/tests/unit/test_custom_theme.py
@@ -69,20 +69,20 @@ class TestInheritedHelpers:
 
 
 class TestDarkStylesheet:
-    """Verify generate_dark_stylesheet() behavior."""
+    """Verify generate_stylesheet() behavior."""
 
     def test_dark_custom_has_stylesheet(self):
         theme = CustomTheme("D", "dark", {}, theme_is_dark=True)
-        ss = theme.generate_dark_stylesheet()
+        ss = theme.generate_stylesheet()
         assert len(ss) > 0
         assert "background-color" in ss
 
     def test_light_custom_empty_stylesheet(self):
         theme = CustomTheme("L", "light", {}, theme_is_dark=False)
-        ss = theme.generate_dark_stylesheet()
+        ss = theme.generate_stylesheet()
         assert ss == ""
 
     def test_dark_stylesheet_uses_theme_colors(self):
         theme = CustomTheme("D", "dark", {"background_primary": "#1A1A2E"}, theme_is_dark=True)
-        ss = theme.generate_dark_stylesheet()
+        ss = theme.generate_stylesheet()
         assert "#1a1a2e" in ss.lower()


### PR DESCRIPTION
## Summary - Add UndoManager.push_already_executed() public method; CircuitController no longer directly accesses private stacks - Add CircuitController.notify() public method; FileController uses it instead of _notify() - Rename generate_dark_stylesheet() to generate_stylesheet() since it handles all themes - Replace f-string logger calls in circuit_canvas.py with lazy %-style formatting ## Test plan - [ ] Existing tests pass (undo/redo, file operations, theme tests) - [ ] Manual: Verify undo/redo works after drag operations - [ ] Manual: Verify theme switching works correctly Closes #827