### PR TITLE
feat: add CI release pipeline for Windows installer (#836)

### DIFF
--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -1,0 +1,90 @@
+name: Build Windows Installer
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: "Version tag (e.g. v1.0.0) — only used for artifact naming"
+        required: false
+        default: "dev"
+
+permissions:
+  contents: write
+
+jobs:
+  build-installer:
+    name: Build Windows Installer
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: app/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          pip install -r app/requirements.txt
+          pip install pyinstaller
+
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            VERSION="${{ github.ref_name }}"
+          elif [[ "${{ github.event.inputs.version_tag }}" != "" && "${{ github.event.inputs.version_tag }}" != "dev" ]]; then
+            VERSION="${{ github.event.inputs.version_tag }}"
+          else
+            VERSION="dev-$(echo ${{ github.sha }} | cut -c1-8)"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building version: $VERSION"
+
+      - name: Build PyInstaller bundle
+        run: python -m PyInstaller SpiceGUI.spec
+
+      - name: Verify bundle
+        shell: bash
+        run: |
+          test -f dist/SpiceGUI/SpiceGUI.exe || { echo "ERROR: SpiceGUI.exe not found in dist/SpiceGUI/"; exit 1; }
+          echo "Bundle contents:"
+          ls -la dist/SpiceGUI/
+
+      - name: Update version in Inno Setup script
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}" -replace '^v', ''
+          $content = Get-Content installer/spicegui.iss -Raw
+          $content = $content -replace '#define MyAppVersion\s+"[^"]+"', "#define MyAppVersion   `"$version`""
+          Set-Content installer/spicegui.iss -Value $content
+          Write-Host "Set installer version to: $version"
+
+      - name: Compile installer with Inno Setup
+        shell: cmd
+        run: |
+          "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" installer\spicegui.iss
+
+      - name: List output
+        shell: bash
+        run: ls -la installer/Output/
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer-${{ steps.version.outputs.version }}
+          path: installer/Output/*.exe
+          retention-days: 30
+
+      - name: Attach installer to GitHub Release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: installer/Output/*.exe
+          fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary - Add GitHub Actions workflow  that builds the Windows installer - Triggers automatically on  tag push (release builds) and supports  for manual testing - Steps: install Python deps → PyInstaller bundle → Inno Setup compile → upload artifact → attach to GitHub Release - Caches pip dependencies for faster builds - Installer  attached to GitHub Release automatically on tagged builds ## Test plan - [ ] Verify workflow file parses correctly (CI yaml check passes) - [ ] Manual dispatch test: trigger workflow_dispatch from Actions tab - [ ] Tag test: push a test tag to verify full pipeline - [ ] Verify artifact is uploaded and downloadable Closes #836 🤖 Generated with [Claude Code](https://claude.com/claude-code)