### PR TITLE
fix: preserve recommended_components in templates/assignments (#485)

### DIFF
--- a/app/controllers/template_controller.py
+++ b/app/controllers/template_controller.py
@@ -58,6 +58,7 @@ class TemplateController:
         instructions: str = "",
         required_analysis: Optional[dict] = None,
         locked_components: Optional[list[str]] = None,
+        recommended_components: Optional[list[str]] = None,
     ) -> None:
         """Save a circuit as an assignment template.
 
@@ -82,6 +83,7 @@ class TemplateController:
             reference_circuit=(reference_circuit.to_dict() if reference_circuit else None),
             required_analysis=required_analysis,
             locked_components=list(locked_components or []),
+            recommended_components=list(recommended_components or []),
         )
 
         with open(filepath, "w") as f:
@@ -133,6 +135,10 @@ class TemplateController:
             analysis_params = template.required_analysis.get("params")
             if analysis_params:
                 model.analysis_params = analysis_params.copy()
+
+        # Template-level recommended_components override the starter circuit's
+        if template.recommended_components:
+            model.recommended_components = list(template.recommended_components)
 
         return model
 

--- a/app/models/template.py
+++ b/app/models/template.py
@@ -50,6 +50,7 @@ class TemplateData:
     reference_circuit: Optional[dict] = None
     required_analysis: Optional[dict] = None
     locked_components: list[str] = field(default_factory=list)
+    recommended_components: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         data = {
@@ -65,6 +66,8 @@ class TemplateData:
             data["required_analysis"] = self.required_analysis
         if self.locked_components:
             data["locked_components"] = list(self.locked_components)
+        if self.recommended_components:
+            data["recommended_components"] = list(self.recommended_components)
         return data
 
     @classmethod
@@ -77,4 +80,5 @@ class TemplateData:
             reference_circuit=data.get("reference_circuit"),
             required_analysis=data.get("required_analysis"),
             locked_components=list(data.get("locked_components", [])),
+            recommended_components=list(data.get("recommended_components", [])),
         )

--- a/app/tests/unit/test_template_controller.py
+++ b/app/tests/unit/test_template_controller.py
@@ -382,3 +382,58 @@ class TestGetTemplateMetadata:
         ctrl = TemplateController()
         with pytest.raises(ValueError, match="title"):
             ctrl.get_template_metadata(filepath)
+
+
+class TestRecommendedComponents:
+    """Issue #485: recommended_components lost when loading templates."""
+
+    def test_save_and_load_preserves_recommended(self, tmp_path):
+        ctrl = TemplateController()
+        circuit = _build_simple_circuit()
+        filepath = tmp_path / "test.spice-template"
+        ctrl.save_as_template(
+            filepath=filepath,
+            metadata=_build_metadata(),
+            starter_circuit=circuit,
+            recommended_components=["Resistor", "Capacitor"],
+        )
+        template = ctrl.load_template(filepath)
+        assert template.recommended_components == ["Resistor", "Capacitor"]
+
+    def test_create_circuit_applies_recommended(self):
+        ctrl = TemplateController()
+        template = TemplateData(
+            metadata=_build_metadata(),
+            recommended_components=["Resistor", "Inductor"],
+        )
+        model = ctrl.create_circuit_from_template(template)
+        assert model.recommended_components == ["Resistor", "Inductor"]
+
+    def test_template_level_overrides_starter_circuit(self, tmp_path):
+        ctrl = TemplateController()
+        circuit = _build_simple_circuit()
+        circuit.recommended_components = ["Op-Amp"]
+        filepath = tmp_path / "test.spice-template"
+        ctrl.save_as_template(
+            filepath=filepath,
+            metadata=_build_metadata(),
+            starter_circuit=circuit,
+            recommended_components=["Resistor", "Capacitor"],
+        )
+        template = ctrl.load_template(filepath)
+        model = ctrl.create_circuit_from_template(template)
+        assert model.recommended_components == ["Resistor", "Capacitor"]
+
+    def test_empty_recommended_preserves_starter_circuit(self, tmp_path):
+        ctrl = TemplateController()
+        circuit = _build_simple_circuit()
+        circuit.recommended_components = ["Op-Amp"]
+        filepath = tmp_path / "test.spice-template"
+        ctrl.save_as_template(
+            filepath=filepath,
+            metadata=_build_metadata(),
+            starter_circuit=circuit,
+        )
+        template = ctrl.load_template(filepath)
+        model = ctrl.create_circuit_from_template(template)
+        assert model.recommended_components == ["Op-Amp"]


### PR DESCRIPTION
## Summary
- Add recommended_components field to TemplateData so template-level recommended components survive serialization
- Wire through save_as_template and create_circuit_from_template
- Template-level values override starter circuit values

## Test plan
- TemplateData round-trip preserves recommended_components
- create_circuit_from_template applies template-level recommended_components
- Empty template recommended_components preserves starter circuit values
- Template-level overrides starter circuit recommended_components