### PR TITLE
fix: add yscale=-1 for flip_v on tripole CircuiTikZ export (#522)

### DIFF
--- a/app/simulation/circuitikz_exporter.py
+++ b/app/simulation/circuitikz_exporter.py
@@ -260,12 +260,15 @@ def _emit_tripole(lines, comp, tikz_name, transform, include_ids):
     xscale = ""
     if comp.flip_h:
         xscale = ", xscale=-1"
+    yscale = ""
+    if comp.flip_v:
+        yscale = ", yscale=-1"
 
     label_opt = ""
     if include_ids:
         label_opt = f", label={{right:{comp.component_id}}}"
 
-    lines.append(f"  \\node[{tikz_name}{rotate_opt}{xscale}{label_opt}] ({node_id}) at {_coord(cx, cy)} {{}};")
+    lines.append(f"  \\node[{tikz_name}{rotate_opt}{xscale}{yscale}{label_opt}] ({node_id}) at {_coord(cx, cy)} {{}};")
 
     # Draw short wires from tripole anchors to terminal positions
     terminals = comp.get_terminal_positions()

--- a/app/tests/unit/test_circuitikz_exporter.py
+++ b/app/tests/unit/test_circuitikz_exporter.py
@@ -236,6 +236,43 @@ class TestTripoleExport:
         assert r"\node[op amp" in output
         assert "OA1.-" in output or "OA1.+" in output
 
+    def test_flip_v_on_tripole(self):
+        """Regression: flip_v was ignored on tripoles before #522."""
+        model = CircuitModel()
+        model.add_component(ComponentData("Q1", "BJT NPN", "2N3904", position=(100, 100), flip_v=True))
+        model.rebuild_nodes()
+        output = generate(
+            model.components,
+            model.wires,
+            model.nodes,
+            model.terminal_to_node,
+        )
+        assert "yscale=-1" in output
+
+    def test_flip_h_on_tripole(self):
+        model = CircuitModel()
+        model.add_component(ComponentData("Q1", "BJT NPN", "2N3904", position=(100, 100), flip_h=True))
+        model.rebuild_nodes()
+        output = generate(
+            model.components,
+            model.wires,
+            model.nodes,
+            model.terminal_to_node,
+        )
+        assert "xscale=-1" in output
+
+    def test_flip_v_absent_when_not_flipped(self):
+        model = CircuitModel()
+        model.add_component(ComponentData("Q1", "BJT NPN", "2N3904", position=(100, 100)))
+        model.rebuild_nodes()
+        output = generate(
+            model.components,
+            model.wires,
+            model.nodes,
+            model.terminal_to_node,
+        )
+        assert "yscale" not in output
+
     def test_all_tripole_types_mapped(self):
         """Ensure every tripole type has a CircuiTikZ mapping."""
         expected_tripoles = {


### PR DESCRIPTION
Closes #522. _emit_tripole handled flip_h (xscale=-1) but ignored flip_v entirely, causing vertically flipped tripole components to render unflipped in CircuiTikZ output. Adds yscale=-1 when comp.flip_v is set. Includes regression tests for flip_v present, flip_h present, and yscale absent when not flipped.