### PR TITLE
fix: add fallback generic renderer for unknown component types (#909)

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -371,13 +371,51 @@ class ComponentGraphicsItem(QGraphicsItem):
         # Grading overlay (temporary visual feedback)
         if self._grading_state == "passed":
             grading_color = theme_manager.color("grading_passed")
-            painter.setPen(QPen(QColor(grading_color.red(), grading_color.green(), grading_color.blue(), 200), 3))
-            painter.setBrush(QBrush(QColor(grading_color.red(), grading_color.green(), grading_color.blue(), 40)))
+            painter.setPen(
+                QPen(
+                    QColor(
+                        grading_color.red(),
+                        grading_color.green(),
+                        grading_color.blue(),
+                        200,
+                    ),
+                    3,
+                )
+            )
+            painter.setBrush(
+                QBrush(
+                    QColor(
+                        grading_color.red(),
+                        grading_color.green(),
+                        grading_color.blue(),
+                        40,
+                    )
+                )
+            )
             painter.drawRoundedRect(QRectF(-42, -22, 84, 44), 4, 4)
         elif self._grading_state == "failed":
             grading_color = theme_manager.color("grading_failed")
-            painter.setPen(QPen(QColor(grading_color.red(), grading_color.green(), grading_color.blue(), 200), 3))
-            painter.setBrush(QBrush(QColor(grading_color.red(), grading_color.green(), grading_color.blue(), 40)))
+            painter.setPen(
+                QPen(
+                    QColor(
+                        grading_color.red(),
+                        grading_color.green(),
+                        grading_color.blue(),
+                        200,
+                    ),
+                    3,
+                )
+            )
+            painter.setBrush(
+                QBrush(
+                    QColor(
+                        grading_color.red(),
+                        grading_color.green(),
+                        grading_color.blue(),
+                        40,
+                    )
+                )
+            )
             painter.drawRoundedRect(QRectF(-42, -22, 84, 44), 4, 4)
 
         # Draw component body
@@ -530,10 +568,8 @@ class ComponentGraphicsItem(QGraphicsItem):
         # Create model first
         comp_data = ComponentData.from_dict(data_dict)
 
-        # Find the right GUI class
-        component_class = COMPONENT_CLASSES.get(comp_data.component_type)
-        if component_class is None:
-            raise ValueError(f"Unknown component type: {comp_data.component_type}")
+        # Find the right GUI class, falling back to GenericComponent
+        component_class = COMPONENT_CLASSES.get(comp_data.component_type, GenericComponent)
 
         # Create GUI component backed by the model
         comp = component_class(comp_data.component_id, model=comp_data)
@@ -541,6 +577,20 @@ class ComponentGraphicsItem(QGraphicsItem):
         comp.update_terminals()
 
         return comp
+
+
+class GenericComponent(ComponentGraphicsItem):
+    """Fallback renderer for unknown/subcircuit component types (e.g. LM7812).
+
+    Renders as a simple rectangle with the type name, allowing files containing
+    unrecognised component types to load without crashing.
+    """
+
+    type_name = "Generic"
+
+    def __init__(self, component_id, model=None):
+        component_type = model.component_type if model else "Generic"
+        super().__init__(component_id, component_type, model=model)
 
 
 class Resistor(ComponentGraphicsItem):
@@ -910,9 +960,7 @@ COMPONENT_CLASSES = {
 
 def create_component(component_type, component_id):
     """Factory function to create components with a backing ComponentData model"""
-    component_class = COMPONENT_CLASSES.get(component_type)
-    if component_class is None:
-        raise ValueError(f"Unknown component type: {component_type}")
+    component_class = COMPONENT_CLASSES.get(component_type, GenericComponent)
 
     comp_model = ComponentData(
         component_id=component_id,

--- a/app/GUI/renderers.py
+++ b/app/GUI/renderers.py
@@ -40,15 +40,47 @@ def register(component_type: str, style: str, renderer: ComponentRenderer):
     _registry[(component_type, style)] = renderer
 
 
+class GenericRenderer(ComponentRenderer):
+    """Fallback renderer for unknown/subcircuit component types.
+
+    Draws a simple rectangle with the component type name inside.
+    """
+
+    def draw(self, painter, component):
+        # Leads
+        painter.drawLine(-30, 0, -15, 0)
+        painter.drawLine(15, 0, 30, 0)
+        # Body rectangle
+        painter.drawRect(-15, -10, 30, 20)
+        # Type label inside the box
+        from PyQt6.QtCore import QRectF, Qt
+        from PyQt6.QtGui import QFont
+
+        font = QFont()
+        font.setPointSize(6)
+        painter.setFont(font)
+        painter.drawText(
+            QRectF(-14, -9, 28, 18),
+            Qt.AlignmentFlag.AlignCenter,
+            component.component_type,
+        )
+
+    def get_obstacle_shape(self, component):
+        return [(-15.0, -10.0), (15.0, -10.0), (15.0, 10.0), (-15.0, 10.0)]
+
+
+_generic_renderer = GenericRenderer()
+
+
 def get_renderer(component_type: str, style: str) -> ComponentRenderer:
     """Look up the renderer for (*component_type*, *style*).
 
-    Raises ``KeyError`` if no renderer is registered.
+    Falls back to a generic rectangular renderer for unknown component types.
     """
     renderer = _registry.get((component_type, style))
     if renderer is not None:
         return renderer
-    raise KeyError(f"No renderer for ({component_type!r}, {style!r})")
+    return _generic_renderer
 
 
 def _bounding_rect_obstacle(component) -> list[tuple[float, float]]:

--- a/app/tests/unit/test_generic_component.py
+++ b/app/tests/unit/test_generic_component.py
@@ -1,0 +1,87 @@
+"""Tests for the generic component fallback (#909).
+
+Unknown component types (e.g. subcircuits like LM7812) should load and
+render as a generic rectangle instead of crashing with ValueError.
+"""
+
+from GUI.component_item import ComponentGraphicsItem, GenericComponent, create_component
+from models.component import ComponentData
+
+
+class TestGenericComponentFromDict:
+    """from_dict should return a GenericComponent for unknown types."""
+
+    def test_unknown_type_returns_generic_component(self):
+        data = {
+            "id": "LM7812_1",
+            "type": "LM7812",
+            "value": "1u",
+            "pos": {"x": 100.0, "y": 200.0},
+        }
+        comp = ComponentGraphicsItem.from_dict(data)
+        assert isinstance(comp, GenericComponent)
+        assert comp.component_type == "LM7812"
+        assert comp.component_id == "LM7812_1"
+
+    def test_unknown_type_has_terminals(self):
+        data = {
+            "id": "X1",
+            "type": "SubcircuitFoo",
+            "value": "1",
+            "pos": {"x": 0.0, "y": 0.0},
+        }
+        comp = ComponentGraphicsItem.from_dict(data)
+        # Default 2-terminal layout for unknown types
+        assert len(comp.terminals) == 2
+
+    def test_unknown_type_preserves_position(self):
+        data = {
+            "id": "X1",
+            "type": "LM7812",
+            "value": "1u",
+            "pos": {"x": 50.0, "y": 75.0},
+        }
+        comp = ComponentGraphicsItem.from_dict(data)
+        assert comp.pos().x() == 50.0
+        assert comp.pos().y() == 75.0
+
+    def test_known_type_still_works(self):
+        data = {
+            "id": "R1",
+            "type": "Resistor",
+            "value": "1k",
+            "pos": {"x": 0.0, "y": 0.0},
+        }
+        comp = ComponentGraphicsItem.from_dict(data)
+        assert not isinstance(comp, GenericComponent)
+        assert comp.component_type == "Resistor"
+
+
+class TestCreateComponentFallback:
+    """create_component should fall back to GenericComponent."""
+
+    def test_unknown_type_creates_generic(self):
+        comp = create_component("LM7812", "X1")
+        assert isinstance(comp, GenericComponent)
+        assert comp.component_type == "LM7812"
+
+    def test_known_type_still_works(self):
+        comp = create_component("Resistor", "R1")
+        assert not isinstance(comp, GenericComponent)
+
+
+class TestGenericRenderer:
+    """The generic renderer should not raise on draw or obstacle shape."""
+
+    def test_get_renderer_returns_fallback(self):
+        from GUI.renderers import get_renderer
+
+        renderer = get_renderer("LM7812", "IEEE")
+        assert renderer is not None
+
+    def test_get_obstacle_shape(self):
+        from GUI.renderers import get_renderer
+
+        renderer = get_renderer("UnknownChip", "IEEE")
+        shape = renderer.get_obstacle_shape(None)
+        assert len(shape) == 4

--- a/app/tests/unit/test_symbol_style.py
+++ b/app/tests/unit/test_symbol_style.py
@@ -194,13 +194,17 @@ class TestRendererRegistry:
         renderer = get_renderer(cls.type_name, "iec")
         assert renderer is not None
 
-    def test_unregistered_type_raises_key_error(self):
-        with pytest.raises(KeyError):
-            get_renderer("Nonexistent", "ieee")
+    def test_unregistered_type_returns_generic_renderer(self):
+        from GUI.renderers import GenericRenderer
 
-    def test_unregistered_style_raises_key_error(self):
-        with pytest.raises(KeyError):
-            get_renderer("Resistor", "bogus")
+        renderer = get_renderer("Nonexistent", "ieee")
+        assert isinstance(renderer, GenericRenderer)
+
+    def test_unregistered_style_returns_generic_renderer(self):
+        from GUI.renderers import GenericRenderer
+
+        renderer = get_renderer("Resistor", "bogus")
+        assert isinstance(renderer, GenericRenderer)
 
 
 # ── Draw dispatch via renderers ─────────────────────────────────────


### PR DESCRIPTION
## Summary - Unknown component types (e.g. subcircuit components like LM7812) no longer crash the app with  in  or  - Added  class that renders as a labeled rectangle with default 2-terminal layout - Added  in the renderer registry as a fallback for unregistered component types - Updated existing tests that expected  from  to verify fallback behavior instead ## Test plan - [x] New unit tests for  via  and  - [x] New unit tests for  fallback - [x] Updated  tests for new fallback behavior - [x] Full test suite passes (4338 passed) - [ ] Human testing: drop a subcircuit component (e.g. LM7812) onto the canvas and verify it renders as a labeled rectangle Closes #909 🤖 Generated with [Claude Code](https://claude.com/claude-code)