### PR TITLE
feat: add Transformer to CircuiTikZ and ASC exports

### DIFF
--- a/app/simulation/asc_exporter.py
+++ b/app/simulation/asc_exporter.py
@@ -27,6 +27,7 @@ _TYPE_TO_SYMBOL = {
     "VCCS": "g",
     "CCVS": "h",
     "Waveform Source": "voltage",
+    "Transformer": "ind2",
 }
 
 # Pin offsets (same as asc_parser._PIN_OFFSETS, with corrected pin spacing)
@@ -49,6 +50,7 @@ _PIN_OFFSETS = {
     "CCVS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
     "VCCS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
     "CCCS": [(-32, 32), (-32, -32), (32, -32), (32, 32)],
+    "Transformer": [(-32, -32), (-32, 32), (32, -32), (32, 32)],
     "Ground": [(0, 0)],
 }
 

--- a/app/simulation/circuitikz_exporter.py
+++ b/app/simulation/circuitikz_exporter.py
@@ -31,6 +31,15 @@ CIRCUITIKZ_TRIPOLES = {
     "Op-Amp": "op amp",
 }
 
+CIRCUITIKZ_QUADPOLES = {
+    "Transformer": "transformer core",
+}
+
+# Terminal name suffixes for quadpole node anchors
+QUADPOLE_ANCHORS = {
+    "Transformer": ["A1", "A2", "B1", "B2"],  # primary+, primary-, secondary+, secondary-
+}
+
 # Terminal name suffixes for tripole node anchors
 TRIPOLE_ANCHORS = {
     "BJT NPN": ["C", "B", "E"],  # collector, base, emitter
@@ -173,6 +182,11 @@ def generate(
             _emit_tripole(lines, comp, tikz_name, transform, include_ids)
             continue
 
+        tikz_name = CIRCUITIKZ_QUADPOLES.get(ctype)
+        if tikz_name is not None:
+            _emit_quadpole(lines, comp, tikz_name, transform, include_ids, include_values)
+            continue
+
     # --- Ground symbols ---
     ground_comps = [c for c in components.values() if c.component_type == "Ground"]
     if ground_comps:
@@ -268,6 +282,41 @@ def _emit_tripole(lines, comp, tikz_name, transform, include_ids):
     lines.append(f"  \\node[{tikz_name}{rotate_opt}{xscale}{label_opt}] ({node_id}) at {_coord(cx, cy)} {{}};")
 
     # Draw short wires from tripole anchors to terminal positions
+    terminals = comp.get_terminal_positions()
+    for i, anchor in enumerate(anchors):
+        tx, ty = transform(*terminals[i])
+        lines.append(f"  \\draw ({node_id}.{anchor}) -- {_coord(tx, ty)};")
+
+
+def _emit_quadpole(lines, comp, tikz_name, transform, include_ids, include_values):
+    """Emit a \\node[component] and terminal connection lines for a 4-terminal component."""
+    cx, cy = transform(*comp.position)
+    anchors = QUADPOLE_ANCHORS[comp.component_type]
+    node_id = comp.component_id.replace(" ", "_")
+
+    rotate_opt = ""
+    if comp.rotation != 0:
+        rotate_opt = f", rotate={comp.rotation}"
+    xscale = ""
+    if comp.flip_h:
+        xscale = ", xscale=-1"
+    yscale = ""
+    if comp.flip_v:
+        yscale = ", yscale=-1"
+
+    label_opt = ""
+    if include_ids:
+        label_opt = f", label={{right:{comp.component_id}}}"
+
+    value_comment = ""
+    if include_values and comp.value:
+        value_comment = f" % value: {comp.value}"
+
+    lines.append(
+        f"  \\node[{tikz_name}{rotate_opt}{xscale}{yscale}{label_opt}] ({node_id}) at {_coord(cx, cy)} {{}};{value_comment}"
+    )
+
+    # Draw short wires from quadpole anchors to terminal positions
     terminals = comp.get_terminal_positions()
     for i, anchor in enumerate(anchors):
         tx, ty = transform(*terminals[i])

--- a/app/tests/unit/test_asc_exporter.py
+++ b/app/tests/unit/test_asc_exporter.py
@@ -185,6 +185,23 @@ class TestExportAsc:
         content = export_asc(model)
         assert "R90" in content
 
+    def test_transformer_exported(self):
+        """Regression: Transformer was silently skipped before #500."""
+        model = CircuitModel()
+        model.add_component(
+            ComponentData(
+                component_id="K1",
+                component_type="Transformer",
+                value="10mH 10mH 0.99",
+                position=(200.0, 200.0),
+                rotation=0,
+            )
+        )
+        content = export_asc(model)
+        assert "SYMBOL ind2" in content
+        assert "SYMATTR InstName K1" in content
+        assert "SYMATTR Value 10mH 10mH 0.99" in content
+
     def test_flip_produces_mirror_code(self):
         model = CircuitModel()
         r1 = ComponentData(

--- a/app/tests/unit/test_circuitikz_exporter.py
+++ b/app/tests/unit/test_circuitikz_exporter.py
@@ -411,6 +411,51 @@ class TestFourTerminalExport:
         assert "closing switch" in output
 
 
+class TestTransformerExport:
+    def test_transformer_node(self):
+        model = CircuitModel()
+        model.add_component(ComponentData("K1", "Transformer", "10mH 10mH 0.99", position=(100, 100)))
+        model.rebuild_nodes()
+        output = generate(
+            model.components,
+            model.wires,
+            model.nodes,
+            model.terminal_to_node,
+        )
+        assert r"\node[transformer core" in output
+        assert "(K1)" in output
+        assert "K1.A1" in output
+        assert "K1.A2" in output
+        assert "K1.B1" in output
+        assert "K1.B2" in output
+
+    def test_transformer_includes_value_comment(self):
+        model = CircuitModel()
+        model.add_component(ComponentData("K1", "Transformer", "10mH 10mH 0.99", position=(100, 100)))
+        model.rebuild_nodes()
+        output = generate(
+            model.components,
+            model.wires,
+            model.nodes,
+            model.terminal_to_node,
+            include_values=True,
+        )
+        assert "10mH 10mH 0.99" in output
+
+    def test_transformer_not_silently_omitted(self):
+        """Regression: Transformer was silently skipped before #500."""
+        model = CircuitModel()
+        model.add_component(ComponentData("K1", "Transformer", "10mH 10mH 0.99", position=(100, 100)))
+        model.rebuild_nodes()
+        output = generate(
+            model.components,
+            model.wires,
+            model.nodes,
+            model.terminal_to_node,
+        )
+        assert "K1" in output
+
+
 class TestCompleteCircuit:
     def test_voltage_divider_compiles_structure(self):
         """Full voltage divider: V1, R1, R2, GND with wires."""


### PR DESCRIPTION
Closes #500. Transformer was silently omitted from both CircuiTikZ and ASC exports. Adds CIRCUITIKZ_QUADPOLES dict and _emit_quadpole() for node-style 4-terminal export (transformer core with A1/A2/B1/B2 anchors). Adds Transformer to ASC _TYPE_TO_SYMBOL (ind2) and _PIN_OFFSETS. Includes regression tests for both exporters.