### PR TITLE
Fix TemplateController instance method called as static (#539)

### DIFF
--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -152,7 +152,7 @@ class ViewOperationsMixin:
             if bundle.template is not None:
                 from controllers.template_controller import TemplateController
 
-                model = TemplateController.create_circuit_from_template(bundle.template)
+                model = TemplateController().create_circuit_from_template(bundle.template)
                 self.file_ctrl.load_from_model(model)
 
             # Load rubric into grading panel if present


### PR DESCRIPTION
Fixes create_circuit_from_template being called as a class method instead of instance method in _on_open_assignment. Closes #539