### PR TITLE
fix: add atomic writes for all persistence points (#765)

### DIFF
--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -849,9 +849,10 @@ class FileOperationsMixin:
             elif export_function == "export_results_excel":
                 self._re_export_results_excel(path)
             elif export_function == "export_circuitikz":
+                from utils.atomic_write import atomic_write_text
+
                 content = self.simulation_ctrl.generate_circuitikz()
-                with open(path, "w") as f:
-                    f.write(content)
+                atomic_write_text(path, content)
             elif export_function == "export_asc":
                 self.file_ctrl.export_asc(path)
             elif export_function == "export_results_markdown":

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -501,8 +501,9 @@ class ViewOperationsMixin:
             filename += ".tex"
 
         try:
-            with open(filename, "w", encoding="utf-8") as f:
-                f.write(tikz_code)
+            from utils.atomic_write import atomic_write_text
+
+            atomic_write_text(filename, tikz_code)
             statusBar = self.statusBar()
             if statusBar:
                 statusBar.showMessage(f"CircuiTikZ exported to {filename}", STATUS_DURATION_DEFAULT)

--- a/app/cli.py
+++ b/app/cli.py
@@ -419,9 +419,10 @@ def cmd_import(args: argparse.Namespace) -> int:
     else:
         out_path = filepath.with_suffix(".json")
 
+    from utils.atomic_write import atomic_write_text
+
     data = model.to_dict()
-    with open(out_path, "w") as f:
-        json.dump(data, f, indent=2)
+    atomic_write_text(out_path, json.dumps(data, indent=2))
 
     print(f"Imported {filepath.name} -> {out_path}", file=sys.stderr)
     return 0

--- a/app/controllers/assignment_controller.py
+++ b/app/controllers/assignment_controller.py
@@ -33,9 +33,10 @@ def save_assignment(bundle: AssignmentBundle, filepath) -> None:
         bundle: The assignment bundle to save.
         filepath: Path to write the file.
     """
+    from utils.atomic_write import atomic_write_text
+
     filepath = Path(filepath)
-    with open(filepath, "w", encoding="utf-8") as f:
-        json.dump(bundle.to_dict(), f, indent=2)
+    atomic_write_text(filepath, json.dumps(bundle.to_dict(), indent=2))
 
 
 def load_assignment(filepath) -> AssignmentBundle:

--- a/app/controllers/file_controller.py
+++ b/app/controllers/file_controller.py
@@ -8,7 +8,6 @@ Recent files tracking uses the centralized settings service for cross-session pe
 import json
 import logging
 import os
-import tempfile
 from dataclasses import fields
 from pathlib import Path
 from typing import List, Optional
@@ -107,14 +106,9 @@ class FileController:
         """
         filepath = Path(filepath)
         data = self.model.to_dict()
-        fd, tmp = tempfile.mkstemp(dir=filepath.parent, suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
-            os.replace(tmp, filepath)
-        except BaseException:
-            os.unlink(tmp)
-            raise
+        from utils.atomic_write import atomic_write_text
+
+        atomic_write_text(filepath, json.dumps(data, indent=2))
         self.current_file = filepath
         self._save_session()
         self.add_recent_file(filepath)  # Track in recent files
@@ -183,14 +177,9 @@ class FileController:
         try:
             session_path = Path(self._session_file)
             content = os.path.abspath(str(self.current_file)) if self.current_file else ""
-            fd, tmp = tempfile.mkstemp(dir=session_path.parent, suffix=".tmp")
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
-                    f.write(content)
-                os.replace(tmp, session_path)
-            except BaseException:
-                os.unlink(tmp)
-                raise
+            from utils.atomic_write import atomic_write_text
+
+            atomic_write_text(session_path, content)
         except OSError:
             logger.warning("Failed to save session file %s", self._session_file, exc_info=True)
 
@@ -272,14 +261,9 @@ class FileController:
         try:
             data = self.model.to_dict()
             data["_autosave_source"] = str(self.current_file) if self.current_file else ""
-            fd, tmp = tempfile.mkstemp(dir=self._autosave_file.parent, suffix=".tmp")
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
-                    json.dump(data, f, indent=2)
-                os.replace(tmp, self._autosave_file)
-            except BaseException:
-                os.unlink(tmp)
-                raise
+            from utils.atomic_write import atomic_write_text
+
+            atomic_write_text(self._autosave_file, json.dumps(data, indent=2))
         except (OSError, TypeError):
             logger.warning("Auto-save failed for %s", self._autosave_file, exc_info=True)
 

--- a/app/controllers/keybindings.py
+++ b/app/controllers/keybindings.py
@@ -128,6 +128,7 @@ class KeybindingsRegistry:
         try:
             from utils.atomic_write import atomic_write_text
 
+            self._config_path.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_text(self._config_path, json.dumps(overrides, indent=2))
         except OSError as e:
             logger.error("Failed to save keybindings: %s", e)

--- a/app/controllers/keybindings.py
+++ b/app/controllers/keybindings.py
@@ -122,13 +122,13 @@ class KeybindingsRegistry:
         self._bindings = dict(DEFAULTS)
 
     def save(self):
-        """Save user overrides to JSON config file."""
+        """Save user overrides to JSON config file (atomic write)."""
         # Only save non-default bindings
         overrides = {k: v for k, v in self._bindings.items() if v != DEFAULTS.get(k)}
         try:
-            self._config_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self._config_path, "w") as f:
-                json.dump(overrides, f, indent=2)
+            from utils.atomic_write import atomic_write_text
+
+            atomic_write_text(self._config_path, json.dumps(overrides, indent=2))
         except OSError as e:
             logger.error("Failed to save keybindings: %s", e)
 

--- a/app/controllers/settings_service.py
+++ b/app/controllers/settings_service.py
@@ -53,11 +53,11 @@ class SettingsService:
             self._data = {}
 
     def _save(self) -> None:
-        """Persist settings to disk."""
+        """Persist settings to disk (atomic write)."""
         try:
-            self._path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self._path, "w") as f:
-                json.dump(self._data, f, indent=2)
+            from utils.atomic_write import atomic_write_text
+
+            atomic_write_text(self._path, json.dumps(self._data, indent=2))
         except OSError:
             logger.warning("Failed to save settings to %s", self._path, exc_info=True)
 

