### PR TITLE
Fix waypoint drag crash (#482)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -322,17 +322,13 @@ class CircuitCanvasView(QGraphicsView):
             self._scene.update()
 
     def _handle_wire_routed(self, data) -> None:
-        """Update wire waypoints"""
-        from PyQt6.QtCore import QPointF
-
+        """Update wire waypoints from a (wire_index, wire_data) tuple."""
         wire_index, wire_data = data
         if 0 <= wire_index < len(self.wires):
             wire = self.wires[wire_index]
-            # Convert waypoints to QPointF if they exist
+            # Sync visual path from persisted model waypoints
             if hasattr(wire_data, "waypoints") and wire_data.waypoints:
-                wire.waypoints = [QPointF(x, y) for x, y in wire_data.waypoints]
-                if hasattr(wire, "update_path"):
-                    wire.update_path()
+                wire._restore_waypoints()
 
     def _handle_wire_lock_changed(self, data) -> None:
         """Update wire visual when lock state changes."""

--- a/app/tests/unit/test_circuit_controller.py
+++ b/app/tests/unit/test_circuit_controller.py
@@ -183,6 +183,22 @@ class TestWireOperations:
         assert controller.model.wires[0].waypoints == pts
         assert recorded[-1][0] == "wire_routed"
 
+    def test_wire_routed_event_sends_tuple_format(self, controller, events):
+        """wire_routed data must be (wire_index, WireData) tuple (#482)."""
+        recorded, callback = events
+        controller.add_component("Resistor", (0.0, 0.0))
+        controller.add_component("Resistor", (100.0, 0.0))
+        controller.add_wire("R1", 1, "R2", 0)
+        controller.add_observer(callback)
+        pts = [(10.0, 0.0), (50.0, 0.0), (90.0, 0.0)]
+        controller.update_wire_waypoints(0, pts)
+        event_name, event_data = recorded[-1]
+        assert event_name == "wire_routed"
+        wire_index, wire_data = event_data  # must unpack without ValueError
+        assert wire_index == 0
+        assert hasattr(wire_data, "waypoints")
+        assert wire_data.waypoints == pts
+
 
 class TestDuplicateWirePrevention:
     """Tests for duplicate wire detection and prevention."""

--- a/app/tests/unit/test_waypoint_editing.py
+++ b/app/tests/unit/test_waypoint_editing.py
@@ -161,6 +161,42 @@ class TestWaypointDragging:
         assert new_path.elementCount() == old_element_count
 
 
+class TestWaypointDragControllerIntegration:
+    """Test that waypoint drag persists through the controller without crash (#482)."""
+
+    def test_finish_drag_waypoints_are_tuples(self, wire_with_waypoints, qtbot):
+        """Waypoints sent to canvas must be (x, y) tuples, not QPointF."""
+        wire_with_waypoints._move_waypoint(1, QPointF(60, 10))
+        wire_with_waypoints._finish_waypoint_drag()
+        call_args = wire_with_waypoints.canvas.on_wire_waypoints_changed.call_args
+        waypoints = call_args[0][1]
+        for wp in waypoints:
+            assert isinstance(wp, tuple), f"Expected tuple, got {type(wp)}"
+            assert len(wp) == 2
+
+    def test_wire_routed_event_unpacks_without_error(self, wire_with_waypoints, qtbot):
+        """Simulate wire_routed event to verify data format is (index, WireData)."""
+        from controllers.circuit_controller import CircuitController
+
+        ctrl = CircuitController()
+        ctrl.add_component("Resistor", (0.0, 0.0))
+        ctrl.add_component("Resistor", (100.0, 0.0))
+        ctrl.add_wire("R1", 1, "R2", 0)
+
+        recorded = []
+        ctrl.add_observer(lambda name, data: recorded.append((name, data)))
+
+        pts = [(0, 0), (60, 10), (50, 50), (100, 50)]
+        ctrl.update_wire_waypoints(0, pts)
+
+        event_name, event_data = recorded[-1]
+        assert event_name == "wire_routed"
+        # This must not raise ValueError
+        wire_index, wire_data = event_data
+        assert wire_index == 0
+        assert wire_data.waypoints == pts
+
+
 class TestWaypointHandleProperties:
     """Test WaypointHandle properties and behavior."""
 


### PR DESCRIPTION
Fixed _handle_wire_routed calling non-existent update_path method on WireGraphicsItem. Replaced with _restore_waypoints which reads from model and rebuilds QPainterPath. Added tests for wire_routed event data format. Closes #482