### PR TITLE
fix: waypoint drag undo/redo, orthogonal constraint, and segment insertion (#483)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -329,6 +329,9 @@ class CircuitCanvasView(QGraphicsView):
             # Sync visual path from persisted model waypoints
             if hasattr(wire_data, "waypoints") and wire_data.waypoints:
                 wire._restore_waypoints()
+                # Refresh handles if the wire is selected (e.g. after undo/redo)
+                if wire.isSelected():
+                    wire._show_handles()
 
     def _handle_wire_lock_changed(self, data) -> None:
         """Update wire visual when lock state changes."""
@@ -359,6 +362,19 @@ class CircuitCanvasView(QGraphicsView):
             idx = self.wires.index(wire_item)
             wps = waypoints if waypoints is not None else wire_item.model.waypoints
             self.controller.update_wire_waypoints(idx, wps)
+            self.controller.set_wire_locked(idx, True)
+
+    def on_waypoint_drag_finished(self, wire_item, new_waypoints) -> None:
+        """Push an undoable MoveWaypointCommand after a waypoint drag."""
+        from controllers.commands import MoveWaypointCommand
+
+        if self.controller and wire_item in self.wires:
+            idx = self.wires.index(wire_item)
+            old_waypoints = wire_item._pre_drag_waypoints
+            cmd = MoveWaypointCommand(self.controller, idx, old_waypoints, new_waypoints)
+            self.controller.push_already_executed(cmd)
+            # Sync the model (the visual state is already correct)
+            self.controller.update_wire_waypoints(idx, new_waypoints)
             self.controller.set_wire_locked(idx, True)
 
     def on_wire_routing_complete(self, wire_item, waypoints, runtime=0.0, iterations=0, routing_failed=False):

--- a/app/GUI/wire_item.py
+++ b/app/GUI/wire_item.py
@@ -17,10 +17,12 @@ logger = logging.getLogger(__name__)
 class WaypointHandle(QGraphicsEllipseItem):
     """Small draggable circle displayed at a wire waypoint.
 
-    When the user drags a handle the parent wire's waypoints list is
+    When the user drags a handle the parent wire's waypoints list are
     updated in real time and the wire path is redrawn.  On release the
-    model is synced and the wire is marked locked so auto-rerouting
-    won't overwrite the manual adjustment.
+    model is synced via an undoable command so Ctrl+Z works.
+
+    Movement is constrained to one axis (horizontal **or** vertical)
+    to preserve orthogonal routing.
     """
 
     def __init__(self, wire: "WireGraphicsItem", index: int, pos: QPointF):
@@ -28,6 +30,8 @@ class WaypointHandle(QGraphicsEllipseItem):
         super().__init__(-r, -r, 2 * r, 2 * r)
         self._wire = wire
         self._index = index
+        self._drag_origin: QPointF | None = None
+        self._axis: str | None = None  # "h" or "v" once locked
         self.setPos(pos)
         self.setBrush(QBrush(theme_manager.color("wire_selected")))
         self.setPen(QPen(Qt.GlobalColor.white, 1))
@@ -35,6 +39,11 @@ class WaypointHandle(QGraphicsEllipseItem):
         self.setFlag(QGraphicsEllipseItem.GraphicsItemFlag.ItemIsMovable, True)
         self.setFlag(QGraphicsEllipseItem.GraphicsItemFlag.ItemSendsGeometryChanges, True)
         self.setCursor(Qt.CursorShape.SizeAllCursor)
+
+    def mousePressEvent(self, event):
+        self._drag_origin = self.pos()
+        self._axis = None
+        super().mousePressEvent(event)
 
     def itemChange(self, change, value):
         if change == QGraphicsEllipseItem.GraphicsItemChange.ItemPositionHasChanged:
@@ -44,6 +53,17 @@ class WaypointHandle(QGraphicsEllipseItem):
                 round(new_pos.x() / GRID_SIZE) * GRID_SIZE,
                 round(new_pos.y() / GRID_SIZE) * GRID_SIZE,
             )
+            # Enforce single-axis movement for orthogonal routing
+            if self._drag_origin is not None:
+                if self._axis is None:
+                    dx = abs(snapped.x() - self._drag_origin.x())
+                    dy = abs(snapped.y() - self._drag_origin.y())
+                    if dx > 0 or dy > 0:
+                        self._axis = "h" if dx >= dy else "v"
+                if self._axis == "h":
+                    snapped = QPointF(snapped.x(), self._drag_origin.y())
+                elif self._axis == "v":
+                    snapped = QPointF(self._drag_origin.x(), snapped.y())
             self._wire._move_waypoint(self._index, snapped)
         return super().itemChange(change, value)
 