--- a/app/controllers/settings_service.py
+++ b/app/controllers/settings_service.py
@@ -57,6 +57,7 @@ class SettingsService:
         try:
             from utils.atomic_write import atomic_write_text
 
+            self._path.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_text(self._path, json.dumps(self._data, indent=2))
         except OSError:
             logger.warning("Failed to save settings to %s", self._path, exc_info=True)

--- a/app/controllers/simulation_controller.py
+++ b/app/controllers/simulation_controller.py
@@ -767,9 +767,10 @@ class SimulationController:
             ValueError, KeyError, TypeError: If netlist generation fails.
             OSError: If the file cannot be written.
         """
+        from utils.atomic_write import atomic_write_text
+
         netlist = self.generate_netlist()
-        with open(filepath, "w", encoding="utf-8") as f:
-            f.write(netlist)
+        atomic_write_text(filepath, netlist)
 
     def generate_results_csv(self, results, results_type: str, circuit_name: str = "") -> Optional[str]:
         """Generate CSV content from simulation results.

--- a/app/controllers/template_controller.py
+++ b/app/controllers/template_controller.py
@@ -86,8 +86,9 @@ class TemplateController:
             recommended_components=list(recommended_components or []),
         )
 
-        with open(filepath, "w") as f:
-            json.dump(template.to_dict(), f, indent=2)
+        from utils.atomic_write import atomic_write_text
+
+        atomic_write_text(filepath, json.dumps(template.to_dict(), indent=2))
 
     def load_template(self, filepath) -> TemplateData:
         """Load a template file and return parsed TemplateData.

--- a/app/controllers/template_manager.py
+++ b/app/controllers/template_manager.py
@@ -177,8 +177,9 @@ class TemplateManager:
             filepath = self.user_dir / f"{stem}_{counter}.json"
             counter += 1
 
-        with open(filepath, "w") as f:
-            json.dump(data, f, indent=2)
+        from utils.atomic_write import atomic_write_text
+
+        atomic_write_text(filepath, json.dumps(data, indent=2))
 
         return filepath
 

--- a/app/grading/feedback_exporter.py
+++ b/app/grading/feedback_exporter.py
@@ -122,6 +122,8 @@ def export_student_reports(
     Raises:
         OSError: If the output directory cannot be created or files can't be written.
     """
+    from utils.atomic_write import atomic_write_text
+
     out_path = Path(output_dir)
     out_path.mkdir(parents=True, exist_ok=True)
 
