### PR TITLE
refactor: use dataclass fields iteration in _replace_model (#499)

### DIFF
--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import tempfile
+from dataclasses import fields
 from pathlib import Path
 from typing import List, Optional
 
@@ -68,15 +69,8 @@ class FileController:
         validate_circuit_data(parsed_data)
 
         self.model.clear()
-        self.model.components = new_model.components
-        self.model.wires = new_model.wires
-        self.model.nodes = new_model.nodes
-        self.model.terminal_to_node = new_model.terminal_to_node
-        self.model.component_counter = new_model.component_counter
-        self.model.analysis_type = new_model.analysis_type
-        self.model.analysis_params = new_model.analysis_params
-        self.model.annotations = new_model.annotations
-        self.model.recommended_components = new_model.recommended_components
+        for f in fields(new_model):
+            setattr(self.model, f.name, getattr(new_model, f.name))
 
     def load_from_model(self, new_model: CircuitModel) -> None:
         """Replace the current circuit with *new_model* and notify observers.

--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -550,6 +550,34 @@ class TestAnnotationsAndRecommendedComponents:
         assert ctrl2.model.analysis_type == "AC Sweep"
 
 
+class TestReplaceModelFieldTransfer:
+    """Issue #499: _replace_model must transfer all CircuitModel dataclass fields."""
+
+    def test_replace_model_copies_all_fields(self):
+        """Every dataclass field on CircuitModel is copied by _replace_model."""
+        from dataclasses import fields
+
+        new_model = build_simple_circuit()
+        new_model.recommended_components = ["Resistor"]
+        new_model.analysis_type = "Transient"
+        new_model.analysis_params = {"tstop": "10m"}
+
+        ctrl = FileController()
+        ctrl._replace_model(new_model)
+
+        for f in fields(CircuitModel):
+            assert getattr(ctrl.model, f.name) == getattr(
+                new_model, f.name
+            ), f"Field '{f.name}' not transferred by _replace_model"
+
+    def test_replace_model_preserves_identity(self):
+        """_replace_model must update the existing model object, not replace it."""
+        ctrl = FileController()
+        original_model = ctrl.model
+        ctrl._replace_model(build_simple_circuit())
+        assert ctrl.model is original_model
+
+
 class TestExportBom:
     """Tests for FileController.export_bom (Issue #570)."""
 


### PR DESCRIPTION
## Summary
- Replace fragile manual field-by-field copy in _replace_model with dataclass fields() iteration
- New CircuitModel fields are now automatically transferred without updating _replace_model
- Add test that verifies all dataclass fields are copied and model identity is preserved

## Test plan
- [x] test_replace_model_copies_all_fields verifies every CircuitModel field is transferred
- [x] test_replace_model_preserves_identity verifies the model object is updated in place