### PR TITLE
feat: add schema_version field to circuit JSON format (#521)

### DIFF
--- a/app/models/circuit.py
+++ b/app/models/circuit.py
@@ -23,6 +23,8 @@ from .wire import WireData
 
 logger = logging.getLogger(__name__)
 
+SCHEMA_VERSION = 1
+
 
 @dataclass
 class CircuitModel:
@@ -139,6 +141,7 @@ class CircuitModel:
     def to_dict(self) -> dict:
         """Serialize circuit to dictionary (matches existing JSON format)."""
         data = {
+            "schema_version": SCHEMA_VERSION,
             "components": [c.to_dict() for c in self.components.values()],
             "wires": [w.to_dict() for w in self.wires],
             "counters": self.component_counter.copy(),

--- a/app/models/circuit_schema_validator.py
+++ b/app/models/circuit_schema_validator.py
@@ -7,6 +7,7 @@ dependencies.
 This module is the canonical location for ``validate_circuit_data``.
 """
 
+from models.circuit import SCHEMA_VERSION
 from models.component import _CLASS_TO_DISPLAY, COMPONENT_TYPES
 
 _VALID_ROTATIONS = {0, 90, 180, 270}
@@ -20,6 +21,16 @@ def validate_circuit_data(data) -> None:
     """
     if not isinstance(data, dict):
         raise ValueError("File does not contain a valid circuit object.")
+
+    version = data.get("schema_version")
+    if version is not None:
+        if not isinstance(version, int):
+            raise ValueError("'schema_version' must be an integer.")
+        if version > SCHEMA_VERSION:
+            raise ValueError(
+                f"File requires schema version {version}, but this application "
+                f"only supports up to version {SCHEMA_VERSION}. Please update the application."
+            )
 
     if "components" not in data or not isinstance(data["components"], list):
         raise ValueError("Missing or invalid 'components' list.")

--- a/app/tests/unit/test_circuit_model.py
+++ b/app/tests/unit/test_circuit_model.py
@@ -247,7 +247,12 @@ class TestSerialization:
     def test_empty_circuit_round_trip(self):
         model = CircuitModel()
         data = model.to_dict()
-        assert data == {"components": [], "wires": [], "counters": {}}
+        assert data == {
+            "schema_version": 1,
+            "components": [],
+            "wires": [],
+            "counters": {},
+        }
 
         reset_node_counter()
         model2 = CircuitModel.from_dict(data)

--- a/app/tests/unit/test_circuit_schema_validator.py
+++ b/app/tests/unit/test_circuit_schema_validator.py
@@ -1,11 +1,13 @@
 """Tests for models.circuit_schema_validator.validate_circuit_data."""
 
 import pytest
+from models.circuit import SCHEMA_VERSION
 from models.circuit_schema_validator import validate_circuit_data
 
 
 def _valid_circuit():
     return {
+        "schema_version": SCHEMA_VERSION,
         "components": [{"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}}],
         "wires": [],
     }
@@ -38,6 +40,41 @@ class TestValidateCircuitDataStructure:
     def test_wires_not_list_raises(self):
         with pytest.raises(ValueError, match="wires"):
             validate_circuit_data({"components": [], "wires": {}})
+
+
+class TestValidateSchemaVersion:
+    """Issue #521: circuit JSON must include a schema_version field."""
+
+    def test_valid_version_passes(self):
+        data = _valid_circuit()
+        validate_circuit_data(data)  # no exception
+
+    def test_missing_version_passes_for_backward_compat(self):
+        data = _valid_circuit()
+        del data["schema_version"]
+        validate_circuit_data(data)  # no exception
+
+    def test_non_integer_version_raises(self):
+        data = _valid_circuit()
+        data["schema_version"] = "1"
+        with pytest.raises(ValueError, match="integer"):
+            validate_circuit_data(data)
+
+    def test_future_version_raises(self):
+        data = _valid_circuit()
+        data["schema_version"] = SCHEMA_VERSION + 1
+        with pytest.raises(ValueError, match="update the application"):
+            validate_circuit_data(data)
+
+    def test_current_version_passes(self):
+        data = _valid_circuit()
+        data["schema_version"] = SCHEMA_VERSION
+        validate_circuit_data(data)  # no exception
+
+    def test_older_version_passes(self):
+        data = _valid_circuit()
+        data["schema_version"] = 1
+        validate_circuit_data(data)  # no exception
 
 
 class TestValidateCircuitDataComponents:

--- a/app/tests/unit/test_file_controller.py
+++ b/app/tests/unit/test_file_controller.py
@@ -33,6 +33,30 @@ class TestSaveLoad:
         assert "components" in data
         assert "wires" in data
 
+    def test_save_includes_schema_version(self, tmp_path):
+        from models.circuit import SCHEMA_VERSION
+
+        ctrl = FileController(build_simple_circuit())
+        filepath = tmp_path / "test.json"
+        ctrl.save_circuit(filepath)
+        data = json.loads(filepath.read_text())
+        assert data["schema_version"] == SCHEMA_VERSION
+
+    def test_load_file_without_schema_version(self, tmp_path):
+        """Files saved before schema_version was added should still load."""
+        data = {
+            "components": [
+                {"id": "R1", "type": "Resistor", "value": "1k", "pos": {"x": 0, "y": 0}},
+            ],
+            "wires": [],
+            "counters": {"Resistor": 1},
+        }
+        filepath = tmp_path / "legacy.json"
+        filepath.write_text(json.dumps(data))
+        ctrl = FileController()
+        ctrl.load_circuit(filepath)
+        assert "R1" in ctrl.model.components
+
     def test_load_restores_components(self, tmp_path):
         model = build_simple_circuit()
         ctrl = FileController(model)


### PR DESCRIPTION
## Summary - Adds a schema_version field (currently 1) to circuit JSON output via to_dict() - Validates schema_version on load: accepts missing (backward compat), rejects future versions with helpful message - New circuit_schema_validator module handles version checking ## Test plan - [x] test_valid_schema_version_passes - [x] test_missing_schema_version_accepted (backward compatibility) - [x] test_non_integer_schema_version_rejected - [x] test_future_schema_version_rejected - [x] test_save_includes_schema_version - [x] test_load_file_without_schema_version Generated with Claude Code