### PR TITLE
Audit GUI: fix unguarded .remove() and legend loc='best' freeze

### DIFF
--- a/app/GUI/measurement_cursors.py
+++ b/app/GUI/measurement_cursors.py
@@ -124,7 +124,10 @@ class MeasurementCursors:
 
     def _draw_cursor_a(self):
         if self._line_a is not None:
-            self._line_a.remove()
+            try:
+                self._line_a.remove()
+            except (NotImplementedError, ValueError):
+                pass
         self._line_a = self._ax.axvline(
             self._a_x,
             color=self.CURSOR_A_COLOR,
@@ -135,7 +138,10 @@ class MeasurementCursors:
 
     def _draw_cursor_b(self):
         if self._line_b is not None:
-            self._line_b.remove()
+            try:
+                self._line_b.remove()
+            except (NotImplementedError, ValueError):
+                pass
         self._line_b = self._ax.axvline(
             self._b_x,
             color=self.CURSOR_B_COLOR,

--- a/app/GUI/parameter_sweep_plot_dialog.py
+++ b/app/GUI/parameter_sweep_plot_dialog.py
@@ -11,6 +11,7 @@ from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from PyQt6.QtWidgets import QDialog, QHBoxLayout, QPushButton, QVBoxLayout
 
+from .plot_utils import safe_legend
 from .results_plot_dialog import save_plot
 
 logger = logging.getLogger(__name__)
@@ -119,7 +120,7 @@ class ParameterSweepPlotDialog(QDialog):
         ax.set_xlabel(f"{component_id} Value")
         ax.set_ylabel("Voltage (V)")
         ax.set_title(f"Parameter Sweep — {component_id}")
-        ax.legend(loc="best", fontsize="small")
+        safe_legend(ax, fontsize="small")
         ax.grid(True, alpha=0.3)
 
     # ------------------------------------------------------------------
@@ -159,7 +160,7 @@ class ParameterSweepPlotDialog(QDialog):
         ax.set_xlabel("Time (s)")
         ax.set_ylabel("Voltage (V)")
         ax.set_title(f"Transient Parameter Sweep — {component_id}")
-        ax.legend(loc="best", fontsize="x-small", ncol=2)
+        safe_legend(ax, fontsize="x-small", ncol=2)
         ax.grid(True, alpha=0.3)
 
     # ------------------------------------------------------------------
@@ -206,12 +207,12 @@ class ParameterSweepPlotDialog(QDialog):
 
         ax_mag.set_ylabel("Magnitude")
         ax_mag.set_title(f"AC Parameter Sweep — {component_id}")
-        ax_mag.legend(loc="best", fontsize="x-small")
+        safe_legend(ax_mag, fontsize="x-small")
         ax_mag.grid(True, which="both", alpha=0.3)
 
         ax_phase.set_xlabel("Frequency (Hz)")
         ax_phase.set_ylabel("Phase (degrees)")
-        ax_phase.legend(loc="best", fontsize="x-small")
+        safe_legend(ax_phase, fontsize="x-small")
         ax_phase.grid(True, which="both", alpha=0.3)
 
     # ------------------------------------------------------------------
@@ -257,7 +258,7 @@ class ParameterSweepPlotDialog(QDialog):
         ax.set_xlabel(x_label)
         ax.set_ylabel("Voltage (V)")
         ax.set_title(f"DC Sweep with Parameter Sweep — {component_id}")
-        ax.legend(loc="best", fontsize="x-small")
+        safe_legend(ax, fontsize="x-small")
         ax.grid(True, alpha=0.3)
 
     def closeEvent(self, event):

--- a/app/GUI/plot_utils.py
+++ b/app/GUI/plot_utils.py
@@ -14,6 +14,28 @@ from .styles import theme_manager
 matplotlib.use("QtAgg")
 
 
+# Threshold above which ``loc="best"`` becomes too expensive (O(n) scan of
+# every data point).  Above this we fall back to a fixed position to avoid
+# freezing the UI.
+_LEGEND_BEST_MAX_POINTS = 10_000
+
+
+def safe_legend(ax, **kwargs):
+    """Call ``ax.legend()`` with a safe ``loc`` value.
+
+    When the total number of data points on *ax* exceeds
+    ``_LEGEND_BEST_MAX_POINTS``, ``loc="best"`` is replaced with
+    ``"upper right"`` to prevent the UI freeze caused by matplotlib's
+    exhaustive placement search.
+    """
+    loc = kwargs.pop("loc", "best")
+    if loc == "best":
+        total_points = sum(len(line.get_xdata()) for line in ax.get_lines())
+        if total_points > _LEGEND_BEST_MAX_POINTS:
+            loc = "upper right"
+    return ax.legend(loc=loc, **kwargs)
+
+
 def apply_mpl_theme(fig):
     """Apply the current application theme colors to a matplotlib figure.
 

--- a/app/GUI/results_plot_dialog.py
+++ b/app/GUI/results_plot_dialog.py
@@ -17,6 +17,7 @@ from PyQt6.QtWidgets import QCheckBox, QDialog, QFileDialog, QHBoxLayout, QPushB
 
 from .measurement_cursors import CursorReadoutPanel, MeasurementCursors
 from .plot_utils import apply_mpl_theme as _apply_mpl_theme
+from .plot_utils import safe_legend
 
 logger = logging.getLogger(__name__)
 
@@ -158,7 +159,7 @@ class DCSweepPlotDialog(QDialog):
         self._ax.grid(True, alpha=0.3)
 
         if self._lines:
-            legend = self._ax.legend(loc="best", fontsize="small")
+            legend = safe_legend(self._ax, fontsize="small")
             self._setup_legend_toggle(legend)
 
         _apply_mpl_theme(self._fig)
@@ -395,9 +396,9 @@ class ACSweepPlotDialog(QDialog):
         self._ax_phase.grid(True, which="both", alpha=0.3)
 
         if has_data:
-            mag_legend = self._ax_mag.legend(loc="best", fontsize="small")
+            mag_legend = safe_legend(self._ax_mag, fontsize="small")
             self._setup_legend_toggle(mag_legend, self._ax_mag)
-            phase_legend = self._ax_phase.legend(loc="best", fontsize="small")
+            phase_legend = safe_legend(self._ax_phase, fontsize="small")
             self._setup_legend_toggle(phase_legend, self._ax_phase)
 
         _apply_mpl_theme(self._fig)
@@ -636,7 +637,7 @@ class NoisePlotDialog(QDialog):
         ax.set_xlabel("Frequency (Hz)")
         ax.set_ylabel("Noise Spectral Density (V/\u221aHz)")
         ax.set_title("Noise Analysis")
-        ax.legend()
+        safe_legend(ax)
         ax.grid(True, which="both", alpha=0.3)
         self._fig.tight_layout()
         self._canvas.draw()

--- a/app/GUI/waveform_dialog.py
+++ b/app/GUI/waveform_dialog.py
@@ -27,6 +27,7 @@ from utils.format_utils import format_value, parse_value
 
 from .measurement_cursors import CursorReadoutPanel, MeasurementCursors
 from .plot_utils import apply_mpl_theme as _apply_mpl_theme
+from .plot_utils import safe_legend
 from .styles import SCROLL_LOAD_COUNT, theme_manager
 
 # Get colors from the 'Paired' colormap for color-blind friendliness
@@ -532,11 +533,7 @@ class WaveformDialog(QDialog):
         self.canvas.axes.set_title("Transient Analysis")
         self.canvas.axes.set_xlabel("Time (s)")
         self.canvas.axes.set_ylabel("Voltage (V)")
-        # loc="best" scans every data point for optimal placement — too slow
-        # for large datasets. Fall back to a fixed position above 10k points.
-        total_points = sum(len(line.get_xdata()) for line in self.canvas.axes.get_lines())
-        legend_loc = "upper right" if total_points > 10_000 else "best"
-        self.canvas.axes.legend(fontsize="small", loc=legend_loc)
+        safe_legend(self.canvas.axes, fontsize="small")
         self.canvas.axes.grid(True)
         _apply_mpl_theme(self.canvas.figure)
         self.canvas.figure.tight_layout()

--- a/app/tests/unit/test_measurement_cursors.py
+++ b/app/tests/unit/test_measurement_cursors.py
@@ -82,6 +82,31 @@ class TestMeasurementCursors:
         mc = MeasurementCursors(ax, canvas)
         mc.remove()  # should not raise
 
+    def test_draw_cursor_after_axes_clear(self):
+        """_draw_cursor_a/b must not crash when axes was cleared (#863)."""
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        mc._a_x = 2.0
+        mc._draw_cursor_a()
+        assert mc._line_a is not None
+
+        # Clearing the axes invalidates the artist; redrawing must not raise
+        ax.clear()
+        mc._a_x = 3.0
+        mc._draw_cursor_a()  # should not raise NotImplementedError
+
+    def test_draw_cursor_b_after_axes_clear(self):
+        """_draw_cursor_b must not crash when axes was cleared (#863)."""
+        fig, canvas, ax, x = _make_axes_with_data()
+        mc = MeasurementCursors(ax, canvas)
+        mc._b_x = 4.0
+        mc._draw_cursor_b()
+        assert mc._line_b is not None
+
+        ax.clear()
+        mc._b_x = 5.0
+        mc._draw_cursor_b()  # should not raise NotImplementedError
+
     def test_callback_called(self):
         fig, canvas, ax, x = _make_axes_with_data()
         calls = []

--- a/app/tests/unit/test_plot_utils.py
+++ b/app/tests/unit/test_plot_utils.py
@@ -1,0 +1,68 @@
+"""
+Unit tests for GUI.plot_utils — shared matplotlib helpers.
+"""
+
+import numpy as np
+from GUI.plot_utils import _LEGEND_BEST_MAX_POINTS, safe_legend
+from matplotlib.figure import Figure
+
+
+def _make_axes():
+    """Return a fresh (Figure, Axes) pair."""
+    fig = Figure(figsize=(4, 3))
+    ax = fig.add_subplot(111)
+    return fig, ax
+
+
+class TestSafeLegend:
+    """Tests for safe_legend() — threshold-based loc fallback."""
+
+    def test_small_dataset_uses_best(self):
+        """When total points are below threshold, loc='best' is preserved."""
+        _, ax = _make_axes()
+        x = np.linspace(0, 1, 100)
+        ax.plot(x, x, label="line")
+        legend = safe_legend(ax, fontsize="small")
+        # matplotlib stores loc as an int code; "best" == 0
+        assert legend._loc == 0
+
+    def test_large_dataset_uses_upper_right(self):
+        """When total points exceed threshold, loc falls back to 'upper right'."""
+        _, ax = _make_axes()
+        x = np.linspace(0, 1, _LEGEND_BEST_MAX_POINTS + 1)
+        ax.plot(x, x, label="big")
+        legend = safe_legend(ax, fontsize="small")
+        # "upper right" == 1
+        assert legend._loc == 1
+
+    def test_explicit_fixed_loc_is_kept(self):
+        """An explicit non-best loc should pass through unchanged."""
+        _, ax = _make_axes()
+        x = np.linspace(0, 1, _LEGEND_BEST_MAX_POINTS + 1)
+        ax.plot(x, x, label="big")
+        legend = safe_legend(ax, loc="lower left", fontsize="small")
+        # "lower left" == 3
+        assert legend._loc == 3
+
+    def test_multiple_lines_summed(self):
+        """Total points is the sum across all lines on the axes."""
+        _, ax = _make_axes()
+        n = _LEGEND_BEST_MAX_POINTS // 2 + 1
+        ax.plot(range(n), range(n), label="a")
+        ax.plot(range(n), range(n), label="b")
+        # Combined > threshold
+        legend = safe_legend(ax)
+        assert legend._loc == 1  # "upper right"
+
+    def test_no_lines_uses_best(self):
+        """With zero data points, loc='best' is fine."""
+        _, ax = _make_axes()
+        legend = safe_legend(ax)
+        assert legend._loc == 0
+
+    def test_kwargs_forwarded(self):
+        """Extra kwargs (fontsize, ncol, etc.) are forwarded to ax.legend()."""
+        _, ax = _make_axes()
+        ax.plot([0, 1], [0, 1], label="line")
+        legend = safe_legend(ax, fontsize="x-small", ncol=2)
+        assert legend._ncols == 2


### PR DESCRIPTION
## Summary Closes #863 — Systematic audit of  for missing value handling patterns that cause crashes or UI freezes. ### High-risk fixes applied - **Unguarded  on matplotlib artists** ():  and  now wrap  in , matching the existing guard in . Crash occurs when axes is cleared between cursor redraws. - ** on legends** (10 call sites across 4 files): Extracted a shared  helper into  that falls back from  to  when total data points exceed 10k. This prevents matplotlib's O(n) exhaustive placement search from freezing the UI. Applied to: -  (replaces inline fix from #862) -  (DCSweepPlotDialog, ACSweepPlotDialog, NoisePlotDialog) -  (5 plot methods) ### Low-risk — audited but no changes needed - **Unguarded  on Qt items**: All 25+  call sites audited.  calls in  and  are already properly guarded with .  calls in , , etc. are on  which always has a scene set during construction. - **Missing None checks before iteration**: , , , and  iterations in  are safe because Qt is single-threaded — these collections don't mutate during iteration within a single event handler. ## Test plan - [ ] New  validates  threshold logic (small dataset -> , large dataset -> , explicit loc passthrough, multi-line sum) - [ ] New tests in  verify  don't crash after  - [ ] Existing plot dialog tests continue to pass (DCSweepPlotDialog, ACSweepPlotDialog, WaveformDialog) - [ ] Human testing: open any plot dialog, verify legend appears correctly; clear and re-plot to verify cursor redraw Generated with Claude Code