### PR TITLE
fix: add file size validation to all user-facing file load paths (#766)

### DIFF
--- a/app/GUI/grading_panel.py
+++ b/app/GUI/grading_panel.py
@@ -143,6 +143,9 @@ class GradingPanel(QWidget):
             return
 
         try:
+            from controllers.file_controller import check_file_size
+
+            check_file_size(filename)
             with open(filename, "r") as f:
                 data = json.load(f)
 

--- a/app/GUI/main_window_file_ops.py
+++ b/app/GUI/main_window_file_ops.py
@@ -543,6 +543,9 @@ class FileOperationsMixin:
 
         for example_file in example_files:
             try:
+                from controllers.file_controller import check_file_size
+
+                check_file_size(example_file)
                 with open(example_file, "r", encoding="utf-8") as f:
                     data = json.load(f)
 
@@ -556,7 +559,7 @@ class FileOperationsMixin:
                 examples_by_category[category].append(
                     {"name": name, "description": description, "filepath": example_file}
                 )
-            except (json.JSONDecodeError, OSError) as e:
+            except (json.JSONDecodeError, OSError, ValueError) as e:
                 logger.warning(f"Failed to load example {example_file}: {e}")
 
         # Create menu entries organized by category

--- a/app/controllers/assignment_controller.py
+++ b/app/controllers/assignment_controller.py
@@ -7,6 +7,7 @@ No Qt dependencies.
 import json
 from pathlib import Path
 
+from controllers.file_controller import check_file_size
 from grading.rubric import Rubric, validate_rubric
 from models.assignment import AssignmentBundle
 from models.template import TemplateData
@@ -52,6 +53,7 @@ def load_assignment(filepath) -> AssignmentBundle:
         ValueError: If the data structure is invalid.
     """
     filepath = Path(filepath)
+    check_file_size(filepath)
     with open(filepath, "r", encoding="utf-8") as f:
         data = json.load(f)
     validate_assignment_data(data)

--- a/app/controllers/template_controller.py
+++ b/app/controllers/template_controller.py
@@ -9,7 +9,7 @@ import json
 from pathlib import Path
 from typing import Optional
 
-from controllers.file_controller import validate_circuit_data
+from controllers.file_controller import check_file_size, validate_circuit_data
 from models.circuit import CircuitModel
 from models.template import TemplateData, TemplateMetadata
 
@@ -104,6 +104,7 @@ class TemplateController:
             OSError: If the file cannot be read.
         """
         filepath = Path(filepath)
+        check_file_size(filepath)
         with open(filepath, "r") as f:
             data = json.load(f)
 
@@ -172,6 +173,7 @@ class TemplateController:
             OSError: If the file cannot be read.
         """
         filepath = Path(filepath)
+        check_file_size(filepath)
         with open(filepath, "r") as f:
             data = json.load(f)
 

--- a/app/controllers/template_manager.py
+++ b/app/controllers/template_manager.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from controllers.file_controller import validate_circuit_data
+from controllers.file_controller import check_file_size, validate_circuit_data
 from models.circuit import CircuitModel
 
 logger = logging.getLogger(__name__)
@@ -65,6 +65,7 @@ class TemplateManager:
 
         for filepath in sorted(directory.glob("*.json")):
             try:
+                check_file_size(filepath)
                 with open(filepath, "r") as f:
                     data = json.load(f)
                 templates.append(
@@ -76,7 +77,7 @@ class TemplateManager:
                         is_builtin=is_builtin,
                     )
                 )
-            except (json.JSONDecodeError, OSError) as e:
+            except (json.JSONDecodeError, OSError, ValueError) as e:
                 logger.warning("Failed to read template %s: %s", filepath, e)
 
         return templates
@@ -100,6 +101,7 @@ class TemplateManager:
             ValueError: If file structure is invalid.
             OSError: If file cannot be read.
         """
+        check_file_size(filepath)
         with open(filepath, "r") as f:
             data = json.load(f)
 

--- a/app/grading/session_persistence.py
+++ b/app/grading/session_persistence.py
@@ -216,6 +216,9 @@ def load_grading_session(filepath) -> GradingSessionData:
     filepath = Path(filepath)
     anchor = filepath.parent.resolve()
 
+    from controllers.file_controller import check_file_size
+
+    check_file_size(filepath)
     with open(filepath, "r") as f:
         data = json.load(f)
     validate_session_data(data)

--- a/app/scripting/circuit.py
+++ b/app/scripting/circuit.py
@@ -49,10 +49,12 @@ class Circuit:
             ValueError: If the JSON structure is invalid.
         """
         path = Path(path)
+
+        from controllers.file_controller import check_file_size, validate_circuit_data
+
+        check_file_size(path)
         with open(path, "r") as f:
             data = json.load(f)
-
-        from controllers.file_controller import validate_circuit_data
 
         validate_circuit_data(data)
         model = CircuitModel.from_dict(data)

--- a/app/tests/unit/test_file_size_validation.py
+++ b/app/tests/unit/test_file_size_validation.py
@@ -1,0 +1,51 @@
+"""Tests for file size validation on load paths (#766)."""
+
+import json
+
+import pytest
+from controllers.file_controller import MAX_FILE_SIZE, FileController, check_file_size
+
+
+class TestCheckFileSize:
+    """Verify check_file_size rejects oversized files."""
+
+    def test_small_file_passes(self, tmp_path):
+        f = tmp_path / "small.json"
+        f.write_text("{}")
+        check_file_size(f)  # should not raise
+
+    def test_oversized_file_raises(self, tmp_path):
+        f = tmp_path / "big.json"
+        f.write_bytes(b"x" * (MAX_FILE_SIZE + 1))
+        with pytest.raises(ValueError, match="too large"):
+            check_file_size(f)
+
+    def test_custom_limit(self, tmp_path):
+        f = tmp_path / "medium.json"
+        f.write_bytes(b"x" * 1001)
+        with pytest.raises(ValueError, match="too large"):
+            check_file_size(f, max_size=1000)
+
+    def test_exact_limit_passes(self, tmp_path):
+        f = tmp_path / "exact.json"
+        f.write_bytes(b"x" * 1000)
+        check_file_size(f, max_size=1000)  # should not raise
+
+
+class TestLoadCircuitFileSizeValidation:
+    """Verify load_circuit rejects oversized files."""
+
+    def test_oversized_circuit_rejected(self, tmp_path):
+        from unittest.mock import patch
+
+        ctrl = FileController()
+        f = tmp_path / "big.json"
+        data = {"components": [], "wires": [], "counters": {}, "pad": "x" * 2000}
+        f.write_text(json.dumps(data))
+
+        with patch(
+            "controllers.file_controller.check_file_size",
+            side_effect=ValueError("File is too large"),
+        ):
+            with pytest.raises(ValueError, match="too large"):
+                ctrl.load_circuit(f)


### PR DESCRIPTION
## Summary - Added check_file_size() calls before json.load() in 7 files that accept user-selected files - Covers: example loading, grading panel, session persistence, scripting API, assignment controller, template controller, and template manager - Oversized files produce a clear ValueError before any data is read into memory ## Test plan - [x] New unit tests for check_file_size (5 tests) - [x] Full test suite passes (4354 passed) - [x] Lint clean Closes #766