### PR TITLE
feat: add Current Probe component for measuring branch currents (#457)

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -773,6 +773,15 @@ class ZenerDiode(ComponentGraphicsItem):
         super().__init__(component_id, self.type_name, model=model)
 
 
+class CurrentProbe(ComponentGraphicsItem):
+    """Current Probe — 0V voltage source for measuring current"""
+
+    type_name = "Current Probe"
+
+    def __init__(self, component_id, model=None):
+        super().__init__(component_id, self.type_name, model=model)
+
+
 class Transformer(ComponentGraphicsItem):
     """Transformer — two coupled inductors (K element)"""
 
@@ -852,6 +861,8 @@ COMPONENT_CLASSES = {
     "Zener Diode": ZenerDiode,
     "ZenerDiode": ZenerDiode,
     "Transformer": Transformer,
+    "CurrentProbe": CurrentProbe,
+    "Current Probe": CurrentProbe,
 }
 
 

--- a/app/GUI/component_palette.py
+++ b/app/GUI/component_palette.py
@@ -37,6 +37,7 @@ COMPONENT_TOOLTIPS = {
     "LED": "LED (D) — Light-emitting diode",
     "Zener Diode": "Zener Diode (D) — Voltage-regulating diode",
     "Transformer": "Transformer (K) — Coupled inductors / ideal transformer",
+    "Current Probe": "Current Probe (VP) — Measures current through a branch (0V source)",
 }
 
 # Name for the recommended section in the palette

--- a/app/GUI/renderers.py
+++ b/app/GUI/renderers.py
@@ -204,6 +204,33 @@ class IEEEACCurrentSource(ComponentRenderer):
         return [(-18.0, -18.0), (18.0, -18.0), (18.0, 18.0), (-18.0, 18.0)]
 
 
+class IEEECurrentProbe(ComponentRenderer):
+    """Current Probe — circle with an arrow showing current measurement direction."""
+
+    def draw(self, painter, component):
+        painter.drawLine(-30, 0, -12, 0)
+        painter.drawLine(12, 0, 30, 0)
+        painter.drawEllipse(-12, -12, 24, 24)
+        # Arrow through circle showing current direction
+        painter.drawLine(-8, 0, 8, 0)
+        painter.drawLine(5, -4, 8, 0)
+        painter.drawLine(5, 4, 8, 0)
+        # "A" label for ampere measurement (small, inside top)
+        from PyQt6.QtCore import QRectF
+        from PyQt6.QtGui import QFont
+
+        old_font = painter.font()
+        small_font = QFont(old_font)
+        small_font.setPixelSize(9)
+        small_font.setBold(True)
+        painter.setFont(small_font)
+        painter.drawText(QRectF(-6, -11, 12, 10), 0x0084, "A")
+        painter.setFont(old_font)
+
+    def get_obstacle_shape(self, component):
+        return [(-14.0, -14.0), (14.0, -14.0), (14.0, 14.0), (-14.0, 14.0)]
+
+
 class IEEEGround(ComponentRenderer):
     def draw(self, painter, component):
         painter.drawLine(0, -10, 0, 0)
@@ -538,6 +565,7 @@ _ieee_current_source = IEEECurrentSource()
 _ieee_waveform_voltage_source = IEEEWaveformVoltageSource()
 _ieee_ac_voltage_source = IEEEACVoltageSource()
 _ieee_ac_current_source = IEEEACCurrentSource()
+_ieee_current_probe = IEEECurrentProbe()
 _ieee_ground = IEEEGround()
 _ieee_opamp = IEEEOpAmp()
 _ieee_vcvs = IEEEVCVS()
@@ -587,6 +615,7 @@ register("Current Source", "ieee", _ieee_current_source)
 register("Waveform Source", "ieee", _ieee_waveform_voltage_source)
 register("AC Voltage Source", "ieee", _ieee_ac_voltage_source)
 register("AC Current Source", "ieee", _ieee_ac_current_source)
+register("Current Probe", "ieee", _ieee_current_probe)
 register("Ground", "ieee", _ieee_ground)
 register("Op-Amp", "ieee", _ieee_opamp)
 register("VCVS", "ieee", _ieee_vcvs)
@@ -611,6 +640,7 @@ register("Current Source", "iec", _make_iec_delegate(_ieee_current_source))
 register("Waveform Source", "iec", _make_iec_delegate(_ieee_waveform_voltage_source))
 register("AC Voltage Source", "iec", _make_iec_delegate(_ieee_ac_voltage_source))
 register("AC Current Source", "iec", _make_iec_delegate(_ieee_ac_current_source))
+register("Current Probe", "iec", _make_iec_delegate(_ieee_current_probe))
 register("Ground", "iec", _make_iec_delegate(_ieee_ground))
 register("Op-Amp", "iec", _make_iec_delegate(_ieee_opamp))
 register("VCVS", "iec", _make_iec_delegate(_ieee_vcvs))

--- a/app/GUI/styles/constants.py
+++ b/app/GUI/styles/constants.py
@@ -64,6 +64,7 @@ _COLOR_KEYS = {
     "LED": "component_led",
     "Zener Diode": "component_zener",
     "Transformer": "component_transformer",
+    "Current Probe": "component_current_probe",
 }
 
 # Component definitions - symbol and terminals sourced from models

--- a/app/models/component.py
+++ b/app/models/component.py
@@ -38,6 +38,7 @@ COMPONENT_TYPES = [
     "LED",
     "Zener Diode",
     "Transformer",
+    "Current Probe",
 ]
 
 # Category groupings for the component palette
@@ -54,7 +55,7 @@ COMPONENT_CATEGORIES = {
         "MOSFET PMOS",
     ],
     "Controlled Sources": ["VCVS", "CCVS", "VCCS", "CCCS"],
-    "Other": ["Op-Amp", "VC Switch", "Ground", "Transformer"],
+    "Other": ["Op-Amp", "VC Switch", "Ground", "Transformer", "Current Probe"],
 }
 
 # Mapping of component types to SPICE symbols
