### PR TITLE
fix: accept Operational Point alias in result parser dispatch (#540)

### DIFF
--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -242,7 +242,7 @@ class SimulationController:
         analysis = self.model.analysis_type
 
         try:
-            if analysis == "DC Operating Point":
+            if analysis in ("DC Operating Point", "Operational Point"):
                 output = self.runner.read_output(output_file)
                 data = ResultParser.parse_op_results(output)
             elif analysis == "DC Sweep":

--- a/app/tests/unit/test_result_parser.py
+++ b/app/tests/unit/test_result_parser.py
@@ -294,3 +294,23 @@ class TestParseErrorPropagation:
     def test_transient_parse_error_on_missing_file(self):
         with pytest.raises(ResultParseError, match="wrdata file not found"):
             ResultParser.parse_transient_results("/nonexistent/path.txt")
+
+
+# ── Operational Point alias (#540) ──────────────────────────────────
+
+
+class TestOperationalPointAlias:
+    """'Operational Point' alias must be handled the same as 'DC Operating Point' (#540)."""
+
+    def test_generate_analysis_command_accepts_alias(self):
+        from simulation.netlist_generator import generate_analysis_command
+
+        assert generate_analysis_command("Operational Point", {}) == ".op"
+        assert generate_analysis_command("DC Operating Point", {}) == ".op"
+
+    def test_parse_op_results_works_for_both_aliases(self):
+        """parse_op_results is analysis-agnostic; the dispatch in
+        SimulationController must route both aliases to it."""
+        output = "v(nodeA) = 5.00000\n"
+        result = ResultParser.parse_op_results(output)
+        assert result["node_voltages"]["nodeA"] == pytest.approx(5.0)

--- a/app/tests/unit/test_simulation_controller.py
+++ b/app/tests/unit/test_simulation_controller.py
@@ -301,6 +301,24 @@ class TestExportResultsMarkdown:
         assert filepath.exists()
 
 
+class TestOperationalPointAlias:
+    """'Operational Point' analysis type must parse results like 'DC Operating Point' (#540)."""
+
+    def test_operational_point_routes_to_op_parser(self):
+        model = _build_simple_circuit()
+        model.analysis_type = "Operational Point"
+        ctrl = SimulationController(model)
+        mock_runner = MagicMock()
+        mock_runner.find_ngspice.return_value = "/usr/bin/ngspice"
+        mock_runner.output_dir = "simulation_output"
+        mock_runner.run_simulation.return_value = (True, "/tmp/out.txt", "", "")
+        mock_runner.read_output.return_value = "v(nodeA) = 5.00000\n"
+        ctrl._runner = mock_runner
+        result = ctrl.run_simulation()
+        assert result.success
+        assert result.data["node_voltages"]["nodeA"] == pytest.approx(5.0)
+
+
 class TestNoQtDependencies:
     def test_no_pyqt_imports(self):
         import controllers.simulation_controller as mod


### PR DESCRIPTION
## Summary
- Add Operational Point as accepted alias in SimulationController result parsing
- Netlist generator already accepted it but parser dispatch did not
- Added tests for both dispatch and command generation

Closes #540