### PR TITLE
fix: robust simulation result parsing with wrdata fallback (#805, #852-#857)

### DIFF
--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -245,49 +245,80 @@ class SimulationController:
         analysis = self.model.analysis_type
 
         try:
+            # Read the output file once; many parsers need it.
+            output = self.runner.read_output(output_file) if output_file else ""
+
             if analysis in ("DC Operating Point", "Operational Point"):
-                output = self.runner.read_output(output_file)
                 data = ResultParser.parse_op_results(output)
+                # Fallback: print output may have gone to stdout instead
+                # of the -o file in some ngspice versions (#852).
+                if not data.get("node_voltages") and raw_output:
+                    fallback = ResultParser.parse_op_results(raw_output)
+                    if fallback.get("node_voltages"):
+                        data = fallback
             elif analysis == "DC Sweep":
                 # Prefer wrdata file (clean tabular format) over log output.
                 data = None
                 if wrdata_filepath and os.path.isfile(wrdata_filepath):
                     data = ResultParser.parse_dc_sweep_wrdata(wrdata_filepath)
                 if data is None:
-                    output = self.runner.read_output(output_file)
                     data = ResultParser.parse_dc_results(output)
+                if data is None and raw_output:
+                    data = ResultParser.parse_dc_results(raw_output)
             elif analysis == "AC Sweep":
-                output = self.runner.read_output(output_file)
-                data = ResultParser.parse_ac_results(output)
+                use_db = str(self.model.analysis_params.get("use_db", "No")).lower() in ("yes", "true", "1")
+                # Prefer wrdata file which always has clean tabular data (#805).
+                data = None
+                if wrdata_filepath and os.path.isfile(wrdata_filepath):
+                    data = ResultParser.parse_ac_wrdata(wrdata_filepath)
+                # Fallback: try the -o output file, then raw stdout.
+                if data is None:
+                    data = ResultParser.parse_ac_results(output)
+                if data is None and raw_output:
+                    data = ResultParser.parse_ac_results(raw_output)
                 if data is not None:
-                    use_db = str(self.model.analysis_params.get("use_db", "No")).lower() in ("yes", "true", "1")
                     data["use_db"] = use_db
             elif analysis == "Transient":
                 data = ResultParser.parse_transient_results(wrdata_filepath)
             elif analysis == "Temperature Sweep":
                 # Temperature sweep with .step produces tabular output;
-                # try wrdata file first, then log output, then OP fallback.
+                # try wrdata file first, then log output, then OP fallback (#856).
                 data = None
                 if wrdata_filepath and os.path.isfile(wrdata_filepath):
                     data = ResultParser.parse_dc_sweep_wrdata(wrdata_filepath)
                 if data is None:
-                    output = self.runner.read_output(output_file)
                     data = ResultParser.parse_dc_results(output)
+                if data is None and raw_output:
+                    data = ResultParser.parse_dc_results(raw_output)
                 if data is None:
-                    output = self.runner.read_output(output_file)
                     data = ResultParser.parse_op_results(output)
+                    # Fallback: try stdout for OP results
+                    if not data.get("node_voltages") and raw_output:
+                        fallback = ResultParser.parse_op_results(raw_output)
+                        if fallback.get("node_voltages"):
+                            data = fallback
             elif analysis == "Noise":
-                output = self.runner.read_output(output_file)
-                data = ResultParser.parse_noise_results(output)
+                # Prefer wrdata file which has clean tabular data (#857).
+                data = None
+                if wrdata_filepath and os.path.isfile(wrdata_filepath):
+                    data = ResultParser.parse_noise_wrdata(wrdata_filepath)
+                # Fallback: try the -o output file, then raw stdout.
+                if data is None:
+                    data = ResultParser.parse_noise_results(output)
+                if data is None and raw_output:
+                    data = ResultParser.parse_noise_results(raw_output)
             elif analysis == "Sensitivity":
-                output = self.runner.read_output(output_file)
                 data = ResultParser.parse_sensitivity_results(output)
+                if data is None and raw_output:
+                    data = ResultParser.parse_sensitivity_results(raw_output)
             elif analysis == "Transfer Function":
-                output = self.runner.read_output(output_file)
                 data = ResultParser.parse_tf_results(output)
+                if data is None and raw_output:
+                    data = ResultParser.parse_tf_results(raw_output)
             elif analysis == "Pole-Zero":
-                output = self.runner.read_output(output_file)
                 data = ResultParser.parse_pz_results(output)
+                if data is None and raw_output:
+                    data = ResultParser.parse_pz_results(raw_output)
             else:
                 return SimulationResult(
                     success=False,

--- a/app/simulation/netlist_generator.py
+++ b/app/simulation/netlist_generator.py
@@ -620,10 +620,10 @@ class NetlistGenerator:
             # is set. Do NOT add the source name (e.g. "v1") — ngspice does not
             # expose it as a vector; the sweep column is always named "v-sweep".
 
-            # For temperature sweep, prepend the temperature vector so the
-            # parser can extract temperature alongside node voltages.
-            if getattr(self, "_is_temp_sweep", False) and all_print_vars:
-                all_print_vars.insert(0, "temp-sweep")
+            # For temperature sweep, do NOT prepend a temperature vector
+            # to the print list — ngspice may reject unknown names (#856).
+            # The wrdata command with wr_singlescale automatically includes
+            # the scale vector (temp-sweep) as the first column.
 
             print_vars = " ".join(all_print_vars)
 

--- a/app/simulation/result_parser.py
+++ b/app/simulation/result_parser.py
@@ -187,6 +187,62 @@ class ResultParser:
             raise ResultParseError(f"Error parsing DC sweep wrdata: {e}") from e
 
     @staticmethod
+    def parse_ac_wrdata(filepath):
+        """Parse AC sweep results from a wrdata file.
+
+        The wrdata file produced by ngspice with ``set wr_vecnames`` and
+        ``set wr_singlescale`` has the frequency as the first column
+        followed by magnitude and phase columns.  Returns a dict compatible
+        with :class:`ACSweepPlotDialog`, or *None* when no data is found.
+        """
+        try:
+            with open(filepath, "r") as f:
+                lines = f.readlines()
+            if not lines:
+                return None
+
+            headers = lines[0].strip().split()
+            if not headers:
+                return None
+
+            ac_data = {"frequencies": [], "magnitude": {}, "phase": {}, "headers": headers}
+
+            for line in lines[1:]:
+                parts = line.strip().split()
+                if len(parts) != len(headers):
+                    continue
+                try:
+                    freq = float(parts[0])
+                    row_mag = {}
+                    row_phase = {}
+                    for j, h in enumerate(headers[1:], start=1):
+                        h_lower = h.lower()
+                        if "vp(" in h_lower:
+                            node = re.sub(r"^vp\(", "", h, flags=re.IGNORECASE).rstrip(")")
+                            row_phase[node] = float(parts[j])
+                        elif "vdb(" in h_lower or "vm(" in h_lower or "v(" in h_lower:
+                            node = re.sub(r"^(?:vdb|vm|v)\(", "", h, flags=re.IGNORECASE).rstrip(")")
+                            row_mag[node] = float(parts[j])
+                        elif "i(" in h_lower:
+                            node = re.sub(r"^i\(", "", h, flags=re.IGNORECASE).rstrip(")")
+                            row_mag[f"i({node})"] = float(parts[j])
+
+                    ac_data["frequencies"].append(freq)
+                    for node, val in row_mag.items():
+                        ac_data["magnitude"].setdefault(node, []).append(val)
+                    for node, val in row_phase.items():
+                        ac_data["phase"].setdefault(node, []).append(val)
+                except (ValueError, IndexError):
+                    logger.debug("Skipping unparseable AC wrdata row: %s", line.strip())
+                    continue
+
+            return ac_data if ac_data["frequencies"] else None
+        except FileNotFoundError as e:
+            raise ResultParseError(f"wrdata file not found at {filepath}") from e
+        except (OSError, ValueError, IndexError) as e:
+            raise ResultParseError(f"Error parsing AC wrdata: {e}") from e
+
+    @staticmethod
     def parse_ac_results(output):
         """Parse AC sweep results"""
         try:
@@ -245,6 +301,54 @@ class ResultParser:
 
         except (ValueError, IndexError, KeyError, AttributeError) as e:
             raise ResultParseError(f"Error parsing AC results: {e}") from e
+
+    @staticmethod
+    def parse_noise_wrdata(filepath):
+        """Parse noise analysis results from a wrdata file.
+
+        The wrdata file produced by ngspice for noise analysis has
+        frequency as the first column followed by onoise_spectrum and
+        inoise_spectrum columns.  Returns a dict compatible with
+        :class:`NoisePlotDialog`, or *None* when no data is found.
+        """
+        try:
+            with open(filepath, "r") as f:
+                lines = f.readlines()
+            if not lines:
+                return None
+
+            headers = lines[0].strip().split()
+            if not headers:
+                return None
+
+            noise_data = {
+                "frequencies": [],
+                "onoise_spectrum": [],
+                "inoise_spectrum": [],
+            }
+
+            for line in lines[1:]:
+                parts = line.strip().split()
+                if len(parts) != len(headers):
+                    continue
+                try:
+                    freq = float(parts[0])
+                    noise_data["frequencies"].append(freq)
+                    for j, h in enumerate(headers[1:], start=1):
+                        h_lower = h.lower()
+                        if "onoise" in h_lower:
+                            noise_data["onoise_spectrum"].append(float(parts[j]))
+                        elif "inoise" in h_lower:
+                            noise_data["inoise_spectrum"].append(float(parts[j]))
+                except (ValueError, IndexError):
+                    logger.debug("Skipping unparseable noise wrdata row: %s", line.strip())
+                    continue
+
+            return noise_data if noise_data["frequencies"] else None
+        except FileNotFoundError as e:
+            raise ResultParseError(f"wrdata file not found at {filepath}") from e
+        except (OSError, ValueError, IndexError) as e:
+            raise ResultParseError(f"Error parsing noise wrdata: {e}") from e
 
     @staticmethod
     def parse_noise_results(output):

--- a/app/tests/unit/test_result_parser.py
+++ b/app/tests/unit/test_result_parser.py
@@ -186,7 +186,85 @@ class TestParseAcResults:
         assert result is None
 
 
-# ── parse_transient_results ──────────────────────────────────────────
+# ── parse_ac_wrdata ─────────────────────────────────────────────────
+
+
+class TestParseAcWrdata:
+    def test_valid_wrdata(self, tmp_path):
+        wrdata = tmp_path / "ac.txt"
+        wrdata.write_text(
+            "frequency vm(out) vp(out)\n"
+            "1.000000e+02 1.000000e+00 -4.500000e+01\n"
+            "1.000000e+03 5.000000e-01 -9.000000e+01\n"
+        )
+        result = ResultParser.parse_ac_wrdata(str(wrdata))
+        assert result is not None
+        assert len(result["frequencies"]) == 2
+        assert result["frequencies"][0] == pytest.approx(100.0)
+        assert "out" in result["magnitude"]
+        assert result["magnitude"]["out"][0] == pytest.approx(1.0)
+        assert "out" in result["phase"]
+        assert result["phase"]["out"][1] == pytest.approx(-90.0)
+
+    def test_vdb_headers(self, tmp_path):
+        wrdata = tmp_path / "ac_db.txt"
+        wrdata.write_text(
+            "frequency vdb(out) vp(out)\n"
+            "1.000000e+02 0.000000e+00 0.000000e+00\n"
+            "1.000000e+03 -6.020000e+00 -9.000000e+01\n"
+        )
+        result = ResultParser.parse_ac_wrdata(str(wrdata))
+        assert result is not None
+        assert "out" in result["magnitude"]
+        assert result["magnitude"]["out"][1] == pytest.approx(-6.02)
+
+    def test_empty_file_returns_none(self, tmp_path):
+        wrdata = tmp_path / "empty.txt"
+        wrdata.write_text("")
+        result = ResultParser.parse_ac_wrdata(str(wrdata))
+        assert result is None
+
+    def test_header_only_returns_none(self, tmp_path):
+        wrdata = tmp_path / "header_only.txt"
+        wrdata.write_text("frequency vm(out) vp(out)\n")
+        result = ResultParser.parse_ac_wrdata(str(wrdata))
+        assert result is None
+
+    def test_missing_file_raises_parse_error(self):
+        with pytest.raises(ResultParseError, match="wrdata file not found"):
+            ResultParser.parse_ac_wrdata("/nonexistent/path.txt")
+
+
+# ── parse_noise_wrdata ──────────────────────────────────────────────
+
+
+class TestParseNoiseWrdata:
+    def test_valid_wrdata(self, tmp_path):
+        wrdata = tmp_path / "noise.txt"
+        wrdata.write_text(
+            "frequency onoise_spectrum inoise_spectrum\n"
+            "1.000000e+00 3.200000e-09 1.600000e-09\n"
+            "1.000000e+01 3.100000e-09 1.550000e-09\n"
+        )
+        result = ResultParser.parse_noise_wrdata(str(wrdata))
+        assert result is not None
+        assert len(result["frequencies"]) == 2
+        assert result["frequencies"][0] == pytest.approx(1.0)
+        assert result["onoise_spectrum"][0] == pytest.approx(3.2e-9)
+        assert result["inoise_spectrum"][1] == pytest.approx(1.55e-9)
+
+    def test_empty_file_returns_none(self, tmp_path):
+        wrdata = tmp_path / "empty.txt"
+        wrdata.write_text("")
+        result = ResultParser.parse_noise_wrdata(str(wrdata))
+        assert result is None
+
+    def test_missing_file_raises_parse_error(self):
+        with pytest.raises(ResultParseError, match="wrdata file not found"):
+            ResultParser.parse_noise_wrdata("/nonexistent/path.txt")
+
+
+# ── parse_transient_results ─────────────────────────────────────���────
 
 
 class TestParseTransientResults:


### PR DESCRIPTION
## Summary - Add  and  methods to  for parsing the clean wrdata files that ngspice always writes via the control block - Update  to try wrdata files first, then the  output file, then raw stdout — ensuring results are found regardless of where ngspice writes  command output - Fix Temperature Sweep (#856): remove invalid  vector name from print/wrdata commands; rely on  to automatically include the scale column - Add unit tests for the new wrdata parsers Fixes #805, #852, #853, #854, #855, #856, #857 ## Root cause In some ngspice versions/configurations, the  command output in  blocks goes to stdout rather than the  output file. Analyses that only read the  file (AC Sweep, Noise, DC OP) would fail to find data. Additionally, the Temperature Sweep netlist referenced  as a vector name, which may not exist in all ngspice versions. ## Test plan - [ ] Verify AC sweep produces Bode plot with magnitude and phase data on an RC low-pass filter - [ ] Verify DC OP shows voltage annotations on circuit nodes and power dissipation in properties panel - [ ] Verify DC Sweep opens plot window with sweep curves - [ ] Verify Parameter Sweep with DC OP base shows overlaid node voltage results - [ ] Verify Temperature Sweep produces results (plot or table) - [ ] Verify Noise analysis displays spectral density plot - [ ] Run  — all existing tests pass 🤖 Generated with [Claude Code](https://claude.com/claude-code)