### PR TITLE
feat: add Inno Setup installer script (#834)

### DIFF
--- a/app/tests/unit/test_inno_setup.py
+++ b/app/tests/unit/test_inno_setup.py
@@ -1,0 +1,104 @@
+"""Structural tests for the Inno Setup installer script (#834).
+
+These validate that the .iss file contains all required sections and
+configuration without requiring Inno Setup to be installed.
+"""
+
+from pathlib import Path
+
+import pytest
+
+INSTALLER_DIR = Path(__file__).resolve().parent.parent.parent.parent / "installer"
+ISS_FILE = INSTALLER_DIR / "spicegui.iss"
+COMBINED_LICENSE = INSTALLER_DIR / "LICENSE-COMBINED.txt"
+
+
+@pytest.fixture
+def iss_content():
+    return ISS_FILE.read_text(encoding="utf-8")
+
+
+class TestIssFileExists:
+    def test_iss_file_exists(self):
+        assert ISS_FILE.is_file(), f"Expected {ISS_FILE}"
+
+    def test_combined_license_exists(self):
+        assert COMBINED_LICENSE.is_file(), f"Expected {COMBINED_LICENSE}"
+
+
+class TestSetupSection:
+    def test_app_name(self, iss_content):
+        assert "AppName={#MyAppName}" in iss_content
+
+    def test_app_version(self, iss_content):
+        assert "#define MyAppVersion" in iss_content
+
+    def test_default_dir(self, iss_content):
+        assert "DefaultDirName=" in iss_content
+
+    def test_privileges_lowest(self, iss_content):
+        assert "PrivilegesRequired=lowest" in iss_content
+
+    def test_privileges_override(self, iss_content):
+        assert "PrivilegesRequiredOverridesAllowed=dialog" in iss_content
+
+    def test_license_file_referenced(self, iss_content):
+        assert "LicenseFile=" in iss_content
+
+    def test_output_filename(self, iss_content):
+        assert "SpiceGUI-v" in iss_content
+        assert "win64-setup" in iss_content
+
+    def test_uninstall_display(self, iss_content):
+        assert "UninstallDisplayName=" in iss_content
+
+
+class TestTasksSection:
+    def test_desktop_icon_task(self, iss_content):
+        assert "desktopicon" in iss_content
+
+    def test_file_association_task(self, iss_content):
+        assert "fileassoc" in iss_content
+        assert ".spice" in iss_content
+
+
+class TestFilesSection:
+    def test_dist_source(self, iss_content):
+        assert r"dist\SpiceGUI\*" in iss_content
+
+    def test_license_files_included(self, iss_content):
+        assert "LICENSE-COMBINED.txt" in iss_content
+        assert "NGSPICE-LICENSE.txt" in iss_content
+
+
+class TestIconsSection:
+    def test_start_menu_shortcut(self, iss_content):
+        assert "{group}" in iss_content
+
+    def test_desktop_shortcut(self, iss_content):
+        assert "{autodesktop}" in iss_content
+
+
+class TestRegistrySection:
+    def test_spice_file_association(self, iss_content):
+        assert r"Software\Classes\.spice" in iss_content
+        assert "SpiceGUI.Circuit" in iss_content
+
+    def test_open_command(self, iss_content):
+        assert r"shell\open\command" in iss_content
+
+
+class TestRunSection:
+    def test_post_install_launch(self, iss_content):
+        assert "postinstall" in iss_content
+
+
+class TestCombinedLicense:
+    def test_contains_mit_license(self):
+        text = COMBINED_LICENSE.read_text(encoding="utf-8")
+        assert "MIT License" in text
+
+    def test_contains_ngspice_bsd(self):
+        text = COMBINED_LICENSE.read_text(encoding="utf-8")
+        assert "ngspice" in text
+        assert "BSD" in text

--- a/installer/LICENSE-COMBINED.txt
+++ b/installer/LICENSE-COMBINED.txt
@@ -1,0 +1,56 @@
+Spice GUI License Agreement
+============================
+
+This installer contains Spice GUI and bundled third-party components.
+By installing this software you agree to the terms below.
+
+
+--- Spice GUI (MIT License) ---
+
+Copyright (c) 2025 SDSMT Capstone Spice GUI Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+--- ngspice (BSD 3-Clause License) ---
+
+Copyright (c) 2000-2024, The ngspice team
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/installer/spicegui.iss
+++ b/installer/spicegui.iss
@@ -1,0 +1,87 @@
+; =========================================================================
+; Spice GUI - Inno Setup Installer Script
+;
+; Build instructions:
+;   1. Build the PyInstaller bundle first:
+;        python -m PyInstaller SpiceGUI.spec
+;
+;   2. Compile this script with Inno Setup 6.x:
+;        iscc installer/spicegui.iss
+;
+;   3. Output: installer/Output/SpiceGUI-v0.1.0-win64-setup.exe
+;
+; The script supports two install modes:
+;   - "Install for all users" (requires admin, installs to Program Files)
+;   - "Install for current user only" (no admin, installs to LocalAppData)
+; =========================================================================
+
+#define MyAppName      "Spice GUI"
+#define MyAppVersion   "0.1.0"
+#define MyAppPublisher "SDSMT Capstone Spice GUI Team"
+#define MyAppURL       "https://github.com/SDSMT-Capstone-Spice-GUI-Team/Spice-GUI"
+#define MyAppExeName   "SpiceGUI.exe"
+
+[Setup]
+AppId={{8F2C4E6A-3B7D-4A1E-9C5F-D8E6F2A4B1C3}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppVerName={#MyAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}/issues
+AppUpdatesURL={#MyAppURL}/releases
+DefaultDirName={autopf}\{#MyAppName}
+DefaultGroupName={#MyAppName}
+LicenseFile=LICENSE-COMBINED.txt
+OutputDir=Output
+OutputBaseFilename=SpiceGUI-v{#MyAppVersion}-win64-setup
+Compression=lzma2/ultra64
+SolidCompression=yes
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+WizardStyle=modern
+; Allow non-admin installs (current user only)
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
+; Uninstaller settings
+UninstallDisplayName={#MyAppName}
+UninstallDisplayIcon={app}\{#MyAppExeName}
+; Installer version info
+VersionInfoVersion={#MyAppVersion}.0
+VersionInfoCompany={#MyAppPublisher}
+VersionInfoDescription={#MyAppName} Installer
+VersionInfoProductName={#MyAppName}
+VersionInfoProductVersion={#MyAppVersion}
+; Uncomment when an .ico file is added:
+; SetupIconFile=..\app\assets\spicegui.ico
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+Name: "fileassoc"; Description: "Associate .spice files with {#MyAppName}"; GroupDescription: "File associations:"; Flags: checkedonce
+
+[Files]
+; Copy the entire PyInstaller dist output
+Source: "..\dist\SpiceGUI\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+; Licenses
+Source: "LICENSE-COMBINED.txt"; DestDir: "{app}\licenses"; Flags: ignoreversion
+Source: "..\licenses\NGSPICE-LICENSE.txt"; DestDir: "{app}\licenses"; Flags: ignoreversion
+
+[Icons]
+; Start Menu
+Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
+; Desktop (optional)
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Registry]
+; .spice file association (only when the user selects the task)
+Root: HKA; Subkey: "Software\Classes\.spice"; ValueType: string; ValueName: ""; ValueData: "SpiceGUI.Circuit"; Flags: uninsdeletevalue; Tasks: fileassoc
+Root: HKA; Subkey: "Software\Classes\SpiceGUI.Circuit"; ValueType: string; ValueName: ""; ValueData: "Spice GUI Circuit"; Flags: uninsdeletekey; Tasks: fileassoc
+Root: HKA; Subkey: "Software\Classes\SpiceGUI.Circuit\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#MyAppExeName},0"; Tasks: fileassoc
+Root: HKA; Subkey: "Software\Classes\SpiceGUI.Circuit\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#MyAppExeName}"" ""%1"""; Tasks: fileassoc
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Summary - Add  Inno Setup script for Windows installer - Install dir selection (default ) - Start Menu + optional desktop shortcut -  file association via registry - Uninstaller in Add/Remove Programs - License agreement page (project MIT + ngspice BSD combined) - Support current-user-only install (no admin) via  - Output filename:  - 21 structural tests for the .iss script Closes #834 ## Test plan - [x] 21 structural tests verify all required .iss sections and configuration - [ ] Manual: compile with  on Windows with Inno Setup 6.x - [ ] Manual: verify installer runs, creates Start Menu shortcut, file association works - [ ] Manual: verify uninstaller removes all files cleanly 🤖 Generated with [Claude Code](https://claude.com/claude-code)