@@ -82,6 +83,7 @@ SPICE_SYMBOLS = {
     "LED": "D",
     "Zener Diode": "D",
     "Transformer": "K",
+    "Current Probe": "VP",
 }
 
 # Number of terminals per component type (default is 2)
@@ -125,6 +127,7 @@ DEFAULT_VALUES = {
     "LED": "IS=1e-20 N=1.8 EG=1.9",
     "Zener Diode": "IS=1e-14 N=1 BV=5.1 IBV=1e-3",
     "Transformer": "10mH 10mH 0.99",
+    "Current Probe": "0",
 }
 
 # Available op-amp models (value field choices)
@@ -197,6 +200,7 @@ COMPONENT_COLORS = {
     "LED": "#FFEB3B",
     "Zener Diode": "#8D6E63",
     "Transformer": "#6F42C1",
+    "Current Probe": "#00BFA5",
 }
 
 # Terminal geometry configuration per component type
@@ -227,6 +231,7 @@ TERMINAL_GEOMETRY = {
     "LED": (10, 20, None),
     "Zener Diode": (10, 20, None),
     "Transformer": (20, 10, [(-30, -10), (-30, 10), (30, -10), (30, 10)]),
+    "Current Probe": (15, 15, None),
 }
 
 # Mapping from serialized class names to canonical display names
@@ -248,6 +253,7 @@ _CLASS_TO_DISPLAY = {
     "MOSFETPMOS": "MOSFET PMOS",
     "VCSwitch": "VC Switch",
     "ZenerDiode": "Zener Diode",
+    "CurrentProbe": "Current Probe",
 }
 
 # Mapping from display names to Python class names (for serialization)
@@ -268,6 +274,7 @@ _DISPLAY_TO_CLASS = {
     "MOSFET PMOS": "MOSFETPMOS",
     "VC Switch": "VCSwitch",
     "Zener Diode": "ZenerDiode",
+    "Current Probe": "CurrentProbe",
 }
 
 

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -259,6 +259,9 @@ class NetlistGenerator:
                 # Ixxx n+ n- AC magnitude phase
                 val = self._sanitize_value(comp.value)
                 lines.append(f"{comp_id} {' '.join(nodes)} AC {val}")
+            elif comp.component_type == "Current Probe":
+                # 0V voltage source for current measurement
+                lines.append(f"{comp_id} {' '.join(nodes)} 0")
             elif comp.component_type == "Waveform Source":
                 # Use get_spice_value() method if available, otherwise use value
                 if hasattr(comp, "get_spice_value"):
@@ -569,6 +572,11 @@ class NetlistGenerator:
 
             # Add resistor voltages to the print list
             all_print_vars.extend(resistor_voltages_print)
+
+            # Add current probe measurements: i(probe_id) for each Current Probe
+            probes = [c for c in self.components.values() if c.component_type == "Current Probe"]
+            for probe in sorted(probes, key=lambda c: c.component_id):
+                all_print_vars.append(f"i({probe.component_id})")
 
             # Note: for DC sweep, the sweep variable (v-sweep) is automatically
             # included as the first column in wrdata output when wr_singlescale

