### PR TITLE
Add rubric content hash for session comparison (#537)

### DIFF
--- a/app/GUI/batch_grading_dialog.py
+++ b/app/GUI/batch_grading_dialog.py
@@ -297,6 +297,7 @@ class BatchGradingDialog(QDialog):
                 self._batch_result,
                 rubric_path=self.rubric_path.text(),
                 student_folder=self.folder_path.text(),
+                rubric_hash=self._rubric.content_hash() if self._rubric else "",
             )
             save_grading_session(filename, session)
             QMessageBox.information(self, "Saved", f"Grading session saved to {filename}")
@@ -339,14 +340,19 @@ class BatchGradingDialog(QDialog):
 
         from grading.session_persistence import batch_result_to_session, compare_sessions
 
-        new_session = batch_result_to_session(self._batch_result)
-        comparisons = compare_sessions(old_session, new_session)
+        new_session = batch_result_to_session(
+            self._batch_result,
+            rubric_hash=self._rubric.content_hash() if self._rubric else "",
+        )
+        comparison = compare_sessions(old_session, new_session)
 
-        if not comparisons:
+        if not comparison["students"]:
             return
 
         lines = ["", "Comparison with previous session:"]
-        for c in comparisons:
+        if comparison["rubric_changed"] is True:
+            lines.append("  \u26a0 Rubric changed between sessions — deltas may not be directly comparable.")
+        for c in comparison["students"]:
             if c["delta"] is not None:
                 sign = "+" if c["delta"] >= 0 else ""
                 lines.append(

--- a/app/grading/rubric.py
+++ b/app/grading/rubric.py
@@ -7,6 +7,7 @@ each worth a certain number of points. Rubrics are serialized as
 No Qt dependencies — pure Python module.
 """
 
+import hashlib
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -72,6 +73,30 @@ class Rubric:
             "total_points": self.total_points,
             "checks": [c.to_dict() for c in self.checks],
         }
+
+    def content_hash(self) -> str:
+        """Return a SHA-256 hex digest of the rubric's grading-relevant content.
+
+        The hash captures check definitions and point values so that two
+        rubrics with identical grading behaviour produce the same hash,
+        regardless of title or cosmetic differences in feedback text.
+        """
+        canonical = json.dumps(
+            {
+                "total_points": self.total_points,
+                "checks": [
+                    {
+                        "check_id": c.check_id,
+                        "check_type": c.check_type,
+                        "points": c.points,
+                        "params": c.params,
+                    }
+                    for c in self.checks
+                ],
+            },
+            sort_keys=True,
+        )
+        return hashlib.sha256(canonical.encode()).hexdigest()
 
     @classmethod
     def from_dict(cls, data: dict) -> "Rubric":

--- a/app/grading/session_persistence.py
+++ b/app/grading/session_persistence.py
@@ -126,12 +126,14 @@ def batch_result_to_session(
     batch_result: BatchGradingResult,
     rubric_path: str = "",
     student_folder: str = "",
+    rubric_hash: str = "",
 ) -> GradingSessionData:
     """Convert a BatchGradingResult into a GradingSessionData for persistence."""
     return GradingSessionData(
         session_version="1.0",
         timestamp=datetime.now(timezone.utc).isoformat(),
         rubric_title=batch_result.rubric_title,
+        rubric_hash=rubric_hash,
         rubric_path=rubric_path,
         student_folder=student_folder,
         results=[grading_result_to_dict(r) for r in batch_result.results],
@@ -229,11 +231,15 @@ def load_grading_session(filepath) -> GradingSessionData:
 # ---------------------------------------------------------------------------
 
 
-def compare_sessions(old: GradingSessionData, new: GradingSessionData) -> list[dict]:
+def compare_sessions(old: GradingSessionData, new: GradingSessionData) -> dict:
     """Compare two grading sessions and return per-student score deltas.
 
-    Returns a list of dicts, one per student that appears in *either* session:
-    ``{student_file, old_score, new_score, old_pct, new_pct, delta}``
+    Returns a dict with:
+    - ``rubric_changed``: ``True`` if the rubric content hashes differ
+      (or if either session has no hash recorded), ``None`` if neither
+      session has a hash.
+    - ``students``: a list of dicts, one per student in *either* session:
+      ``{student_file, old_score, new_score, old_pct, new_pct, delta}``
 
     Students present in only one session have ``None`` for the missing scores.
     """
@@ -242,7 +248,7 @@ def compare_sessions(old: GradingSessionData, new: GradingSessionData) -> list[d
 
     all_students = sorted(set(old_map) | set(new_map))
 
-    comparisons: list[dict] = []
+    students: list[dict] = []
     for student in all_students:
         old_r = old_map.get(student)
         new_r = new_map.get(student)
@@ -255,7 +261,7 @@ def compare_sessions(old: GradingSessionData, new: GradingSessionData) -> list[d
         else:
             delta = None
 
-        comparisons.append(
+        students.append(
             {
                 "student_file": student,
                 "old_score": (f"{old_r['earned_points']}/{old_r['total_points']}" if old_r else None),
@@ -266,7 +272,19 @@ def compare_sessions(old: GradingSessionData, new: GradingSessionData) -> list[d
             }
         )
 
-    return comparisons
+    # Determine whether the rubric changed between sessions.
+    if old.rubric_hash and new.rubric_hash:
+        rubric_changed = old.rubric_hash != new.rubric_hash
+    elif old.rubric_hash or new.rubric_hash:
+        # One session has a hash but the other doesn't — can't confirm match.
+        rubric_changed = True
+    else:
+        rubric_changed = None
+
+    return {
+        "rubric_changed": rubric_changed,
+        "students": students,
+    }
 
 
 def _pct(result_dict: dict) -> float:

--- a/app/models/grading_session.py
+++ b/app/models/grading_session.py
@@ -17,6 +17,7 @@ class GradingSessionData:
         session_version: Schema version for forward compatibility.
         timestamp: ISO-8601 timestamp when session was created/saved.
         rubric_title: Title of the rubric used.
+        rubric_hash: SHA-256 content hash of the rubric used to grade this session.
         rubric_path: Optional filesystem path to the rubric file.
         student_folder: Optional filesystem path to the student submissions folder.
         results: List of serialized GradingResult dicts.
@@ -26,6 +27,7 @@ class GradingSessionData:
     session_version: str = "1.0"
     timestamp: str = ""
     rubric_title: str = ""
+    rubric_hash: str = ""
     rubric_path: str = ""
     student_folder: str = ""
     results: list[dict] = field(default_factory=list)
@@ -37,6 +39,7 @@ class GradingSessionData:
             "session_version": self.session_version,
             "timestamp": self.timestamp,
             "rubric_title": self.rubric_title,
+            "rubric_hash": self.rubric_hash,
             "rubric_path": self.rubric_path,
             "student_folder": self.student_folder,
             "results": list(self.results),
@@ -50,6 +53,7 @@ class GradingSessionData:
             session_version=data.get("session_version", "1.0"),
             timestamp=data.get("timestamp", ""),
             rubric_title=data.get("rubric_title", ""),
+            rubric_hash=data.get("rubric_hash", ""),
             rubric_path=data.get("rubric_path", ""),
             student_folder=data.get("student_folder", ""),
             results=list(data.get("results", [])),

--- a/app/tests/unit/test_grading_session.py
+++ b/app/tests/unit/test_grading_session.py
@@ -5,6 +5,7 @@ import json
 import pytest
 from grading.batch_grader import BatchGradingResult
 from grading.grader import CheckGradeResult, GradingResult
+from grading.rubric import Rubric, RubricCheck
 from grading.session_persistence import (
     GRADES_EXTENSION,
     batch_result_to_session,
@@ -381,7 +382,8 @@ class TestCompareSessions:
         new.results[0]["earned_points"] = 18  # alice: was 20 -> 18
         new.results[1]["earned_points"] = 15  # bob: was 10 -> 15
 
-        comparisons = compare_sessions(old, new)
+        result = compare_sessions(old, new)
+        comparisons = result["students"]
 
         assert len(comparisons) == 2
         alice = next(c for c in comparisons if c["student_file"] == "alice.json")
@@ -400,8 +402,8 @@ class TestCompareSessions:
         dave_result = grading_result_to_dict(_make_grading_result("dave.json", earned=15))
         new = _make_session(results=[new_result, dave_result])
 
-        comparisons = compare_sessions(old, new)
-        dave = next(c for c in comparisons if c["student_file"] == "dave.json")
+        result = compare_sessions(old, new)
+        dave = next(c for c in result["students"] if c["student_file"] == "dave.json")
         assert dave["old_score"] is None
         assert dave["old_pct"] is None
         assert dave["new_pct"] == 75.0
@@ -413,8 +415,8 @@ class TestCompareSessions:
         old = _make_session(results=[alice_result, bob_result])
         new = _make_session(results=[alice_result])
 
-        comparisons = compare_sessions(old, new)
-        bob = next(c for c in comparisons if c["student_file"] == "bob.json")
+        result = compare_sessions(old, new)
+        bob = next(c for c in result["students"] if c["student_file"] == "bob.json")
         assert bob["new_score"] is None
         assert bob["new_pct"] is None
         assert bob["delta"] is None
@@ -422,24 +424,49 @@ class TestCompareSessions:
     def test_empty_sessions(self):
         old = _make_session(results=[])
         new = _make_session(results=[])
-        comparisons = compare_sessions(old, new)
-        assert comparisons == []
+        result = compare_sessions(old, new)
+        assert result["students"] == []
 
     def test_zero_total_points(self):
-        result = {
+        result_dict = {
             "student_file": "zero.json",
             "rubric_title": "Zero",
             "total_points": 0,
             "earned_points": 0,
             "check_results": [],
         }
-        old = _make_session(results=[result])
-        new = _make_session(results=[result])
+        old = _make_session(results=[result_dict])
+        new = _make_session(results=[result_dict])
 
-        comparisons = compare_sessions(old, new)
+        result = compare_sessions(old, new)
+        comparisons = result["students"]
         assert len(comparisons) == 1
         assert comparisons[0]["old_pct"] == 100.0  # 0/0 => 100%
         assert comparisons[0]["delta"] == 0.0
+
+    def test_rubric_changed_both_hashes_differ(self):
+        old = _make_session(rubric_hash="aaa")
+        new = _make_session(rubric_hash="bbb")
+        result = compare_sessions(old, new)
+        assert result["rubric_changed"] is True
+
+    def test_rubric_unchanged_same_hash(self):
+        old = _make_session(rubric_hash="aaa")
+        new = _make_session(rubric_hash="aaa")
+        result = compare_sessions(old, new)
+        assert result["rubric_changed"] is False
+
+    def test_rubric_changed_one_hash_missing(self):
+        old = _make_session(rubric_hash="")
+        new = _make_session(rubric_hash="bbb")
+        result = compare_sessions(old, new)
+        assert result["rubric_changed"] is True
+
+    def test_rubric_changed_none_when_no_hashes(self):
+        old = _make_session(rubric_hash="")
+        new = _make_session(rubric_hash="")
+        result = compare_sessions(old, new)
+        assert result["rubric_changed"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -468,6 +495,7 @@ class TestEdgeCases:
         validate_session_data(minimal)
         session = GradingSessionData.from_dict(minimal)
         assert session.rubric_path == ""
+        assert session.rubric_hash == ""
         assert session.student_folder == ""
         assert session.errors == []
 
@@ -493,3 +521,132 @@ class TestEdgeCases:
         }
         result = dict_to_grading_result(data)
         assert result.check_results[0].feedback == ""
+
+
+# ---------------------------------------------------------------------------
+# Rubric content_hash
+# ---------------------------------------------------------------------------
+
+
+def _make_rubric(**overrides):
+    defaults = dict(
+        title="Test Rubric",
+        total_points=20,
+        checks=[
+            RubricCheck(check_id="r1", check_type="component_exists", points=10, params={"component_id": "R1"}),
+            RubricCheck(check_id="r2", check_type="component_value", points=10, params={"component_id": "R1"}),
+        ],
+    )
+    defaults.update(overrides)
+    return Rubric(**defaults)
+
+
+class TestRubricContentHash:
+    def test_hash_is_hex_string(self):
+        rubric = _make_rubric()
+        h = rubric.content_hash()
+        assert isinstance(h, str)
+        assert len(h) == 64  # SHA-256 hex digest
+
+    def test_identical_rubrics_same_hash(self):
+        a = _make_rubric()
+        b = _make_rubric()
+        assert a.content_hash() == b.content_hash()
+
+    def test_different_checks_different_hash(self):
+        a = _make_rubric()
+        b = _make_rubric(
+            checks=[RubricCheck(check_id="r1", check_type="component_exists", points=20, params={"component_id": "R1"})]
+        )
+        assert a.content_hash() != b.content_hash()
+
+    def test_different_title_same_hash(self):
+        """Title is cosmetic — should not affect the content hash."""
+        a = _make_rubric(title="Rubric A")
+        b = _make_rubric(title="Rubric B")
+        assert a.content_hash() == b.content_hash()
+
+    def test_different_feedback_same_hash(self):
+        """Feedback text is cosmetic — should not affect the content hash."""
+        checks_a = [RubricCheck("c1", "ground", 10, feedback_pass="Good")]
+        checks_b = [RubricCheck("c1", "ground", 10, feedback_pass="Great")]
+        a = _make_rubric(total_points=10, checks=checks_a)
+        b = _make_rubric(total_points=10, checks=checks_b)
+        assert a.content_hash() == b.content_hash()
+
+    def test_different_points_different_hash(self):
+        a = _make_rubric(total_points=20)
+        b = _make_rubric(
+            total_points=30,
+            checks=[
+                RubricCheck("r1", "component_exists", 15, params={"component_id": "R1"}),
+                RubricCheck("r2", "component_value", 15, params={"component_id": "R1"}),
+            ],
+        )
+        assert a.content_hash() != b.content_hash()
+
+    def test_different_params_different_hash(self):
+        checks_a = [RubricCheck("c1", "component_exists", 10, params={"component_id": "R1"})]
+        checks_b = [RubricCheck("c1", "component_exists", 10, params={"component_id": "R2"})]
+        a = _make_rubric(total_points=10, checks=checks_a)
+        b = _make_rubric(total_points=10, checks=checks_b)
+        assert a.content_hash() != b.content_hash()
+
+    def test_hash_stable_across_calls(self):
+        rubric = _make_rubric()
+        assert rubric.content_hash() == rubric.content_hash()
+
+
+# ---------------------------------------------------------------------------
+# rubric_hash in session serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSessionRubricHash:
+    def test_rubric_hash_roundtrip(self):
+        session = _make_session(rubric_hash="abc123")
+        d = session.to_dict()
+        assert d["rubric_hash"] == "abc123"
+        restored = GradingSessionData.from_dict(d)
+        assert restored.rubric_hash == "abc123"
+
+    def test_rubric_hash_in_saved_file(self, tmp_path):
+        rubric = _make_rubric()
+        session = _make_session(rubric_hash=rubric.content_hash())
+        filepath = tmp_path / f"test{GRADES_EXTENSION}"
+        save_grading_session(filepath, session)
+
+        with open(filepath) as f:
+            data = json.load(f)
+        assert data["rubric_hash"] == rubric.content_hash()
+
+    def test_rubric_hash_loaded_from_file(self, tmp_path):
+        rubric = _make_rubric()
+        session = _make_session(rubric_hash=rubric.content_hash())
+        filepath = tmp_path / f"test{GRADES_EXTENSION}"
+        save_grading_session(filepath, session)
+
+        loaded = load_grading_session(filepath)
+        assert loaded.rubric_hash == rubric.content_hash()
+
+    def test_rubric_hash_defaults_empty_for_old_files(self, tmp_path):
+        """Sessions saved before rubric_hash was added should load with empty hash."""
+        session = _make_session()
+        filepath = tmp_path / f"test{GRADES_EXTENSION}"
+        save_grading_session(filepath, session)
+
+        # Simulate an old file by removing rubric_hash
+        with open(filepath) as f:
+            data = json.load(f)
+        del data["rubric_hash"]
+        with open(filepath, "w") as f:
+            json.dump(data, f)
+
+        loaded = load_grading_session(filepath)
+        assert loaded.rubric_hash == ""
+
+    def test_batch_result_to_session_stores_hash(self):
+        batch = _make_batch_result()
+        rubric = _make_rubric()
+        session = batch_result_to_session(batch, rubric_hash=rubric.content_hash())
+        assert session.rubric_hash == rubric.content_hash()


### PR DESCRIPTION
## Summary
- Adds Rubric.content_hash() -- SHA-256 digest of grading-relevant content (checks, points, params), ignoring cosmetic fields like title and feedback text
- Adds rubric_hash field to GradingSessionData so sessions record which rubric version produced the grades
- Updates compare_sessions() to return a rubric_changed flag alongside the per-student deltas, so the UI can warn when comparisons span rubric changes
- Updates BatchGradingDialog to pass rubric hash when saving/comparing sessions and display a warning when rubric changed

Closes #537

## Test plan
- [x] Rubric.content_hash() is deterministic and stable across calls
- [x] Identical rubrics (same checks/points) produce the same hash regardless of title/feedback
- [x] Different checks/points/params produce different hashes
- [x] rubric_hash round-trips through GradingSessionData serialization
- [x] rubric_hash persists through file save/load cycle
- [x] Old session files (without rubric_hash) load with empty hash (backward compatible)
- [x] compare_sessions() returns rubric_changed correctly for all hash combinations