@@ -54,8 +74,90 @@ class WaypointHandle(QGraphicsEllipseItem):
             round(self.pos().x() / GRID_SIZE) * GRID_SIZE,
             round(self.pos().y() / GRID_SIZE) * GRID_SIZE,
         )
+        if self._drag_origin is not None:
+            if self._axis == "h":
+                snapped = QPointF(snapped.x(), self._drag_origin.y())
+            elif self._axis == "v":
+                snapped = QPointF(self._drag_origin.x(), snapped.y())
         self.setPos(snapped)
         self._wire._finish_waypoint_drag()
+        self._drag_origin = None
+        self._axis = None
+
+
+class SegmentHandle(QGraphicsEllipseItem):
+    """Handle placed at the midpoint of a wire segment.
+
+    Dragging this handle inserts a new waypoint pair that creates an
+    orthogonal detour while keeping the wire path orthogonal.
+    """
+
+    def __init__(self, wire: "WireGraphicsItem", segment_index: int, pos: QPointF):
+        r = _HANDLE_RADIUS - 1
+        super().__init__(-r, -r, 2 * r, 2 * r)
+        self._wire = wire
+        self._segment_index = segment_index
+        self._drag_origin: QPointF | None = None
+        self._inserted = False
+        self._handle_index: int | None = None
+        self.setPos(pos)
+        color = theme_manager.color("wire_selected").lighter(140)
+        self.setBrush(QBrush(color))
+        self.setPen(QPen(Qt.GlobalColor.white, 1))
+        self.setZValue(199)
+        self.setFlag(QGraphicsEllipseItem.GraphicsItemFlag.ItemIsMovable, True)
+        self.setFlag(QGraphicsEllipseItem.GraphicsItemFlag.ItemSendsGeometryChanges, True)
+        self.setCursor(Qt.CursorShape.SizeAllCursor)
+
+    def mousePressEvent(self, event):
+        self._drag_origin = self.pos()
+        super().mousePressEvent(event)
+
+    def itemChange(self, change, value):
+        if change == QGraphicsEllipseItem.GraphicsItemChange.ItemPositionHasChanged:
+            new_pos = value
+            snapped = QPointF(
+                round(new_pos.x() / GRID_SIZE) * GRID_SIZE,
+                round(new_pos.y() / GRID_SIZE) * GRID_SIZE,
+            )
+            if not self._inserted and self._drag_origin is not None:
+                dx = abs(snapped.x() - self._drag_origin.x())
+                dy = abs(snapped.y() - self._drag_origin.y())
+                if dx > 0 or dy > 0:
+                    self._insert_pair(snapped)
+            elif self._inserted and self._handle_index is not None:
+                # Constrain to the axis determined at insertion
+                if self._axis == "h":
+                    snapped = QPointF(snapped.x(), self._drag_origin.y())
+                else:
+                    snapped = QPointF(self._drag_origin.x(), snapped.y())
+                self._wire._move_waypoint(self._handle_index, snapped)
+        return super().itemChange(change, value)
+
+    def _insert_pair(self, pos: QPointF):
+        """Insert two new waypoints to create an orthogonal detour."""
+        origin = self._drag_origin
+        dx = abs(pos.x() - origin.x())
+        dy = abs(pos.y() - origin.y())
+        # Determine axis: user is dragging perpendicular to the segment
+        self._axis = "v" if dx >= dy else "h"
+
+        seg = self._segment_index
+        # Insert two waypoints at the origin position; the dragged one will move
+        wp1 = QPointF(origin.x(), origin.y())
+        wp2 = QPointF(origin.x(), origin.y())
+        self._wire.waypoints.insert(seg + 1, wp1)
+        self._wire.waypoints.insert(seg + 2, wp2)
+        # The user drags wp at seg+1
+        self._handle_index = seg + 1
+        self._inserted = True
+        self._wire._rebuild_path_from_waypoints()
+
+    def mouseReleaseEvent(self, event):
+        super().mouseReleaseEvent(event)
+        if self._inserted:
+            self._wire._finish_waypoint_drag()
+        self._drag_origin = None
 
 
 class WireGraphicsItem(QGraphicsPathItem):
