### PR TITLE
feat: add --selftest CLI flag for post-install smoke tests (#838)

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -747,7 +747,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="Output format (default: text)",
     )
 
+    # selftest
+    subparsers.add_parser("selftest", help="Run post-install smoke tests to verify the installation")
+
     return parser
+
+
+def cmd_selftest(args: argparse.Namespace) -> int:
+    """Run post-install smoke tests."""
+    from simulation.selftest import print_selftest, run_selftest
+
+    result = run_selftest()
+    print_selftest(result)
+    return 0 if result.passed else 1
 
 
 def main(argv=None) -> int:
@@ -764,6 +776,7 @@ def main(argv=None) -> int:
         "import": cmd_import,
         "diff": cmd_diff,
         "stats": cmd_stats,
+        "selftest": cmd_selftest,
     }
 
     handler = handlers.get(args.command)

--- a/app/main.py
+++ b/app/main.py
@@ -16,11 +16,19 @@ This prototype implements:
 
 import sys
 
-from GUI.main_window import MainWindow
-from PyQt6.QtWidgets import QApplication
-
 
 def main():
+    # Handle --selftest before importing Qt to allow headless execution.
+    if "--selftest" in sys.argv:
+        from simulation.selftest import print_selftest, run_selftest
+
+        result = run_selftest()
+        print_selftest(result)
+        sys.exit(0 if result.passed else 1)
+
+    from GUI.main_window import MainWindow
+    from PyQt6.QtWidgets import QApplication
+
     app = QApplication(sys.argv)
     window = MainWindow()
     window.show()

--- a/app/simulation/selftest.py
+++ b/app/simulation/selftest.py
@@ -1,0 +1,184 @@
+"""Post-install smoke test suite.
+
+Verifies that the application is correctly installed and functional:
+
+1. **App importable** -- core modules can be loaded.
+2. **ngspice found** -- an ngspice executable is available.
+3. **Example loads** -- a bundled example circuit loads without error.
+4. **Simulation runs** -- a basic DC operating-point simulation completes.
+
+Usage from CLI::
+
+    python -m cli selftest
+    python -m main --selftest
+
+Each check prints PASS or FAIL with an actionable error message.
+The overall exit code is 0 when all checks pass, 1 otherwise.
+"""
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class CheckResult:
+    """Outcome of a single smoke-test check."""
+
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class SelftestResult:
+    """Aggregate outcome of the full smoke-test suite."""
+
+    checks: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return all(c.passed for c in self.checks)
+
+    @property
+    def summary(self) -> str:
+        total = len(self.checks)
+        ok = sum(1 for c in self.checks if c.passed)
+        return f"{ok}/{total} checks passed"
+
+
+def _find_examples_dir() -> Path | None:
+    """Locate the examples directory.
+
+    Works both in development (app/examples/) and in a PyInstaller
+    frozen bundle (where files land relative to sys._MEIPASS or the exe).
+    """
+    # PyInstaller frozen bundle
+    if getattr(sys, "frozen", False):
+        meipass = Path(getattr(sys, "_MEIPASS", Path(sys.executable).parent))
+        candidate = meipass / "examples"
+        if candidate.is_dir():
+            return candidate
+
+    # Development layout: app/examples/
+    app_dir = Path(__file__).resolve().parent.parent
+    candidate = app_dir / "examples"
+    if candidate.is_dir():
+        return candidate
+
+    return None
+
+
+def check_imports() -> CheckResult:
+    """Verify that core application modules can be imported."""
+    try:
+        import controllers.simulation_controller  # noqa: F401
+        import models.circuit  # noqa: F401
+        import simulation.ngspice_runner  # noqa: F401
+
+        return CheckResult("Core imports", True, "models, simulation, controllers OK")
+    except ImportError as e:
+        return CheckResult("Core imports", False, f"Import failed: {e}")
+
+
+def check_ngspice() -> CheckResult:
+    """Verify that an ngspice executable can be found."""
+    try:
+        from simulation.ngspice_config import resolve_ngspice_path
+
+        path = resolve_ngspice_path()
+        if path:
+            return CheckResult("ngspice found", True, path)
+        return CheckResult("ngspice found", False, "No ngspice executable found on PATH or in bundle")
+    except Exception as e:
+        return CheckResult("ngspice found", False, str(e))
+
+
+def check_example_load() -> CheckResult:
+    """Verify that an example circuit file can be loaded."""
+    examples = _find_examples_dir()
+    if examples is None:
+        return CheckResult("Example circuit loads", False, "Examples directory not found")
+
+    # Pick the simplest example
+    circuit_file = examples / "voltage_divider.json"
+    if not circuit_file.is_file():
+        # Fall back to any available .json
+        json_files = sorted(examples.glob("*.json"))
+        if not json_files:
+            return CheckResult("Example circuit loads", False, "No .json files in examples/")
+        circuit_file = json_files[0]
+
+    try:
+        from cli import try_load_circuit
+
+        model, error = try_load_circuit(str(circuit_file))
+        if model is None:
+            return CheckResult("Example circuit loads", False, f"{circuit_file.name}: {error}")
+        n_comp = len(model.components)
+        n_wire = len(model.wires)
+        return CheckResult("Example circuit loads", True, f"{circuit_file.name}: {n_comp} components, {n_wire} wires")
+    except Exception as e:
+        return CheckResult("Example circuit loads", False, str(e))
+
+
+def check_simulation() -> CheckResult:
+    """Verify that a basic DC operating-point simulation completes.
+
+    This check requires ngspice to be available. If ngspice is not found
+    the check is reported as FAIL with a hint to install ngspice.
+    """
+    examples = _find_examples_dir()
+    if examples is None:
+        return CheckResult("Basic simulation runs", False, "Examples directory not found")
+
+    circuit_file = examples / "voltage_divider.json"
+    if not circuit_file.is_file():
+        json_files = sorted(examples.glob("*.json"))
+        if not json_files:
+            return CheckResult("Basic simulation runs", False, "No .json files in examples/")
+        circuit_file = json_files[0]
+
+    try:
+        from cli import try_load_circuit
+        from controllers.circuit_controller import CircuitController
+        from controllers.simulation_controller import SimulationController
+
+        model, error = try_load_circuit(str(circuit_file))
+        if model is None:
+            return CheckResult("Basic simulation runs", False, f"Load failed: {error}")
+
+        controller = CircuitController(model)
+        sim = SimulationController(model, controller)
+        result = sim.run_simulation()
+
+        if result.success:
+            return CheckResult("Basic simulation runs", True, f"{result.analysis_type}: OK")
+        return CheckResult("Basic simulation runs", False, result.error or "Simulation returned failure")
+    except Exception as e:
+        return CheckResult("Basic simulation runs", False, str(e))
+
+
+def run_selftest() -> SelftestResult:
+    """Execute all smoke-test checks and return the aggregate result."""
+    result = SelftestResult()
+    result.checks.append(check_imports())
+    result.checks.append(check_ngspice())
+    result.checks.append(check_example_load())
+    result.checks.append(check_simulation())
+    return result
+
+
+def print_selftest(result: SelftestResult) -> None:
+    """Print the selftest results to stdout in a human-readable format."""
+    print("Spice GUI Self-Test")
+    print("=" * 40)
+    for check in result.checks:
+        status = "PASS" if check.passed else "FAIL"
+        print(f"  [{status}] {check.name}")
+        if check.detail:
+            print(f"         {check.detail}")
+    print("-" * 40)
+    print(result.summary)
+    if not result.passed:
+        print("\nSome checks failed. See details above for actionable errors.")

