### PR TITLE
refactor: read shortcuts from keybindings registry in tooltips (#513)

### DIFF
--- a/app/GUI/canvas_context_menu.py
+++ b/app/GUI/canvas_context_menu.py
@@ -62,6 +62,21 @@ def build_context_menu(canvas, scene_pos):
     return menu
 
 
+def _get_keybinding(canvas, action_name):
+    """Return the shortcut string for *action_name*, or '' if unavailable."""
+    main_window = canvas.window()
+    if main_window and hasattr(main_window, "keybindings"):
+        return main_window.keybindings.get(action_name)
+    return ""
+
+
+def _action_label_with_shortcut(label, shortcut):
+    """Return 'Label (Shortcut)' when a shortcut is defined."""
+    if shortcut:
+        return f"{label} ({shortcut})"
+    return label
+
+
 def _build_component_menu(menu, canvas, item):
     """Populate *menu* with actions for a right-clicked component."""
     delete_action = QAction(f"Delete {item.component_id}", canvas)
@@ -70,21 +85,29 @@ def _build_component_menu(menu, canvas, item):
 
     menu.addSeparator()
 
-    rotate_cw_action = QAction("Rotate Clockwise (R)", canvas)
+    rotate_cw_action = QAction(
+        _action_label_with_shortcut("Rotate Clockwise", _get_keybinding(canvas, "edit.rotate_cw")), canvas
+    )
     rotate_cw_action.triggered.connect(lambda: canvas.rotate_component(item, True))
     menu.addAction(rotate_cw_action)
 
-    rotate_ccw_action = QAction("Rotate Counter-Clockwise (Shift+R)", canvas)
+    rotate_ccw_action = QAction(
+        _action_label_with_shortcut("Rotate Counter-Clockwise", _get_keybinding(canvas, "edit.rotate_ccw")), canvas
+    )
     rotate_ccw_action.triggered.connect(lambda: canvas.rotate_component(item, False))
     menu.addAction(rotate_ccw_action)
 
     menu.addSeparator()
 
-    flip_h_action = QAction("Flip Horizontal (F)", canvas)
+    flip_h_action = QAction(
+        _action_label_with_shortcut("Flip Horizontal", _get_keybinding(canvas, "edit.flip_h")), canvas
+    )
     flip_h_action.triggered.connect(lambda: canvas.flip_component(item, True))
     menu.addAction(flip_h_action)
 
-    flip_v_action = QAction("Flip Vertical (Shift+F)", canvas)
+    flip_v_action = QAction(
+        _action_label_with_shortcut("Flip Vertical", _get_keybinding(canvas, "edit.flip_v")), canvas
+    )
     flip_v_action.triggered.connect(lambda: canvas.flip_component(item, False))
     menu.addAction(flip_v_action)
 

--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -169,13 +169,14 @@ class MainWindow(
         left_panel.addWidget(QLabel("Component Palette"))
         self.palette = ComponentPalette()
         left_panel.addWidget(self.palette)
+        kb = self.keybindings
         instructions = QLabel(
             "📦 Drag components from palette to canvas\n"
             "🔌 Left-click terminal → click another terminal to wire\n"
             "🖱️ Drag components to move (wires follow!)\n"
-            "🔄 Press R to rotate selected\n"
+            f"🔄 Press {kb.get('edit.rotate_cw')} to rotate selected\n"
             "🗑️ Right-click for context menu\n"
-            "⌫ Delete key to remove selected\n"
+            f"⌫ {kb.get('edit.delete')} key to remove selected\n"
             "\n"
             "Wires auto-route using IDA* path finding!"
         )
@@ -194,12 +195,12 @@ class MainWindow(
         canvas_toolbar.addWidget(QLabel("Circuit Canvas"))
         btn_zoom_in = QPushButton("+")
         btn_zoom_in.setFixedWidth(30)
-        btn_zoom_in.setToolTip("Zoom In (Ctrl++)")
+        btn_zoom_in.setToolTip(f"Zoom In ({self.keybindings.get('view.zoom_in')})")
         btn_zoom_out = QPushButton("-")
         btn_zoom_out.setFixedWidth(30)
-        btn_zoom_out.setToolTip("Zoom Out (Ctrl+-)")
+        btn_zoom_out.setToolTip(f"Zoom Out ({self.keybindings.get('view.zoom_out')})")
         btn_zoom_fit = QPushButton("Fit")
-        btn_zoom_fit.setToolTip("Fit to Circuit (Ctrl+0)")
+        btn_zoom_fit.setToolTip(f"Fit to Circuit ({self.keybindings.get('view.zoom_fit')})")
         self.zoom_label = QLabel("100%")
         self.zoom_label.setFixedWidth(45)
         canvas_toolbar.addStretch()

--- a/app/tests/unit/test_dynamic_shortcut_tooltips.py
+++ b/app/tests/unit/test_dynamic_shortcut_tooltips.py
@@ -1,0 +1,74 @@
+"""Tests for dynamic shortcut display in tooltips and context menus (#513).
+
+Verifies that keyboard shortcuts shown in UI elements are read from
+the keybindings registry rather than hardcoded.
+"""
+
+from controllers.keybindings import DEFAULTS, KeybindingsRegistry
+from GUI.canvas_context_menu import _action_label_with_shortcut, _get_keybinding
+
+
+class TestActionLabelWithShortcut:
+    """Helper function formats labels with optional shortcut suffix."""
+
+    def test_with_shortcut(self):
+        assert _action_label_with_shortcut("Zoom In", "Ctrl+=") == "Zoom In (Ctrl+=)"
+
+    def test_without_shortcut(self):
+        assert _action_label_with_shortcut("Zoom In", "") == "Zoom In"
+
+    def test_none_shortcut(self):
+        assert _action_label_with_shortcut("Zoom In", None) == "Zoom In"
+
+
+class TestGetKeybinding:
+    """_get_keybinding reads from the main window's keybindings registry."""
+
+    def test_returns_empty_when_no_window(self):
+        class FakeCanvas:
+            def window(self):
+                return None
+
+        assert _get_keybinding(FakeCanvas(), "edit.rotate_cw") == ""
+
+    def test_returns_empty_when_no_keybindings_attr(self):
+        class FakeWindow:
+            pass
+
+        class FakeCanvas:
+            def window(self):
+                return FakeWindow()
+
+        assert _get_keybinding(FakeCanvas(), "edit.rotate_cw") == ""
+
+    def test_returns_shortcut_from_registry(self):
+        kb = KeybindingsRegistry(config_path="/dev/null")
+
+        class FakeWindow:
+            keybindings = kb
+
+        class FakeCanvas:
+            def window(self):
+                return FakeWindow()
+
+        result = _get_keybinding(FakeCanvas(), "edit.rotate_cw")
+        assert result == DEFAULTS["edit.rotate_cw"]
+
+
+class TestDefaultShortcutsMatchTooltips:
+    """Default keybinding values should produce the same tooltip text as previously hardcoded."""
+
+    def test_zoom_in_default(self):
+        assert DEFAULTS["view.zoom_in"] == "Ctrl+="
+
+    def test_zoom_out_default(self):
+        assert DEFAULTS["view.zoom_out"] == "Ctrl+-"
+
+    def test_zoom_fit_default(self):
+        assert DEFAULTS["view.zoom_fit"] == "Ctrl+0"
+
+    def test_rotate_cw_default(self):
+        assert DEFAULTS["edit.rotate_cw"] == "R"
+
+    def test_delete_default(self):
+        assert DEFAULTS["edit.delete"] == "Del"


### PR DESCRIPTION
Toolbar zoom tooltips, instruction panel text, and context menu action labels now read from KeybindingsRegistry instead of hardcoding shortcut strings.

Closes #513