--- a/app/tests/unit/test_current_probe.py
+++ b/app/tests/unit/test_current_probe.py
@@ -1,0 +1,126 @@
+"""Tests for Current Probe component (#457)."""
+
+from models.component import (
+    COMPONENT_CATEGORIES,
+    COMPONENT_COLORS,
+    COMPONENT_TYPES,
+    DEFAULT_VALUES,
+    SPICE_SYMBOLS,
+    TERMINAL_GEOMETRY,
+    ComponentData,
+)
+from models.node import NodeData
+from models.wire import WireData
+from simulation.netlist_generator import NetlistGenerator
+from tests.conftest import make_component, make_wire
+
+
+class TestCurrentProbeRegistration:
+    """Current Probe is registered in all component dictionaries."""
+
+    def test_in_types(self):
+        assert "Current Probe" in COMPONENT_TYPES
+
+    def test_spice_symbol(self):
+        assert SPICE_SYMBOLS["Current Probe"] == "VP"
+
+    def test_in_other_category(self):
+        assert "Current Probe" in COMPONENT_CATEGORIES["Other"]
+
+    def test_default_value_is_zero(self):
+        assert DEFAULT_VALUES["Current Probe"] == "0"
+
+    def test_has_color(self):
+        assert "Current Probe" in COMPONENT_COLORS
+
+    def test_has_geometry(self):
+        assert "Current Probe" in TERMINAL_GEOMETRY
+
+    def test_two_terminals(self):
+        comp = make_component("Current Probe", "VP1", "0", (0, 0))
+        assert comp.get_terminal_count() == 2
+
+
+class TestCurrentProbeComponentData:
+    def test_serialization_roundtrip(self):
+        comp = make_component("Current Probe", "VP1", "0", (50, 100))
+        d = comp.to_dict()
+        assert d["type"] == "CurrentProbe"
+        restored = ComponentData.from_dict(d)
+        assert restored.component_type == "Current Probe"
+        assert restored.value == "0"
+
+
+def _build_probe_circuit():
+    """V1 -- CurrentProbe -- R1 -- GND, with V1- to GND."""
+    components = {
+        "V1": make_component("Voltage Source", "V1", "5V", (0, 0)),
+        "VP1": make_component("Current Probe", "VP1", "0", (100, 0)),
+        "R1": make_component("Resistor", "R1", "1k", (200, 0)),
+        "GND1": make_component("Ground", "GND1", "0V", (200, 100)),
+    }
+    wires = [
+        make_wire("V1", 0, "VP1", 0),
+        make_wire("VP1", 1, "R1", 0),
+        make_wire("R1", 1, "GND1", 0),
+        make_wire("V1", 1, "GND1", 0),
+    ]
+    node_a = NodeData(
+        terminals={("V1", 0), ("VP1", 0)},
+        wire_indices={0},
+        auto_label="nodeA",
+    )
+    node_b = NodeData(
+        terminals={("VP1", 1), ("R1", 0)},
+        wire_indices={1},
+        auto_label="nodeB",
+    )
+    node_gnd = NodeData(
+        terminals={("R1", 1), ("GND1", 0), ("V1", 1)},
+        wire_indices={2, 3},
+        is_ground=True,
+        auto_label="0",
+    )
+    nodes = [node_a, node_b, node_gnd]
+    t2n = {
+        ("V1", 0): node_a,
+        ("VP1", 0): node_a,
+        ("VP1", 1): node_b,
+        ("R1", 0): node_b,
+        ("R1", 1): node_gnd,
+        ("GND1", 0): node_gnd,
+        ("V1", 1): node_gnd,
+    }
+    return components, wires, nodes, t2n
+
+
+class TestCurrentProbeNetlist:
+    """Current Probe generates a 0V source and prints i(probe_id)."""
+
+    def test_probe_is_zero_volt_source(self):
+        components, wires, nodes, t2n = _build_probe_circuit()
+        gen = NetlistGenerator(
+            components=components,
+            wires=wires,
+            nodes=nodes,
+            terminal_to_node=t2n,
+            analysis_type="DC Operating Point",
+            analysis_params={},
+        )
+        netlist = gen.generate()
+        # Should appear as a 0V source line
+        assert "VP1 nodeA nodeB 0" in netlist
+
+    def test_probe_prints_current(self):
+        components, wires, nodes, t2n = _build_probe_circuit()
+        gen = NetlistGenerator(
+            components=components,
+            wires=wires,
+            nodes=nodes,
+            terminal_to_node=t2n,
+            analysis_type="DC Operating Point",
+            analysis_params={},
+        )
+        netlist = gen.generate()
+        # Should include print/wrdata with i(VP1)
+        assert "i(VP1)" in netlist


### PR DESCRIPTION
## Summary
- Adds a **Current Probe** component that acts as a 0V voltage source internally
- Netlist automatically includes `i(probe_id)` in print/wrdata commands for current measurement
- Distinctive probe renderer with arrow and "A" label to differentiate from other sources

## Details
- SPICE symbol: `VP` (voltage probe, for unique counter IDs)
- Default value: `0` (0V source — transparent to circuit operation)
- Netlist output: `VP1 nodeA nodeB 0` plus `i(VP1)` in control block
- Placed in the "Other" component category alongside Ground, Op-Amp, etc.

## Test plan
- [x] Unit tests for component registration
- [x] Unit tests for serialization roundtrip
- [x] Unit tests for netlist generation (0V source line + i() print directive)
- [ ] Human testing: place probe in series, run simulation, verify current appears in results

Closes #457
