### PR TITLE
fix: escape tilde and caret in _escape_latex (#525)

### DIFF
--- a/app/simulation/circuitikz_exporter.py
+++ b/app/simulation/circuitikz_exporter.py
@@ -37,7 +37,12 @@ CIRCUITIKZ_QUADPOLES = {
 
 # Terminal name suffixes for quadpole node anchors
 QUADPOLE_ANCHORS = {
-    "Transformer": ["A1", "A2", "B1", "B2"],  # primary+, primary-, secondary+, secondary-
+    "Transformer": [
+        "A1",
+        "A2",
+        "B1",
+        "B2",
+    ],  # primary+, primary-, secondary+, secondary-
 }
 
 # Terminal name suffixes for tripole node anchors
@@ -69,6 +74,8 @@ def _escape_latex(s):
     """Escape special LaTeX characters in a string."""
     for ch in ("\\", "&", "%", "$", "#", "_", "{", "}"):
         s = s.replace(ch, "\\" + ch)
+    s = s.replace("~", r"\textasciitilde{}")
+    s = s.replace("^", r"\textasciicircum{}")
     return s
 
 

--- a/app/tests/unit/test_circuitikz_exporter.py
+++ b/app/tests/unit/test_circuitikz_exporter.py
@@ -66,6 +66,17 @@ class TestFormatHelpers:
         assert _escape_latex("100%") == "100\\%"
         assert _escape_latex("a&b") == "a\\&b"
 
+    def test_escape_latex_tilde(self):
+        """Issue #525: tilde must not produce a non-breaking space."""
+        assert _escape_latex("V~out") == r"V\textasciitilde{}out"
+
+    def test_escape_latex_caret(self):
+        """Issue #525: caret must not produce a superscript."""
+        assert _escape_latex("x^2") == r"x\textasciicircum{}2"
+
+    def test_escape_latex_tilde_and_caret_together(self):
+        assert _escape_latex("a~b^c") == r"a\textasciitilde{}b\textasciicircum{}c"
+
 
 class TestCoordinateTransform:
     def test_transform_normalizes_origin(self):


### PR DESCRIPTION
Tilde (~) and caret (^) are special LaTeX characters that were not escaped, producing non-breaking spaces and superscripts instead of literal characters in exported CircuiTikZ labels. Added escaping to textasciitilde{} and textasciicircum{} respectively, with tests.