### PR TITLE
Fix GradingPanel highlighting on main canvas instead of student circuit (#538)

### DIFF
--- a/app/GUI/grading_panel.py
+++ b/app/GUI/grading_panel.py
@@ -48,6 +48,7 @@ class GradingPanel(QWidget):
         self._grader = None  # Lazy-initialized to avoid circular import
         self._rubric: Optional[Rubric] = None
         self._student_circuit: Optional[CircuitModel] = None
+        self._reference_circuit: Optional[CircuitModel] = None
         self._student_file: str = ""
         self._result: Optional[GradingResult] = None
         self._highlighted_components: list = []
@@ -130,7 +131,7 @@ class GradingPanel(QWidget):
     # --- Load operations ---
 
     def _on_load_student(self):
-        """Load a student circuit file."""
+        """Load a student circuit file and display it on the canvas."""
         from controllers.file_controller import validate_circuit_data
 
         filename, _ = QFileDialog.getOpenFileName(
@@ -156,6 +157,15 @@ class GradingPanel(QWidget):
             else:
                 validate_circuit_data(data)
                 self._student_circuit = CircuitModel.from_dict(data)
+
+            # Snapshot the current (reference) circuit before replacing the canvas
+            if self._reference_circuit is None:
+                self._reference_circuit = CircuitModel.from_dict(self._model.to_dict())
+
+            # Display student circuit on canvas so highlights target the correct components
+            parent = self.parent()
+            if parent is not None and hasattr(parent, "file_ctrl"):
+                parent.file_ctrl.load_from_model(self._student_circuit)
 
             self._student_file = Path(filename).name
             self.student_label.setText(f"Student: {self._student_file}")
@@ -199,10 +209,11 @@ class GradingPanel(QWidget):
 
             self._grader = CircuitGrader()
 
+        reference = self._reference_circuit if self._reference_circuit is not None else self._model
         self._result = self._grader.grade(
             student_circuit=self._student_circuit,
             rubric=self._rubric,
-            reference_circuit=self._model,
+            reference_circuit=reference,
             student_file=self._student_file,
         )
 
@@ -326,6 +337,14 @@ class GradingPanel(QWidget):
     def clear_results(self):
         """Clear all grading results, overlays, and reset the panel."""
         self._clear_highlights()
+
+        # Restore the reference (instructor) circuit on the canvas
+        if self._reference_circuit is not None:
+            parent = self.parent()
+            if parent is not None and hasattr(parent, "file_ctrl"):
+                parent.file_ctrl.load_from_model(self._reference_circuit)
+            self._reference_circuit = None
+
         self._result = None
         self._student_circuit = None
         self._student_file = ""


### PR DESCRIPTION
GradingPanel highlighted components on the main canvas instead of the student circuit. Now loads the student circuit onto the canvas when a student file is opened, snapshots the reference circuit for grading comparison, and restores it when results are cleared. Closes #538