@@ -109,6 +211,7 @@ class WireGraphicsItem(QGraphicsPathItem):
         self.waypoints = []  # List of QPointF waypoints (computed during routing)
 
         self._waypoint_handles: list[WaypointHandle] = []
+        self._pre_drag_waypoints: list[tuple[float, float]] = []
 
         self._hovered = False
 
@@ -362,18 +465,40 @@ class WireGraphicsItem(QGraphicsPathItem):
         return super().itemChange(change, value)
 
     def _show_handles(self):
-        """Create draggable handles at each interior waypoint."""
+        """Create draggable handles at each interior waypoint and segment midpoints."""
         self._hide_handles()
-        if len(self.waypoints) < 3:
-            return  # Only start/end — nothing to drag
         scene = self.scene()
         if scene is None:
             return
-        for i, wp in enumerate(self.waypoints):
-            if i == 0 or i == len(self.waypoints) - 1:
-                continue  # Skip terminal endpoints
-            pt = wp if isinstance(wp, QPointF) else QPointF(wp[0], wp[1])
-            handle = WaypointHandle(self, i, pt)
+
+        # Snapshot waypoints before any drag starts so undo knows the "before" state
+        self._pre_drag_waypoints = self._waypoints_as_tuples()
+
+        # Interior waypoint handles
+        if len(self.waypoints) >= 3:
+            for i, wp in enumerate(self.waypoints):
+                if i == 0 or i == len(self.waypoints) - 1:
+                    continue  # Skip terminal endpoints
+                pt = wp if isinstance(wp, QPointF) else QPointF(wp[0], wp[1])
+                handle = WaypointHandle(self, i, pt)
+                scene.addItem(handle)
+                self._waypoint_handles.append(handle)
+
+        # Segment midpoint handles for inserting new waypoints
+        for i in range(len(self.waypoints) - 1):
+            a = self.waypoints[i]
+            b = self.waypoints[i + 1]
+            ax = a.x() if isinstance(a, QPointF) else a[0]
+            ay = a.y() if isinstance(a, QPointF) else a[1]
+            bx = b.x() if isinstance(b, QPointF) else b[0]
+            by = b.y() if isinstance(b, QPointF) else b[1]
+            mid = QPointF((ax + bx) / 2, (ay + by) / 2)
+            # Snap midpoint to grid
+            mid = QPointF(
+                round(mid.x() / GRID_SIZE) * GRID_SIZE,
+                round(mid.y() / GRID_SIZE) * GRID_SIZE,
+            )
+            handle = SegmentHandle(self, i, mid)
             scene.addItem(handle)
             self._waypoint_handles.append(handle)
 
@@ -385,6 +510,13 @@ class WireGraphicsItem(QGraphicsPathItem):
                 scene.removeItem(handle)
         self._waypoint_handles.clear()
 
+    def _waypoints_as_tuples(self):
+        """Return current waypoints as a list of (x, y) tuples."""
+        return [
+            (wp.x() if isinstance(wp, QPointF) else wp[0], wp.y() if isinstance(wp, QPointF) else wp[1])
+            for wp in self.waypoints
+        ]
+
     def _move_waypoint(self, index: int, new_pos: QPointF):
         """Called by WaypointHandle during drag to update the wire path."""
         if 0 < index < len(self.waypoints):
@@ -392,17 +524,10 @@ class WireGraphicsItem(QGraphicsPathItem):
             self._rebuild_path_from_waypoints()
 
     def _finish_waypoint_drag(self):
-        """Called by WaypointHandle on mouse release to persist changes."""
-        tuple_waypoints = [
-            (
-                wp.x() if isinstance(wp, QPointF) else wp[0],
-                wp.y() if isinstance(wp, QPointF) else wp[1],
-            )
-            for wp in self.waypoints
-        ]
-        # Persist waypoints and lock through canvas -> controller
-        if self.canvas and hasattr(self.canvas, "on_wire_waypoints_changed"):
-            self.canvas.on_wire_waypoints_changed(self, tuple_waypoints)
+        """Called by WaypointHandle on mouse release — push undoable command."""
+        new_waypoints = self._waypoints_as_tuples()
+        if self.canvas and hasattr(self.canvas, "on_waypoint_drag_finished"):
+            self.canvas.on_waypoint_drag_finished(self, new_waypoints)
 
     def _rebuild_path_from_waypoints(self):
         """Rebuild the QPainterPath from the current waypoints list."""

--- a/app/controllers/commands.py
+++ b/app/controllers/commands.py
@@ -656,6 +656,42 @@ class UpdateInitialConditionCommand(Command):
         return f"Update {self.component_id} initial condition"
 
 
