### PR TITLE
fix: monochrome mode illegible in light theme (#911)

### DIFF
--- a/app/GUI/component_item.py
+++ b/app/GUI/component_item.py
@@ -420,7 +420,7 @@ class ComponentGraphicsItem(QGraphicsItem):
 
         # Draw component body
         painter.setPen(QPen(color, 2))
-        painter.setBrush(QBrush(color.lighter(150)))
+        painter.setBrush(theme_manager.brush("component_fill"))
         self.draw_component_body(painter)
 
         # Draw label (check canvas visibility settings via injected reference)
@@ -704,7 +704,7 @@ class Ground(ComponentGraphicsItem):
             painter.drawRect(QRectF(-40, -20, 80, 40))
 
         painter.setPen(QPen(color, 2))
-        painter.setBrush(QBrush(color.lighter(150)))
+        painter.setBrush(theme_manager.brush("component_fill"))
         self.draw_component_body(painter)
 
         show_label = (

--- a/app/GUI/component_palette.py
+++ b/app/GUI/component_palette.py
@@ -2,7 +2,7 @@ from controllers.settings_service import settings as app_settings
 from models.builtin_subcircuits import register_builtin_subcircuits
 from models.component import COMPONENT_CATEGORIES
 from PyQt6.QtCore import QMimeData, QSize, Qt, pyqtSignal
-from PyQt6.QtGui import QBrush, QDrag, QFont, QIcon, QPainter, QPen, QPixmap
+from PyQt6.QtGui import QDrag, QFont, QIcon, QPainter, QPen, QPixmap
 from PyQt6.QtWidgets import QLineEdit, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 
 from .component_item import COMPONENT_CLASSES
@@ -63,7 +63,7 @@ def create_component_icon(component_type, size=48):
         # Fallback icon for subcircuit components without a renderer class
         color = theme_manager.get_component_color(component_type)
         painter.setPen(QPen(color, 2))
-        painter.setBrush(QBrush(color.lighter(150)))
+        painter.setBrush(theme_manager.brush("component_fill"))
         margin = int(size * 0.15)
         painter.drawRect(margin, margin, size - 2 * margin, size - 2 * margin)
         painter.end()
@@ -74,7 +74,7 @@ def create_component_icon(component_type, size=48):
     # Set up painter with theme color
     color = theme_manager.get_component_color(temp_comp.component_type)
     painter.setPen(QPen(color, 2))
-    painter.setBrush(QBrush(color.lighter(150)))
+    painter.setBrush(theme_manager.brush("component_fill"))
 
     # Center and scale to fit icon
     painter.translate(size / 2, size / 2)

--- a/app/tests/unit/test_monochrome_legibility.py
+++ b/app/tests/unit/test_monochrome_legibility.py
@@ -1,0 +1,82 @@
+"""Tests for monochrome mode component legibility (#911).
+
+Verifies that component rendering uses the theme's background-based fill
+(component_fill brush) instead of a derivative of the component color,
+ensuring internal details remain visible in monochrome mode on both
+light and dark themes.
+"""
+
+from pathlib import Path
+
+import pytest
+from GUI.styles import LightTheme, theme_manager
+from GUI.styles.dark_theme import DarkTheme
+
+
+def _module_source(module):
+    return Path(module.__file__).read_text(encoding="utf-8")
+
+
+class TestComponentFillUsesThemeBrush:
+    """Verify component rendering uses theme_manager.brush('component_fill')."""
+
+    def test_component_item_uses_component_fill_brush(self):
+        from GUI import component_item
+
+        src = _module_source(component_item)
+        assert 'theme_manager.brush("component_fill")' in src
+        assert "color.lighter(150)" not in src
+
+    def test_palette_uses_component_fill_brush(self):
+        from GUI import component_palette
+
+        src = _module_source(component_palette)
+        assert 'theme_manager.brush("component_fill")' in src
+        assert "color.lighter(150)" not in src
+
+
+class TestComponentFillContrastMonochrome:
+    """Verify component_fill provides contrast with foreground in monochrome mode."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_teardown(self):
+        theme_manager.set_theme(LightTheme())
+        theme_manager.set_color_mode("color")
+        yield
+        theme_manager.set_theme(LightTheme())
+        theme_manager.set_color_mode("color")
+
+    def test_light_monochrome_fill_differs_from_foreground(self):
+        theme_manager.set_theme(LightTheme())
+        theme_manager.set_color_mode("monochrome")
+        fg = theme_manager.get_component_color("Voltage Source")
+        fill = theme_manager.brush("component_fill").color()
+        assert fg.name() != fill.name(), (
+            f"In light+monochrome, fill ({fill.name()}) must differ from "
+            f"foreground ({fg.name()}) for internal details to be visible"
+        )
+
+    def test_dark_monochrome_fill_differs_from_foreground(self):
+        theme_manager.set_theme(DarkTheme())
+        theme_manager.set_color_mode("monochrome")
+        fg = theme_manager.get_component_color("Voltage Source")
+        fill = theme_manager.brush("component_fill").color()
+        assert fg.name() != fill.name(), (
+            f"In dark+monochrome, fill ({fill.name()}) must differ from "
+            f"foreground ({fg.name()}) for internal details to be visible"
+        )
+
+    def test_light_monochrome_fill_is_background(self):
+        """Fill should be the theme background so details drawn with foreground are visible."""
+        theme_manager.set_theme(LightTheme())
+        theme_manager.set_color_mode("monochrome")
+        bg = theme_manager.color("background_primary")
+        fill = theme_manager.brush("component_fill").color()
+        assert fill.name() == bg.name()
+
+    def test_dark_monochrome_fill_is_background(self):
+        theme_manager.set_theme(DarkTheme())
+        theme_manager.set_color_mode("monochrome")
+        bg = theme_manager.color("background_primary")
+        fill = theme_manager.brush("component_fill").color()
+        assert fill.name() == bg.name()


### PR DESCRIPTION
## Summary - Replace  brush fill with  in component rendering - Fixes components losing internal details (+/-, arrows, sine waves) in light theme monochrome mode - Affected: Voltage Source, Current Source, Waveform Source, AC sources, BJTs, VC Switch, Current Probe ## Root cause  on black (#000000) returns nearly black, so filled shapes (circles/rects) and their internal details (drawn with the same black pen) become indistinguishable. Using  (white for light theme) ensures contrast. ## Test plan - [x] Unit tests verify component_fill brush is used (not color.lighter) - [x] Unit tests verify fill color differs from foreground in both light+monochrome and dark+monochrome - [ ] Manually verify affected components are legible in light+monochrome mode - [ ] Manually verify dark+monochrome mode still looks correct Closes #911 🤖 Generated with [Claude Code](https://claude.com/claude-code)