### PR TITLE
fix: PDF/image export has dark background in dark mode (#867)

### DIFF
--- a/app/GUI/main_window_print.py
+++ b/app/GUI/main_window_print.py
@@ -39,7 +39,7 @@ class PrintExportMixin:
         aspect ratio. Forces a white background regardless of theme.
         """
         from PyQt6.QtCore import QRectF, Qt
-        from PyQt6.QtGui import QPainter
+        from PyQt6.QtGui import QBrush, QPainter
 
         source_rect = self._get_circuit_source_rect()
         if source_rect is None:
@@ -63,7 +63,12 @@ class PrintExportMixin:
         target_y = (page_rect.height() - target_h) / 2
         target_rect = QRectF(target_x, target_y, target_w, target_h)
 
-        self.canvas.scene().render(painter, target=target_rect, source=source_rect)
+        # Override scene background to white so dark-mode theme doesn't leak
+        scene = self.canvas.scene()
+        original_brush = scene.backgroundBrush()
+        scene.setBackgroundBrush(QBrush(Qt.GlobalColor.white))
+        scene.render(painter, target=target_rect, source=source_rect)
+        scene.setBackgroundBrush(original_brush)
         painter.end()
 
     def _on_print(self):

--- a/app/GUI/main_window_view.py
+++ b/app/GUI/main_window_view.py
@@ -426,7 +426,14 @@ class ViewOperationsMixin:
 
             painter = QPainter(generator)
             painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+            # Override scene background to white so dark-mode theme doesn't leak
+            from PyQt6.QtCore import Qt
+            from PyQt6.QtGui import QBrush
+
+            original_brush = scene.backgroundBrush()
+            scene.setBackgroundBrush(QBrush(Qt.GlobalColor.white))
             scene.render(painter, QRectF(0, 0, width, height), source_rect)
+            scene.setBackgroundBrush(original_brush)
             painter.end()
 
             # Embed circuit data in the SVG for shareable round-trip import
@@ -447,7 +454,13 @@ class ViewOperationsMixin:
             painter = QPainter(image)
             painter.setRenderHint(QPainter.RenderHint.Antialiasing)
             target_rect = QRectF(0, 0, width, height)
+            # Override scene background to white so dark-mode theme doesn't leak
+            from PyQt6.QtGui import QBrush
+
+            original_brush = scene.backgroundBrush()
+            scene.setBackgroundBrush(QBrush(Qt.GlobalColor.white))
             scene.render(painter, target=target_rect, source=source_rect)
+            scene.setBackgroundBrush(original_brush)
             painter.end()
             image.save(filename)
 

--- a/app/GUI/report_renderer.py
+++ b/app/GUI/report_renderer.py
@@ -199,8 +199,14 @@ class PDFReportRenderer:
         target_y = avail.top() + (avail.height() - target_h) / 2
         target_rect = QRectF(target_x, target_y, target_w, target_h)
 
+        # Override scene background to white so dark-mode theme doesn't leak
+        from PyQt6.QtGui import QBrush
+
+        original_brush = scene.backgroundBrush()
+        scene.setBackgroundBrush(QBrush(Qt.GlobalColor.white))
         painter.fillRect(target_rect, Qt.GlobalColor.white)
         scene.render(painter, target=target_rect, source=source_rect)
+        scene.setBackgroundBrush(original_brush)
 
     def _render_text_section(
         self,

--- a/app/tests/unit/test_print_export.py
+++ b/app/tests/unit/test_print_export.py
@@ -179,3 +179,44 @@ class TestPdfExportEndToEnd:
         assert corner_color.red() == 255
         assert corner_color.green() == 255
         assert corner_color.blue() == 255
+
+    def test_dark_mode_scene_exports_white_background(self, qtbot):
+        """Scene with dark background brush should still export white (#867)."""
+        from PyQt6.QtCore import Qt
+        from PyQt6.QtGui import QBrush, QColor, QImage, QPainter
+        from PyQt6.QtWidgets import QGraphicsRectItem, QGraphicsScene
+
+        scene = QGraphicsScene()
+        scene.addItem(QGraphicsRectItem(0, 0, 50, 50))
+
+        # Simulate dark mode by setting a dark background brush
+        dark_color = QColor(30, 30, 30)
+        scene.setBackgroundBrush(QBrush(dark_color))
+
+        # Render using the same pattern as _render_to_printer:
+        # fill white, override scene background, render, restore
+        image = QImage(200, 200, QImage.Format.Format_ARGB32_Premultiplied)
+        image.fill(Qt.GlobalColor.white)
+
+        painter = QPainter(image)
+        source = scene.itemsBoundingRect()
+        source.adjust(-10, -10, 10, 10)
+        target = QRectF(0, 0, 200, 200)
+
+        original_brush = scene.backgroundBrush()
+        scene.setBackgroundBrush(QBrush(Qt.GlobalColor.white))
+        scene.render(painter, target=target, source=source)
+        scene.setBackgroundBrush(original_brush)
+        painter.end()
+
+        # Corner pixel should be white, not dark
+        corner_color = QColor(image.pixel(0, 0))
+        assert corner_color.red() == 255
+        assert corner_color.green() == 255
+        assert corner_color.blue() == 255
+
+        # Scene background should be restored to dark
+        restored = scene.backgroundBrush().color()
+        assert restored.red() == 30
+        assert restored.green() == 30
+        assert restored.blue() == 30


### PR DESCRIPTION
## Summary - **Fixes #867**: PDF export (and PNG/SVG) rendered the scene's dark-mode background brush over the white fill, producing a dark background in exported files -  paints the scene's background brush before items — the existing  was painted underneath and not visible - Fix: temporarily swap the scene background brush to white around every export  call, then restore the original brush - Applied consistently across all export paths: PDF export, print/print preview, report renderer schematic page, PNG export, and SVG export ## Test plan - [x] Added  — sets dark scene background, renders with the fix pattern, verifies corner pixel is white and original brush is restored - [ ] Manual: enable dark mode, export PDF/PNG/SVG, verify white background - [ ] Manual: verify canvas returns to dark theme after export 🤖 Generated with [Claude Code](https://claude.com/claude-code)