### PR TITLE
Fix fragile field-by-field CircuitModel copy (#532)

### DIFF
--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -5,6 +5,7 @@ File dialog interaction is the responsibility of the view layer.
 Recent files tracking uses the centralized settings service for cross-session persistence.
 """
 
+import dataclasses
 import json
 import logging
 import os
@@ -60,23 +61,18 @@ class FileController:
         """Replace the current model's data with *new_model* in place.
 
         Validates the parsed data **before** clearing the existing circuit
-        so that a corrupt import can never cause data loss.  Copies all
-        fields from *new_model* into ``self.model`` so that existing
-        references to the model object remain valid.
+        so that a corrupt import can never cause data loss.  Round-trips
+        through ``to_dict`` / ``from_dict`` to produce a fully independent
+        copy, then transfers every dataclass field so that existing
+        references to ``self.model`` remain valid.
         """
         parsed_data = new_model.to_dict()
         validate_circuit_data(parsed_data)
 
+        fresh = CircuitModel.from_dict(parsed_data)
         self.model.clear()
-        self.model.components = new_model.components
-        self.model.wires = new_model.wires
-        self.model.nodes = new_model.nodes
-        self.model.terminal_to_node = new_model.terminal_to_node
-        self.model.component_counter = new_model.component_counter
-        self.model.analysis_type = new_model.analysis_type
-        self.model.analysis_params = new_model.analysis_params
-        self.model.annotations = new_model.annotations
-        self.model.recommended_components = new_model.recommended_components
+        for f in dataclasses.fields(fresh):
+            setattr(self.model, f.name, getattr(fresh, f.name))
 
     def load_from_model(self, new_model: CircuitModel) -> None:
         """Replace the current circuit with *new_model* and notify observers.

--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -550,6 +550,47 @@ class TestAnnotationsAndRecommendedComponents:
         assert ctrl2.model.analysis_type == "AC Sweep"
 
 
+class TestReplaceModelDeepCopy:
+    """Issue #532: _replace_model must produce an independent copy, not share references."""
+
+    def test_replace_model_does_not_share_component_dict(self):
+        """Mutating components after replace must not affect the source model."""
+        source = build_simple_circuit()
+        ctrl = FileController(CircuitModel())
+        ctrl._replace_model(source)
+
+        # Mutate the loaded model
+        ctrl.model.components["R1"].value = "CHANGED"
+
+        # Source model must be unaffected
+        assert source.components["R1"].value != "CHANGED"
+
+    def test_replace_model_does_not_share_wire_list(self):
+        """Appending to wires after replace must not affect the source model."""
+        source = build_simple_circuit()
+        original_wire_count = len(source.wires)
+        ctrl = FileController(CircuitModel())
+        ctrl._replace_model(source)
+
+        ctrl.model.wires.clear()
+        assert len(source.wires) == original_wire_count
+
+    def test_replace_model_copies_all_dataclass_fields(self):
+        """Every field on CircuitModel must be transferred by _replace_model."""
+        import dataclasses
+
+        source = build_simple_circuit()
+        source.analysis_type = "AC Sweep"
+        source.analysis_params = {"fstart": "1", "fstop": "1Meg"}
+        source.recommended_components = ["Inductor"]
+
+        ctrl = FileController(CircuitModel())
+        ctrl._replace_model(source)
+
+        for f in dataclasses.fields(CircuitModel):
+            assert getattr(ctrl.model, f.name) is not None, f"Field {f.name!r} was not copied"
+
+
 class TestExportBom:
     """Tests for FileController.export_bom (Issue #570)."""
 


### PR DESCRIPTION
Use proper copy method instead of fragile field-by-field transfer when opening assignments. Closes #532