### PR TITLE
Deduplicate identical starter/reference circuits in Save Assignment (#530)

### DIFF
--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -213,10 +213,11 @@ class ViewOperationsMixin:
             from models.assignment import AssignmentBundle
             from models.template import TemplateData, TemplateMetadata
 
+            circuit_data = self.model.to_dict()
             template = TemplateData(
                 metadata=TemplateMetadata(title=rubric.title),
-                starter_circuit=self.model.to_dict(),
-                reference_circuit=self.model.to_dict(),
+                starter_circuit=circuit_data,
+                reference_circuit=circuit_data,
             )
             bundle = AssignmentBundle(
                 template=template,

--- a/app/models/template.py
+++ b/app/models/template.py
@@ -59,7 +59,7 @@ class TemplateData:
         }
         if self.starter_circuit is not None:
             data["starter_circuit"] = self.starter_circuit
-        if self.reference_circuit is not None:
+        if self.reference_circuit is not None and self.reference_circuit != self.starter_circuit:
             data["reference_circuit"] = self.reference_circuit
         if self.required_analysis is not None:
             data["required_analysis"] = self.required_analysis
@@ -69,12 +69,18 @@ class TemplateData:
 
     @classmethod
     def from_dict(cls, data: dict) -> "TemplateData":
+        starter = data.get("starter_circuit")
+        reference = data.get("reference_circuit")
+        # When reference_circuit was omitted because it matched starter_circuit,
+        # fall back to starter_circuit so the loaded template is complete.
+        if reference is None and starter is not None:
+            reference = starter
         return cls(
             template_version=data.get("template_version", "1.0"),
             metadata=TemplateMetadata.from_dict(data.get("metadata", {})),
             instructions=data.get("instructions", ""),
-            starter_circuit=data.get("starter_circuit"),
-            reference_circuit=data.get("reference_circuit"),
+            starter_circuit=starter,
+            reference_circuit=reference,
             required_analysis=data.get("required_analysis"),
             locked_components=list(data.get("locked_components", [])),
         )

--- a/app/tests/unit/test_template_controller.py
+++ b/app/tests/unit/test_template_controller.py
@@ -104,7 +104,8 @@ class TestTemplateData:
         )
         d = template.to_dict()
         assert "starter_circuit" in d
-        assert "reference_circuit" in d
+        # Identical reference_circuit is omitted (deduplication)
+        assert "reference_circuit" not in d
         assert "components" in d["starter_circuit"]
 
     def test_from_dict_round_trip(self):
@@ -119,7 +120,8 @@ class TestTemplateData:
         assert restored.metadata.title == "Test Template"
         assert restored.instructions == "Build a voltage divider"
         assert restored.starter_circuit is not None
-        assert restored.reference_circuit is None
+        # from_dict falls back reference_circuit to starter_circuit when absent
+        assert restored.reference_circuit == restored.starter_circuit
         assert restored.required_analysis["type"] == "DC Operating Point"
 
     def test_from_dict_missing_optional_fields(self):
@@ -216,7 +218,8 @@ class TestTemplateControllerSaveLoad:
         )
         data = json.loads(filepath.read_text())
         assert "starter_circuit" in data
-        assert "reference_circuit" in data
+        # Identical reference_circuit is omitted (deduplication)
+        assert "reference_circuit" not in data
         assert data["instructions"] == "Follow the steps."
 
     def test_load_returns_template_data(self, tmp_path):

--- a/app/tests/unit/test_template_model.py
+++ b/app/tests/unit/test_template_model.py
@@ -57,11 +57,28 @@ class TestTemplateData:
         assert "required_analysis" not in d
 
     def test_to_dict_includes_present_optionals(self):
+        starter = {"components": [], "wires": []}
+        reference = {"components": [{"id": "R1"}], "wires": []}
+        td = TemplateData(starter_circuit=starter, reference_circuit=reference)
+        d = td.to_dict()
+        assert "starter_circuit" in d
+        assert "reference_circuit" in d
+
+    def test_to_dict_omits_reference_when_identical_to_starter(self):
+        """Issue #530: identical circuits must not be duplicated in the bundle."""
         circuit = {"components": [], "wires": []}
         td = TemplateData(starter_circuit=circuit, reference_circuit=circuit)
         d = td.to_dict()
         assert "starter_circuit" in d
-        assert "reference_circuit" in d
+        assert "reference_circuit" not in d
+
+    def test_from_dict_falls_back_reference_to_starter(self):
+        """Issue #530: when reference_circuit is absent, fall back to starter."""
+        circuit = {"components": [], "wires": []}
+        td = TemplateData(starter_circuit=circuit)
+        d = td.to_dict()
+        restored = TemplateData.from_dict(d)
+        assert restored.reference_circuit == circuit
 
     def test_to_dict_excludes_empty_locked_components(self):
         td = TemplateData()
@@ -87,7 +104,8 @@ class TestTemplateData:
         assert restored.instructions == "Build it."
         assert restored.starter_circuit == circuit
         assert restored.locked_components == ["R1"]
-        assert restored.reference_circuit is None
+        # reference_circuit falls back to starter_circuit when absent
+        assert restored.reference_circuit == circuit
 
     def test_from_dict_with_empty_dict_uses_defaults(self):
         td = TemplateData.from_dict({})


### PR DESCRIPTION
Detect when starter and reference circuits are identical and store only one copy in the bundle. Closes #530