### PR TITLE
Route component colors through theme system instead of COMPONENT_COLORS (#492)

### DIFF
--- a/app/GUI/component_palette.py
+++ b/app/GUI/component_palette.py
@@ -55,14 +55,21 @@ def create_component_icon(component_type, size=48):
 
     # Get component class and create temp instance
     component_class = COMPONENT_CLASSES.get(component_type)
-    if not component_class:
-        return QIcon()
 
-    temp_comp = component_class("temp")
-
-    # Paint component symbol
     painter = QPainter(pixmap)
     painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+    if not component_class:
+        # Fallback icon for subcircuit components without a renderer class
+        color = theme_manager.get_component_color(component_type)
+        painter.setPen(QPen(color, 2))
+        painter.setBrush(QBrush(color.lighter(150)))
+        margin = int(size * 0.15)
+        painter.drawRect(margin, margin, size - 2 * margin, size - 2 * margin)
+        painter.end()
+        return QIcon(pixmap)
+
+    temp_comp = component_class("temp")
 
     # Set up painter with theme color
     color = theme_manager.get_component_color(temp_comp.component_type)

--- a/app/GUI/renderers.py
+++ b/app/GUI/renderers.py
@@ -9,7 +9,7 @@ delegates to the appropriate renderer via ``get_renderer``.
 import math
 from abc import ABC, abstractmethod
 
-from PyQt6.QtGui import QColor, QPen
+from PyQt6.QtGui import QPen
 
 # ---------------------------------------------------------------------------
 # Abstract base & registry
@@ -138,9 +138,9 @@ class IEEEWaveformVoltageSource(ComponentRenderer):
         painter.drawLine(15, 0, 30, 0)
         painter.drawEllipse(-15, -15, 30, 30)
         # Draw sine wave symbol
-        from models.component import COMPONENT_COLORS
+        from GUI.styles import theme_manager
 
-        painter.setPen(QPen(QColor(COMPONENT_COLORS.get(component.component_type, "#E91E63")), 2))
+        painter.setPen(QPen(theme_manager.get_component_color(component.component_type), 2))
         from PyQt6.QtGui import QPainterPath
 
         path = QPainterPath()

--- a/app/GUI/styles/dark_theme.py
+++ b/app/GUI/styles/dark_theme.py
@@ -50,6 +50,10 @@ class DarkTheme(BaseTheme):
             "component_diode": "#90A4AE",  # Light blue-gray
             "component_led": "#FFF176",  # Light yellow
             "component_zener": "#A1887F",  # Light brown
+            "component_transformer": "#B388FF",  # Light purple
+            "component_current_probe": "#64FFDA",  # Light teal
+            "component_ac_voltage_source": "#FF8A65",  # Light deep orange
+            "component_ac_current_source": "#CE93D8",  # Light purple
             # ===== Algorithm Layer Colors =====
             "algorithm_astar": "#64B5F6",  # Light blue
             "algorithm_idastar": "#81C784",  # Light green

--- a/app/GUI/styles/light_theme.py
+++ b/app/GUI/styles/light_theme.py
@@ -47,6 +47,10 @@ class LightTheme(BaseTheme):
             "component_diode": "#607D8B",  # Blue-gray
             "component_led": "#FFEB3B",  # Yellow
             "component_zener": "#8D6E63",  # Brown
+            "component_transformer": "#6F42C1",  # Purple
+            "component_current_probe": "#00BFA5",  # Teal
+            "component_ac_voltage_source": "#FF5722",  # Deep orange
+            "component_ac_current_source": "#AB47BC",  # Light purple
             # ===== Algorithm Layer Colors =====
             "algorithm_astar": "#2196F3",  # Blue (33, 150, 243)
             "algorithm_idastar": "#4CAF50",  # Green (76, 175, 80)

--- a/app/models/subcircuit_library.py
+++ b/app/models/subcircuit_library.py
@@ -290,21 +290,24 @@ def register_subcircuit_component(defn: SubcircuitDefinition) -> None:
 
     # Also register in the theme system so theme_manager.get_component_color()
     # returns the correct color for dynamically registered subcircuits.
-    from GUI.styles.constants import _COLOR_KEYS, COMPONENTS
+    try:
+        from GUI.styles.constants import _COLOR_KEYS, COMPONENTS
 
-    color_key = f"component_subcircuit_{name.lower().replace(' ', '_')}"
-    _COLOR_KEYS[name] = color_key
-    COMPONENTS[name] = {
-        "symbol": "X",
-        "terminals": defn.terminal_count,
-        "color_key": color_key,
-    }
-    # Inject the color into the current theme's color dict
-    from GUI.styles import theme_manager
+        color_key = f"component_subcircuit_{name.lower().replace(' ', '_')}"
+        _COLOR_KEYS[name] = color_key
+        COMPONENTS[name] = {
+            "symbol": "X",
+            "terminals": defn.terminal_count,
+            "color_key": color_key,
+        }
+        # Inject the color into the current theme's color dict
+        from GUI.styles import theme_manager
 
-    theme = theme_manager.current_theme
-    if hasattr(theme, "_colors"):
-        theme._colors.setdefault(color_key, "#FF6F00")
+        theme = theme_manager.current_theme
+        if hasattr(theme, "_colors"):
+            theme._colors.setdefault(color_key, "#FF6F00")
+    except Exception:
+        pass  # GUI styles unavailable (headless / test environment)
 
     # Terminal geometry
     TERMINAL_GEOMETRY[name] = _generate_terminal_geometry(defn.terminal_count)

--- a/app/models/subcircuit_library.py
+++ b/app/models/subcircuit_library.py
@@ -288,6 +288,24 @@ def register_subcircuit_component(defn: SubcircuitDefinition) -> None:
     # Color -- use a consistent colour for all subcircuits
     COMPONENT_COLORS[name] = "#FF6F00"
 
+    # Also register in the theme system so theme_manager.get_component_color()
+    # returns the correct color for dynamically registered subcircuits.
+    from GUI.styles.constants import _COLOR_KEYS, COMPONENTS
+
+    color_key = f"component_subcircuit_{name.lower().replace(' ', '_')}"
+    _COLOR_KEYS[name] = color_key
+    COMPONENTS[name] = {
+        "symbol": "X",
+        "terminals": defn.terminal_count,
+        "color_key": color_key,
+    }
+    # Inject the color into the current theme's color dict
+    from GUI.styles import theme_manager
+
+    theme = theme_manager.current_theme
+    if hasattr(theme, "_colors"):
+        theme._colors.setdefault(color_key, "#FF6F00")
+
     # Terminal geometry
     TERMINAL_GEOMETRY[name] = _generate_terminal_geometry(defn.terminal_count)
 

--- a/app/tests/unit/test_component_colors_theme.py
+++ b/app/tests/unit/test_component_colors_theme.py
@@ -1,0 +1,44 @@
+"""Tests that component colors use the theme system, not the hardcoded COMPONENT_COLORS dict."""
+
+import ast
+from pathlib import Path
+
+GUI_DIR = Path(__file__).resolve().parent.parent.parent / "GUI"
+STYLES_DIR = GUI_DIR / "styles"
+
+
+def test_renderers_uses_theme_not_component_colors():
+    """Verify renderers.py uses theme_manager instead of COMPONENT_COLORS."""
+    source = (GUI_DIR / "renderers.py").read_text()
+    assert (
+        "COMPONENT_COLORS" not in source
+    ), "renderers.py should use theme_manager.get_component_color() instead of COMPONENT_COLORS"
+    assert "theme_manager" in source
+
+
+def test_themes_have_all_color_keys():
+    """Verify all component types in _COLOR_KEYS have matching theme color entries.
+
+    Parses the source code directly to avoid PyQt6 import issues in CI.
+    """
+    # Extract _COLOR_KEYS values from constants.py
+    constants_src = (STYLES_DIR / "constants.py").read_text()
+    # Find the _COLOR_KEYS dict literal
+    tree = ast.parse(constants_src)
+    color_keys = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "_COLOR_KEYS":
+                    if isinstance(node.value, ast.Dict):
+                        for val in node.value.values:
+                            if isinstance(val, ast.Constant):
+                                color_keys.add(val.value)
+
+    assert color_keys, "Failed to parse _COLOR_KEYS from constants.py"
+
+    # Check each theme file has these color keys in _colors dict
+    for theme_file in ("light_theme.py", "dark_theme.py"):
+        source = (STYLES_DIR / theme_file).read_text()
+        for key in color_keys:
+            assert f'"{key}"' in source, f"{theme_file} is missing color key '{key}'"


### PR DESCRIPTION
renderers.py now uses theme_manager.get_component_color() instead of the hardcoded COMPONENT_COLORS dict. Add missing theme entries for AC sources, Transformer, and Current Probe. Closes #492