+class MoveWaypointCommand(Command):
+    """Command to record a waypoint drag so it can be undone/redone.
+
+    The drag has already been applied visually by the time this command
+    is pushed, so ``execute()`` writes the *new* waypoints into the model
+    and ``undo()`` restores the *old* ones.
+    """
+
+    def __init__(
+        self,
+        controller,
+        wire_index: int,
+        old_waypoints: list[tuple[float, float]],
+        new_waypoints: list[tuple[float, float]],
+    ):
+        self.controller = controller
+        self.wire_index = wire_index
+        self.old_waypoints = old_waypoints
+        self.new_waypoints = new_waypoints
+
+    def execute(self) -> None:
+        if self.wire_index >= len(self.controller.model.wires):
+            return
+        self.controller.update_wire_waypoints(self.wire_index, self.new_waypoints)
+        self.controller.set_wire_locked(self.wire_index, True)
+
+    def undo(self) -> None:
+        if self.wire_index >= len(self.controller.model.wires):
+            return
+        self.controller.update_wire_waypoints(self.wire_index, self.old_waypoints)
+        self.controller.set_wire_locked(self.wire_index, True)
+
+    def get_description(self) -> str:
+        return "Move waypoint"
+
+
 class CompoundCommand(Command):
     """Command that groups multiple commands into a single undo step."""
 

--- a/app/tests/unit/test_scene_item_decoupling.py
+++ b/app/tests/unit/test_scene_item_decoupling.py
@@ -162,8 +162,8 @@ class TestWireItemDecoupling:
         wire.waypoints = [(0, 0), (50, 50), (100, 100)]
         wire._finish_waypoint_drag()
 
-        mock_canvas.on_wire_waypoints_changed.assert_called_once()
-        call_args = mock_canvas.on_wire_waypoints_changed.call_args
+        mock_canvas.on_waypoint_drag_finished.assert_called_once()
+        call_args = mock_canvas.on_waypoint_drag_finished.call_args
         assert call_args[0][0] is wire  # first positional arg is the wire item
 
     def test_no_window_statusbar_access_in_source(self):

--- a/app/tests/unit/test_waypoint_editing.py
+++ b/app/tests/unit/test_waypoint_editing.py
@@ -66,9 +66,9 @@ class TestWaypointHandleCreation:
 
         scene = QGraphicsScene()
         scene.addItem(wire_with_waypoints)
-        # 4 waypoints, interior = index 1 and 2
+        # 4 waypoints: 2 interior waypoint handles + 3 segment midpoint handles = 5
         wire_with_waypoints._show_handles()
-        assert len(wire_with_waypoints._waypoint_handles) == 2
+        assert len(wire_with_waypoints._waypoint_handles) == 5
 
     def test_hide_handles_removes_all(self, wire_with_waypoints, qtbot):
         from PyQt6.QtWidgets import QGraphicsScene
@@ -76,7 +76,7 @@ class TestWaypointHandleCreation:
         scene = QGraphicsScene()
         scene.addItem(wire_with_waypoints)
         wire_with_waypoints._show_handles()
-        assert len(wire_with_waypoints._waypoint_handles) == 2
+        assert len(wire_with_waypoints._waypoint_handles) == 5
         wire_with_waypoints._hide_handles()
         assert len(wire_with_waypoints._waypoint_handles) == 0
 
@@ -110,17 +110,21 @@ class TestWaypointHandleCreation:
         scene = QGraphicsScene()
         scene.addItem(wire)
         wire._show_handles()
-        assert len(wire._waypoint_handles) == 0
+        # 2-point wire: no interior handles, but 1 segment midpoint handle
+        assert len(wire._waypoint_handles) == 1
 
     def test_handles_positioned_at_waypoints(self, wire_with_waypoints, qtbot):
+        from GUI.wire_item import WaypointHandle
         from PyQt6.QtWidgets import QGraphicsScene
 
         scene = QGraphicsScene()
         scene.addItem(wire_with_waypoints)
         wire_with_waypoints._show_handles()
-        handle1, handle2 = wire_with_waypoints._waypoint_handles
-        assert handle1.pos() == QPointF(50, 0)
-        assert handle2.pos() == QPointF(50, 50)
+        # Filter to only WaypointHandle (interior) handles
+        wp_handles = [h for h in wire_with_waypoints._waypoint_handles if isinstance(h, WaypointHandle)]
+        assert len(wp_handles) == 2
+        assert wp_handles[0].pos() == QPointF(50, 0)
+        assert wp_handles[1].pos() == QPointF(50, 50)
 
 
 class TestWaypointDragging:
@@ -139,15 +143,15 @@ class TestWaypointDragging:
     def test_finish_drag_passes_waypoints_to_canvas(self, wire_with_waypoints, qtbot):
         wire_with_waypoints._move_waypoint(1, QPointF(60, 10))
         wire_with_waypoints._finish_waypoint_drag()
-        call_args = wire_with_waypoints.canvas.on_wire_waypoints_changed.call_args
+        call_args = wire_with_waypoints.canvas.on_waypoint_drag_finished.call_args
         waypoints = call_args[0][1]  # second positional arg
         assert (60.0, 10.0) in waypoints
 
     def test_finish_drag_notifies_canvas_with_waypoints(self, wire_with_waypoints, qtbot):
         wire_with_waypoints._move_waypoint(1, QPointF(60, 10))
         wire_with_waypoints._finish_waypoint_drag()
-        wire_with_waypoints.canvas.on_wire_waypoints_changed.assert_called_once()
-        call_args = wire_with_waypoints.canvas.on_wire_waypoints_changed.call_args
+        wire_with_waypoints.canvas.on_waypoint_drag_finished.assert_called_once()
+        call_args = wire_with_waypoints.canvas.on_waypoint_drag_finished.call_args
         assert call_args[0][0] is wire_with_waypoints
         # Second arg is tuple waypoints list
         assert isinstance(call_args[0][1], list)
@@ -168,7 +172,7 @@ class TestWaypointDragControllerIntegration:
         """Waypoints sent to canvas must be (x, y) tuples, not QPointF."""
         wire_with_waypoints._move_waypoint(1, QPointF(60, 10))
         wire_with_waypoints._finish_waypoint_drag()
-        call_args = wire_with_waypoints.canvas.on_wire_waypoints_changed.call_args
+        call_args = wire_with_waypoints.canvas.on_waypoint_drag_finished.call_args
         waypoints = call_args[0][1]
         for wp in waypoints:
             assert isinstance(wp, tuple), f"Expected tuple, got {type(wp)}"
@@ -231,7 +235,8 @@ class TestSelectionToggle:
         scene = QGraphicsScene()
         scene.addItem(wire_with_waypoints)
         wire_with_waypoints.setSelected(True)
-        assert len(wire_with_waypoints._waypoint_handles) == 2
+        # 2 interior + 3 segment = 5
+        assert len(wire_with_waypoints._waypoint_handles) == 5
 
     def test_deselection_hides_handles(self, wire_with_waypoints, qtbot):
         from PyQt6.QtWidgets import QGraphicsScene
@@ -239,6 +244,6 @@ class TestSelectionToggle:
         scene = QGraphicsScene()
         scene.addItem(wire_with_waypoints)
         wire_with_waypoints.setSelected(True)
-        assert len(wire_with_waypoints._waypoint_handles) == 2
+        assert len(wire_with_waypoints._waypoint_handles) == 5
         wire_with_waypoints.setSelected(False)
         assert len(wire_with_waypoints._waypoint_handles) == 0

