### PR TITLE
feat: validate component values before netlist generation (#541)

### DIFF
--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -132,11 +132,15 @@ class NetlistGenerator:
 
         Raises ValueError with a descriptive message if any component has
         an invalid value (empty, unparseable, or out of range).
+        Subcircuit instances (SPICE symbol "X") are skipped because their
+        value is a model/subcircuit name, not a numeric quantity.
         """
         from utils.format_utils import validate_component_value
 
         errors = []
         for comp in self.components.values():
+            if comp.get_spice_symbol() == "X":
+                continue  # subcircuit name, not numeric
             is_valid, msg = validate_component_value(comp.value, comp.component_type)
             if not is_valid:
                 errors.append(f"{comp.component_id} ({comp.component_type}): {msg}")

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -127,12 +127,31 @@ class NetlistGenerator:
         self.measurements = measurements or []
         self._is_temp_sweep = False
 
+    def _validate_component_values(self):
+        """Validate all component values before netlist generation (#541).
+
+        Raises ValueError with a descriptive message if any component has
+        an invalid value (empty, unparseable, or out of range).
+        """
+        from utils.format_utils import validate_component_value
+
+        errors = []
+        for comp in self.components.values():
+            is_valid, msg = validate_component_value(comp.value, comp.component_type)
+            if not is_valid:
+                errors.append(f"{comp.component_id} ({comp.component_type}): {msg}")
+        if errors:
+            raise ValueError("Invalid component values:\n" + "\n".join(errors))
+
     def _sanitize_value(self, value: str) -> str:
         """Sanitize a component value before interpolation into the netlist."""
         return sanitize_spice_value(value)
 
     def generate(self):
         """Generate complete SPICE netlist"""
+        # Validate component values before generation (#541)
+        self._validate_component_values()
+
         lines = ["My Test Circuit", "* Generated netlist", ""]
 
         # Add op-amp subcircuit definitions for each model used

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -127,13 +127,22 @@ class NetlistGenerator:
         self.measurements = measurements or []
         self._is_temp_sweep = False
 
+    # Component types that use non-numeric or compound value formats and
+    # should not be rejected by the simple numeric validator.
+    _SKIP_NUMERIC_VALIDATION = {
+        "Voltage Source",  # may contain "AC 1" or "DC 5V"
+        "Current Source",
+        "AC Voltage Source",
+        "AC Current Source",
+    }
+
     def _validate_component_values(self):
         """Validate all component values before netlist generation (#541).
 
         Raises ValueError with a descriptive message if any component has
         an invalid value (empty, unparseable, or out of range).
-        Subcircuit instances (SPICE symbol "X") are skipped because their
-        value is a model/subcircuit name, not a numeric quantity.
+        Subcircuit instances (SPICE symbol "X") and source types with
+        compound value formats are skipped.
         """
         from utils.format_utils import validate_component_value
 
@@ -141,6 +150,8 @@ class NetlistGenerator:
         for comp in self.components.values():
             if comp.get_spice_symbol() == "X":
                 continue  # subcircuit name, not numeric
+            if comp.component_type in self._SKIP_NUMERIC_VALIDATION:
+                continue  # source values can have complex SPICE formats
             is_valid, msg = validate_component_value(comp.value, comp.component_type)
             if not is_valid:
                 errors.append(f"{comp.component_id} ({comp.component_type}): {msg}")

--- a/app/tests/unit/test_netlist_generator.py
+++ b/app/tests/unit/test_netlist_generator.py
@@ -526,6 +526,85 @@ class TestUnconnectedTerminal:
         assert "999" not in netlist
 
 
+class TestComponentValueValidation:
+    """Component values must be validated before netlist generation (#541)."""
+
+    def test_invalid_resistor_value_raises(self):
+        from tests.conftest import make_component, make_wire
+
+        components = {
+            "V1": make_component("Voltage Source", "V1", "5V", (0, 0)),
+            "R1": make_component("Resistor", "R1", "abc", (100, 0)),  # invalid
+            "GND1": make_component("Ground", "GND1", "0V", (100, 100)),
+        }
+        wires = [
+            make_wire("V1", 0, "R1", 0),
+            make_wire("R1", 1, "GND1", 0),
+            make_wire("V1", 1, "GND1", 0),
+        ]
+        node_a = NodeData(
+            terminals={("V1", 0), ("R1", 0)},
+            wire_indices={0},
+            auto_label="nodeA",
+        )
+        node_gnd = NodeData(
+            terminals={("R1", 1), ("GND1", 0), ("V1", 1)},
+            wire_indices={1, 2},
+            is_ground=True,
+            auto_label="0",
+        )
+        nodes = [node_a, node_gnd]
+        t2n = {
+            ("V1", 0): node_a,
+            ("R1", 0): node_a,
+            ("R1", 1): node_gnd,
+            ("GND1", 0): node_gnd,
+            ("V1", 1): node_gnd,
+        }
+        with pytest.raises(ValueError, match="Invalid component values"):
+            _generate(components, wires, nodes, t2n)
+
+    def test_negative_resistor_value_raises(self):
+        from tests.conftest import make_component, make_wire
+
+        components = {
+            "V1": make_component("Voltage Source", "V1", "5V", (0, 0)),
+            "R1": make_component("Resistor", "R1", "-1k", (100, 0)),  # negative
+            "GND1": make_component("Ground", "GND1", "0V", (100, 100)),
+        }
+        wires = [
+            make_wire("V1", 0, "R1", 0),
+            make_wire("R1", 1, "GND1", 0),
+            make_wire("V1", 1, "GND1", 0),
+        ]
+        node_a = NodeData(
+            terminals={("V1", 0), ("R1", 0)},
+            wire_indices={0},
+            auto_label="nodeA",
+        )
+        node_gnd = NodeData(
+            terminals={("R1", 1), ("GND1", 0), ("V1", 1)},
+            wire_indices={1, 2},
+            is_ground=True,
+            auto_label="0",
+        )
+        nodes = [node_a, node_gnd]
+        t2n = {
+            ("V1", 0): node_a,
+            ("R1", 0): node_a,
+            ("R1", 1): node_gnd,
+            ("GND1", 0): node_gnd,
+            ("V1", 1): node_gnd,
+        }
+        with pytest.raises(ValueError, match="positive"):
+            _generate(components, wires, nodes, t2n)
+
+    def test_valid_circuit_passes_validation(self, simple_resistor_circuit):
+        components, wires, nodes, t2n = simple_resistor_circuit
+        netlist = _generate(components, wires, nodes, t2n)
+        assert "R1" in netlist  # generation succeeds
+
+
 class TestResistorDivider:
     def test_two_nodes_labeled(self, resistor_divider_circuit):
         components, wires, nodes, t2n = resistor_divider_circuit


### PR DESCRIPTION
## Summary
- Validate all component values at the start of NetlistGenerator.generate()
- Invalid values (empty, unparseable, negative resistance) raise ValueError with descriptive message
- Uses existing validate_component_value() from format_utils
- Added tests for invalid value, negative resistor, and valid circuit

Closes #541