### PR TITLE
fix VersionInfoProductVersion for dev builds (#916)

### DIFF
--- a/installer/spicegui.iss
+++ b/installer/spicegui.iss
@@ -52,7 +52,7 @@ VersionInfoVersion={#MyAppNumericVersion}.0
 VersionInfoCompany={#MyAppPublisher}
 VersionInfoDescription={#MyAppName} Installer
 VersionInfoProductName={#MyAppName}
-VersionInfoProductVersion={#MyAppVersion}
+VersionInfoProductVersion={#MyAppNumericVersion}
 ; Uncomment when an .ico file is added:
 ; SetupIconFile=..\app\assets\spicegui.ico
 


### PR DESCRIPTION
## Summary
- `VersionInfoProductVersion` (line 55) also requires strict numeric format
- Changed from `{#MyAppVersion}` to `{#MyAppNumericVersion}`
- First fix (#917) caught `VersionInfoVersion` on line 51, this catches the second directive

Completes #916.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>