### PR TITLE
Store relative paths in GradingSessionData for portability (#535)

### DIFF
--- a/app/grading/session_persistence.py
+++ b/app/grading/session_persistence.py
@@ -144,17 +144,56 @@ def batch_result_to_session(
 # ---------------------------------------------------------------------------
 
 
+def _to_relative(path_str: str, anchor: Path) -> str:
+    """Convert an absolute path to a relative path based on *anchor* directory.
+
+    Returns the original string unchanged when it is empty or already relative.
+    """
+    if not path_str:
+        return path_str
+    p = Path(path_str)
+    if not p.is_absolute():
+        return path_str
+    try:
+        return str(p.relative_to(anchor))
+    except ValueError:
+        # On different drive / no common prefix — use os.path.relpath
+        return os.path.relpath(path_str, anchor)
+
+
+def _to_absolute(path_str: str, anchor: Path) -> str:
+    """Resolve a (possibly relative) path against *anchor* directory.
+
+    Returns the original string unchanged when it is empty.
+    """
+    if not path_str:
+        return path_str
+    p = Path(path_str)
+    if p.is_absolute():
+        return path_str
+    return str((anchor / p).resolve())
+
+
 def save_grading_session(filepath, session: GradingSessionData) -> None:
     """Save a grading session to a .spice-grades JSON file.
+
+    Paths are stored relative to the session file's directory so the
+    file remains portable across machines.
 
     Raises:
         OSError: If the file cannot be written.
     """
     filepath = Path(filepath)
+    anchor = filepath.parent.resolve()
+
+    data = session.to_dict()
+    data["rubric_path"] = _to_relative(data.get("rubric_path", ""), anchor)
+    data["student_folder"] = _to_relative(data.get("student_folder", ""), anchor)
+
     fd, tmp = tempfile.mkstemp(dir=filepath.parent, suffix=".tmp")
     try:
         with os.fdopen(fd, "w") as f:
-            json.dump(session.to_dict(), f, indent=2)
+            json.dump(data, f, indent=2)
         os.replace(tmp, filepath)
     except BaseException:
         os.unlink(tmp)
@@ -164,15 +203,24 @@ def save_grading_session(filepath, session: GradingSessionData) -> None:
 def load_grading_session(filepath) -> GradingSessionData:
     """Load and validate a grading session from a .spice-grades JSON file.
 
+    Relative paths stored in the file are resolved against the session
+    file's directory.
+
     Raises:
         json.JSONDecodeError: If the file is not valid JSON.
         ValueError: If the session structure is invalid.
         OSError: If the file cannot be read.
     """
     filepath = Path(filepath)
+    anchor = filepath.parent.resolve()
+
     with open(filepath, "r") as f:
         data = json.load(f)
     validate_session_data(data)
+
+    data["rubric_path"] = _to_absolute(data.get("rubric_path", ""), anchor)
+    data["student_folder"] = _to_absolute(data.get("student_folder", ""), anchor)
+
     return GradingSessionData.from_dict(data)
 
 

--- a/app/tests/unit/test_grading_session.py
+++ b/app/tests/unit/test_grading_session.py
@@ -325,6 +325,48 @@ class TestSaveLoadSession:
             assert restored_result.earned_points == orig_result.earned_points
             assert restored_result.total_points == orig_result.total_points
 
+    def test_paths_stored_as_relative_in_file(self, tmp_path):
+        """Issue #535: paths on disk must be relative, not absolute."""
+        rubric = tmp_path / "rubric.spice-rubric"
+        students = tmp_path / "students"
+        session = _make_session(
+            rubric_path=str(rubric),
+            student_folder=str(students),
+        )
+        filepath = tmp_path / f"test{GRADES_EXTENSION}"
+        save_grading_session(filepath, session)
+
+        with open(filepath) as f:
+            data = json.load(f)
+        # Stored paths must be relative to the session file directory
+        assert data["rubric_path"] == "rubric.spice-rubric"
+        assert data["student_folder"] == "students"
+
+    def test_relative_paths_resolved_on_load(self, tmp_path):
+        """Issue #535: relative paths are resolved back to absolute on load."""
+        rubric = tmp_path / "rubric.spice-rubric"
+        students = tmp_path / "students"
+        session = _make_session(
+            rubric_path=str(rubric),
+            student_folder=str(students),
+        )
+        filepath = tmp_path / f"test{GRADES_EXTENSION}"
+        save_grading_session(filepath, session)
+
+        loaded = load_grading_session(filepath)
+        assert loaded.rubric_path == str(rubric.resolve())
+        assert loaded.student_folder == str(students.resolve())
+
+    def test_empty_paths_preserved(self, tmp_path):
+        """Empty paths must stay empty through save/load."""
+        session = _make_session(rubric_path="", student_folder="")
+        filepath = tmp_path / f"test{GRADES_EXTENSION}"
+        save_grading_session(filepath, session)
+
+        loaded = load_grading_session(filepath)
+        assert loaded.rubric_path == ""
+        assert loaded.student_folder == ""
+
 
 # ---------------------------------------------------------------------------
 # compare_sessions


### PR DESCRIPTION
Convert absolute paths to relative when saving grading sessions so they work across machines. Closes #535