--- a/app/tests/unit/test_waypoint_undo.py
+++ b/app/tests/unit/test_waypoint_undo.py
@@ -1,0 +1,105 @@
+"""Tests for MoveWaypointCommand undo/redo (issue #483).
+
+Waypoint drags should be undoable/redoable through the command pattern.
+These tests validate the model-layer command without requiring a Qt canvas.
+"""
+
+from controllers.circuit_controller import CircuitController
+from controllers.commands import MoveWaypointCommand
+from models.circuit import CircuitModel
+from tests.conftest import make_component, make_wire
+
+
+def _make_controller_with_wire():
+    """Create a controller with two components and a wire between them."""
+    model = CircuitModel()
+    ctrl = CircuitController(model)
+    ctrl.add_component("Resistor", (0.0, 0.0))
+    ctrl.add_component("Resistor", (200.0, 0.0))
+    comp_ids = list(model.components.keys())
+    ctrl.add_wire(comp_ids[0], 0, comp_ids[1], 0)
+    # Set some initial waypoints on the wire
+    initial_wps = [(0.0, 0.0), (100.0, 0.0), (200.0, 0.0)]
+    ctrl.update_wire_waypoints(0, initial_wps)
+    return ctrl, initial_wps
+
+
+class TestMoveWaypointCommand:
+    """MoveWaypointCommand should record before/after waypoints for undo."""
+
+    def test_command_exists(self):
+        """MoveWaypointCommand should be importable and constructable."""
+        ctrl, old = _make_controller_with_wire()
+        new = [(0.0, 0.0), (100.0, 50.0), (200.0, 0.0)]
+        cmd = MoveWaypointCommand(ctrl, 0, old, new)
+        assert cmd is not None
+
+    def test_execute_updates_waypoints(self):
+        """execute() should set the new waypoints on the wire model."""
+        ctrl, old = _make_controller_with_wire()
+        new = [(0.0, 0.0), (100.0, 50.0), (200.0, 0.0)]
+        cmd = MoveWaypointCommand(ctrl, 0, old, new)
+        cmd.execute()
+        assert ctrl.model.wires[0].waypoints == new
+
+    def test_undo_restores_old_waypoints(self):
+        """undo() should restore the old waypoints."""
+        ctrl, old = _make_controller_with_wire()
+        new = [(0.0, 0.0), (100.0, 50.0), (200.0, 0.0)]
+        cmd = MoveWaypointCommand(ctrl, 0, old, new)
+        cmd.execute()
+        cmd.undo()
+        assert ctrl.model.wires[0].waypoints == old
+
+    def test_redo_reapplies_new_waypoints(self):
+        """execute() after undo() should reapply the new waypoints."""
+        ctrl, old = _make_controller_with_wire()
+        new = [(0.0, 0.0), (100.0, 50.0), (200.0, 0.0)]
+        cmd = MoveWaypointCommand(ctrl, 0, old, new)
+        cmd.execute()
+        cmd.undo()
+        cmd.execute()
+        assert ctrl.model.wires[0].waypoints == new
+
+    def test_execute_locks_wire(self):
+        """execute() should lock the wire to prevent auto-reroute."""
+        ctrl, old = _make_controller_with_wire()
+        new = [(0.0, 0.0), (100.0, 50.0), (200.0, 0.0)]
+        cmd = MoveWaypointCommand(ctrl, 0, old, new)
+        cmd.execute()
+        assert ctrl.model.wires[0].locked is True
+
+    def test_undo_keeps_wire_locked(self):
+        """undo() should keep the wire locked (manual edit history)."""
+        ctrl, old = _make_controller_with_wire()
+        new = [(0.0, 0.0), (100.0, 50.0), (200.0, 0.0)]
+        cmd = MoveWaypointCommand(ctrl, 0, old, new)
+        cmd.execute()
+        cmd.undo()
+        assert ctrl.model.wires[0].locked is True
+
+    def test_push_already_executed_enables_undo(self):
+        """push_already_executed should allow undo without calling execute."""
+        ctrl, old = _make_controller_with_wire()
+        new = [(0.0, 0.0), (100.0, 50.0), (200.0, 0.0)]
+        # Simulate what the canvas does: sync model then push command
+        ctrl.update_wire_waypoints(0, new)
+        cmd = MoveWaypointCommand(ctrl, 0, old, new)
+        ctrl.push_already_executed(cmd)
+        # Undo should restore old waypoints
+        ctrl.undo()
+        assert ctrl.model.wires[0].waypoints == old
+
+    def test_out_of_range_wire_index_is_safe(self):
+        """Command should not crash with invalid wire index."""
+        ctrl, old = _make_controller_with_wire()
+        new = [(0.0, 0.0), (100.0, 50.0), (200.0, 0.0)]
+        cmd = MoveWaypointCommand(ctrl, 99, old, new)
+        cmd.execute()  # Should not raise
+        cmd.undo()  # Should not raise
+
+    def test_description(self):
+        """get_description() should return a meaningful string."""
+        ctrl, old = _make_controller_with_wire()
+        cmd = MoveWaypointCommand(ctrl, 0, old, old)
+        assert "waypoint" in cmd.get_description().lower()


### PR DESCRIPTION
## Summary
- Adds MoveWaypointCommand for undo/redo support on waypoint drags
- Constrains waypoint handle movement to a single axis (H or V) to maintain orthogonal routing
- Adds SegmentHandle at segment midpoints for inserting new waypoint pairs
- Refreshes handles after undo/redo when wire is selected

Closes #483

## Test plan
- New test_waypoint_undo.py with 9 tests for MoveWaypointCommand
- Updated existing test_waypoint_editing.py and test_scene_item_decoupling.py
- Full suite: 4221 passed, 6 skipped