@@ -133,8 +135,7 @@ def export_student_reports(
         report_path = out_path / report_name
 
         html_content = generate_student_report_html(gr)
-        with open(report_path, "w", encoding="utf-8") as f:
-            f.write(html_content)
+        atomic_write_text(report_path, html_content)
 
         created_files.append(str(report_path))
 

--- a/app/grading/rubric.py
+++ b/app/grading/rubric.py
@@ -155,9 +155,10 @@ def validate_rubric(data: dict) -> None:
 
 def save_rubric(rubric: Rubric, filepath) -> None:
     """Save a rubric to a .spice-rubric JSON file."""
+    from utils.atomic_write import atomic_write_text
+
     filepath = Path(filepath)
-    with open(filepath, "w") as f:
-        json.dump(rubric.to_dict(), f, indent=2)
+    atomic_write_text(filepath, json.dumps(rubric.to_dict(), indent=2))
 
 
 def load_rubric(filepath) -> Rubric:

--- a/app/scripting/circuit.py
+++ b/app/scripting/circuit.py
@@ -227,10 +227,11 @@ class Circuit:
         Args:
             path: Destination file path.
         """
+        from utils.atomic_write import atomic_write_text
+
         path = Path(path)
         data = self._model.to_dict()
-        with open(path, "w") as f:
-            json.dump(data, f, indent=2)
+        atomic_write_text(path, json.dumps(data, indent=2))
 
     # --- Properties ---
 
@@ -402,32 +403,47 @@ class Circuit:
 
 def _write_op_csv(data: dict, path: Path) -> None:
     """Write DC Operating Point results as name,value rows."""
-    with open(path, "w", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow(["name", "value"])
-        for name, value in data.get("node_voltages", {}).items():
-            writer.writerow([name, value])
-        for name, value in data.get("branch_currents", {}).items():
-            writer.writerow([name, value])
+    import io
+
+    from utils.atomic_write import atomic_write_text
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["name", "value"])
+    for name, value in data.get("node_voltages", {}).items():
+        writer.writerow([name, value])
+    for name, value in data.get("branch_currents", {}).items():
+        writer.writerow([name, value])
+    atomic_write_text(path, output.getvalue())
 
 
 def _write_tabular_csv(data, path: Path) -> None:
     """Write list-of-dicts data as a CSV table."""
     if isinstance(data, list) and data:
+        import io
+
+        from utils.atomic_write import atomic_write_text
+
         keys = list(data[0].keys())
-        with open(path, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=keys)
-            writer.writeheader()
-            writer.writerows(data)
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=keys)
+        writer.writeheader()
+        writer.writerows(data)
+        atomic_write_text(path, output.getvalue())
     elif isinstance(data, dict):
         _write_generic_csv(data, path)
 
 
 def _write_generic_csv(data, path: Path) -> None:
     """Fallback: write dict data as key,value rows."""
-    with open(path, "w", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow(["key", "value"])
-        if isinstance(data, dict):
-            for key, value in data.items():
-                writer.writerow([key, value])
+    import io
+
+    from utils.atomic_write import atomic_write_text
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["key", "value"])
+    if isinstance(data, dict):
+        for key, value in data.items():
+            writer.writerow([key, value])
+    atomic_write_text(path, output.getvalue())

--- a/app/scripting/circuit.py
+++ b/app/scripting/circuit.py
@@ -414,7 +414,7 @@ def _write_op_csv(data: dict, path: Path) -> None:
         writer.writerow([name, value])
     for name, value in data.get("branch_currents", {}).items():
         writer.writerow([name, value])
-    atomic_write_text(path, output.getvalue())
+    atomic_write_text(path, output.getvalue(), newline="")
 
 
 def _write_tabular_csv(data, path: Path) -> None:
@@ -429,7 +429,7 @@ def _write_tabular_csv(data, path: Path) -> None:
         writer = csv.DictWriter(output, fieldnames=keys)
         writer.writeheader()
         writer.writerows(data)
-        atomic_write_text(path, output.getvalue())
+        atomic_write_text(path, output.getvalue(), newline="")
     elif isinstance(data, dict):
         _write_generic_csv(data, path)
 
@@ -446,4 +446,4 @@ def _write_generic_csv(data, path: Path) -> None:
     if isinstance(data, dict):
         for key, value in data.items():
             writer.writerow([key, value])
-    atomic_write_text(path, output.getvalue())
+    atomic_write_text(path, output.getvalue(), newline="")

--- a/app/simulation/asc_exporter.py
+++ b/app/simulation/asc_exporter.py
@@ -212,5 +212,6 @@ def write_asc(content, filepath):
         content: str from export_asc()
         filepath: output file path
     """
-    with open(filepath, "w") as f:
-        f.write(content)
+    from utils.atomic_write import atomic_write_text
+
+    atomic_write_text(filepath, content)

--- a/app/simulation/bom_exporter.py
+++ b/app/simulation/bom_exporter.py
@@ -164,5 +164,6 @@ def write_bom_csv(csv_content, filepath):
         csv_content: str from export_bom_csv()
         filepath: path to write to
     """
-    with open(filepath, "w", newline="") as f:
-        f.write(csv_content)
+    from utils.atomic_write import atomic_write_text
+
+    atomic_write_text(filepath, csv_content)

--- a/app/simulation/bom_exporter.py
+++ b/app/simulation/bom_exporter.py
@@ -166,4 +166,4 @@ def write_bom_csv(csv_content, filepath):
     """
     from utils.atomic_write import atomic_write_text
 
-    atomic_write_text(filepath, csv_content)
+    atomic_write_text(filepath, csv_content, newline="")

--- a/app/simulation/csv_exporter.py
+++ b/app/simulation/csv_exporter.py
@@ -202,4 +202,4 @@ def write_csv(csv_content, filepath):
     """
     from utils.atomic_write import atomic_write_text
 
-    atomic_write_text(filepath, csv_content)
+    atomic_write_text(filepath, csv_content, newline="")

--- a/app/simulation/csv_exporter.py
+++ b/app/simulation/csv_exporter.py
@@ -200,5 +200,6 @@ def write_csv(csv_content, filepath):
         csv_content: str from one of the export_* functions
         filepath: path to write to
     """
-    with open(filepath, "w", newline="") as f:
-        f.write(csv_content)
+    from utils.atomic_write import atomic_write_text
+
+    atomic_write_text(filepath, csv_content)

--- a/app/simulation/markdown_exporter.py
+++ b/app/simulation/markdown_exporter.py
@@ -153,5 +153,6 @@ def export_noise_results(noise_data, circuit_name=""):
 
 def write_markdown(md_content, filepath):
     """Write Markdown content string to a file."""
-    with open(filepath, "w") as f:
-        f.write(md_content)
+    from utils.atomic_write import atomic_write_text
+
+    atomic_write_text(filepath, md_content)

--- a/app/tests/unit/test_atomic_write.py
+++ b/app/tests/unit/test_atomic_write.py
@@ -1,0 +1,74 @@
+"""Tests for the atomic write utility (#765)."""
+
+import os
+
+from utils.atomic_write import atomic_write_text
+
+
+class TestAtomicWriteText:
+    """Verify atomic_write_text writes files safely."""
+
+    def test_writes_content(self, tmp_path):
+        target = tmp_path / "test.json"
+        atomic_write_text(target, '{"key": "value"}')
+        assert target.read_text() == '{"key": "value"}'
+
+    def test_overwrites_existing(self, tmp_path):
+        target = tmp_path / "test.txt"
+        target.write_text("old")
+        atomic_write_text(target, "new")
+        assert target.read_text() == "new"
+
+    def test_no_temp_files_left(self, tmp_path):
+        target = tmp_path / "test.txt"
+        atomic_write_text(target, "content")
+        files = list(tmp_path.iterdir())
+        assert files == [target], f"Unexpected files: {files}"
+
+    def test_creates_parent_directories(self, tmp_path):
+        target = tmp_path / "sub" / "dir" / "test.txt"
+        atomic_write_text(target, "deep")
+        assert target.read_text() == "deep"
+
+    def test_original_preserved_on_failure(self, tmp_path):
+        """If the write fails, the original file should be untouched."""
+        target = tmp_path / "test.txt"
+        target.write_text("original")
+
+        class FakeError(Exception):
+            pass
+
+        try:
+            # Make a read-only subdirectory to force a failure
+            # Instead, use a custom approach - mock os.replace to fail
+            import unittest.mock
+
+            with unittest.mock.patch("utils.atomic_write.os.replace", side_effect=FakeError("boom")):
+                atomic_write_text(target, "corrupted")
+        except FakeError:
+            pass
+
+        assert target.read_text() == "original"
+
+    def test_no_temp_file_after_failure(self, tmp_path):
+        """Temp file should be cleaned up after a failure."""
+        target = tmp_path / "test.txt"
+
+        class FakeError(Exception):
+            pass
+
+        try:
+            import unittest.mock
+
+            with unittest.mock.patch("utils.atomic_write.os.replace", side_effect=FakeError("boom")):
+                atomic_write_text(target, "content")
+        except FakeError:
+            pass
+
+        files = list(tmp_path.iterdir())
+        assert len(files) == 0, f"Temp file not cleaned up: {files}"
+
+    def test_encoding_parameter(self, tmp_path):
+        target = tmp_path / "test.txt"
+        atomic_write_text(target, "héllo wörld", encoding="utf-8")
+        assert target.read_text(encoding="utf-8") == "héllo wörld"

--- a/app/tests/unit/test_atomic_write.py
+++ b/app/tests/unit/test_atomic_write.py
@@ -2,6 +2,7 @@
 
 import os
 
+import pytest
 from utils.atomic_write import atomic_write_text
 
 
@@ -25,10 +26,10 @@ class TestAtomicWriteText:
         files = list(tmp_path.iterdir())
         assert files == [target], f"Unexpected files: {files}"
 
-    def test_creates_parent_directories(self, tmp_path):
-        target = tmp_path / "sub" / "dir" / "test.txt"
-        atomic_write_text(target, "deep")
-        assert target.read_text() == "deep"
+    def test_fails_if_parent_directory_missing(self, tmp_path):
+        target = tmp_path / "nonexistent" / "test.txt"
+        with pytest.raises(OSError):
+            atomic_write_text(target, "deep")
 
     def test_original_preserved_on_failure(self, tmp_path):
         """If the write fails, the original file should be untouched."""

--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -733,8 +733,8 @@ class TestAtomicWrites:
         ctrl.save_circuit(filepath)
         original_content = filepath.read_text()
 
-        # Now make json.dump raise mid-write
-        with patch("controllers.file_controller.json.dump", side_effect=OSError("disk full")):
+        # Now make json.dumps raise mid-write
+        with patch("controllers.file_controller.json.dumps", side_effect=OSError("disk full")):
             with pytest.raises(OSError, match="disk full"):
                 ctrl.save_circuit(filepath)
 

--- a/app/utils/atomic_write.py
+++ b/app/utils/atomic_write.py
@@ -10,7 +10,7 @@ import tempfile
 from pathlib import Path
 
 
-def atomic_write_text(filepath, content: str, encoding: str = "utf-8") -> None:
+def atomic_write_text(filepath, content: str, encoding: str = "utf-8", newline=None) -> None:
     """Atomically write *content* to *filepath*.
 
     Creates a temporary file in the same directory as *filepath*,
@@ -21,15 +21,16 @@ def atomic_write_text(filepath, content: str, encoding: str = "utf-8") -> None:
         filepath: Target file path (str or Path).
         content: Text content to write.
         encoding: Text encoding (default utf-8).
+        newline: Newline translation mode (passed to open). Use ``""``
+            for CSV files to prevent ``\\r\\n`` doubling on Windows.
 
     Raises:
         OSError: If the write or replace fails.
     """
     filepath = Path(filepath)
-    filepath.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=filepath.parent, suffix=".tmp")
     try:
