### PR TITLE
fix: use separate numeric version for Inno Setup VersionInfoVersion (#916)

### DIFF
--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -61,10 +61,18 @@ jobs:
         shell: pwsh
         run: |
           $version = "${{ steps.version.outputs.version }}" -replace '^v', ''
+          # VersionInfoVersion requires strict numeric X.Y.Z — derive a valid one
+          if ($version -match '^(\d+)\.(\d+)\.(\d+)') {
+            $numericVersion = "$($matches[1]).$($matches[2]).$($matches[3])"
+          } else {
+            # dev build — fall back to 0.0.0
+            $numericVersion = "0.0.0"
+          }
           $content = Get-Content installer/spicegui.iss -Raw
-          $content = $content -replace '#define MyAppVersion\s+"[^"]+"', "#define MyAppVersion   `"$version`""
+          $content = $content -replace '#define MyAppVersion\s+"[^"]+"', "#define MyAppVersion        `"$version`""
+          $content = $content -replace '#define MyAppNumericVersion\s+"[^"]+"', "#define MyAppNumericVersion `"$numericVersion`""
           Set-Content installer/spicegui.iss -Value $content
-          Write-Host "Set installer version to: $version"
+          Write-Host "Display version: $version, numeric: $numericVersion"
 
       - name: Compile installer with Inno Setup
         shell: cmd

--- a/installer/spicegui.iss
+++ b/installer/spicegui.iss
@@ -16,7 +16,8 @@
 ; =========================================================================
 
 #define MyAppName      "Spice GUI"
-#define MyAppVersion   "0.1.0"
+#define MyAppVersion        "0.1.0"
+#define MyAppNumericVersion "0.1.0"
 #define MyAppPublisher "SDSMT Capstone Spice GUI Team"
 #define MyAppURL       "https://github.com/SDSMT-Capstone-Spice-GUI-Team/Spice-GUI"
 #define MyAppExeName   "SpiceGUI.exe"
@@ -47,7 +48,7 @@ PrivilegesRequiredOverridesAllowed=dialog
 UninstallDisplayName={#MyAppName}
 UninstallDisplayIcon={app}\{#MyAppExeName}
 ; Installer version info
-VersionInfoVersion={#MyAppVersion}.0
+VersionInfoVersion={#MyAppNumericVersion}.0
 VersionInfoCompany={#MyAppPublisher}
 VersionInfoDescription={#MyAppName} Installer
 VersionInfoProductName={#MyAppName}


### PR DESCRIPTION
Adds MyAppNumericVersion define to installer/spicegui.iss to separate display version from strict numeric VersionInfoVersion. Updates PowerShell step in release-installer.yml to derive valid X.Y.Z numeric version from tag builds and fall back to 0.0.0 for dev builds. Closes #916