### PR TITLE
docs: wiki accuracy scrub for presentation

### DIFF
--- a/wiki/Analysis-Types.md
+++ b/wiki/Analysis-Types.md
@@ -240,6 +240,71 @@ Performs Fast Fourier Transform on transient simulation results to show the freq
 
 ---
 
+## Noise Analysis
+
+### Description
+Computes the noise contribution of each component in a circuit at a specified output node. Shows noise spectral density as a function of frequency.
+
+### When to Use
+- Analyzing noise performance of amplifier circuits
+- Identifying dominant noise sources
+- Designing low-noise signal chains
+
+### How to Run
+1. Go to **Analysis > Noise Analysis**
+2. Select the output node and reference node
+3. Configure frequency range
+4. Click **Run**
+
+### Output
+- Noise spectral density vs frequency
+- Per-component noise contribution breakdown
+
+---
+
+## Monte Carlo Analysis
+
+### Description
+Runs multiple simulations with randomized component values within specified tolerances. Shows statistical distribution of circuit behavior to assess manufacturing yield and worst-case performance.
+
+### When to Use
+- Evaluating circuit sensitivity to component tolerances
+- Estimating manufacturing yield
+- Finding worst-case operating conditions
+
+### How to Run
+1. Go to **Analysis > Monte Carlo**
+2. Set tolerances for target components
+3. Configure number of iterations and base analysis type
+4. Click **Run**
+
+### Output
+- Overlaid traces from all iterations
+- Statistical summary (mean, std dev, min/max)
+
+---
+
+## Sensitivity Analysis
+
+### Description
+Measures how much each component's value affects a circuit output. Ranks components by their impact, helping identify which tolerances matter most.
+
+### When to Use
+- Prioritizing which component tolerances to tighten
+- Understanding circuit sensitivity to parameter changes
+- Design optimization
+
+### How to Run
+1. Go to **Analysis > Sensitivity**
+2. Select the output variable to measure
+3. Click **Run**
+
+### Output
+- Table of components ranked by sensitivity and normalized sensitivity
+- Identifies which components have the most impact on circuit behavior
+
+---
+
 ## Analysis Comparison
 
 | Analysis | Domain | Typical Use | Output |
@@ -251,6 +316,9 @@ Performs Fast Fourier Transform on transient simulation results to show the freq
 | Temperature Sweep | Temperature | Thermal sensitivity | Parameters vs temperature |
 | Parameter Sweep | Varies | Component sensitivity | Overlaid traces per value |
 | FFT Analysis | Frequency | Harmonic distortion | Spectrum from transient data |
+| Noise | Frequency | Amplifier noise | Noise spectral density |
+| Monte Carlo | Statistical | Manufacturing yield | Distribution of results |
+| Sensitivity | Parametric | Component ranking | Sensitivity table |
 
 ---
 

--- a/wiki/Components.md
+++ b/wiki/Components.md
@@ -161,24 +161,22 @@ Example: `EXP(0 5 0 1m 5m 1m)` - Exponential rise and fall
 | Property | Value |
 |----------|-------|
 | Symbol | OA |
-| Terminals | 5 |
+| Terminals | 3 |
 | Color | Yellow |
 | Status | Fully Functional |
 
-**Description:** An ideal operational amplifier with very high gain.
+**Description:** An operational amplifier with selectable models.
 
 **Terminals:**
 1. Inverting input (-)
 2. Non-inverting input (+)
 3. Output
-4. Positive supply (V+)
-5. Negative supply (V-)
 
-**Model:** Uses an ideal op-amp subcircuit with:
+**Models available:** Ideal, LM741, TL081, LM358
+
+**Ideal model parameters:**
 - Gain: 1,000,000 (1e6)
 - Output resistance: 0.001 ohms
-
-**Note:** Currently uses an ideal model. Real op-amp models with bandwidth limitations and other non-idealities are planned for future releases.
 
 ---
 
@@ -387,11 +385,14 @@ SDM Spice supports standard engineering notation:
 
 ---
 
-## Planned Components
+## Recently Added Components
 
-The following components are planned for future releases:
+The following components have been implemented and are fully functional:
 
-- **Transformer** - Coupled inductors
+- **Transformer** — Coupled inductors with configurable turns ratio
+- **Current Probe** — Measures branch current through a wire
+- **AC Voltage Source (VAC)** — Sinusoidal voltage source for AC sweep analysis
+- **AC Current Source (IAC)** — Sinusoidal current source for AC sweep analysis
 
 See the [GitHub Issues](https://github.com/SDSMT-Capstone-Spice-GUI-Team/Spice-GUI/issues) for component requests and status.
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -8,9 +8,9 @@ SDM Spice is an open-source circuit design and simulation platform developed at 
 
 ### Key Features
 - Visual circuit schematic editor with drag-and-drop component placement
-- 20+ components: passives, sources, dependent sources, semiconductors (BJT, MOSFET, diodes), switches
+- 24 components: passives, sources (DC and AC), dependent sources, semiconductors (BJT, MOSFET, diodes), switches, transformer, current probe
 - Intelligent wire routing with automatic pathfinding
-- Integrated ngspice simulation (DC OP, DC Sweep, AC Sweep, Transient, Temperature Sweep)
+- Integrated ngspice simulation (DC OP, DC Sweep, AC Sweep, Transient, Temperature Sweep, Noise, Monte Carlo, Sensitivity)
 - Parameter sweep across component values
 - Interactive waveform viewer with measurement cursors and result overlay
 - FFT/harmonic analysis with THD calculation

--- a/wiki/System-Requirements.md
+++ b/wiki/System-Requirements.md
@@ -177,4 +177,3 @@ For long simulations, consider:
 
 - [[Installation Guide]] - Step-by-step setup
 - [[Technology Stack]] - Technical details
-- [[Troubleshooting]] - Common issues


### PR DESCRIPTION
## Summary
Pre-presentation wiki audit — fixes all inaccuracies found:

### Components.md (CRITICAL)
- Op-Amp terminal count: 5 → 3 (matches code)
- Op-Amp models: added LM741, TL081, LM358 (were implemented but undocumented)
- Transformer + Current Probe: moved from "Planned" to "Recently Added"
- Added AC Voltage Source (VAC) and AC Current Source (IAC)

### Analysis-Types.md (CRITICAL)
- Added 3 missing analysis types: Noise, Monte Carlo, Sensitivity
- Updated comparison table: 7 → 10 analysis types

### Home.md
- Component count: "20+" → "24"
- Analysis list: added Noise, Monte Carlo, Sensitivity

### System-Requirements.md
- Removed broken `[[Troubleshooting]]` wiki link (page doesn't exist)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>