### PR TITLE
fix: validate component types and rotation in validate_circuit_data (#526)

### DIFF
--- a/app/models/circuit_schema_validator.py
+++ b/app/models/circuit_schema_validator.py
@@ -7,9 +7,10 @@ dependencies.
 This module is the canonical location for ``validate_circuit_data``.
 """
 
-from models.component import COMPONENT_TYPES
+from models.component import _CLASS_TO_DISPLAY, COMPONENT_TYPES
 
 _VALID_ROTATIONS = {0, 90, 180, 270}
+_VALID_TYPES = set(COMPONENT_TYPES) | set(_CLASS_TO_DISPLAY)
 
 
 def validate_circuit_data(data) -> None:
@@ -37,7 +38,7 @@ def validate_circuit_data(data) -> None:
         if not isinstance(pos["x"], (int, float)) or not isinstance(pos["y"], (int, float)):
             raise ValueError(f"Component '{comp['id']}' position values must be numeric.")
         ctype = comp["type"]
-        if ctype not in COMPONENT_TYPES:
+        if ctype not in _VALID_TYPES:
             raise ValueError(f"Component '{comp['id']}' has unknown type '{ctype}'.")
         rotation = comp.get("rotation", 0)
         if rotation not in _VALID_ROTATIONS:

--- a/app/models/circuit_schema_validator.py
+++ b/app/models/circuit_schema_validator.py
@@ -10,7 +10,6 @@ This module is the canonical location for ``validate_circuit_data``.
 from models.component import _CLASS_TO_DISPLAY, COMPONENT_TYPES
 
 _VALID_ROTATIONS = {0, 90, 180, 270}
-_VALID_TYPES = set(COMPONENT_TYPES) | set(_CLASS_TO_DISPLAY)
 
 
 def validate_circuit_data(data) -> None:
@@ -38,7 +37,9 @@ def validate_circuit_data(data) -> None:
         if not isinstance(pos["x"], (int, float)) or not isinstance(pos["y"], (int, float)):
             raise ValueError(f"Component '{comp['id']}' position values must be numeric.")
         ctype = comp["type"]
-        if ctype not in _VALID_TYPES:
+        # Check both display names and serialized class names; use live
+        # COMPONENT_TYPES list because subcircuit registration can extend it.
+        if ctype not in set(COMPONENT_TYPES) | set(_CLASS_TO_DISPLAY):
             raise ValueError(f"Component '{comp['id']}' has unknown type '{ctype}'.")
         rotation = comp.get("rotation", 0)
         if rotation not in _VALID_ROTATIONS:

--- a/app/models/circuit_schema_validator.py
+++ b/app/models/circuit_schema_validator.py
@@ -7,6 +7,10 @@ dependencies.
 This module is the canonical location for ``validate_circuit_data``.
 """
 
+from models.component import COMPONENT_TYPES
+
+_VALID_ROTATIONS = {0, 90, 180, 270}
+
 
 def validate_circuit_data(data) -> None:
     """
@@ -32,6 +36,15 @@ def validate_circuit_data(data) -> None:
             raise ValueError(f"Component '{comp.get('id', i)}' has invalid position data.")
         if not isinstance(pos["x"], (int, float)) or not isinstance(pos["y"], (int, float)):
             raise ValueError(f"Component '{comp['id']}' position values must be numeric.")
+        ctype = comp["type"]
+        if ctype not in COMPONENT_TYPES:
+            raise ValueError(f"Component '{comp['id']}' has unknown type '{ctype}'.")
+        rotation = comp.get("rotation", 0)
+        if rotation not in _VALID_ROTATIONS:
+            raise ValueError(
+                f"Component '{comp['id']}' has invalid rotation {rotation}. "
+                f"Must be one of {sorted(_VALID_ROTATIONS)}."
+            )
         comp_ids.add(comp["id"])
 
     for i, wire in enumerate(data["wires"]):

--- a/app/tests/unit/test_circuit_schema_validator.py
+++ b/app/tests/unit/test_circuit_schema_validator.py
@@ -42,55 +42,162 @@ class TestValidateCircuitDataStructure:
 
 class TestValidateCircuitDataComponents:
     def test_component_missing_id_raises(self):
-        data = {"components": [{"type": "R", "value": "1k", "pos": {"x": 0, "y": 0}}], "wires": []}
+        data = {
+            "components": [{"type": "R", "value": "1k", "pos": {"x": 0, "y": 0}}],
+            "wires": [],
+        }
         with pytest.raises(ValueError, match="'id'"):
             validate_circuit_data(data)
 
     def test_component_missing_type_raises(self):
-        data = {"components": [{"id": "R1", "value": "1k", "pos": {"x": 0, "y": 0}}], "wires": []}
+        data = {
+            "components": [{"id": "R1", "value": "1k", "pos": {"x": 0, "y": 0}}],
+            "wires": [],
+        }
         with pytest.raises(ValueError, match="'type'"):
             validate_circuit_data(data)
 
     def test_component_missing_value_raises(self):
-        data = {"components": [{"id": "R1", "type": "Resistor", "pos": {"x": 0, "y": 0}}], "wires": []}
+        data = {
+            "components": [{"id": "R1", "type": "Resistor", "pos": {"x": 0, "y": 0}}],
+            "wires": [],
+        }
         with pytest.raises(ValueError, match="'value'"):
             validate_circuit_data(data)
 
     def test_component_missing_pos_raises(self):
-        data = {"components": [{"id": "R1", "type": "Resistor", "value": "1k"}], "wires": []}
+        data = {
+            "components": [{"id": "R1", "type": "Resistor", "value": "1k"}],
+            "wires": [],
+        }
         with pytest.raises(ValueError, match="'pos'"):
             validate_circuit_data(data)
 
     def test_component_pos_missing_x_raises(self):
-        data = {"components": [{"id": "R1", "type": "R", "value": "1k", "pos": {"y": 0}}], "wires": []}
+        data = {
+            "components": [{"id": "R1", "type": "R", "value": "1k", "pos": {"y": 0}}],
+            "wires": [],
+        }
         with pytest.raises(ValueError, match="invalid position"):
             validate_circuit_data(data)
 
     def test_component_pos_missing_y_raises(self):
-        data = {"components": [{"id": "R1", "type": "R", "value": "1k", "pos": {"x": 0}}], "wires": []}
+        data = {
+            "components": [{"id": "R1", "type": "R", "value": "1k", "pos": {"x": 0}}],
+            "wires": [],
+        }
         with pytest.raises(ValueError, match="invalid position"):
             validate_circuit_data(data)
 
     def test_component_pos_non_numeric_x_raises(self):
-        data = {"components": [{"id": "R1", "type": "R", "value": "1k", "pos": {"x": "a", "y": 0}}], "wires": []}
+        data = {
+            "components": [{"id": "R1", "type": "R", "value": "1k", "pos": {"x": "a", "y": 0}}],
+            "wires": [],
+        }
         with pytest.raises(ValueError, match="numeric"):
             validate_circuit_data(data)
 
     def test_component_pos_non_numeric_y_raises(self):
-        data = {"components": [{"id": "R1", "type": "R", "value": "1k", "pos": {"x": 0, "y": "b"}}], "wires": []}
+        data = {
+            "components": [{"id": "R1", "type": "R", "value": "1k", "pos": {"x": 0, "y": "b"}}],
+            "wires": [],
+        }
         with pytest.raises(ValueError, match="numeric"):
             validate_circuit_data(data)
 
     def test_component_pos_accepts_float(self):
-        data = {"components": [{"id": "R1", "type": "R", "value": "1k", "pos": {"x": 1.5, "y": 2.5}}], "wires": []}
+        data = {
+            "components": [
+                {
+                    "id": "R1",
+                    "type": "Resistor",
+                    "value": "1k",
+                    "pos": {"x": 1.5, "y": 2.5},
+                }
+            ],
+            "wires": [],
+        }
         validate_circuit_data(data)  # no exception
+
+
+class TestValidateComponentTypeAndRotation:
+    """Issue #526: validate_circuit_data must check component types and rotation values."""
+
+    def test_unknown_component_type_raises(self):
+        data = {
+            "components": [
+                {
+                    "id": "X1",
+                    "type": "FakeComponent",
+                    "value": "1k",
+                    "pos": {"x": 0, "y": 0},
+                }
+            ],
+            "wires": [],
+        }
+        with pytest.raises(ValueError, match="unknown type.*FakeComponent"):
+            validate_circuit_data(data)
+
+    def test_all_known_types_pass(self):
+        from models.component import COMPONENT_TYPES
+
+        for ctype in COMPONENT_TYPES:
+            data = {
+                "components": [{"id": "X1", "type": ctype, "value": "", "pos": {"x": 0, "y": 0}}],
+                "wires": [],
+            }
+            validate_circuit_data(data)  # no exception
+
+    def test_valid_rotations_pass(self):
+        for rotation in (0, 90, 180, 270):
+            data = {
+                "components": [
+                    {
+                        "id": "R1",
+                        "type": "Resistor",
+                        "value": "1k",
+                        "pos": {"x": 0, "y": 0},
+                        "rotation": rotation,
+                    }
+                ],
+                "wires": [],
+            }
+            validate_circuit_data(data)  # no exception
+
+    def test_invalid_rotation_raises(self):
+        data = {
+            "components": [
+                {
+                    "id": "R1",
+                    "type": "Resistor",
+                    "value": "1k",
+                    "pos": {"x": 0, "y": 0},
+                    "rotation": 45,
+                }
+            ],
+            "wires": [],
+        }
+        with pytest.raises(ValueError, match="invalid rotation"):
+            validate_circuit_data(data)
+
+    def test_missing_rotation_defaults_to_zero(self):
+        data = {
+            "components": [{"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}}],
+            "wires": [],
+        }
+        validate_circuit_data(data)  # no exception — rotation defaults to 0
 
 
 class TestValidateCircuitDataWires:
     def _base_circuit(self):
         return {
             "components": [
-                {"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}},
+                {
+                    "id": "R1",
+                    "type": "Resistor",
+                    "value": "1k",
+                    "pos": {"x": 0, "y": 0},
+                },
                 {"id": "GND1", "type": "Ground", "value": "0", "pos": {"x": 1, "y": 0}},
             ],
             "wires": [],
@@ -115,7 +222,14 @@ class TestValidateCircuitDataWires:
 
     def test_wire_unknown_start_comp_raises(self):
         data = self._base_circuit()
-        data["wires"] = [{"start_comp": "UNKNOWN", "end_comp": "GND1", "start_term": 0, "end_term": 0}]
+        data["wires"] = [
+            {
+                "start_comp": "UNKNOWN",
+                "end_comp": "GND1",
+                "start_term": 0,
+                "end_term": 0,
+            }
+        ]
         with pytest.raises(ValueError, match="unknown component"):
             validate_circuit_data(data)
 

--- a/app/tests/unit/test_circuit_schema_validator.py
+++ b/app/tests/unit/test_circuit_schema_validator.py
@@ -148,6 +148,16 @@ class TestValidateComponentTypeAndRotation:
             }
             validate_circuit_data(data)  # no exception
 
+    def test_serialized_class_names_pass(self):
+        from models.component import _CLASS_TO_DISPLAY
+
+        for class_name in _CLASS_TO_DISPLAY:
+            data = {
+                "components": [{"id": "X1", "type": class_name, "value": "", "pos": {"x": 0, "y": 0}}],
+                "wires": [],
+            }
+            validate_circuit_data(data)  # no exception
+
     def test_valid_rotations_pass(self):
         for rotation in (0, 90, 180, 270):
             data = {

--- a/app/tests/unit/test_circuit_schema_validator.py
+++ b/app/tests/unit/test_circuit_schema_validator.py
@@ -43,7 +43,7 @@ class TestValidateCircuitDataStructure:
 class TestValidateCircuitDataComponents:
     def test_component_missing_id_raises(self):
         data = {
-            "components": [{"type": "R", "value": "1k", "pos": {"x": 0, "y": 0}}],
+            "components": [{"type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}}],
             "wires": [],
         }
         with pytest.raises(ValueError, match="'id'"):
@@ -75,7 +75,7 @@ class TestValidateCircuitDataComponents:
 
     def test_component_pos_missing_x_raises(self):
         data = {
-            "components": [{"id": "R1", "type": "R", "value": "1k", "pos": {"y": 0}}],
+            "components": [{"id": "R1", "type": "Resistor", "value": "1k", "pos": {"y": 0}}],
             "wires": [],
         }
         with pytest.raises(ValueError, match="invalid position"):
@@ -83,7 +83,7 @@ class TestValidateCircuitDataComponents:
 
     def test_component_pos_missing_y_raises(self):
         data = {
-            "components": [{"id": "R1", "type": "R", "value": "1k", "pos": {"x": 0}}],
+            "components": [{"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0}}],
             "wires": [],
         }
         with pytest.raises(ValueError, match="invalid position"):
@@ -91,7 +91,7 @@ class TestValidateCircuitDataComponents:
 
     def test_component_pos_non_numeric_x_raises(self):
         data = {
-            "components": [{"id": "R1", "type": "R", "value": "1k", "pos": {"x": "a", "y": 0}}],
+            "components": [{"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": "a", "y": 0}}],
             "wires": [],
         }
         with pytest.raises(ValueError, match="numeric"):
@@ -99,7 +99,7 @@ class TestValidateCircuitDataComponents:
 
     def test_component_pos_non_numeric_y_raises(self):
         data = {
-            "components": [{"id": "R1", "type": "R", "value": "1k", "pos": {"x": 0, "y": "b"}}],
+            "components": [{"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": "b"}}],
             "wires": [],
         }
         with pytest.raises(ValueError, match="numeric"):


### PR DESCRIPTION
## Summary
- Reject unknown component types (must be in COMPONENT_TYPES) during schema validation
- Reject non-standard rotation values (must be 0, 90, 180, or 270)
- Fix existing test that used short type name "R" instead of "Resistor"
- Add tests for all known types, valid/invalid rotations, and missing rotation default

## Test plan
- [x] Unknown component type raises ValueError
- [x] All known COMPONENT_TYPES pass validation
- [x] Valid rotations (0, 90, 180, 270) pass
- [x] Invalid rotation (45) raises ValueError
- [x] Missing rotation defaults to 0 and passes