### PR TITLE
docs: update human-testing-guide for installer-based testing path (#914)

### DIFF
--- a/docs/human-testing-guide.md
+++ b/docs/human-testing-guide.md
@@ -9,13 +9,59 @@ This guide walks you through regression testing the Spice-GUI application. No pr
 - **Testing board**: https://github.com/orgs/SDSMT-Capstone-Spice-GUI-Team/projects/3 — this is your home base. Each card is a testing section with checkboxes you can tick off directly on GitHub.
 - **Overview issue**: [#278](https://github.com/SDSMT-Capstone-Spice-GUI-Team/Spice-GUI/issues/278) — has a table of all testing issues and setup instructions.
 
+### Which Setup Path Should I Use?
+
+| Path | Best for | Prerequisites |
+|------|----------|---------------|
+| **Option A — Windows Installer** (recommended) | Testing released builds, regression testing the installed app, testers who don't write code | None — everything is bundled |
+| **Option B — From Source** | Testing unmerged PRs, testing on macOS/Linux, development work | Python, Git, VSCode |
+
+If you're only running through the testing board and don't need to test code that hasn't been released yet, **use Option A**.
+
 ---
 
-## Part 1: One-Time Setup (Windows)
+## Part 1A: One-Time Setup — Windows Installer (Recommended)
 
-You only need to do this once on your machine.
+This is the simplest way to get started. No programming tools needed.
 
-### 1.1 Install Python
+### 1A.1 Download and Install
+
+1. Go to the [Releases page](https://github.com/SDSMT-Capstone-Spice-GUI-Team/Spice-GUI/releases)
+2. Under the latest release, download the file named **`SpiceGUI-vX.Y.Z-win64-setup.exe`**
+3. Run the installer — if Windows SmartScreen warns you, click **"More info"** then **"Run anyway"** (this is normal for unsigned software)
+4. Follow the installer prompts. For most testers, the defaults are fine
+
+For detailed installation steps and screenshots, see the **[Installation Guide](installation-guide.md)**.
+
+### 1A.2 Verify the App Runs
+
+1. Launch Spice GUI from the Start Menu or desktop shortcut
+2. The Spice-GUI window should appear. If it does, setup is complete! Close the app.
+
+> **Trouble?** See the [Installation Guide troubleshooting section](installation-guide.md#troubleshooting) for solutions to common problems.
+
+---
+
+## Part 1A-Extra: Testing the Installer Itself
+
+In addition to testing the app's features, you can verify the installer works correctly. Run through these checks after a fresh install:
+
+| Check | What to verify |
+|-------|----------------|
+| **Per-user install** | Run the installer and choose "Install for current user only" — no admin prompt should appear |
+| **All-users install** | Run the installer and choose "Install for all users" — requires admin, installs to Program Files |
+| **.spice file association** | If you selected "Associate .spice files", double-clicking a `.spice` file should open Spice GUI |
+| **Desktop icon** | If you selected "Create a desktop icon", a shortcut should appear on the desktop |
+| **Start Menu entry** | Spice GUI should appear in the Start Menu |
+| **Uninstall** | Uninstall via Settings > Apps — the app should be fully removed |
+
+---
+
+## Part 1B: One-Time Setup — From Source (Windows)
+
+Use this path if you need to test unmerged code or run on macOS/Linux. You only need to do this once on your machine.
+
+### 1B.1 Install Python
 
 1. Go to https://www.python.org/downloads/
 2. Download the latest **Python 3.11+** installer for Windows
@@ -27,7 +73,7 @@ You only need to do this once on your machine.
    ```
    You should see something like `Python 3.12.x`. If you see an error, restart your computer and try again.
 
-### 1.2 Open a Terminal in VSCode
+### 1B.2 Open a Terminal in VSCode
 
 Throughout this guide, "terminal" means the built-in terminal inside VSCode:
 
@@ -35,7 +81,7 @@ Throughout this guide, "terminal" means the built-in terminal inside VSCode:
 2. Press **Ctrl + `** (the backtick key, located above Tab) to open the terminal panel at the bottom
 3. All commands in this guide should be typed into this terminal
 
-### 1.3 Clone the Repository
+### 1B.3 Clone the Repository
 
 1. Open VSCode
 2. Open the terminal (Ctrl + `)
@@ -49,7 +95,7 @@ Throughout this guide, "terminal" means the built-in terminal inside VSCode:
    ```
 5. Open the cloned folder in VSCode: **File > Open Folder** and select the `Spice-GUI` folder you just created
 
-### 1.4 Set Up the Python Environment
+### 1B.4 Set Up the Python Environment
 
 1. Open the terminal in VSCode (Ctrl + `)
 2. Create a virtual environment (this keeps project files separate from your system):
@@ -67,7 +113,7 @@ Throughout this guide, "terminal" means the built-in terminal inside VSCode:
    ```
    This will download everything the app needs to run. It may take a minute.
 
-### 1.5 Verify the App Runs
+### 1B.5 Verify the App Runs
 
 1. Make sure `(.venv)` is showing in your terminal
 2. Start the application using one of these methods:
@@ -86,7 +132,14 @@ Throughout this guide, "terminal" means the built-in terminal inside VSCode:
 
 Do these steps every time you sit down to test.
 
-### 2.1 Open the Project and Activate
+### 2.1 Launch the App
+
+**If you installed via the Windows installer (Part 1A):**
+
+1. Check for updates: visit the [Releases page](https://github.com/SDSMT-Capstone-Spice-GUI-Team/Spice-GUI/releases) and compare the latest version to your installed version (shown in **Help > About**). If a newer version is available, download and run the new installer — it will upgrade in place.
+2. Launch Spice GUI from the Start Menu or desktop shortcut.
+
+**If you installed from source (Part 1B):**
 
 1. Open VSCode
 2. **File > Open Folder** > select the `Spice-GUI` folder
@@ -104,10 +157,7 @@ Do these steps every time you sit down to test.
    ```
    pip install -r app/requirements.txt
    ```
-
-### 2.2 Launch the App
-
-Press **F5** (and select "Run Spice-GUI" if prompted) or run `python app/main.py` in the terminal.
+7. Press **F5** (and select "Run Spice-GUI" if prompted) or run `python app/main.py` in the terminal.
 
 You are now ready to test!
 
@@ -207,6 +257,20 @@ After a testing session:
 
 ## Quick Reference
 
+### Installer Path (Part 1A)
+
+| Step | What to Do |
+|------|------------|
+| **Start session** | Check [Releases](https://github.com/SDSMT-Capstone-Spice-GUI-Team/Spice-GUI/releases) for updates > launch from Start Menu |
+| **Find what to test** | Go to the [Human Testing board](https://github.com/orgs/SDSMT-Capstone-Spice-GUI-Team/projects/3), pick from "Ready to Test" |
+| **Claim it** | Drag the issue to "Testing" on the board |
+| **Test** | Try each item, check boxes directly on the GitHub issue |
+| **All passed** | Comment "all verified", move to "Passed" |
+| **Bug found** | Click "report bug" link on the item, fill in blanks, submit. Move to "Bugs Found" ([detailed guide](how-to-file-a-bug.md)) |
+| **Not sure** | Comment with question, leave in "Testing" |
+
+### From-Source Path (Part 1B)
+
 | Step | What to Do |
 |------|------------|
 | **Start session** | Open VSCode > activate venv > `git checkout main && git pull` > `pip install -r app/requirements.txt` |
@@ -221,6 +285,17 @@ After a testing session:
 ---
 
 ## Troubleshooting
+
+### Installer Path
+
+| Problem | Solution |
+|---------|----------|
+| Windows SmartScreen blocks the installer | Click **"More info"** then **"Run anyway"** — this is normal for unsigned software |
+| App won't start (missing DLL error) | Install the [Visual C++ Redistributable (x64)](https://aka.ms/vs/17/release/vc_redist.x64.exe) and restart your computer |
+| App is quarantined by antivirus | Restore from quarantine and add an exclusion for the Spice GUI install folder. See the [Installation Guide](installation-guide.md#troubleshooting) |
+| Simulations fail ("ngspice not found") | Open **Edit > Preferences** and check the ngspice path. See the [Installation Guide](installation-guide.md#troubleshooting) |
+
+### From-Source Path
 
 | Problem | Solution |
 |---------|----------|


### PR DESCRIPTION
## Summary - Adds Windows installer as the recommended setup path (Part 1A) for non-technical testers — no Python, Git, or VSCode needed - Preserves the from-source path (Part 1B) for testing unmerged PRs or running on macOS/Linux - Adds an installer verification checklist (install modes, file association, desktop icon, uninstall) - Splits session-start instructions and troubleshooting into installer vs from-source sections - Cross-links to docs/installation-guide.md for detailed install steps and screenshots Closes #914 ## Test plan - [ ] Read through the updated guide and verify a non-technical tester can follow the installer path end-to-end - [ ] Verify all cross-links resolve correctly (installation-guide.md, Releases page, testing board) - [ ] Confirm the from-source path (Part 1B) still reads correctly and hasn't lost any steps 🤖 Generated with [Claude Code](https://claude.com/claude-code)