### PR TITLE
Replace hardcoded grading overlay colors with colorblind-friendly theme (#491)

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -370,12 +370,14 @@ class ComponentGraphicsItem(QGraphicsItem):
             painter.drawRect(QRectF(-42, -22, 84, 44))
         # Grading overlay (temporary visual feedback)
         if self._grading_state == "passed":
-            painter.setPen(QPen(QColor(0, 200, 0, 200), 3))
-            painter.setBrush(QBrush(QColor(0, 200, 0, 40)))
+            grading_color = theme_manager.color("grading_passed")
+            painter.setPen(QPen(QColor(grading_color.red(), grading_color.green(), grading_color.blue(), 200), 3))
+            painter.setBrush(QBrush(QColor(grading_color.red(), grading_color.green(), grading_color.blue(), 40)))
             painter.drawRoundedRect(QRectF(-42, -22, 84, 44), 4, 4)
         elif self._grading_state == "failed":
-            painter.setPen(QPen(QColor(220, 0, 0, 200), 3))
-            painter.setBrush(QBrush(QColor(220, 0, 0, 40)))
+            grading_color = theme_manager.color("grading_failed")
+            painter.setPen(QPen(QColor(grading_color.red(), grading_color.green(), grading_color.blue(), 200), 3))
+            painter.setBrush(QBrush(QColor(grading_color.red(), grading_color.green(), grading_color.blue(), 40)))
             painter.drawRoundedRect(QRectF(-42, -22, 84, 44), 4, 4)
 
         # Draw component body

--- a/app/GUI/grading_panel.py
+++ b/app/GUI/grading_panel.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Optional
 from grading.component_mapper import extract_component_ids
 from models.circuit import CircuitModel
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import (
     QFileDialog,
     QGroupBox,
@@ -248,9 +247,9 @@ class GradingPanel(QWidget):
             item.setData(Qt.ItemDataRole.UserRole, cr)
 
             if cr.passed:
-                item.setForeground(QColor("green"))
+                item.setForeground(theme_manager.color("grading_passed"))
             else:
-                item.setForeground(QColor("red"))
+                item.setForeground(theme_manager.color("grading_failed"))
 
             self.results_list.addItem(item)
 

--- a/app/GUI/styles/dark_theme.py
+++ b/app/GUI/styles/dark_theme.py
@@ -104,6 +104,9 @@ class DarkTheme(BaseTheme):
             "syntax_comment": "#81C784",  # Light green for dark bg
             "syntax_directive": "#64B5F6",  # Light blue for dark bg
             "syntax_keyword": "#CE93D8",  # Light purple for dark bg
+            # ===== Grading Overlay Colors (colorblind-friendly) =====
+            "grading_passed": "#33BBEE",  # Light blue for dark bg
+            "grading_failed": "#EE7733",  # Orange for dark bg
             # ===== Measurement Cursor Colors =====
             "cursor_a": "#FF6B6B",  # Light red cursor for dark bg
             "cursor_b": "#5DADE2",  # Light blue cursor for dark bg

--- a/app/GUI/styles/light_theme.py
+++ b/app/GUI/styles/light_theme.py
@@ -101,6 +101,9 @@ class LightTheme(BaseTheme):
             "syntax_comment": "#4CAF50",  # Green for SPICE comments
             "syntax_directive": "#2196F3",  # Blue for SPICE directives
             "syntax_keyword": "#9C27B0",  # Purple for control keywords
+            # ===== Grading Overlay Colors (colorblind-friendly) =====
+            "grading_passed": "#0077BB",  # Blue (distinguishable by most color vision)
+            "grading_failed": "#EE7733",  # Orange (distinguishable by most color vision)
             # ===== Measurement Cursor Colors =====
             "cursor_a": "#E74C3C",  # Red cursor
             "cursor_b": "#2980B9",  # Blue cursor

--- a/app/tests/unit/test_grading_overlay_theme.py
+++ b/app/tests/unit/test_grading_overlay_theme.py
@@ -1,0 +1,47 @@
+"""Tests that grading overlay colors use the theme system and are colorblind-friendly."""
+
+from pathlib import Path
+
+GUI_DIR = Path(__file__).resolve().parent.parent.parent / "GUI"
+STYLES_DIR = GUI_DIR / "styles"
+
+
+def test_component_item_no_hardcoded_grading_colors():
+    """Verify component_item.py grading overlay uses theme colors."""
+    source = (GUI_DIR / "component_item.py").read_text()
+    assert "QColor(0, 200, 0" not in source, "Grading passed color should come from theme"
+    assert "QColor(220, 0, 0" not in source, "Grading failed color should come from theme"
+    assert "grading_passed" in source
+    assert "grading_failed" in source
+
+
+def test_grading_panel_no_hardcoded_colors():
+    """Verify grading_panel.py uses theme colors for pass/fail indicators."""
+    source = (GUI_DIR / "grading_panel.py").read_text()
+    assert 'QColor("green")' not in source, "Grading panel should use theme, not hardcoded green"
+    assert 'QColor("red")' not in source, "Grading panel should use theme, not hardcoded red"
+    assert "grading_passed" in source
+    assert "grading_failed" in source
+
+
+def test_grading_colors_in_both_themes():
+    """Verify grading color keys exist in both themes."""
+    keys = ["grading_passed", "grading_failed"]
+    for theme_file in ("light_theme.py", "dark_theme.py"):
+        source = (STYLES_DIR / theme_file).read_text()
+        for key in keys:
+            assert f'"{key}"' in source, f"{theme_file} is missing color key '{key}'"
+
+
+def test_grading_colors_are_not_red_green():
+    """Verify grading colors avoid pure red/green for colorblind accessibility."""
+    for theme_file in ("light_theme.py", "dark_theme.py"):
+        source = (STYLES_DIR / theme_file).read_text()
+        # Find the grading color values - they should not be pure red or green
+        for line in source.splitlines():
+            if "grading_passed" in line and "#" in line:
+                # Should not be a pure green (e.g., #00XX00 or #28A745)
+                assert "#00FF00" not in line, "grading_passed should not use pure green"
+            if "grading_failed" in line and "#" in line:
+                # Should not be a pure red (e.g., #FF0000 or #DC3545)
+                assert "#FF0000" not in line, "grading_failed should not use pure red"


### PR DESCRIPTION
Grading overlays now use blue/orange from the theme system instead of hardcoded green/red for colorblind accessibility. Closes #491