### PR TITLE
fix: add missing tooltips to right panel buttons (#910)

### DIFF
--- a/app/GUI/main_window.py
+++ b/app/GUI/main_window.py
@@ -277,24 +277,29 @@ class MainWindow(
         right_panel_layout.addWidget(QLabel("Actions"))
 
         self.btn_save = QPushButton("Save Circuit")
+        self.btn_save.setToolTip(f"Save Circuit ({self.keybindings.get('file.save_as')})")
         self.btn_save.clicked.connect(self._on_save_as)
         right_panel_layout.addWidget(self.btn_save)
 
         self.btn_load = QPushButton("Load Circuit")
+        self.btn_load.setToolTip(f"Load Circuit ({self.keybindings.get('file.open')})")
         self.btn_load.clicked.connect(self._on_load)
         right_panel_layout.addWidget(self.btn_load)
 
         self.btn_clear = QPushButton("Clear Canvas")
+        self.btn_clear.setToolTip("Clear Canvas")
         self.btn_clear.clicked.connect(self.clear_canvas)
         right_panel_layout.addWidget(self.btn_clear)
 
         right_panel_layout.addWidget(QLabel(""))  # Spacer
 
         self.btn_netlist = QPushButton("Generate Netlist")
+        self.btn_netlist.setToolTip(f"Generate Netlist ({self.keybindings.get('sim.netlist')})")
         self.btn_netlist.clicked.connect(self.generate_netlist)
         right_panel_layout.addWidget(self.btn_netlist)
 
         self.btn_simulate = QPushButton("Run Simulation")
+        self.btn_simulate.setToolTip(f"Run Simulation ({self.keybindings.get('sim.run')})")
         self.btn_simulate.clicked.connect(self.run_simulation)
         right_panel_layout.addWidget(self.btn_simulate)
 

--- a/app/GUI/results_panel.py
+++ b/app/GUI/results_panel.py
@@ -31,14 +31,17 @@ class ResultsPanel(QWidget):
         header.addWidget(QLabel("Simulation Results"))
 
         self.btn_export_csv = QPushButton("Export CSV")
+        self.btn_export_csv.setToolTip("Export simulation results to CSV")
         self.btn_export_csv.setEnabled(False)
         header.addWidget(self.btn_export_csv)
 
         self.btn_export_excel = QPushButton("Export Excel")
+        self.btn_export_excel.setToolTip("Export simulation results to Excel")
         self.btn_export_excel.setEnabled(False)
         header.addWidget(self.btn_export_excel)
 
         self.btn_copy_markdown = QPushButton("Copy Markdown")
+        self.btn_copy_markdown.setToolTip("Copy simulation results as Markdown")
         self.btn_copy_markdown.setEnabled(False)
         header.addWidget(self.btn_copy_markdown)
 

--- a/app/tests/unit/test_right_panel_tooltips.py
+++ b/app/tests/unit/test_right_panel_tooltips.py
@@ -1,0 +1,58 @@
+"""Tests for right-panel and results-panel button tooltips (#910).
+
+Structural tests verify that setToolTip() is called on buttons that
+previously lacked tooltips, without instantiating a full MainWindow.
+"""
+
+import ast
+import inspect
+
+
+class TestRightPanelTooltipsStructural:
+    """Verify setToolTip is called on right-panel action buttons in MainWindow."""
+
+    def _get_source(self):
+        from GUI.main_window import MainWindow
+
+        return inspect.getsource(MainWindow._init_ui)
+
+    def test_btn_save_has_tooltip(self):
+        src = self._get_source()
+        assert "btn_save.setToolTip" in src
+
+    def test_btn_load_has_tooltip(self):
+        src = self._get_source()
+        assert "btn_load.setToolTip" in src
+
+    def test_btn_clear_has_tooltip(self):
+        src = self._get_source()
+        assert "btn_clear.setToolTip" in src
+
+    def test_btn_netlist_has_tooltip(self):
+        src = self._get_source()
+        assert "btn_netlist.setToolTip" in src
+
+    def test_btn_simulate_has_tooltip(self):
+        src = self._get_source()
+        assert "btn_simulate.setToolTip" in src
+
+
+class TestResultsPanelTooltipsStructural:
+    """Verify setToolTip is called on results-panel export buttons."""
+
+    def _get_source(self):
+        from GUI.results_panel import ResultsPanel
+
+        return inspect.getsource(ResultsPanel._init_ui)
+
+    def test_btn_export_csv_has_tooltip(self):
+        src = self._get_source()
+        assert "btn_export_csv.setToolTip" in src
+
+    def test_btn_export_excel_has_tooltip(self):
+        src = self._get_source()
+        assert "btn_export_excel.setToolTip" in src
+
+    def test_btn_copy_markdown_has_tooltip(self):
+        src = self._get_source()
+        assert "btn_copy_markdown.setToolTip" in src

--- a/app/tests/unit/test_right_panel_tooltips.py
+++ b/app/tests/unit/test_right_panel_tooltips.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 def _module_source(module):
     """Return the source text of a module by reading its __file__."""
-    return Path(module.__file__).read_text()
+    return Path(module.__file__).read_text(encoding="utf-8")
 
 
 class TestRightPanelTooltipsStructural:

--- a/app/tests/unit/test_right_panel_tooltips.py
+++ b/app/tests/unit/test_right_panel_tooltips.py
@@ -1,20 +1,25 @@
 """Tests for right-panel and results-panel button tooltips (#910).
 
 Structural tests verify that setToolTip() is called on buttons that
-previously lacked tooltips, without instantiating a full MainWindow.
+previously lacked tooltips, by reading source files directly
+(not via inspect.getsource).
 """
 
-import ast
-import inspect
+from pathlib import Path
+
+
+def _module_source(module):
+    """Return the source text of a module by reading its __file__."""
+    return Path(module.__file__).read_text()
 
 
 class TestRightPanelTooltipsStructural:
     """Verify setToolTip is called on right-panel action buttons in MainWindow."""
 
     def _get_source(self):
-        from GUI.main_window import MainWindow
+        from GUI import main_window
 
-        return inspect.getsource(MainWindow._init_ui)
+        return _module_source(main_window)
 
     def test_btn_save_has_tooltip(self):
         src = self._get_source()
@@ -41,9 +46,9 @@ class TestResultsPanelTooltipsStructural:
     """Verify setToolTip is called on results-panel export buttons."""
 
     def _get_source(self):
-        from GUI.results_panel import ResultsPanel
+        from GUI import results_panel
 
-        return inspect.getsource(ResultsPanel._init_ui)
+        return _module_source(results_panel)
 
     def test_btn_export_csv_has_tooltip(self):
         src = self._get_source()


### PR DESCRIPTION
## Summary - Add  calls to all 5 right-panel action buttons (Save, Load, Clear, Generate Netlist, Run Simulation) with keyboard shortcuts where available - Add  calls to 3 results-panel export buttons (CSV, Excel, Markdown) - Add structural tests verifying tooltip presence on all affected buttons Closes #910 ## Test plan - [ ] Hover over each right-panel button and verify tooltip appears - [ ] Hover over results-panel export buttons and verify tooltip appears - [ ] Verify tooltips show correct keyboard shortcuts (e.g. Ctrl+Shift+S for Save) - [ ] CI passes structural tests 🤖 Generated with [Claude Code](https://claude.com/claude-code)