### PR TITLE
docs: fix stale references and update line counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,7 @@ SDM Spice is currently in **Phase 1 (Student MVP)** development as part of an SD
 
 - **[Installation Guide](docs/installation-guide.md)** - Windows installer setup, troubleshooting, and uninstall instructions
 - **[Architecture Decision Records](Doc/decisions/)** - Important architectural decisions and their rationale
-- **[Development Methodology](Doc/autonomous-workflow.md)** - AI-assisted development approach and autonomous workflow
-- **[Project Evolution](Doc/project-evolution.md)** - How the project evolved from discovery to implementation
+- **[Project Evolution](Doc/project-evolution.md)** - AI-assisted development approach and how the project evolved
 - **[Discovery Documentation](DiscoveryDocs/)** - Initial exploration and requirements gathering (academic assignment)
 
 ## Development Setup

--- a/docs/adr/canvas-architecture.md
+++ b/docs/adr/canvas-architecture.md
@@ -25,7 +25,7 @@ CircuitCanvasView (QGraphicsView)     ← primary interaction surface
 
 ```
 QGraphicsView
-└── CircuitCanvasView                    app/GUI/circuit_canvas.py (~2266 lines)
+└── CircuitCanvasView                    app/GUI/circuit_canvas.py (~1916 lines)
     │
     └── QGraphicsScene (aggregated)
             │
@@ -52,7 +52,7 @@ _WireAdapter        — wraps WireGraphicsItem for pathfinding obstacle queries
 ### Rendering
 
 ```
-ComponentRenderer (ABC)                  app/GUI/renderers.py (~585 lines)
+ComponentRenderer (ABC)                  app/GUI/renderers.py (~694 lines)
 ├── IEEEResistor, IEEECapacitor, IEEEInductor, …
 └── (IEC variants follow the same interface)
 ```
@@ -323,12 +323,12 @@ probe_mode: bool                # Probe tool active
 
 | File | Lines | Purpose |
 |---|---|---|
-| `app/GUI/circuit_canvas.py` | ~2266 | Main view: events, editing, serialization, overlays |
-| `app/GUI/component_item.py` | ~872 | Component rendering, drag, terminal detection |
-| `app/GUI/wire_item.py` | ~524 | Wire routing, waypoint handles, pathfinding adapters |
+| `app/GUI/circuit_canvas.py` | ~1916 | Main view: events, editing, serialization, overlays |
+| `app/GUI/component_item.py` | ~971 | Component rendering, drag, terminal detection |
+| `app/GUI/wire_item.py` | ~637 | Wire routing, waypoint handles, pathfinding adapters |
 | `app/GUI/annotation_item.py` | ~72 | Free-form text labels |
-| `app/GUI/renderers.py` | ~585 | Component symbol renderers (IEEE/IEC), obstacle shapes |
-| `app/GUI/styles/constants.py` | ~79 | Grid, zoom, terminal, and layout constants |
+| `app/GUI/renderers.py` | ~694 | Component symbol renderers (IEEE/IEC), obstacle shapes |
+| `app/GUI/styles/constants.py` | ~96 | Grid, zoom, terminal, and layout constants |
 | `app/models/component.py` | — | `ComponentData`, `COMPONENT_TYPES`, `SPICE_SYMBOLS`, `TERMINAL_COUNTS` |
 | `app/models/wire.py` | ~96 | `WireData` |
 | `app/models/node.py` | — | `NodeData`, node label generator |

--- a/docs/canvas-rebuild-guide.md
+++ b/docs/canvas-rebuild-guide.md
@@ -3,7 +3,8 @@
 **Goal:** Rebuild the 5 canvas files from scratch to reduce bloat and produce
 clean, well-documented code. Each phase is independently testable.
 
-**Current state:** ~4,300 lines across 5 files.
+**Status:** Planning document — this rebuild has not been started.
+**Current state (as of 2026-04-13):** ~4,310 lines across 5 files.
 **Target:** ~3,500 lines (−800, ~19% reduction) with better docs.
 
 ---


### PR DESCRIPTION
## Summary
Pre-presentation documentation scrub:

- **README.md**: Remove broken link to `Doc/autonomous-workflow.md` (file doesn't exist)
- **docs/adr/canvas-architecture.md**: Update line counts to current values (circuit_canvas 2266→1916, component_item 872→971, wire_item 524→637, renderers 585→694, constants 79→96)
- **docs/canvas-rebuild-guide.md**: Add status note clarifying this is an unstarted planning document

Also fixes: CLAUDE.md has `app/main_window.py` should be `app/GUI/main_window.py` — that fix is in the orchestrator's worker-CLAUDE.md (CLAUDE.md is gitignored in this repo, injected from the orchestrator).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>