-        with os.fdopen(fd, "w", encoding=encoding) as f:
+        with os.fdopen(fd, "w", encoding=encoding, newline=newline) as f:
             f.write(content)
         os.replace(tmp, filepath)
     except BaseException:

--- a/app/utils/atomic_write.py
+++ b/app/utils/atomic_write.py
@@ -1,0 +1,40 @@
+"""Atomic file write utility for crash-safe persistence.
+
+Writes data to a temporary file in the same directory, then atomically
+replaces the target file via ``os.replace()``.  This ensures the target
+file is never left in a partially-written state after a crash or power loss.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_text(filepath, content: str, encoding: str = "utf-8") -> None:
+    """Atomically write *content* to *filepath*.
+
+    Creates a temporary file in the same directory as *filepath*,
+    writes *content* to it, then atomically replaces *filepath*.
+    On failure, the temporary file is removed.
+
+    Args:
+        filepath: Target file path (str or Path).
+        content: Text content to write.
+        encoding: Text encoding (default utf-8).
+
+    Raises:
+        OSError: If the write or replace fails.
+    """
+    filepath = Path(filepath)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=filepath.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as f:
+            f.write(content)
+        os.replace(tmp, filepath)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise


### PR DESCRIPTION
## Summary - Created shared atomic_write_text utility (write to temp file, then os.replace) - Applied atomic writes to all 17 file write paths across the codebase - Consolidated existing inline atomic write patterns in file_controller.py to use the shared utility ## Test plan - [x] New unit tests for atomic_write_text (7 tests: basic write, overwrite, no temp files, parent dirs, failure preservation, cleanup, encoding) - [x] Existing atomic write tests updated and passing - [x] Full test suite passes (4345 passed) Closes #765