--- a/app/tests/unit/test_selftest.py
+++ b/app/tests/unit/test_selftest.py
@@ -1,0 +1,172 @@
+"""Tests for simulation.selftest (#838)."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from simulation.selftest import (
+    CheckResult,
+    SelftestResult,
+    check_example_load,
+    check_imports,
+    check_ngspice,
+    check_simulation,
+    run_selftest,
+)
+
+
+class TestCheckResult:
+    def test_passed_check(self):
+        c = CheckResult("test", True, "ok")
+        assert c.passed is True
+        assert c.name == "test"
+
+    def test_failed_check(self):
+        c = CheckResult("test", False, "bad")
+        assert c.passed is False
+
+
+class TestSelftestResult:
+    def test_all_pass(self):
+        r = SelftestResult(checks=[CheckResult("a", True), CheckResult("b", True)])
+        assert r.passed is True
+        assert "2/2" in r.summary
+
+    def test_one_fails(self):
+        r = SelftestResult(checks=[CheckResult("a", True), CheckResult("b", False)])
+        assert r.passed is False
+        assert "1/2" in r.summary
+
+    def test_empty(self):
+        r = SelftestResult()
+        assert r.passed is True
+        assert "0/0" in r.summary
+
+
+class TestCheckImports:
+    def test_imports_succeed(self):
+        result = check_imports()
+        assert result.passed is True
+        assert "OK" in result.detail
+
+    def test_import_failure(self):
+        with patch.dict(sys.modules, {"models.circuit": None}):
+            with patch("builtins.__import__", side_effect=ImportError("no module")):
+                result = check_imports()
+        assert result.passed is False
+
+
+class TestCheckNgspice:
+    def test_ngspice_found(self):
+        with patch("simulation.ngspice_config.resolve_ngspice_path", return_value="/usr/bin/ngspice"):
+            result = check_ngspice()
+        assert result.passed is True
+        assert "/usr/bin/ngspice" in result.detail
+
+    def test_ngspice_not_found(self):
+        with patch("simulation.ngspice_config.resolve_ngspice_path", return_value=None):
+            result = check_ngspice()
+        assert result.passed is False
+
+
+class TestCheckExampleLoad:
+    def test_loads_successfully(self):
+        result = check_example_load()
+        # In the dev environment, examples/ exists
+        if result.passed:
+            assert "components" in result.detail
+        # If examples dir not found, that's also valid in some environments
+
+    def test_missing_examples_dir(self):
+        with patch("simulation.selftest._find_examples_dir", return_value=None):
+            result = check_example_load()
+        assert result.passed is False
+        assert "not found" in result.detail
+
+    def test_no_json_files(self, tmp_path):
+        with patch("simulation.selftest._find_examples_dir", return_value=tmp_path):
+            result = check_example_load()
+        assert result.passed is False
+
+
+class TestCheckSimulation:
+    def test_missing_examples_dir(self):
+        with patch("simulation.selftest._find_examples_dir", return_value=None):
+            result = check_simulation()
+        assert result.passed is False
+
+    def test_simulation_succeeds(self):
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.analysis_type = "DC Operating Point"
+
+        examples = Path(__file__).resolve().parent.parent.parent / "examples"
+        if not examples.is_dir():
+            pytest.skip("No examples directory available")
+
+        with (
+            patch("simulation.selftest._find_examples_dir", return_value=examples),
+            patch("controllers.simulation_controller.SimulationController.run_simulation", return_value=mock_result),
+        ):
+            result = check_simulation()
+        assert isinstance(result, CheckResult)
+        assert result.passed is True
+
+    def test_simulation_fails(self):
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.error = "ngspice not found"
+
+        examples = Path(__file__).resolve().parent.parent.parent / "examples"
+        if not examples.is_dir():
+            pytest.skip("No examples directory available")
+
+        with (
+            patch("simulation.selftest._find_examples_dir", return_value=examples),
+            patch("controllers.simulation_controller.SimulationController.run_simulation", return_value=mock_result),
+        ):
+            result = check_simulation()
+        assert result.passed is False
+
+
+class TestRunSelftest:
+    def test_returns_selftest_result(self):
+        with (
+            patch("simulation.selftest.check_imports", return_value=CheckResult("imports", True)),
+            patch("simulation.selftest.check_ngspice", return_value=CheckResult("ngspice", True)),
+            patch("simulation.selftest.check_example_load", return_value=CheckResult("load", True)),
+            patch("simulation.selftest.check_simulation", return_value=CheckResult("sim", True)),
+        ):
+            result = run_selftest()
+        assert isinstance(result, SelftestResult)
+        assert len(result.checks) == 4
+        assert result.passed is True
+
+
+class TestCliIntegration:
+    def test_selftest_subcommand_exists(self):
+        from cli import build_parser
+
+        parser = build_parser()
+        # Should not raise
+        args = parser.parse_args(["selftest"])
+        assert args.command == "selftest"
+
+    def test_cmd_selftest_returns_zero_on_pass(self):
+        from cli import cmd_selftest
+
+        mock_result = SelftestResult(checks=[CheckResult("test", True)])
+        with patch("simulation.selftest.run_selftest", return_value=mock_result):
+            with patch("simulation.selftest.print_selftest"):
+                exit_code = cmd_selftest(MagicMock())
+        assert exit_code == 0
+
+    def test_cmd_selftest_returns_one_on_fail(self):
+        from cli import cmd_selftest
+
+        mock_result = SelftestResult(checks=[CheckResult("test", False, "broken")])
+        with patch("simulation.selftest.run_selftest", return_value=mock_result):
+            with patch("simulation.selftest.print_selftest"):
+                exit_code = cmd_selftest(MagicMock())
+        assert exit_code == 1


### PR DESCRIPTION
## Summary - Add  with 4 post-install verification checks - Add  subcommand to CLI () - Add  flag to GUI entry point () - Checks: core imports, ngspice detection, example circuit loading, basic simulation - Clear PASS/FAIL output with actionable error messages - Exit code 0 on all pass, 1 on any failure - 19 unit tests covering checks, runner, and CLI integration Closes #838 ## Test plan - [x] 19 unit tests pass covering all check functions and CLI integration - [x]  CLI subcommand registered and callable - [ ] Manual: run  on machine with ngspice installed - [ ] Manual: run  to verify headless execution - [ ] CI: can be integrated as post-install step in build pipeline 🤖 Generated with [Claude Code](https://claude.com/claude-code)