### PR TITLE
Replace hardcoded syntax highlighter colors with theme system (#493)

### DIFF
--- a/app/GUI/netlist_preview.py
+++ b/app/GUI/netlist_preview.py
@@ -5,7 +5,7 @@ with basic syntax highlighting.
 
 import re
 
-from PyQt6.QtGui import QColor, QFont, QSyntaxHighlighter, QTextCharFormat
+from PyQt6.QtGui import QFont, QSyntaxHighlighter, QTextCharFormat
 from PyQt6.QtWidgets import QHBoxLayout, QLabel, QPushButton, QTextEdit, QVBoxLayout, QWidget
 
 from .styles import theme_manager
@@ -17,21 +17,27 @@ class SpiceHighlighter(QSyntaxHighlighter):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._rules = []
+        self._build_rules()
+        theme_manager.on_theme_changed(self._on_theme_changed)
 
-        # Comments: lines starting with * (green)
+    def _build_rules(self):
+        """Build highlighting rules using current theme colors."""
+        self._rules.clear()
+
+        # Comments: lines starting with *
         comment_fmt = QTextCharFormat()
-        comment_fmt.setForeground(QColor("#4CAF50"))
+        comment_fmt.setForeground(theme_manager.color("syntax_comment"))
         self._rules.append((re.compile(r"^\*.*$"), comment_fmt))
 
-        # Directives: lines starting with . (blue)
+        # Directives: lines starting with .
         directive_fmt = QTextCharFormat()
-        directive_fmt.setForeground(QColor("#2196F3"))
+        directive_fmt.setForeground(theme_manager.color("syntax_directive"))
         directive_fmt.setFontWeight(QFont.Weight.Bold)
         self._rules.append((re.compile(r"^\..*$"), directive_fmt))
 
-        # Control block keywords (purple)
+        # Control block keywords
         control_fmt = QTextCharFormat()
-        control_fmt.setForeground(QColor("#9C27B0"))
+        control_fmt.setForeground(theme_manager.color("syntax_keyword"))
         control_fmt.setFontWeight(QFont.Weight.Bold)
         self._rules.append(
             (
@@ -39,6 +45,11 @@ class SpiceHighlighter(QSyntaxHighlighter):
                 control_fmt,
             )
         )
+
+    def _on_theme_changed(self, _theme):
+        """Rebuild rules with new theme colors and rehighlight."""
+        self._build_rules()
+        self.rehighlight()
 
     def highlightBlock(self, text):
         """Apply syntax highlighting rules to a single line of text."""

--- a/app/GUI/styles/dark_theme.py
+++ b/app/GUI/styles/dark_theme.py
@@ -96,6 +96,10 @@ class DarkTheme(BaseTheme):
             "border_error": "#FF6B6B",  # Red border for invalid inputs
             "border_light": "#444444",  # Subtle border for dark bg
             "panel_bg": "#2D2D2D",  # Match background_secondary
+            # ===== Syntax Highlighting Colors =====
+            "syntax_comment": "#81C784",  # Light green for dark bg
+            "syntax_directive": "#64B5F6",  # Light blue for dark bg
+            "syntax_keyword": "#CE93D8",  # Light purple for dark bg
             # ===== Measurement Cursor Colors =====
             "cursor_a": "#FF6B6B",  # Light red cursor for dark bg
             "cursor_b": "#5DADE2",  # Light blue cursor for dark bg

--- a/app/GUI/styles/light_theme.py
+++ b/app/GUI/styles/light_theme.py
@@ -93,6 +93,10 @@ class LightTheme(BaseTheme):
             "border_error": "#DC3545",  # Red border for invalid inputs
             "border_light": "#DDDDDD",  # Light border for panels
             "panel_bg": "#F9F9F9",  # Light panel background
+            # ===== Syntax Highlighting Colors =====
+            "syntax_comment": "#4CAF50",  # Green for SPICE comments
+            "syntax_directive": "#2196F3",  # Blue for SPICE directives
+            "syntax_keyword": "#9C27B0",  # Purple for control keywords
             # ===== Measurement Cursor Colors =====
             "cursor_a": "#E74C3C",  # Red cursor
             "cursor_b": "#2980B9",  # Blue cursor

--- a/app/tests/unit/test_netlist_highlighter_theme.py
+++ b/app/tests/unit/test_netlist_highlighter_theme.py
@@ -1,0 +1,30 @@
+"""Tests that the SPICE netlist syntax highlighter uses theme colors."""
+
+from pathlib import Path
+
+GUI_DIR = Path(__file__).resolve().parent.parent.parent / "GUI"
+STYLES_DIR = GUI_DIR / "styles"
+
+
+def test_highlighter_no_hardcoded_colors():
+    """Verify SpiceHighlighter does not contain hardcoded color values."""
+    source = (GUI_DIR / "netlist_preview.py").read_text()
+    assert "#4CAF50" not in source, "Comment color should come from theme, not hardcoded"
+    assert "#2196F3" not in source, "Directive color should come from theme, not hardcoded"
+    assert "#9C27B0" not in source, "Keyword color should come from theme, not hardcoded"
+
+
+def test_highlighter_uses_theme_manager():
+    """Verify SpiceHighlighter uses theme_manager for colors."""
+    source = (GUI_DIR / "netlist_preview.py").read_text()
+    assert "theme_manager.color" in source, "Highlighter should use theme_manager.color()"
+    assert "on_theme_changed" in source, "Highlighter should listen for theme changes"
+
+
+def test_syntax_colors_in_both_themes():
+    """Verify syntax highlighting color keys exist in both themes."""
+    keys = ["syntax_comment", "syntax_directive", "syntax_keyword"]
+    for theme_file in ("light_theme.py", "dark_theme.py"):
+        source = (STYLES_DIR / theme_file).read_text()
+        for key in keys:
+            assert f'"{key}"' in source, f"{theme_file} is missing color key '{key}'"


### PR DESCRIPTION
SpiceHighlighter now reads colors from theme_manager and rebuilds on theme change. Closes #493