### PR TITLE
feat: wire routing blocked-path feedback (#913)

### DIFF
--- a/app/GUI/circuit_canvas.py
+++ b/app/GUI/circuit_canvas.py
@@ -107,6 +107,7 @@ class CircuitCanvasView(QGraphicsView):
         self.temp_wire_line = None  # Temporary line while drawing wire
         self._wire_waypoints: list[QPointF] = []  # In-progress waypoints (click-to-place)
         self._wire_waypoint_markers: list = []  # Visual markers for placed waypoints
+        self._wire_path_blocked = False  # True when preview path intersects a component
 
         # Rubber band selection
         self._rubber_band = None
@@ -909,6 +910,18 @@ class CircuitCanvasView(QGraphicsView):
             else:
                 anchor = self.wire_start_comp.get_terminal_pos(self.wire_start_term)
             self.temp_wire_line.setLine(anchor.x(), anchor.y(), scene_pos.x(), scene_pos.y())
+
+            # Check if wire path intersects any component
+            blocked = self._check_wire_preview_blocked(scene_pos)
+            if blocked and not self._wire_path_blocked:
+                self._wire_path_blocked = True
+                pen = QPen(Qt.GlobalColor.red, 2, Qt.PenStyle.DashLine)
+                self.temp_wire_line.setPen(pen)
+                self.statusMessage.emit("Wire path is blocked by a component", 3000)
+            elif not blocked and self._wire_path_blocked:
+                self._wire_path_blocked = False
+                self.temp_wire_line.setPen(theme_manager.pen("wire_preview"))
+
             self.temp_wire_line.update()
             event.accept()
             return
@@ -942,6 +955,40 @@ class CircuitCanvasView(QGraphicsView):
 
         super().mouseReleaseEvent(event)
 
+    def _wire_preview_intersects_component(self, p1: QPointF, p2: QPointF) -> bool:
+        """Check if a line segment intersects any component's bounding rect.
+
+        Excludes the component where wire drawing started.
+        """
+        from PyQt6.QtCore import QLineF
+
+        line = QLineF(p1, p2)
+        for comp in self.components.values():
+            if comp is self.wire_start_comp:
+                continue
+            rect = comp.sceneBoundingRect()
+            # Check intersection with all four edges of the bounding rect
+            edges = [
+                QLineF(rect.topLeft(), rect.topRight()),
+                QLineF(rect.topRight(), rect.bottomRight()),
+                QLineF(rect.bottomRight(), rect.bottomLeft()),
+                QLineF(rect.bottomLeft(), rect.topLeft()),
+            ]
+            for edge in edges:
+                intersection_type = line.intersects(edge)[0]
+                if intersection_type == QLineF.IntersectionType.BoundedIntersection:
+                    return True
+        return False
+
+    def _check_wire_preview_blocked(self, scene_pos: QPointF) -> bool:
+        """Check if the full wire preview path (all waypoints + current segment) is blocked."""
+        start_pos = self.wire_start_comp.get_terminal_pos(self.wire_start_term)
+        points = [start_pos] + list(self._wire_waypoints) + [scene_pos]
+        for i in range(len(points) - 1):
+            if self._wire_preview_intersects_component(points[i], points[i + 1]):
+                return True
+        return False
+
     def cancel_wire_drawing(self):
         """Cancel any in-progress wire drawing and clean up the preview line."""
         was_drawing = self.wire_start_comp is not None
@@ -951,6 +998,7 @@ class CircuitCanvasView(QGraphicsView):
         self.wire_start_comp = None
         self.wire_start_term = None
         self._wire_waypoints.clear()
+        self._wire_path_blocked = False
         self._remove_waypoint_markers()
         # Restore default cursor when wire drawing ends
         if was_drawing:

--- a/app/tests/unit/test_wire_blocked_feedback.py
+++ b/app/tests/unit/test_wire_blocked_feedback.py
@@ -1,0 +1,127 @@
+"""Tests for wire routing blocked-path feedback (issue #913).
+
+When drawing a wire, if the preview path intersects a component's bounding
+rect, the preview line should turn red/dashed and a status bar message should
+be emitted.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from PyQt6.QtCore import QLineF, QPointF, QRectF
+
+
+class TestWirePreviewIntersectsComponent:
+    """_wire_preview_intersects_component checks line-vs-component collision."""
+
+    def _make_canvas(self):
+        from GUI.circuit_canvas import CircuitCanvasView
+
+        method = CircuitCanvasView._wire_preview_intersects_component
+        canvas = MagicMock()
+        canvas._wire_preview_intersects_component = lambda p1, p2: method(canvas, p1, p2)
+        return canvas
+
+    def test_line_through_component_returns_true(self):
+        """A line passing through a component bounding rect is blocked."""
+        canvas = self._make_canvas()
+        comp = MagicMock()
+        # Component occupies (40,40)-(80,80)
+        comp.sceneBoundingRect.return_value = QRectF(40, 40, 40, 40)
+        canvas.wire_start_comp = MagicMock()
+        canvas.components = {"other": comp}
+
+        result = canvas._wire_preview_intersects_component(QPointF(0, 60), QPointF(100, 60))
+        assert result is True
+
+    def test_line_around_component_returns_false(self):
+        """A line that doesn't cross the component is not blocked."""
+        canvas = self._make_canvas()
+        comp = MagicMock()
+        comp.sceneBoundingRect.return_value = QRectF(40, 40, 40, 40)
+        canvas.wire_start_comp = MagicMock()
+        canvas.components = {"other": comp}
+
+        result = canvas._wire_preview_intersects_component(QPointF(0, 0), QPointF(100, 0))
+        assert result is False
+
+    def test_start_component_excluded(self):
+        """The component where wire drawing started should be excluded."""
+        canvas = self._make_canvas()
+        start_comp = MagicMock()
+        start_comp.sceneBoundingRect.return_value = QRectF(0, 0, 40, 40)
+        canvas.wire_start_comp = start_comp
+        canvas.components = {"start": start_comp}
+
+        # Line goes right through start_comp but should be ignored
+        result = canvas._wire_preview_intersects_component(QPointF(-10, 20), QPointF(50, 20))
+        assert result is False
+
+    def test_no_components_returns_false(self):
+        """Empty canvas should never report blocked."""
+        canvas = self._make_canvas()
+        canvas.wire_start_comp = MagicMock()
+        canvas.components = {}
+
+        result = canvas._wire_preview_intersects_component(QPointF(0, 0), QPointF(100, 100))
+        assert result is False
+
+
+class TestCheckWirePreviewBlocked:
+    """_check_wire_preview_blocked checks full path including waypoints."""
+
+    def _make_canvas(self):
+        from GUI.circuit_canvas import CircuitCanvasView
+
+        method = CircuitCanvasView._check_wire_preview_blocked
+        intersect_method = CircuitCanvasView._wire_preview_intersects_component
+        canvas = MagicMock()
+        canvas._check_wire_preview_blocked = lambda pos: method(canvas, pos)
+        canvas._wire_preview_intersects_component = lambda p1, p2: intersect_method(canvas, p1, p2)
+        return canvas
+
+    def test_blocked_on_first_segment(self):
+        """Path blocked between start terminal and first waypoint."""
+        canvas = self._make_canvas()
+        start_comp = MagicMock()
+        start_comp.get_terminal_pos.return_value = QPointF(0, 60)
+        canvas.wire_start_comp = start_comp
+        canvas.wire_start_term = 0
+        canvas._wire_waypoints = [QPointF(100, 60)]
+
+        # Obstacle in the middle
+        comp = MagicMock()
+        comp.sceneBoundingRect.return_value = QRectF(40, 40, 20, 40)
+        canvas.components = {"blocker": comp}
+
+        assert canvas._check_wire_preview_blocked(QPointF(200, 60)) is True
+
+    def test_not_blocked_clear_path(self):
+        """No components in the way should return False."""
+        canvas = self._make_canvas()
+        start_comp = MagicMock()
+        start_comp.get_terminal_pos.return_value = QPointF(0, 0)
+        canvas.wire_start_comp = start_comp
+        canvas.wire_start_term = 0
+        canvas._wire_waypoints = []
+        canvas.components = {}
+
+        assert canvas._check_wire_preview_blocked(QPointF(100, 0)) is False
+
+
+class TestCancelClearsBlockedState:
+    """cancel_wire_drawing should reset _wire_path_blocked."""
+
+    def test_blocked_flag_reset(self):
+        from GUI.circuit_canvas import CircuitCanvasView
+
+        cancel = CircuitCanvasView.cancel_wire_drawing
+        canvas = MagicMock()
+        canvas.cancel_wire_drawing = lambda: cancel(canvas)
+        canvas._scene = MagicMock()
+        canvas.temp_wire_line = None
+        canvas.wire_start_comp = MagicMock()
+        canvas._wire_path_blocked = True
+
+        canvas.cancel_wire_drawing()
+
+        assert canvas._wire_path_blocked is False


### PR DESCRIPTION
## Summary
- When drawing a wire, if the preview path intersects a component bounding rect, the preview line turns red/dashed and a status bar message is emitted
- Checks all segments (start terminal, waypoints, cursor position) for intersection with component bounding rects
- Resets visual feedback when the path becomes clear or wire drawing is cancelled
- Excludes the wire start component from intersection checks

## Test plan
- [x] Unit tests for intersection detection (line through, around, start excluded, empty canvas)
- [x] Unit tests for full path check (blocked first segment, clear path)
- [x] Unit test for cancel resetting blocked state
- [ ] Human testing: Place components close together, draw wire through blocked area, verify dashed red line and status bar message

Closes #913

Generated with Claude Code